### PR TITLE
replace fastokens-b10 with fastokens

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -127,7 +127,7 @@ policy:
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
     chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
-    use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens-b10 wheel. NRL_USE_FASTOKENS overrides at runtime.
+    use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens wheel. NRL_USE_FASTOKENS overrides at runtime.
   hf_config_overrides: {} 
   train_global_batch_size: 512
   train_micro_batch_size: 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "pybase64",                                                                                                 # for sglang refit
   "awscrt>=0.35.0",                                                                                           # for parallel S3 refit transport
   "zstandard",                                                                                                # for sparse refit body compression
-  "fastokens-b10>=0.1.1",                                                                                     # Rust-backed BPE tokenizer (~10x faster encode); enable at runtime with NRL_USE_FASTOKENS=1
+  "fastokens>=0.2.0",                                                                                         # Rust-backed BPE tokenizer (~10x faster encode); enable at runtime with NRL_USE_FASTOKENS=1
   "nvidia-cudnn-cu13==9.20.0.48; sys_platform != 'darwin'",                                                   # for transformer-engine no build isolation
   # tilelang — replacement Triton kernel mamba-ssm requires when
   # Triton >= 3.4.0 on Hopper, see github.com/state-spaces/mamba#640.

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -133,7 +133,7 @@ policy:
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
     chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
-    use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens-b10 wheel. NRL_USE_FASTOKENS overrides at runtime.
+    use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens wheel. NRL_USE_FASTOKENS overrides at runtime.
   hf_config_overrides: {}
   train_global_batch_size: 512
   train_micro_batch_size: 4

--- a/uv.lock
+++ b/uv.lock
@@ -1729,18 +1729,23 @@ wheels = [
 ]
 
 [[package]]
-name = "fastokens-b10"
-version = "0.2.3"
+name = "fastokens"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/a1/6306a05fd7fdbbcf4e7fd9524fa7d7d28cb4fd239142be24166336dafb91/fastokens_b10-0.2.3.tar.gz", hash = "sha256:0e31edf627be68aba2c86891c71e5b3860a1fe1fde9a62642656f4e33d144e39", size = 694497, upload-time = "2026-07-15T21:33:46.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/6e/200398babdffd99dca58ef3d19a15319ecde33d62f680ab1ddf4405196d5/fastokens-0.3.1.tar.gz", hash = "sha256:c1baf730f8458aa090a81fa3acea60b60f7e04aaaf8fed79546b8585ecfc9731", size = 737468, upload-time = "2026-08-04T11:15:45.395Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/1b/f3c1d002044a1acf7370c671ac695c92f270f3c5331da5a7896aea28814f/fastokens_b10-0.2.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32305d8c290c552f3039032e9a112eb4edcd4a074d18dacd7f55d280a1534ef8", size = 3460894, upload-time = "2026-07-15T21:33:28.394Z" },
-    { url = "https://files.pythonhosted.org/packages/37/0b/456eb095240c0a32a74483252adf465012986df26aad2d7f7745ed9f0721/fastokens_b10-0.2.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:664aeeec9d9aad5218cde1d321f7c285076862c2a4efbf41bace99781b130c4d", size = 3467196, upload-time = "2026-07-15T21:33:18.6Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/74/1a9221be36162f65ef8a636db315c6acac1a10d42f4d43f5ef365cad27a0/fastokens_b10-0.2.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6afd9e274ce82418ca9831ba820bf293b35e60889643a9e86f372b8e1768c692", size = 3550631, upload-time = "2026-07-15T21:33:37.108Z" },
-    { url = "https://files.pythonhosted.org/packages/50/bc/75310f0b83859799820351394254fbac3a9dcd2dff94314bd6288a1c55f2/fastokens_b10-0.2.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:048434b953311af5f1f294db54dab754354f92d72878b589d42cacc8353b36bb", size = 3806707, upload-time = "2026-07-15T21:33:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/dd/6bb16c6969ed576780dcb719ea68348e18042a6f3dd3313fcd21238e9b9c/fastokens-0.3.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3b89ae6343bd95fc112e16d57e578d0a0afbc8b42f9a4198f54a2de899ef307a", size = 3192486, upload-time = "2026-08-04T11:15:38.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/70/bfcee9a238aad5e8a098239aaab4d4eec2bdab0551f156292f0f4e57c283/fastokens-0.3.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e229518521c31d87c6fb64aa7c4a2f748a3c33b120b7a1a43c29764e3ab833c1", size = 3099805, upload-time = "2026-08-04T11:15:36.862Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/9c23e29e4faa818076526f8ac759fbbdd9d12af386e6fbb2976e8128de4a/fastokens-0.3.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:59c4a2f286ca66967a7656cc999c3ecf978fb06f101dd925529e4561a521e7ea", size = 3509398, upload-time = "2026-08-04T11:15:34.337Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/44ec5ef4703a97bce8fbd981caa41adeb405ab98c39ad5e2605831a153c4/fastokens-0.3.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:778724ba69061b9eaa2cb049ed475d80413d945c88ed87366d8049ad2c854f6e", size = 3404814, upload-time = "2026-08-04T11:15:35.539Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/9a/2cb6c702fae8a54f17876f80ce60a1713d7093d6fc018d13a129824a3983/fastokens-0.3.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:509cf8634f5f1cb59ec5e7cc671d3a0e120b6972b03a290b089f547a2a4777ab", size = 3408322, upload-time = "2026-08-04T11:15:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ba/39f3ac8d4b6df6e5233440316e650f0f9689cbdd802cbd93623488c8fa0c/fastokens-0.3.1-cp39-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:44c3fef2e9fe918a7c7a673153c99e368fde7f702bf77e76cdcfc3d4384a03b9", size = 3168252, upload-time = "2026-08-04T11:15:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ff/c1e5be97dd5fcb748dcadca63a1e54308355a08107afe471fd5816bbc1f2/fastokens-0.3.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5c4dbc086ff086057dc097bf8f9c8c83b24b35ceb7dc9a47ccac7aea3f9c9a2c", size = 3837204, upload-time = "2026-08-04T11:15:32.922Z" },
+    { url = "https://files.pythonhosted.org/packages/41/38/2b9bf9d77c39fc77c5b344b6a3ea4ac1c090f7e52118fdf5a8a0bc7b033d/fastokens-0.3.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:636e118d56034a7c91e93d98149cf6aab9e437e614afee8772eaa00239247658", size = 3492055, upload-time = "2026-08-04T11:15:39.724Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ea/a3006fc7f091112591f81d775dc4b7d419a61a6ec6c7315d760bb63f9acd/fastokens-0.3.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:91d3d2adab86595904bc713b9054cd5ca85fb6ba50209e971b4ab7aee68e1554", size = 3320614, upload-time = "2026-08-04T11:15:40.967Z" },
+    { url = "https://files.pythonhosted.org/packages/88/56/9182de6be27d2cc5e99e4816622bc7d862a87efd820898918a8dfd1996a8/fastokens-0.3.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:c5260a7f5a5df612f9532ff7bca185830dd90a336ff7664ec237458eb8dfc667", size = 3587027, upload-time = "2026-08-04T11:15:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/57/7d3940a3caf62a9fb1a555d3bcdd55b2c8bcd0748c7a153b3e014dcd1366/fastokens-0.3.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:497b1d0d6e64a5c2afa9fd852b9ff890017be249fd0eeccac6b4cda5dc4abd88", size = 3748538, upload-time = "2026-08-04T11:15:43.746Z" },
+    { url = "https://files.pythonhosted.org/packages/68/61/df098d987b835bebe6f86ba0cda5a82ad86faa8d68d130fda4f85e8e0994/fastokens-0.3.1-cp39-abi3-win_amd64.whl", hash = "sha256:d1905dec91023069a34da5cc9852667582d2011cb21e794a895f7b6ab000ff80", size = 2913904, upload-time = "2026-08-04T11:15:46.455Z" },
 ]
 
 [[package]]
