### PR TITLE
fix(vllm): patch flashinfer_trtllm moe backend to support refit

### DIFF
--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -14,7 +14,29 @@
 
 import os
 from contextlib import contextmanager
+from functools import wraps
 from importlib.util import find_spec
+from typing import Any
+
+G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR = "_nrl_flashinfer_trtllm_w13_weight"
+G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR = "_nrl_flashinfer_trtllm_w2_weight"
+G_FLASHINFER_TRTLLM_PATCH_ATTR = "_nrl_flashinfer_trtllm_refit_patch_applied"
+G_FLASHINFER_TRTLLM_INTERMEDIATE_ALIGNMENT = 128
+G_FLASHINFER_TRTLLM_ENGINE_CORE_PATCH_ATTR = (
+    "_nrl_flashinfer_trtllm_refit_engine_core_patch_applied"
+)
+G_FLASHINFER_TRTLLM_ENGINE_CORE_ORIGINAL_ATTR = "_nrl_original_run_engine_core"
+G_FLASHINFER_TRTLLM_RAY_WORKER_PATCH_ATTR = (
+    "_nrl_flashinfer_trtllm_refit_ray_worker_patch_applied"
+)
+G_FLASHINFER_TRTLLM_RAY_WORKER_ORIGINAL_ATTR = "_nrl_original_initialize_worker"
+G_FLASHINFER_TRTLLM_RAY_EXECUTOR_PATCH_ATTR = (
+    "_nrl_flashinfer_trtllm_refit_ray_executor_patch_applied"
+)
+G_FLASHINFER_TRTLLM_RAY_EXECUTOR_ORIGINAL_ATTR = "_nrl_original_collective_rpc"
+G_FLASHINFER_TRTLLM_RAY_EXECUTOR_WORKERS_PATCHED_ATTR = (
+    "_nrl_flashinfer_trtllm_refit_workers_patched"
+)
 
 
 def _get_vllm_file(relative_path: str) -> str:
@@ -566,6 +588,469 @@ def _patch_vllm_radio_layerscale_loader(logger) -> None:
     logger.info("Successfully patched vLLM RADIO LayerScale loading.")
 
 
