### PR TITLE
fix(sc): apply reward scaling before advantage estimation

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -87,6 +87,7 @@ from nemo_rl.algorithms.grpo import (
     _write_latest_checkpoint_status,
     aggregate_rollout_metrics,
     compute_and_apply_seq_logprob_error_masking,
+    scale_rewards,
 )
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.ppo import _compute_critic_metrics
@@ -4210,6 +4211,16 @@ class SingleControllerActor:
         final_sample_mask = sample_mask * (~mask_sample).to(sample_mask.dtype)
         if self._algo_cfg.overlong_filtering:
             final_sample_mask = final_sample_mask * (~truncated).to(sample_mask.dtype)
+
+        # Before anything reads the rewards, matching grpo.py's ordering. A
+        # no-op unless reward scaling exists and is enabled. Not every
+        # SingleController algorithm defines the GRPO-only config block.
+        reward_scaling_cfg = getattr(self._algo_cfg, "reward_scaling", None)
+        if reward_scaling_cfg is not None:
+            rewards = scale_rewards(
+                BatchedDataDict({"total_reward": rewards}),
+                reward_scaling_cfg,
+            )["total_reward"]
 
         seq_logprob_error_threshold = self._algo_cfg.seq_logprob_error_threshold
         # Match the legacy path: whenever real policy logprobs are available,

--- a/tests/unit/single_controller/test_single_controller_actor.py
+++ b/tests/unit/single_controller/test_single_controller_actor.py
@@ -27,7 +27,11 @@ from tensordict import TensorDict
 import nemo_rl.algorithms.single_controller as single_controller
 from nemo_rl.algorithms.async_utils.replay_buffer import DataPlaneCheckpointBarrier
 from nemo_rl.algorithms.async_utils.staleness_sampler import BaseSampler
-from nemo_rl.algorithms.grpo import GRPOConfig, _initial_grpo_save_state
+from nemo_rl.algorithms.grpo import (
+    GRPOConfig,
+    RewardScalingConfig,
+    _initial_grpo_save_state,
+)
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.ppo import PPOConfig
@@ -518,10 +522,12 @@ class _AdvantageDataPlane:
 class _MaskRecordingAdvantageEstimator:
     def __init__(self) -> None:
         self.mask: torch.Tensor | None = None
+        self.rewards: torch.Tensor | None = None
 
     def compute_advantage(self, *, rewards, mask, **kwargs) -> torch.Tensor:
         del kwargs
         self.mask = mask.clone()
+        self.rewards = rewards.clone()
         return rewards.unsqueeze(-1).expand_as(mask).clone()
 
 
@@ -832,6 +838,66 @@ def test_advantage_stage_clips_training_values_and_metrics() -> None:
     logged = torch.cat(ctrl._step_log_dict["masked_advantages"])
     assert logged.min().item() == pytest.approx(-1.0)
     assert logged.max().item() == pytest.approx(2.0)
+
+
+def test_advantage_stage_scales_rewards_before_estimation() -> None:
+    batch_size, sequence_length = 2, 4
+    data = TensorDict(
+        {
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([-4.0, 6.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.ones(batch_size),
+            "mask_sample": torch.zeros(batch_size, dtype=torch.bool),
+            "truncated": torch.zeros(batch_size, dtype=torch.bool),
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = _MaskRecordingAdvantageEstimator()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
+    ctrl._policy_logprobs_required = False
+    ctrl._reference_logprobs_required = False
+    ctrl._teacher_logprobs_required = False
+    ctrl._is_ppo = False
+    ctrl._message_level_advantage_penalties_enabled = False
+    ctrl._algo_cfg = GRPOConfig(
+        reward_scaling=RewardScalingConfig(
+            enabled=True,
+            source_min=-4.0,
+            source_max=6.0,
+            target_min=0.0,
+            target_max=1.0,
+        )
+    )
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "sample_masks": [],
+        "masked_advantages": [],
+        "num_mask_sample_filtered": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        fields=list(data.keys()),
+    )
+
+    asyncio.run(ctrl._advantage_stage(meta))
+
+    assert estimator.rewards is not None
+    torch.testing.assert_close(estimator.rewards, torch.tensor([0.0, 1.0]))
+    torch.testing.assert_close(ctrl._step_log_dict["rewards"][0], estimator.rewards)
 
 
 def test_advantage_stage_skips_estimator_when_seq_mask_removes_whole_chunk(


### PR DESCRIPTION
## What does this PR do?

Makes Single Controller apply the existing `grpo.reward_scaling` setting before advantage estimation, using the shared `scale_rewards` helper.

This PR is intentionally limited to reward scaling. Current main already provides advantage clipping, overlong filtering, and environment sample masking. Reward shaping and message-level penalties remain out of scope because Single Controller does not yet carry the response-length/message fields they need.

The shipped default remains a no-op, and algorithms without a reward-scaling block remain unchanged.

## Validation

Current head `90d294e9df9376dec52d71d94488d814a8d20b72`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- full `tests/unit/single_controller/test_single_controller_actor.py`: **61 passed**
- caller-level coverage verifies scaling happens before advantage estimation and that logged rewards use the scaled values
- Ruff check, Ruff format check, and `git diff --check`: passed

An earlier pre-refresh head completed a real 2×H100 SC run with Qwen3-0.6B, Megatron policy/reference, vLLM, and TQ. With scaling enabled, rewards were mapped from `0..1` to `-1..1`; training completed with loss `0.1040` and grad norm `2.6518`. The current head was shrunk against main and rerun through the full SC actor suite; the 2-GPU functional run was not repeated after that refresh.