@@ -4265,7 +4270,7 @@ dependencies = [
     { name = "cuda-bindings" },
     { name = "datasets" },
     { name = "debugpy" },
-    { name = "fastokens-b10" },
+    { name = "fastokens" },
     { name = "hydra-core", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-7-nemo-rl-mcore' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-trtllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-8-nemo-gym-vllm') or (extra == 'extra-7-nemo-rl-trtllm' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-trtllm' and extra == 'extra-8-nemo-gym-vllm') or (extra == 'extra-7-nemo-rl-vllm' and extra == 'extra-8-nemo-gym-vllm') or (extra == 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-trtllm') or (extra == 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra == 'extra-8-nemo-gym-vllm')" },
     { name = "hydra-core", version = "1.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-7-nemo-rl-automodel' or extra != 'extra-7-nemo-rl-mcore' or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-trtllm') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-8-nemo-gym-vllm')" },
     { name = "math-verify" },
@@ -4444,7 +4449,7 @@ requires-dist = [
     { name = "deep-ep", marker = "platform_machine == 'x86_64' and extra == 'mcore'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=29d31c095796f3c8ece47ee9cdcc167051bbeed9" },
     { name = "deep-ep", marker = "platform_machine == 'x86_64' and extra == 'vllm'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=29d31c095796f3c8ece47ee9cdcc167051bbeed9" },
     { name = "deep-gemm", marker = "extra == 'vllm'", git = "https://github.com/deepseek-ai/DeepGEMM.git?rev=67fc64863d43521080bf2005e6528d0fceee9510" },
-    { name = "fastokens-b10", specifier = ">=0.1.1" },
+    { name = "fastokens", specifier = ">=0.2.0" },
     { name = "flash-attn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'automodel'", url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu13torch2.10cxx11abiTRUE-cp313-cp313-linux_aarch64.whl" },
     { name = "flash-attn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'fsdp'", url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu13torch2.10cxx11abiTRUE-cp313-cp313-linux_aarch64.whl" },
     { name = "flash-attn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'mcore'", url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu13torch2.10cxx11abiTRUE-cp313-cp313-linux_aarch64.whl" },


### PR DESCRIPTION
# What does this PR do ?

Replace the `fastokens-b10` dependency with the canonical `fastokens` package and update the lockfile to `fastokens==0.3.1`.

Both packages expose the same `fastokens` Python module, so no runtime code changes are required. Using the canonical distribution also provides the `fastokens` package metadata expected by downstream consumers such as vLLM.

# Issues
N/A


# Usage
No usage change

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
