### PR TITLE
fix: Warn on expandable segments at IPC sender

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import gc
+import os
 import warnings
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import Any, Generator, Iterable, Optional
@@ -198,6 +199,19 @@ def get_train_context(
         if autocast_enabled:
             stack.enter_context(torch.autocast(device_type="cuda", dtype=dtype))
         yield
+
+
+def _uses_expandable_segments() -> bool:
+    """Return True if PYTORCH_CUDA_ALLOC_CONF enables expandable_segments."""
+    for entry in os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "").split(","):
+        key, _, value = entry.partition(":")
+        if key.strip() == "expandable_segments" and value.strip().lower() not in (
+            "",
+            "false",
+            "0",
+        ):
+            return True
+    return False
 
 
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
@@ -1111,6 +1125,15 @@ class DTensorPolicyWorkerV2Impl(
         kv_scales: Optional[dict[str, float]] = None,
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
+        if _uses_expandable_segments():
+            warnings.warn(
+                "PYTORCH_CUDA_ALLOC_CONF enables expandable_segments, but "
+                "the colocated IPC weight refit cannot share tensors in "
+                "expandable segments. update_weights_via_ipc_zmq will likely "
+                "fail with 'pidfd_getfd: Operation not permitted'. Remove "
+                "expandable_segments from this worker's allocator config.",
+                stacklevel=2,
+            )
         if kv_scales is not None:
             raise NotImplementedError(
                 "FP8 kvcache is not currently supported for DTensor path, we will support it in the future."

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -34,6 +34,7 @@ try:
     from nemo_rl.models.policy.workers.dtensor_policy_worker_v2 import (
         DTensorPolicyWorkerV2Impl,
         _maybe_adapt_tensor_to_hf,
+        _uses_expandable_segments,
         dtensor_params_generator,
         get_train_context,
     )
@@ -1003,3 +1004,28 @@ class TestGetTrainContext:
             sequence_dim,
         ], "sequence_dim should be replicated for each buffer"
         assert len(call_kwargs["cp_seq_dims"]) == 3
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+@pytest.mark.parametrize(
+    ("alloc_conf", "expected"),
+    [
+        ("expandable_segments:True", True),
+        ("expandable_segments: true ", True),
+        ("max_split_size_mb:512,expandable_segments:True", True),
+        ("max_split_size_mb:512", False),
+        ("expandable_segments:False", False),
+        ("expandable_segments:0", False),
+    ],
+)
+def test_uses_expandable_segments(alloc_conf, expected, monkeypatch):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", alloc_conf)
+    assert _uses_expandable_segments() is expected
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+def test_uses_expandable_segments_unset_env(monkeypatch):
+    monkeypatch.delenv("PYTORCH_CUDA_ALLOC_CONF", raising=False)
+    assert _uses_expandable_segments() is False


### PR DESCRIPTION
# What does this PR do ?

Warns at the colocated IPC weight-stream sender when `PYTORCH_CUDA_ALLOC_CONF` enables `expandable_segments`, naming the allocator setting and the downstream error the refit will die with.

# Issues

None.

# Usage

No API change. With `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` set on the training worker, `stream_weights_via_ipc_zmq` now emits a `UserWarning` at the sender:

```
PYTORCH_CUDA_ALLOC_CONF enables expandable_segments, but the colocated IPC
weight refit cannot share tensors in expandable segments.
update_weights_via_ipc_zmq will likely fail with 'pidfd_getfd: Operation
not permitted'. Remove expandable_segments from this worker's allocator config.
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build, and test the docs.

# Additional Information
* Why warn instead of fail: tensors in expandable (cu_mem_map) segments cannot be shared through `cudaIpcGetMemHandle`, so torch falls back to `pidfd_getfd`, which sibling Ray workers reject with EPERM. The failure surfaces far from its cause, in the receiver, as a `pidfd_getfd` RuntimeError and an `IPCWeightManifestError` listing hundreds of missing keys. The connection is visible only at the sender, where the config can be fixed.
* Tests: parametrized `_uses_expandable_segments` parser cases (`True`/`false`/`0` values, multi-entry configs, whitespace, unset env) — 7 passed.
* Ran locally with the automodel extra; full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)