### PR TITLE
fix: Hoist val metrics dict in validate()

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3852,14 +3852,13 @@ def validate(
         max_batches = (
             master_config.grpo.max_val_samples // master_config.grpo.val_batch_size
         )
+        additional_metrics_to_report = dict()
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break
 
             if val_num_generations_per_prompt > 1:
                 val_batch = val_batch.repeat_interleave(val_num_generations_per_prompt)
-
-            additional_metrics_to_report = dict()
             # Generate responses (updates the LLMMessageLogType in batch_with_msg_logs)
             # Use async rollouts when enabled by config/backend defaults.
             # We cascade NeMo-Gym first since NeMo-Gym also uses async rollouts.

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -5297,3 +5297,34 @@ def test_train_fields_for_step(skip_prev_logprobs, expect_prev):
 )
 def test_needs_hf_refit_handshake(backend, nccl_reshard, colocated, expected):
     assert _needs_hf_refit_handshake(backend, nccl_reshard, colocated) is expected
+
+
+def test_validate_reports_empty_metrics_when_max_val_samples_below_batch_size():
+    """max_val_samples < val_batch_size floors max_batches to 0.
+
+    The loop then breaks on its first iteration, so no metrics are collected.
+    validate() must still return its metric dicts instead of raising
+    UnboundLocalError on the hoisted additional_metrics_to_report.
+    """
+    master_config = MasterConfig.model_construct(
+        grpo=GRPOConfig.model_construct(
+            val_num_generations_per_prompt=1,
+            max_val_samples=1,
+            val_batch_size=256,
+        ),
+        logger={"num_val_samples_to_print": 0},
+    )
+    policy_generation = MagicMock()
+
+    val_metrics, timing_metrics = validate(
+        policy_generation,
+        [MagicMock()],  # one batch stays queued; the loop must skip it
+        tokenizer=MagicMock(),
+        val_task_to_env=None,
+        step=0,
+        master_config=master_config,
+    )
+
+    assert val_metrics == {"accuracy": 0.0, "avg_length": 0.0}
+    assert "total_validation_time" in timing_metrics
+    policy_generation.assert_not_called()


### PR DESCRIPTION
# What does this PR do ?

Fixes a crash in `grpo.validate()` when `grpo.max_val_samples < grpo.val_batch_size` (the default `val_batch_size` is 256).

# Issues

None.

# Usage

Any run with fewer validation samples than one validation batch:

```yaml
grpo:
  max_val_samples: 1
  val_batch_size: 256
```

Before: validation crashes with `UnboundLocalError: cannot access local variable 'additional_metrics_to_report'`.
After: validation reports `{"accuracy": 0.0, "avg_length": 0.0}`.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build, and test the docs.

# Additional Information
* Root cause: `max_val_samples // val_batch_size` floors to zero batches, so the validation loop body that assigned `additional_metrics_to_report` never runs, but the metric reporting below the loop reads it.
* Test: `test_validate_reports_empty_metrics_when_max_val_samples_below_batch_size` fails on `main` with the exact `UnboundLocalError` and passes with this change.
* Ran locally: `uv run --group dev --with pytest python -m pytest tests/unit/algorithms/test_grpo.py -k validate_reports_empty` (targeted unit tests; full suite left to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
