### PR TITLE
docs(sc): document the checkpoint metric constraint

### DIFF
--- a/docs/guides/single-controller.md
+++ b/docs/guides/single-controller.md
@@ -89,6 +89,11 @@ uv run examples/run_grpo_single_controller.py --config <your-sc.yaml>
 
 ## Checkpointing and Replay Recovery
 
+Single-Controller does not have a validation loop yet. When checkpointing is
+enabled, `checkpointing.metric_name` must therefore be `null` or a
+`train:<name>` metric; setup rejects other values instead of letting top-k
+retention silently become a no-op.
+
 With `checkpointing.save_data_plane: true`, each Single-Controller checkpoint contains:
 
 - The normal model, dataloader, and controller state, plus optimizer state when configured.


### PR DESCRIPTION
## What does this PR do?

Documents the remaining Single-Controller checkpoint metric constraint: while SC has no validation loop, `checkpointing.metric_name` must be `null` or a `train:<name>` metric.

Setup already rejects other values so top-k retention cannot silently become a no-op. Current main now documents replay recovery in detail, so this refresh drops the older duplicate checkpoint/replay explanation and keeps only the missing user-facing constraint.

## Validation

Current head `4d7bd3630bff7440f4bfcb8e918c1969fdcecf91`, rebased onto upstream `main` at `d633032b2a8017c69ddfff9183deb42cab6b36f4`.

- docs-only, one paragraph
- claim checked against `validate_single_controller_config`
- `git diff --check`: passed