+def _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
+    logger: Any | None = None,
+) -> None:
+    """Keep FlashInfer TRTLLM MoE kernel weights stable across vLLM refits.
+
+    vLLM 0.25.1 converts unquantized FlashInfer TRTLLM MoE weights from the
+    canonical loader shape to the kernel's block layout by replacing
+    ``layer.w13_weight`` and ``layer.w2_weight``. NeMo-RL later refits by
+    calling vLLM's HF loader again, which expects those parameters to still
+    have the canonical 3D expert-weight shapes. Keep the registered
+    Parameters as canonical views for loading, and store the converted
+    block-layout tensors separately for the kernels.
+    """
+    # These imports require vLLM, so keep them out of module import time.
+    import torch
+    from vllm.logger import init_logger
+    from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+        UnquantizedMoeBackend,
+        convert_to_unquantized_kernel_format,
+        make_unquantized_moe_kernel,
+    )
+    from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+        UnquantizedFusedMoEMethod,
+    )
+
+    if logger is None:
+        logger = init_logger("vllm_patch")
+
+    if getattr(UnquantizedFusedMoEMethod, G_FLASHINFER_TRTLLM_PATCH_ATTR, False):
+        logger.info("vLLM FlashInfer TRTLLM refit buffer patch already applied.")
+        return
+
+    original_setup_kernel = UnquantizedFusedMoEMethod._setup_kernel
+    original_forward_native = UnquantizedFusedMoEMethod.forward_native
+    original_apply_monolithic = UnquantizedFusedMoEMethod.apply_monolithic
+
+    def _load_shape_numel(load_shape: tuple[int, ...]) -> int:
+        numel = 1
+        for dim in load_shape:
+            numel *= dim
+        return numel
+
+    def _raise_if_unsupported_flashinfer_trtllm_padding(
+        layer: Any,
+        w2: torch.Tensor,
+    ) -> None:
+        moe_config = getattr(layer, "moe_config", None)
+        if getattr(moe_config, "is_act_and_mul", None) is not False:
+            return
+
+        intermediate_size_per_partition = getattr(
+            moe_config, "intermediate_size_per_partition", None
+        )
+        if intermediate_size_per_partition is None and w2.dim() >= 3:
+            intermediate_size_per_partition = w2.shape[-1]
+        if intermediate_size_per_partition is None:
+            return
+
+        intermediate_size_per_partition = int(intermediate_size_per_partition)
+        remainder = (
+            intermediate_size_per_partition % G_FLASHINFER_TRTLLM_INTERMEDIATE_ALIGNMENT
+        )
+        if remainder == 0:
+            return
+
+        padded_intermediate_size = (
+            intermediate_size_per_partition
+            + G_FLASHINFER_TRTLLM_INTERMEDIATE_ALIGNMENT
+            - remainder
+        )
+        raise ValueError(
+            "NeMo-RL's FlashInfer TRTLLM refit patch does not support "
+            "padded non-gated MoE layouts. "
+            f"intermediate_size_per_partition={intermediate_size_per_partition} "
+            "is not divisible by "
+            f"{G_FLASHINFER_TRTLLM_INTERMEDIATE_ALIGNMENT}, so vLLM pads it "
+            f"to {padded_intermediate_size} before converting weights. "
+            "The padded kernel tensor has more elements than the load-layout "
+            "tensor, which requires a dedicated padded-layout refit path. "
+            "Use expert_parallel_size to avoid the MoE TP split, or choose a "
+            "backend that does not expand the MoE weights."
+        )
+
+    def _ensure_kernel_weight(
+        layer: Any,
+        *,
+        weight_name: str,
+        kernel_attr: str,
+        kernel_weight: torch.Tensor,
+        load_shape: tuple[int, ...],
+    ) -> torch.Tensor:
+        load_numel = _load_shape_numel(load_shape)
+        if kernel_weight.numel() != load_numel:
+            raise ValueError(
+                "NeMo-RL's FlashInfer TRTLLM refit patch currently supports "
+                "only conversions that preserve the number of elements. "
+                f"{weight_name} load shape is {load_shape} "
+                f"({load_numel} elements), but the kernel layout has shape "
+                f"{tuple(kernel_weight.shape)} ({kernel_weight.numel()} elements). "
+                "This is likely a padded or otherwise expanded MoE shape."
+            )
+
+        existing_kernel_weight = getattr(layer, kernel_attr, None)
+        if existing_kernel_weight is None:
+            stable_kernel_weight = kernel_weight.contiguous()
+            setattr(layer, kernel_attr, stable_kernel_weight)
+        else:
+            if existing_kernel_weight.shape != kernel_weight.shape:
+                raise ValueError(
+                    "NeMo-RL's FlashInfer TRTLLM refit patch cannot preserve "
+                    f"CUDA graph addresses for {weight_name}: existing kernel "
+                    f"shape is {tuple(existing_kernel_weight.shape)}, but the "
+                    f"new kernel shape is {tuple(kernel_weight.shape)}."
+                )
+            if existing_kernel_weight.dtype != kernel_weight.dtype:
+                raise ValueError(
+                    "NeMo-RL's FlashInfer TRTLLM refit patch cannot preserve "
+                    f"CUDA graph addresses for {weight_name}: existing kernel "
+                    f"dtype is {existing_kernel_weight.dtype}, but the new "
+                    f"kernel dtype is {kernel_weight.dtype}."
+                )
+            if existing_kernel_weight.device != kernel_weight.device:
+                raise ValueError(
+                    "NeMo-RL's FlashInfer TRTLLM refit patch cannot preserve "
+                    f"CUDA graph addresses for {weight_name}: existing kernel "
+                    f"device is {existing_kernel_weight.device}, but the new "
+                    f"kernel device is {kernel_weight.device}."
+                )
+            stable_kernel_weight = existing_kernel_weight
+            with torch.no_grad():
+                stable_kernel_weight.copy_(kernel_weight)
+
+        getattr(layer, weight_name).data = stable_kernel_weight.view(load_shape)
+        return stable_kernel_weight
+
+    def _flashinfer_trtllm_kernel_weights(
+        layer: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        try:
+            return (
+                getattr(layer, G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR),
+                getattr(layer, G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR),
+            )
+        except AttributeError as error:
+            raise RuntimeError(
+                "NeMo-RL's FlashInfer TRTLLM refit patch did not find the "
+                "separate kernel-layout MoE weights. "
+                "process_weights_after_loading must run before inference."
+            ) from error
+
+    @wraps(original_setup_kernel)
+    def patched_setup_kernel(
+        self: Any,
+        layer: Any,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+    ) -> None:
+        if self.unquantized_backend != UnquantizedMoeBackend.FLASHINFER_TRTLLM:
+            return original_setup_kernel(self, layer, w13, w2)
+
+        _raise_if_unsupported_flashinfer_trtllm_padding(layer, w2)
+
+        w13_load_shape = tuple(w13.shape)
+        w2_load_shape = tuple(w2.shape)
+        w13_new, w2_new = convert_to_unquantized_kernel_format(
+            self.unquantized_backend,
+            moe_config=layer.moe_config,
+            w13_weight=w13,
+            w2_weight=w2,
+        )
+
+        _ensure_kernel_weight(
+            layer,
+            weight_name="w13_weight",
+            kernel_attr=G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR,
+            kernel_weight=w13_new,
+            load_shape=w13_load_shape,
+        )
+        _ensure_kernel_weight(
+            layer,
+            weight_name="w2_weight",
+            kernel_attr=G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR,
+            kernel_weight=w2_new,
+            load_shape=w2_load_shape,
+        )
+
+        if self.moe_kernel is None:
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+            assert self.moe_quant_config is not None
+            assert self.experts_cls is not None
+            self.moe_kernel = make_unquantized_moe_kernel(
+                quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                backend=self.unquantized_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+            )
+
+    @wraps(original_forward_native)
+    def patched_forward_native(
+        self: Any,
+        layer: Any,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if self.unquantized_backend != UnquantizedMoeBackend.FLASHINFER_TRTLLM:
+            return original_forward_native(
+                self,
+                layer,
+                x,
+                topk_weights,
+                topk_ids,
+                shared_experts,
+                shared_experts_input,
+            )
+
+        assert self.moe_kernel is not None
+        w13_kernel, w2_kernel = _flashinfer_trtllm_kernel_weights(layer)
+        return self.moe_kernel.apply(
+            hidden_states=x,
+            w1=w13_kernel,
+            w2=w2_kernel,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=layer.activation,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+        )
+
+    @wraps(original_apply_monolithic)
+    def patched_apply_monolithic(
+        self: Any,
+        layer: Any,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.unquantized_backend != UnquantizedMoeBackend.FLASHINFER_TRTLLM:
+            return original_apply_monolithic(self, layer, x, router_logits, input_ids)
+
+        assert self.is_monolithic
+        assert self.moe_kernel is not None
+        w13_kernel, w2_kernel = _flashinfer_trtllm_kernel_weights(layer)
+        return self.moe_kernel.apply_monolithic(
+            x,
+            w13_kernel,
+            w2_kernel,
+            router_logits,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            num_expert_group=layer.num_expert_group,
+            topk_group=layer.topk_group,
+            e_score_correction_bias=layer.e_score_correction_bias,
+            routed_scaling_factor=layer.routed_scaling_factor,
+        )
+
+    UnquantizedFusedMoEMethod._nrl_original_setup_kernel = original_setup_kernel
+    UnquantizedFusedMoEMethod._nrl_original_forward_native = original_forward_native
+    UnquantizedFusedMoEMethod._nrl_original_apply_monolithic = original_apply_monolithic
+    UnquantizedFusedMoEMethod._setup_kernel = patched_setup_kernel
+    UnquantizedFusedMoEMethod.forward_native = patched_forward_native
+    UnquantizedFusedMoEMethod.apply_monolithic = patched_apply_monolithic
+    setattr(UnquantizedFusedMoEMethod, G_FLASHINFER_TRTLLM_PATCH_ATTR, True)
+    logger.info("Successfully patched vLLM FlashInfer TRTLLM MoE refit buffers.")
+
+
+def _run_engine_core_with_flashinfer_trtllm_refit_patch(
+    *args: Any, **kwargs: Any
+) -> Any:
+    """Apply the refit patch inside EngineCore before model construction."""
+    _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch()
+    _patch_vllm_flashinfer_trtllm_refit_from_collective_rpc()
+
+    # Import here because this function is also the multiprocessing target for
+    # spawned EngineCore processes, where module import state is rebuilt.
+    from vllm.v1.engine.core import EngineCoreProc
+
+    original_run_engine_core = getattr(
+        EngineCoreProc, G_FLASHINFER_TRTLLM_ENGINE_CORE_ORIGINAL_ATTR, None
+    )
+    if original_run_engine_core is None:
+        original_run_engine_core = EngineCoreProc.run_engine_core
+    if original_run_engine_core is _run_engine_core_with_flashinfer_trtllm_refit_patch:
+        raise RuntimeError(
+            "NeMo-RL's FlashInfer TRTLLM refit EngineCore entrypoint patch "
+            "could not find the original vLLM EngineCoreProc.run_engine_core."
+        )
+    return original_run_engine_core(*args, **kwargs)
+
+
+def _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch_on_worker(
+    _worker: Any | None = None,
+) -> None:
+    """Adapter for vLLM v1 Ray workers that pass their worker as arg 0."""
+    del _worker
+    _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch()
+
+
+def _ray_worker_initialize_with_flashinfer_trtllm_refit_patch(
+    self: Any, *args: Any, **kwargs: Any
+) -> Any:
+    """Apply the refit patch before RayExecutorV2 initializes a worker model."""
+    _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch()
+
+    original_initialize_worker = getattr(
+        type(self), G_FLASHINFER_TRTLLM_RAY_WORKER_ORIGINAL_ATTR, None
+    )
+    if original_initialize_worker is None:
+        from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
+
+        original_initialize_worker = RayWorkerProc.initialize_worker
+    if (
+        original_initialize_worker
+        is _ray_worker_initialize_with_flashinfer_trtllm_refit_patch
+    ):
+        raise RuntimeError(
+            "NeMo-RL's FlashInfer TRTLLM refit RayExecutorV2 worker patch could "
+            "not find the original vLLM RayWorkerProc.initialize_worker."
+        )
+    return original_initialize_worker(self, *args, **kwargs)
+
+
+def _collective_rpc_with_flashinfer_trtllm_refit_patch(
+    self: Any, *args: Any, **kwargs: Any
+) -> Any:
+    """Patch vLLM v1 Ray workers before their first collective RPC."""
+    original_collective_rpc = getattr(
+        type(self), G_FLASHINFER_TRTLLM_RAY_EXECUTOR_ORIGINAL_ATTR, None
+    )
+    if original_collective_rpc is None:
+        from vllm.v1.executor.ray_executor import RayDistributedExecutor
+
+        original_collective_rpc = RayDistributedExecutor.collective_rpc
+    if original_collective_rpc is _collective_rpc_with_flashinfer_trtllm_refit_patch:
+        raise RuntimeError(
+            "NeMo-RL's FlashInfer TRTLLM refit Ray executor patch could not "
+            "find the original vLLM RayDistributedExecutor.collective_rpc."
+        )
+
+    if not getattr(self, G_FLASHINFER_TRTLLM_RAY_EXECUTOR_WORKERS_PATCHED_ATTR, False):
+        from vllm.v1.executor.ray_utils import ray
+
+        futures = [
+            worker.execute_method.remote(
+                _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch_on_worker
+            )
+            for worker in self.workers
+        ]
+        ray.get(futures)
+        setattr(self, G_FLASHINFER_TRTLLM_RAY_EXECUTOR_WORKERS_PATCHED_ATTR, True)
+
+    return original_collective_rpc(self, *args, **kwargs)
+
+
+def _patch_vllm_flashinfer_trtllm_refit_from_collective_rpc(
+    logger: Any | None = None,
+) -> None:
+    """Patch vLLM process entrypoints that can construct the model."""
+    if logger is None:
+        from vllm.logger import init_logger
+
+        logger = init_logger("vllm_patch")
+
+    try:
+        from vllm.v1.engine.core import EngineCoreProc
+    except (AttributeError, ImportError) as error:
+        logger.warning(
+            "Could not patch vLLM EngineCoreProc for FlashInfer TRTLLM refits: %s",
+            error,
+        )
+    else:
+        if getattr(EngineCoreProc, G_FLASHINFER_TRTLLM_ENGINE_CORE_PATCH_ATTR, False):
+            logger.info(
+                "vLLM EngineCoreProc FlashInfer TRTLLM refit patch already applied."
+            )
+        else:
+            setattr(
+                EngineCoreProc,
+                G_FLASHINFER_TRTLLM_ENGINE_CORE_ORIGINAL_ATTR,
+                EngineCoreProc.run_engine_core,
+            )
+            EngineCoreProc.run_engine_core = staticmethod(
+                _run_engine_core_with_flashinfer_trtllm_refit_patch
+            )
+            setattr(EngineCoreProc, G_FLASHINFER_TRTLLM_ENGINE_CORE_PATCH_ATTR, True)
+            logger.info(
+                "Successfully patched vLLM EngineCoreProc for FlashInfer TRTLLM refits."
+            )
+
+    try:
+        from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
+    except (AttributeError, ImportError) as error:
+        logger.info(
+            "Skipping RayExecutorV2 FlashInfer TRTLLM refit worker patch: %s",
+            error,
+        )
+    else:
+        if getattr(RayWorkerProc, G_FLASHINFER_TRTLLM_RAY_WORKER_PATCH_ATTR, False):
+            logger.info(
+                "vLLM RayWorkerProc FlashInfer TRTLLM refit patch already applied."
+            )
+        else:
+            setattr(
+                RayWorkerProc,
+                G_FLASHINFER_TRTLLM_RAY_WORKER_ORIGINAL_ATTR,
+                RayWorkerProc.initialize_worker,
+            )
+            RayWorkerProc.initialize_worker = (
+                _ray_worker_initialize_with_flashinfer_trtllm_refit_patch
+            )
+            setattr(RayWorkerProc, G_FLASHINFER_TRTLLM_RAY_WORKER_PATCH_ATTR, True)
+            logger.info(
+                "Successfully patched vLLM RayWorkerProc for FlashInfer TRTLLM refits."
+            )
+
+    try:
+        from vllm.v1.executor.ray_executor import RayDistributedExecutor
+    except (AttributeError, ImportError) as error:
+        logger.info(
+            "Skipping vLLM v1 Ray executor FlashInfer TRTLLM refit patch: %s",
+            error,
+        )
+    else:
+        if getattr(
+            RayDistributedExecutor, G_FLASHINFER_TRTLLM_RAY_EXECUTOR_PATCH_ATTR, False
+        ):
+            logger.info(
+                "vLLM RayDistributedExecutor FlashInfer TRTLLM refit patch "
+                "already applied."
+            )
+        else:
+            patched_collective_rpc = _collective_rpc_with_flashinfer_trtllm_refit_patch
+            setattr(
+                RayDistributedExecutor,
+                G_FLASHINFER_TRTLLM_RAY_EXECUTOR_ORIGINAL_ATTR,
+                RayDistributedExecutor.collective_rpc,
+            )
+            RayDistributedExecutor.collective_rpc = patched_collective_rpc
+            setattr(
+                RayDistributedExecutor,
+                G_FLASHINFER_TRTLLM_RAY_EXECUTOR_PATCH_ATTR,
+                True,
+            )
+            logger.info(
+                "Successfully patched vLLM RayDistributedExecutor for "
+                "FlashInfer TRTLLM refits."
+            )
+
+
+def _patch_vllm_flashinfer_trtllm_refit_buffers(logger: Any) -> None:
+    """Patch current and child vLLM processes for FlashInfer TRTLLM refits."""
+    _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(logger)
+    _patch_vllm_flashinfer_trtllm_refit_from_collective_rpc(logger)
+
+
 def ensure_vllm_source_compat() -> None:
     """Apply interpreter-independent vLLM source-compat patches.
 
@@ -634,3 +1119,4 @@ def _apply_vllm_patches(
     _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)
     _patch_vllm_shm_broadcast_bind_retry(patch_logger)
     _patch_vllm_radio_layerscale_loader(patch_logger)
+    _patch_vllm_flashinfer_trtllm_refit_buffers(patch_logger)

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -603,7 +603,6 @@ def _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
     """
     # These imports require vLLM, so keep them out of module import time.
     import torch
-    from vllm.logger import init_logger
     from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
         UnquantizedMoeBackend,
         convert_to_unquantized_kernel_format,
@@ -614,6 +613,8 @@ def _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
     )
 
     if logger is None:
+        from vllm.logger import init_logger
+
         logger = init_logger("vllm_patch")
 
     if getattr(UnquantizedFusedMoEMethod, G_FLASHINFER_TRTLLM_PATCH_ATTR, False):

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -1067,6 +1067,21 @@ def ensure_vllm_source_compat() -> None:
     _patch_vllm_radio_layerscale_loader(patch_logger)
 
 
+def _apply_external_vllm_patches() -> None:
+    """Apply only compatibility patches required by external vLLM servers.
+
+    External Gym model servers are inference-only. Keep this list explicit so
+    policy-specific runtime patches, such as refit support, are not installed
+    in their vLLM engine processes.
+    """
+    from vllm.logger import init_logger
+
+    patch_logger = init_logger("vllm_patch")
+    _patch_vllm_tool_parser_namespace_tool(patch_logger)
+    _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)
+    _patch_vllm_shm_broadcast_bind_retry(patch_logger)
+
+
 def _apply_vllm_patches(
     py_executable: str,
     *,

--- a/ray.sub
+++ b/ray.sub
@@ -252,6 +252,7 @@ COMMON_SRUN_ARGS+=" --no-container-mount-home"
 COMMON_SRUN_ARGS+=" --mpi=pmix"
 COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
 COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$SLURM_SUBMIT_DIR"
 # Pass partition/account explicitly for overlapping srun calls.
 COMMON_SRUN_ARGS+=" -p $SLURM_JOB_PARTITION"
 COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
@@ -1120,6 +1121,7 @@ else
   echo "[INFO][$(date '+%Y-%m-%dT%H:%M:%S%z')] All workers connected!"
 
   log_phase "generating attach helper (scontrol show job)"
+  CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
 # No args launches on the head node (node 0)
@@ -1128,9 +1130,9 @@ else
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
   if [[ -n "\${COMMAND:-}" ]]; then
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
   fi
 elif [[ $SLURM_JOB_NUM_NODES -eq 1 ]]; then
   echo "Error: Single-node mode — only the head node is available. Run without arguments."
@@ -1145,9 +1147,9 @@ else
   nodes_array=($nodes)
   node="\${nodes_array[\$WORKER_NUM]}"
   if [[ -n "\${COMMAND:-}" ]]; then
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID --pty bash
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID --pty bash
   fi
 fi
 EOF

--- a/ray.sub
+++ b/ray.sub
@@ -252,7 +252,6 @@ COMMON_SRUN_ARGS+=" --no-container-mount-home"
 COMMON_SRUN_ARGS+=" --mpi=pmix"
 COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
 COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
-COMMON_SRUN_ARGS+=" --container-workdir=$SLURM_SUBMIT_DIR"
 # Pass partition/account explicitly for overlapping srun calls.
 COMMON_SRUN_ARGS+=" -p $SLURM_JOB_PARTITION"
 COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
@@ -1121,7 +1120,6 @@ else
   echo "[INFO][$(date '+%Y-%m-%dT%H:%M:%S%z')] All workers connected!"
 
   log_phase "generating attach helper (scontrol show job)"
-  CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
 # No args launches on the head node (node 0)
@@ -1130,9 +1128,9 @@ else
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
   if [[ -n "\${COMMAND:-}" ]]; then
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
   fi
 elif [[ $SLURM_JOB_NUM_NODES -eq 1 ]]; then
   echo "Error: Single-node mode — only the head node is available. Run without arguments."
@@ -1147,9 +1145,9 @@ else
   nodes_array=($nodes)
   node="\${nodes_array[\$WORKER_NUM]}"
   if [[ -n "\${COMMAND:-}" ]]; then
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID --pty bash
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID --pty bash
   fi
 fi
 EOF

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -31,8 +31,11 @@ The two port patches ship their own suites. These cover the remaining two:
 import ast
 import logging
 import os
+import sys
+import types
 
 import pytest
+import torch
 
 from nemo_rl.models.generation.vllm import patches
 from tests.unit.models.generation.vllm_patch_source_utils import (
@@ -221,3 +224,450 @@ def test_init_workers_ray_reports_success_and_is_idempotent(monkeypatch, tmp_pat
 
     assert patches._patch_vllm_init_workers_ray("py-exec", None) is True
     assert ray_executor.read_text() == once
+
+
+@pytest.fixture
+def fake_vllm_unquantized_moe_modules(monkeypatch):
+    """Install a tiny fake vLLM MoE module tree for the runtime monkeypatch."""
+    package_names = [
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+        "vllm.model_executor.layers.fused_moe",
+        "vllm.model_executor.layers.fused_moe.oracle",
+    ]
+    for name in package_names:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    method_module = types.ModuleType(
+        "vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method"
+    )
+    oracle_module = types.ModuleType(
+        "vllm.model_executor.layers.fused_moe.oracle.unquantized"
+    )
+    monkeypatch.setitem(sys.modules, method_module.__name__, method_module)
+    monkeypatch.setitem(sys.modules, oracle_module.__name__, oracle_module)
+
+    class FakeUnquantizedMoeBackend:
+        FLASHINFER_TRTLLM = "flashinfer_trtllm"
+        TRITON = "triton"
+
+    class FakeExperts:
+        pass
+
+    class FakeKernel:
+        def __init__(self):
+            self.apply_kwargs = None
+            self.apply_monolithic_args = None
+            self.apply_monolithic_kwargs = None
+
+        def apply(self, **kwargs):
+            self.apply_kwargs = kwargs
+            return kwargs["w1"].shape, kwargs["w2"].shape
+
+        def apply_monolithic(self, *args, **kwargs):
+            self.apply_monolithic_args = args
+            self.apply_monolithic_kwargs = kwargs
+            return args[1].shape, args[2].shape
+
+    kernels = []
+
+    def make_unquantized_moe_kernel(**_kwargs):
+        kernel = FakeKernel()
+        kernels.append(kernel)
+        return kernel
+
+    def convert_to_unquantized_kernel_format(
+        _unquantized_backend,
+        *,
+        moe_config,
+        w13_weight,
+        w2_weight,
+    ):
+        moe_config.converted = True
+        return w13_weight.reshape(4, 2).clone(), w2_weight.reshape(2, 4).clone()
+
+    class FakeUnquantizedFusedMoEMethod:
+        def __init__(self, backend):
+            self.unquantized_backend = backend
+            self.moe_kernel = None
+            self.moe_quant_config = None
+            self.moe = types.SimpleNamespace(name="moe")
+            self.experts_cls = FakeExperts
+            self.is_monolithic = True
+            self.original_setup_called = False
+            self.original_forward_native_called = False
+            self.original_apply_monolithic_called = False
+
+        def _setup_kernel(self, layer, w13, w2):
+            self.original_setup_called = True
+
+        def forward_native(
+            self,
+            layer,
+            x,
+            topk_weights,
+            topk_ids,
+            shared_experts,
+            shared_experts_input,
+        ):
+            self.original_forward_native_called = True
+            return "original-forward-native"
+
+        def apply_monolithic(self, layer, x, router_logits, input_ids=None):
+            self.original_apply_monolithic_called = True
+            return "original-apply-monolithic"
+
+        def get_fused_moe_quant_config(self, layer):
+            return types.SimpleNamespace(name="quant")
+
+    class FakeLayer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.moe_config = types.SimpleNamespace(converted=False)
+            self.w13_weight = torch.nn.Parameter(
+                torch.arange(8, dtype=torch.float32).reshape(2, 4),
+                requires_grad=False,
+            )
+            self.w2_weight = torch.nn.Parameter(
+                torch.arange(8, 16, dtype=torch.float32).reshape(4, 2),
+                requires_grad=False,
+            )
+            self.activation = "silu"
+            self.apply_router_weight_on_input = False
+            self.global_num_experts = 2
+            self.expert_map = None
+            self.num_expert_group = 1
+            self.topk_group = 1
+            self.e_score_correction_bias = None
+            self.routed_scaling_factor = 1.0
+
+        def _expert_routing_tables(self):
+            return ("route",)
+
+    oracle_module.UnquantizedMoeBackend = FakeUnquantizedMoeBackend
+    oracle_module.convert_to_unquantized_kernel_format = (
+        convert_to_unquantized_kernel_format
+    )
+    oracle_module.make_unquantized_moe_kernel = make_unquantized_moe_kernel
+    method_module.UnquantizedFusedMoEMethod = FakeUnquantizedFusedMoEMethod
+
+    return types.SimpleNamespace(
+        backend=FakeUnquantizedMoeBackend,
+        method_cls=FakeUnquantizedFusedMoEMethod,
+        layer_cls=FakeLayer,
+        oracle_module=oracle_module,
+        kernels=kernels,
+    )
+
+
+def test_flashinfer_trtllm_refit_patch_preserves_kernel_weight_storage(
+    fake_vllm_unquantized_moe_modules,
+):
+    fake_vllm = fake_vllm_unquantized_moe_modules
+    patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
+        logging.getLogger(__name__)
+    )
+
+    method = fake_vllm.method_cls(fake_vllm.backend.FLASHINFER_TRTLLM)
+    layer = fake_vllm.layer_cls()
+    method._setup_kernel(layer, layer.w13_weight, layer.w2_weight)
+
+    w13_kernel = getattr(layer, patches.G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR)
+    w2_kernel = getattr(layer, patches.G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR)
+    first_kernel = method.moe_kernel
+    assert layer.w13_weight.shape == torch.Size([2, 4])
+    assert layer.w2_weight.shape == torch.Size([4, 2])
+    assert w13_kernel.shape == torch.Size([4, 2])
+    assert w2_kernel.shape == torch.Size([2, 4])
+    assert layer.w13_weight.data_ptr() == w13_kernel.data_ptr()
+    assert layer.w2_weight.data_ptr() == w2_kernel.data_ptr()
+
+    w13_kernel_id = id(w13_kernel)
+    w2_kernel_id = id(w2_kernel)
+    w13_kernel_ptr = w13_kernel.data_ptr()
+    w2_kernel_ptr = w2_kernel.data_ptr()
+
+    with torch.no_grad():
+        layer.w13_weight.copy_(torch.arange(100, 108, dtype=torch.float32).view(2, 4))
+        layer.w2_weight.copy_(torch.arange(200, 208, dtype=torch.float32).view(4, 2))
+
+    method._setup_kernel(layer, layer.w13_weight, layer.w2_weight)
+
+    assert method.moe_kernel is first_kernel
+    assert getattr(layer, patches.G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR) is w13_kernel
+    assert getattr(layer, patches.G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR) is w2_kernel
+    assert id(w13_kernel) == w13_kernel_id
+    assert id(w2_kernel) == w2_kernel_id
+    assert w13_kernel.data_ptr() == w13_kernel_ptr
+    assert w2_kernel.data_ptr() == w2_kernel_ptr
+    assert torch.equal(
+        w13_kernel, torch.arange(100, 108, dtype=torch.float32).view(4, 2)
+    )
+    assert torch.equal(
+        w2_kernel, torch.arange(200, 208, dtype=torch.float32).view(2, 4)
+    )
+
+    x = torch.empty(1)
+    topk_weights = torch.empty(1)
+    topk_ids = torch.empty(1, dtype=torch.int64)
+    assert method.forward_native(layer, x, topk_weights, topk_ids, None, None) == (
+        torch.Size([4, 2]),
+        torch.Size([2, 4]),
+    )
+    assert fake_vllm.kernels[-1].apply_kwargs["w1"] is w13_kernel
+    assert fake_vllm.kernels[-1].apply_kwargs["w2"] is w2_kernel
+
+    assert method.apply_monolithic(layer, x, torch.empty(1)) == (
+        torch.Size([4, 2]),
+        torch.Size([2, 4]),
+    )
+    assert fake_vllm.kernels[-1].apply_monolithic_args[1] is w13_kernel
+    assert fake_vllm.kernels[-1].apply_monolithic_args[2] is w2_kernel
+
+
+def test_flashinfer_trtllm_refit_patch_leaves_other_backends_on_original_paths(
+    fake_vllm_unquantized_moe_modules,
+):
+    fake_vllm = fake_vllm_unquantized_moe_modules
+    patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
+        logging.getLogger(__name__)
+    )
+
+    method = fake_vllm.method_cls(fake_vllm.backend.TRITON)
+    layer = fake_vllm.layer_cls()
+
+    method._setup_kernel(layer, layer.w13_weight, layer.w2_weight)
+    assert method.original_setup_called
+    assert method.forward_native(layer, None, None, None, None, None) == (
+        "original-forward-native"
+    )
+    assert method.original_forward_native_called
+    assert method.apply_monolithic(layer, None, None) == "original-apply-monolithic"
+    assert method.original_apply_monolithic_called
+    assert not hasattr(layer, patches.G_FLASHINFER_TRTLLM_W13_KERNEL_ATTR)
+    assert not hasattr(layer, patches.G_FLASHINFER_TRTLLM_W2_KERNEL_ATTR)
+
+
+def test_flashinfer_trtllm_refit_patch_rejects_padded_non_gated_layout_early(
+    fake_vllm_unquantized_moe_modules,
+):
+    fake_vllm = fake_vllm_unquantized_moe_modules
+
+    def convert_should_not_run(*_args, **_kwargs):
+        raise AssertionError("conversion should not run for padded layouts")
+
+    fake_vllm.oracle_module.convert_to_unquantized_kernel_format = (
+        convert_should_not_run
+    )
+    patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
+        logging.getLogger(__name__)
+    )
+
+    method = fake_vllm.method_cls(fake_vllm.backend.FLASHINFER_TRTLLM)
+    layer = fake_vllm.layer_cls()
+    layer.moe_config.is_act_and_mul = False
+    layer.moe_config.intermediate_size_per_partition = 672
+
+    with pytest.raises(
+        ValueError,
+        match="intermediate_size_per_partition=672.*not divisible by 128",
+    ):
+        method._setup_kernel(layer, layer.w13_weight, layer.w2_weight)
+
+
+def test_flashinfer_trtllm_refit_patch_rejects_expanded_kernel_layout(
+    fake_vllm_unquantized_moe_modules,
+):
+    fake_vllm = fake_vllm_unquantized_moe_modules
+
+    def convert_to_expanded_kernel_format(
+        _unquantized_backend,
+        *,
+        moe_config,
+        w13_weight,
+        w2_weight,
+    ):
+        return torch.empty(9), w2_weight.reshape(2, 4).clone()
+
+    fake_vllm.oracle_module.convert_to_unquantized_kernel_format = (
+        convert_to_expanded_kernel_format
+    )
+    patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
+        logging.getLogger(__name__)
+    )
+
+    method = fake_vllm.method_cls(fake_vllm.backend.FLASHINFER_TRTLLM)
+    layer = fake_vllm.layer_cls()
+
+    with pytest.raises(ValueError, match="preserve the number of elements"):
+        method._setup_kernel(layer, layer.w13_weight, layer.w2_weight)
+
+
+@pytest.fixture
+def fake_vllm_process_entrypoint_modules(monkeypatch):
+    """Install fake vLLM process-entrypoint modules for propagation tests."""
+    package_names = [
+        "vllm",
+        "vllm.v1",
+        "vllm.v1.engine",
+        "vllm.v1.executor",
+    ]
+    for name in package_names:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    engine_core_module = types.ModuleType("vllm.v1.engine.core")
+    ray_executor_v2_module = types.ModuleType("vllm.v1.executor.ray_executor_v2")
+    ray_executor_module = types.ModuleType("vllm.v1.executor.ray_executor")
+    ray_utils_module = types.ModuleType("vllm.v1.executor.ray_utils")
+    logger_module = types.ModuleType("vllm.logger")
+    monkeypatch.setitem(sys.modules, engine_core_module.__name__, engine_core_module)
+    monkeypatch.setitem(
+        sys.modules, ray_executor_v2_module.__name__, ray_executor_v2_module
+    )
+    monkeypatch.setitem(sys.modules, ray_executor_module.__name__, ray_executor_module)
+    monkeypatch.setitem(sys.modules, ray_utils_module.__name__, ray_utils_module)
+    monkeypatch.setitem(sys.modules, logger_module.__name__, logger_module)
+
+    calls = []
+
+    class FakeEngineCoreProc:
+        @staticmethod
+        def run_engine_core(*args, **kwargs):
+            calls.append(("engine_core", args, kwargs))
+            return "engine-core-result"
+
+    class FakeRayWorkerProc:
+        def initialize_worker(self, *args, **kwargs):
+            calls.append(("ray_worker_initialize", args, kwargs))
+            return "ray-worker-result"
+
+    class FakeWorkerHandle:
+        def __init__(self, name):
+            self.name = name
+            self.execute_method = types.SimpleNamespace(remote=self.remote)
+
+        def remote(self, func):
+            calls.append(("ray_execute_method", self.name, func))
+            func(None)
+            return f"{self.name}-future"
+
+    class FakeRay:
+        @staticmethod
+        def get(futures):
+            calls.append(("ray_get", tuple(futures)))
+            return futures
+
+    class FakeRayDistributedExecutor:
+        def __init__(self):
+            self.workers = [FakeWorkerHandle("w0"), FakeWorkerHandle("w1")]
+
+        def collective_rpc(self, *args, **kwargs):
+            calls.append(("ray_collective_rpc", args, kwargs))
+            return "ray-collective-result"
+
+    engine_core_module.EngineCoreProc = FakeEngineCoreProc
+    ray_executor_v2_module.RayWorkerProc = FakeRayWorkerProc
+    ray_executor_module.RayDistributedExecutor = FakeRayDistributedExecutor
+    ray_utils_module.ray = FakeRay
+    logger_module.init_logger = logging.getLogger
+
+    return types.SimpleNamespace(
+        calls=calls,
+        engine_core_cls=FakeEngineCoreProc,
+        ray_worker_cls=FakeRayWorkerProc,
+        ray_executor_cls=FakeRayDistributedExecutor,
+    )
+
+
+def test_flashinfer_trtllm_refit_collective_rpc_patch_is_idempotent(
+    fake_vllm_process_entrypoint_modules,
+    monkeypatch,
+):
+    fake_vllm = fake_vllm_process_entrypoint_modules
+    runtime_calls = []
+
+    def apply_runtime_patch(logger=None):
+        runtime_calls.append(logger)
+
+    monkeypatch.setattr(
+        patches,
+        "_apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch",
+        apply_runtime_patch,
+    )
+
+    original_engine_core = fake_vllm.engine_core_cls.run_engine_core
+    original_ray_worker = fake_vllm.ray_worker_cls.initialize_worker
+    original_ray_collective = fake_vllm.ray_executor_cls.collective_rpc
+
+    patches._patch_vllm_flashinfer_trtllm_refit_from_collective_rpc(
+        logging.getLogger(__name__)
+    )
+    first_engine_core = fake_vllm.engine_core_cls.run_engine_core
+    first_ray_worker = fake_vllm.ray_worker_cls.initialize_worker
+    first_ray_collective = fake_vllm.ray_executor_cls.collective_rpc
+
+    patches._patch_vllm_flashinfer_trtllm_refit_from_collective_rpc(
+        logging.getLogger(__name__)
+    )
+
+    assert fake_vllm.engine_core_cls.run_engine_core is first_engine_core
+    assert fake_vllm.ray_worker_cls.initialize_worker is first_ray_worker
+    assert fake_vllm.ray_executor_cls.collective_rpc is first_ray_collective
+    assert (
+        getattr(
+            fake_vllm.engine_core_cls,
+            patches.G_FLASHINFER_TRTLLM_ENGINE_CORE_ORIGINAL_ATTR,
+        )
+        is original_engine_core
+    )
+    assert (
+        getattr(
+            fake_vllm.ray_worker_cls,
+            patches.G_FLASHINFER_TRTLLM_RAY_WORKER_ORIGINAL_ATTR,
+        )
+        is original_ray_worker
+    )
+    assert (
+        getattr(
+            fake_vllm.ray_executor_cls,
+            patches.G_FLASHINFER_TRTLLM_RAY_EXECUTOR_ORIGINAL_ATTR,
+        )
+        is original_ray_collective
+    )
+
+    assert (
+        fake_vllm.engine_core_cls.run_engine_core("engine", vllm_config="cfg")
+        == "engine-core-result"
+    )
+    assert (
+        fake_vllm.ray_worker_cls().initialize_worker("ray-worker")
+        == "ray-worker-result"
+    )
+
+    ray_executor = fake_vllm.ray_executor_cls()
+    assert ray_executor.collective_rpc("ray-call") == "ray-collective-result"
+    assert ray_executor.collective_rpc("ray-call-2") == "ray-collective-result"
+
+    assert len(runtime_calls) == 4
+    assert fake_vllm.calls == [
+        ("engine_core", ("engine",), {"vllm_config": "cfg"}),
+        ("ray_worker_initialize", ("ray-worker",), {}),
+        (
+            "ray_execute_method",
+            "w0",
+            patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch_on_worker,
+        ),
+        (
+            "ray_execute_method",
+            "w1",
+            patches._apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch_on_worker,
+        ),
+        ("ray_get", ("w0-future", "w1-future")),
+        ("ray_collective_rpc", ("ray-call",), {}),
+        ("ray_collective_rpc", ("ray-call-2",), {}),
+    ]

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -50,6 +50,32 @@ _RADIO_PATCH_FN = "_patch_vllm_radio_layerscale_loader"
 _RADIO_MARKER = "initializer_factor = self.config.initializer_factor"
 
 
+def test_external_vllm_patch_allowlist(monkeypatch):
+    vllm_module = types.ModuleType("vllm")
+    vllm_module.__path__ = []
+    logger_module = types.ModuleType("vllm.logger")
+    logger_module.init_logger = logging.getLogger
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.logger", logger_module)
+
+    calls = []
+    allowed_patches = (
+        "_patch_vllm_tool_parser_namespace_tool",
+        "_patch_vllm_ray_executor_v2_tcpstore_port",
+        "_patch_vllm_shm_broadcast_bind_retry",
+    )
+    for patch_name in allowed_patches:
+        monkeypatch.setattr(
+            patches,
+            patch_name,
+            lambda _logger, name=patch_name: calls.append(name),
+        )
+
+    patches._apply_external_vllm_patches()
+
+    assert calls == list(allowed_patches)
+
+
 @pytest.fixture
 def patched_tool_parser_source(tmp_path, monkeypatch):
     """The installed tool_parsers/utils.py, unpatched then patched in tmp."""

--- a/tests/unit/tools/test_external_gym_vllm.py
+++ b/tests/unit/tools/test_external_gym_vllm.py
@@ -45,8 +45,8 @@ def test_serve_wrapper_applies_only_external_vllm_patches(monkeypatch):
     calls = []
     monkeypatch.setattr(
         serve_vllm_on_ray,
-        "_apply_external_vllm_patches",
-        lambda: calls.append("patches"),
+        "_load_apply_external_vllm_patches",
+        lambda: lambda: calls.append("patches"),
     )
     monkeypatch.setattr(
         serve_vllm_on_ray.ray,
@@ -71,7 +71,7 @@ def test_serve_wrapper_applies_only_external_vllm_patches(monkeypatch):
 
     assert calls == ["patches", "ray", "vllm"]
 
-    
+
 def test_serve_wrapper_loads_patches_without_importing_nemo_rl_package():
     script = REPO_ROOT / "tools/external_gym_vllm/serve_vllm_on_ray.py"
     program = textwrap.dedent(
@@ -82,7 +82,8 @@ def test_serve_wrapper_loads_patches_without_importing_nemo_rl_package():
 
         sys.modules["ray"] = types.ModuleType("ray")
         namespace = runpy.run_path({str(script)!r})
-        namespace["_load_apply_vllm_patches"]()
+        apply_external_vllm_patches = namespace["_load_apply_external_vllm_patches"]()
+        assert callable(apply_external_vllm_patches)
         assert "nemo_rl.models.generation" not in sys.modules
         assert "nemo_rl.models.policy" not in sys.modules
         """

--- a/tests/unit/tools/test_external_gym_vllm.py
+++ b/tests/unit/tools/test_external_gym_vllm.py
@@ -16,9 +16,11 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -35,6 +37,39 @@ from tools.external_gym_vllm.vllm_pool_lb import (
 )
 
 REPO_ROOT = Path(__file__).parents[3]
+
+
+def test_serve_wrapper_applies_only_external_vllm_patches(monkeypatch):
+    from tools.external_gym_vllm import serve_vllm_on_ray
+
+    calls = []
+    monkeypatch.setattr(
+        serve_vllm_on_ray,
+        "_apply_external_vllm_patches",
+        lambda: calls.append("patches"),
+    )
+    monkeypatch.setattr(
+        serve_vllm_on_ray.ray,
+        "init",
+        lambda **_kwargs: calls.append("ray"),
+    )
+
+    vllm_module = types.ModuleType("vllm")
+    vllm_module.__path__ = []
+    entrypoints_module = types.ModuleType("vllm.entrypoints")
+    entrypoints_module.__path__ = []
+    cli_module = types.ModuleType("vllm.entrypoints.cli")
+    cli_module.__path__ = []
+    cli_main_module = types.ModuleType("vllm.entrypoints.cli.main")
+    cli_main_module.main = lambda: calls.append("vllm")
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.entrypoints", entrypoints_module)
+    monkeypatch.setitem(sys.modules, "vllm.entrypoints.cli", cli_module)
+    monkeypatch.setitem(sys.modules, "vllm.entrypoints.cli.main", cli_main_module)
+
+    serve_vllm_on_ray.main()
+
+    assert calls == ["patches", "ray", "vllm"]
 
 
 def test_shutdown_timeout_bounds_watchdog_restart_outage():

--- a/tools/external_gym_vllm/README.md
+++ b/tools/external_gym_vllm/README.md
@@ -168,8 +168,11 @@ Each pool container must provide:
 - importable `nemo_rl`, `ray`, and `vllm` packages in that environment; and
 - the `ray` command on `PATH`.
 
-`serve_vllm_on_ray.py` applies NeMo RL's vLLM compatibility patches before it
-imports the vLLM API server. `CONTAINER` must provide
+`serve_vllm_on_ray.py` applies an explicit allowlist of NeMo RL compatibility
+patches before it imports the vLLM API server: OpenAI `NamespaceTool`
+compatibility plus the RayExecutorV2 TCPStore and MessageQueue port-race fixes.
+It does not apply model-, worker-, or policy-refit-specific patches because
+these servers are inference-only. `CONTAINER` must provide
 `EXTERNAL_VLLM_LB_PYTHON` with `aiohttp` installed.
 
 ## Slurm submission

--- a/tools/external_gym_vllm/README.md
+++ b/tools/external_gym_vllm/README.md
@@ -181,12 +181,15 @@ Each pool container must provide:
   package as a fallback; and
 - the `ray` command on `PATH`.
 
-`serve_vllm_on_ray.py` applies an explicit allowlist of NeMo RL compatibility
-patches before it imports the vLLM API server: OpenAI `NamespaceTool`
-compatibility plus the RayExecutorV2 TCPStore and MessageQueue port-race fixes.
-It does not apply model-, worker-, or policy-refit-specific patches because
-these servers are inference-only. `CONTAINER` must provide
-`EXTERNAL_VLLM_LB_PYTHON` with `aiohttp` installed.
+`serve_vllm_on_ray.py` loads NeMo RL's vLLM compatibility patch module directly
+from the matching source checkout before importing the vLLM API server. This
+avoids importing NeMo RL's policy modules and training dependency stack into a
+purpose-built serving container. If the source checkout is unavailable, the
+wrapper falls back to the installed `nemo_rl` package. The wrapper applies an
+explicit allowlist: OpenAI `NamespaceTool` compatibility plus the RayExecutorV2
+TCPStore and MessageQueue port-race fixes. It does not apply model-, worker-, or
+policy-refit-specific patches because these servers are inference-only.
+`CONTAINER` must provide `EXTERNAL_VLLM_LB_PYTHON` with `aiohttp` installed.
 
 ## Slurm submission
 

--- a/tools/external_gym_vllm/serve_vllm_on_ray.py
+++ b/tools/external_gym_vllm/serve_vllm_on_ray.py
@@ -21,14 +21,13 @@ import sys
 
 import ray
 
-from nemo_rl.models.generation.vllm.patches import _apply_vllm_patches
+from nemo_rl.models.generation.vllm.patches import _apply_external_vllm_patches
 
 
 def main() -> None:
     """Connect to the private cluster and start the requested vLLM command."""
-    worker_python = sys.executable
-    _apply_vllm_patches(worker_python)
-    ray.init(address="auto", runtime_env={"py_executable": worker_python})
+    _apply_external_vllm_patches()
+    ray.init(address="auto", runtime_env={"py_executable": sys.executable})
 
     # vLLM is available only in the generation worker environment and must be
     # imported after NeMo RL applies its runtime patches.

--- a/tools/external_gym_vllm/serve_vllm_on_ray.py
+++ b/tools/external_gym_vllm/serve_vllm_on_ray.py
@@ -25,12 +25,29 @@ from typing import cast
 
 import ray
 
-from nemo_rl.models.generation.vllm.patches import _apply_external_vllm_patches
+
+def _load_apply_external_vllm_patches() -> Callable[[], None]:
+    """Load external-server patches without importing NeMo RL dependencies."""
+    repo_root = Path(__file__).resolve().parents[2]
+    patches_path = repo_root / "nemo_rl/models/generation/vllm/patches.py"
+    if patches_path.is_file():
+        namespace = runpy.run_path(str(patches_path))
+        apply_external_vllm_patches = namespace.get("_apply_external_vllm_patches")
+        if not callable(apply_external_vllm_patches):
+            raise RuntimeError(
+                f"_apply_external_vllm_patches is missing from {patches_path}"
+            )
+        return cast(Callable[[], None], apply_external_vllm_patches)
+
+    # Support installations that copy this tool without the source checkout.
+    from nemo_rl.models.generation.vllm.patches import _apply_external_vllm_patches
+
+    return _apply_external_vllm_patches
 
 
 def main() -> None:
     """Connect to the private cluster and start the requested vLLM command."""
-    _apply_external_vllm_patches()
+    _load_apply_external_vllm_patches()()
     ray.init(address="auto", runtime_env={"py_executable": sys.executable})
 
     # vLLM is available only in the generation worker environment and must be


### PR DESCRIPTION
Summary:
- Patch vLLM flashinfer_trtllm MoE weight processing to preserve refit buffers.
- Add coverage for the monkeypatch path.

Verification:
- git diff --check HEAD~1..HEAD
- python3 -m py_compile nemo_rl/models/generation/vllm/patches.py nemo_rl/models/generation/vllm/vllm_worker.py tests/unit/models/generation/test_vllm_patches.py