### PR TITLE
fix(dtensor): count TP-replicated gradients once in get_grad_norm

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -813,6 +813,46 @@ def clip_grad_by_total_norm_(
             g.mul_(clip_coeff)
 
 
+def _is_tp_duplicate(
+    grad: Union[torch.Tensor, DTensor],
+    tp_group: torch.distributed.ProcessGroup,
+) -> bool:
+    """Whether every rank of ``tp_group`` holds an identical copy of ``grad``.
+
+    Tensor parallelism only shards the parameters named in the parallel plan
+    (attention/MLP projections, embeddings). Everything else stays replicated:
+    norm weights, biases, router weights, and any module the plan does not
+    cover. Each TP rank therefore computes the very same gradient for those
+    parameters, and that gradient must contribute to the global norm exactly
+    once.
+
+    A plain ``torch.Tensor`` is replicated by definition. A ``DTensor`` is
+    replicated when its placement on the mesh dimension backed by ``tp_group``
+    is not a ``Shard``. The mesh dimension is located by comparing group ranks
+    rather than object identity so that mesh slices (``mesh["tp"]``) resolve
+    correctly.
+
+    Args:
+        grad: The gradient to classify.
+        tp_group: Tensor-parallel process group, or ``None`` when TP is unused.
+
+    Returns:
+        bool: True when the gradient is duplicated across ``tp_group``.
+    """
+    if tp_group is None or not isinstance(grad, DTensor):
+        return True
+
+    mesh = grad.device_mesh
+    tp_ranks = torch.distributed.get_process_group_ranks(tp_group)
+    for dim in range(mesh.ndim):
+        if torch.distributed.get_process_group_ranks(mesh.get_group(dim)) == tp_ranks:
+            return not isinstance(grad.placements[dim], Shard)
+
+    # The gradient does not live on the TP mesh at all, so it is replicated
+    # across the group.
+    return True
+
+
 def get_grad_norm(
     parameters: Union[list[Union[torch.Tensor, DTensor]], Union[torch.Tensor, DTensor]],
     dp_cp_group: torch.distributed.ProcessGroup,
@@ -840,10 +880,17 @@ def get_grad_norm(
     if isinstance(parameters, (torch.Tensor, DTensor)):
         parameters = [parameters]
 
-    # Grads.
-    grads_for_norm = [
-        to_local_if_dtensor(p.grad.detach()) for p in parameters if p.grad is not None
-    ]
+    # Grads, split by whether the TP group holds duplicate copies of them.
+    grads_for_norm = []
+    tp_duplicate_grads = []
+    for p in parameters:
+        if p.grad is None:
+            continue
+        grad = p.grad.detach()
+        if _is_tp_duplicate(grad, tp_group):
+            tp_duplicate_grads.append(to_local_if_dtensor(grad))
+        else:
+            grads_for_norm.append(to_local_if_dtensor(grad))
 
     # Norm parameters.
     norm_type = float(norm_type)
@@ -851,6 +898,8 @@ def get_grad_norm(
 
     # Calculate norm.
     if norm_type == torch.inf:
+        # A max-reduction is idempotent, so duplicates need no special handling.
+        grads_for_norm = grads_for_norm + tp_duplicate_grads
         total_norm = max(grad.abs().max().item() for grad in grads_for_norm)
         total_norm_cuda = torch.tensor([float(total_norm)], dtype=dtype, device="cuda")
         # Take max across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
@@ -864,19 +913,32 @@ def get_grad_norm(
         total_norm = float(total_norm_cuda[0].item())
 
     else:
-        total_norm_cuda = torch.tensor(0.0, dtype=dtype, device="cuda")
-        for grad in grads_for_norm:
-            grad_norm = torch.linalg.vector_norm(grad, ord=norm_type, dtype=dtype)
-            total_norm_cuda += torch.pow(grad_norm, norm_type)
+
+        def _sum_of_powers(grads: list[torch.Tensor]) -> torch.Tensor:
+            acc = torch.tensor(0.0, dtype=dtype, device="cuda")
+            for grad in grads:
+                grad_norm = torch.linalg.vector_norm(grad, ord=norm_type, dtype=dtype)
+                acc += torch.pow(grad_norm, norm_type)
+            return acc
+
+        # [sharded-on-TP, duplicated-on-TP]. Both halves are sharded across DP by
+        # FSDP, so both are summed over dp_cp_group; only the sharded half may be
+        # summed over tp_group, otherwise every TP rank's identical copy of a
+        # replicated gradient is counted tp_size times and inflates the norm.
+        partial_norms = torch.stack(
+            [_sum_of_powers(grads_for_norm), _sum_of_powers(tp_duplicate_grads)]
+        )
 
         # Sum across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
         torch.distributed.all_reduce(
-            total_norm_cuda, op=torch.distributed.ReduceOp.SUM, group=dp_cp_group
+            partial_norms, op=torch.distributed.ReduceOp.SUM, group=dp_cp_group
         )
 
+        sharded_norm = partial_norms[0].clone()
         torch.distributed.all_reduce(
-            total_norm_cuda, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            sharded_norm, op=torch.distributed.ReduceOp.SUM, group=tp_group
         )
+        total_norm_cuda = sharded_norm + partial_norms[1]
         total_norm = float(total_norm_cuda.item() ** (1.0 / norm_type))
 
     return total_norm

--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -14,7 +14,7 @@
 
 from functools import lru_cache, partial
 from types import FunctionType
-from typing import Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 import torch
 from hydra.utils import get_class
@@ -815,9 +815,10 @@ def clip_grad_by_total_norm_(
 
 def _is_tp_duplicate(
     grad: Union[torch.Tensor, DTensor],
-    tp_group: torch.distributed.ProcessGroup,
+    tp_ranks: Optional[list[int]],
+    mesh_dim_cache: Optional[dict[Any, Optional[int]]] = None,
 ) -> bool:
-    """Whether every rank of ``tp_group`` holds an identical copy of ``grad``.
+    """Whether every rank of the TP group holds an identical copy of ``grad``.
 
     Tensor parallelism only shards the parameters named in the parallel plan
     (attention/MLP projections, embeddings). Everything else stays replicated:
@@ -826,37 +827,68 @@ def _is_tp_duplicate(
     parameters, and that gradient must contribute to the global norm exactly
     once.
 
-    A plain ``torch.Tensor`` is replicated by definition. A ``DTensor`` is
-    replicated when its placement on the mesh dimension backed by ``tp_group``
-    is not a ``Shard``. The mesh dimension is located by comparing group ranks
-    rather than object identity so that mesh slices (``mesh["tp"]``) resolve
-    correctly.
+    A plain ``torch.Tensor`` is replicated by definition. For a ``DTensor`` the
+    mesh dimension backed by the TP group is located by comparing group ranks
+    rather than object identity, so that mesh slices (``mesh["tp"]``) resolve
+    correctly, and the placement on that dimension decides the answer.
 
     Args:
         grad: The gradient to classify.
-        tp_group: Tensor-parallel process group, or ``None`` when TP is unused.
+        tp_ranks: Global ranks of the tensor-parallel group, or ``None`` when TP
+            is unused.
+        mesh_dim_cache: Optional cache reused across parameters so the mesh
+            dimension is resolved once per device mesh instead of once per
+            parameter.
 
     Returns:
-        bool: True when the gradient is duplicated across ``tp_group``.
+        bool: True when the gradient is duplicated across the TP group.
+
+    Raises:
+        ValueError: If the placement on the TP mesh dimension is neither
+            ``Shard`` nor ``Replicate``. A ``Partial`` gradient in particular is
+            neither: each rank holds a different addend, so counting it once
+            would drop the other ranks' contributions and counting it on every
+            rank would leave the ranks with different totals.
     """
-    if tp_group is None or not isinstance(grad, DTensor):
+    if tp_ranks is None or not isinstance(grad, DTensor):
         return True
 
     mesh = grad.device_mesh
-    tp_ranks = torch.distributed.get_process_group_ranks(tp_group)
-    for dim in range(mesh.ndim):
-        if torch.distributed.get_process_group_ranks(mesh.get_group(dim)) == tp_ranks:
-            return not isinstance(grad.placements[dim], Shard)
+    if mesh_dim_cache is None:
+        mesh_dim_cache = {}
+    if mesh not in mesh_dim_cache:
+        mesh_dim_cache[mesh] = next(
+            (
+                dim
+                for dim in range(mesh.ndim)
+                if torch.distributed.get_process_group_ranks(mesh.get_group(dim))
+                == tp_ranks
+            ),
+            None,
+        )
+    tp_dim = mesh_dim_cache[mesh]
 
     # The gradient does not live on the TP mesh at all, so it is replicated
     # across the group.
-    return True
+    if tp_dim is None:
+        return True
+
+    placement = grad.placements[tp_dim]
+    if isinstance(placement, Shard):
+        return False
+    if isinstance(placement, Replicate):
+        return True
+    raise ValueError(
+        f"Cannot compute a gradient norm for TP placement {placement!r}; only "
+        "Shard and Replicate are supported on the tensor-parallel mesh "
+        "dimension."
+    )
 
 
 def get_grad_norm(
     parameters: Union[list[Union[torch.Tensor, DTensor]], Union[torch.Tensor, DTensor]],
-    dp_cp_group: torch.distributed.ProcessGroup,
-    tp_group: torch.distributed.ProcessGroup,
+    dp_cp_group: Optional[torch.distributed.ProcessGroup],
+    tp_group: Optional[torch.distributed.ProcessGroup],
     norm_type: Union[int, float] = 2,
     dtype: torch.dtype = torch.float32,
 ) -> float:
@@ -881,13 +913,19 @@ def get_grad_norm(
         parameters = [parameters]
 
     # Grads, split by whether the TP group holds duplicate copies of them.
+    tp_ranks = (
+        torch.distributed.get_process_group_ranks(tp_group)
+        if tp_group is not None
+        else None
+    )
+    mesh_dim_cache: dict[Any, Optional[int]] = {}
     grads_for_norm = []
     tp_duplicate_grads = []
     for p in parameters:
         if p.grad is None:
             continue
         grad = p.grad.detach()
-        if _is_tp_duplicate(grad, tp_group):
+        if _is_tp_duplicate(grad, tp_ranks, mesh_dim_cache):
             tp_duplicate_grads.append(to_local_if_dtensor(grad))
         else:
             grads_for_norm.append(to_local_if_dtensor(grad))

--- a/tests/unit/models/dtensor/test_grad_norm_tp.py
+++ b/tests/unit/models/dtensor/test_grad_norm_tp.py
@@ -1,0 +1,155 @@
+import os
+
+import pytest
+import ray
+import torch
+
+from nemo_rl.distributed.named_sharding import NamedSharding
+from nemo_rl.distributed.ray_actor_environment_registry import (
+    ACTOR_ENVIRONMENT_REGISTRY,
+    PY_EXECUTABLES,
+)
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+
+
+@ray.remote(num_gpus=1)  # pragma: no cover
+class GradNormTPTestActor:
+    """Builds one TP-sharded and one TP-replicated gradient and checks the norm."""
+
+    def __init__(self, tp_size):
+        self.tp_size = tp_size
+
+    def run_grad_norm_check(self):
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import Replicate, Shard, distribute_tensor
+
+        from nemo_rl.models.dtensor.parallelize import _is_tp_duplicate, get_grad_norm
+
+        torch.distributed.init_process_group(backend="nccl")
+        torch.cuda.set_device(0)
+        mesh = init_device_mesh("cuda", (1, self.tp_size), mesh_dim_names=("dp", "tp"))
+        dp_group = mesh["dp"].get_group()
+        tp_group = mesh["tp"].get_group()
+
+        # Same seed on every rank, so the replicated gradient really is identical
+        # across the TP group, exactly like a norm/bias gradient in training.
+        torch.manual_seed(1234)
+        replicated_grad = torch.randn(4096, device="cuda")
+        sharded_grad = torch.randn(4096 * self.tp_size, device="cuda")
+
+        replicated_param = torch.nn.Parameter(
+            distribute_tensor(
+                torch.zeros_like(replicated_grad), mesh, [Replicate(), Replicate()]
+            )
+        )
+        replicated_param.grad = distribute_tensor(
+            replicated_grad, mesh, [Replicate(), Replicate()]
+        )
+        sharded_param = torch.nn.Parameter(
+            distribute_tensor(
+                torch.zeros_like(sharded_grad), mesh, [Replicate(), Shard(0)]
+            )
+        )
+        sharded_param.grad = distribute_tensor(
+            sharded_grad, mesh, [Replicate(), Shard(0)]
+        )
+
+        params = [replicated_param, sharded_param]
+        expected = torch.linalg.vector_norm(
+            torch.cat([replicated_grad, sharded_grad]).to(torch.float64)
+        ).item()
+        # What the norm would be if each TP rank's copy of the replicated
+        # gradient were summed instead of counted once.
+        inflated = (
+            (
+                self.tp_size * replicated_grad.to(torch.float64).pow(2).sum()
+                + sharded_grad.to(torch.float64).pow(2).sum()
+            )
+            .sqrt()
+            .item()
+        )
+
+        actual = get_grad_norm(params, dp_cp_group=dp_group, tp_group=tp_group)
+        inf_norm = get_grad_norm(
+            params, dp_cp_group=dp_group, tp_group=tp_group, norm_type=torch.inf
+        )
+        expected_inf = torch.cat([replicated_grad, sharded_grad]).abs().max().item()
+
+        return {
+            "rank": int(os.environ["RANK"]),
+            "classified_replicated": _is_tp_duplicate(replicated_param.grad, tp_group),
+            "classified_sharded": _is_tp_duplicate(sharded_param.grad, tp_group),
+            "expected": expected,
+            "inflated": inflated,
+            "actual": actual,
+            "inf_actual": inf_norm,
+            "inf_expected": expected_inf,
+        }
+
+
+GRAD_NORM_TP_ACTOR_FQN = f"{GradNormTPTestActor.__module__}.GradNormTPTestActor"
+
+
+@pytest.fixture
+def register_grad_norm_tp_actor():
+    original = ACTOR_ENVIRONMENT_REGISTRY.get(GRAD_NORM_TP_ACTOR_FQN)
+    ACTOR_ENVIRONMENT_REGISTRY[GRAD_NORM_TP_ACTOR_FQN] = PY_EXECUTABLES.SYSTEM
+
+    yield GRAD_NORM_TP_ACTOR_FQN
+
+    if GRAD_NORM_TP_ACTOR_FQN in ACTOR_ENVIRONMENT_REGISTRY:
+        if original is None:
+            del ACTOR_ENVIRONMENT_REGISTRY[GRAD_NORM_TP_ACTOR_FQN]
+        else:
+            ACTOR_ENVIRONMENT_REGISTRY[GRAD_NORM_TP_ACTOR_FQN] = original
+
+
+@pytest.mark.parametrize("tp_size", [2])
+def test_get_grad_norm_counts_tp_replicated_grads_once(
+    register_grad_norm_tp_actor, tp_size
+):
+    """TP-replicated gradients must contribute to the global norm exactly once.
+
+    Tensor parallelism leaves norm weights, biases and every module outside the
+    parallel plan replicated, so all TP ranks hold the same gradient for them.
+    Summing the per-rank squared norms over the TP group therefore counts those
+    gradients tp_size times and over-reports the norm, which in turn makes
+    gradient clipping fire too aggressively.
+    """
+    if not torch.cuda.is_available() or torch.cuda.device_count() < tp_size:
+        pytest.skip(
+            f"Not enough GPUs available. Need {tp_size}, got {torch.cuda.device_count()}"
+        )
+
+    cluster = RayVirtualCluster(bundle_ct_per_node_list=[tp_size], use_gpus=True)
+    try:
+        sharding = NamedSharding(layout=list(range(tp_size)), names=["tp"])
+        builder = RayWorkerBuilder(register_grad_norm_tp_actor, tp_size)
+        worker_group = RayWorkerGroup(
+            cluster=cluster,
+            remote_worker_builder=builder,
+            workers_per_node=None,
+            sharding_annotations=sharding,
+        )
+        results = ray.get(
+            worker_group.run_all_workers_single_data("run_grad_norm_check")
+        )
+        worker_group.shutdown(force=True)
+    finally:
+        cluster.shutdown()
+
+    for result in results:
+        print(
+            f"[rank {result['rank']}] expected={result['expected']:.6f} "
+            f"actual={result['actual']:.6f} "
+            f"inflated_if_double_counted={result['inflated']:.6f} "
+            f"ratio_actual_over_expected={result['actual'] / result['expected']:.6f}"
+        )
+        assert result["classified_replicated"] is True
+        assert result["classified_sharded"] is False
+        assert result["actual"] == pytest.approx(result["expected"], rel=1e-5)
+        # Guard against the test passing for the wrong reason: the two candidate
+        # values must actually differ for tp_size > 1.
+        assert result["inflated"] != pytest.approx(result["expected"], rel=1e-5)
+        assert result["inf_actual"] == pytest.approx(result["inf_expected"], rel=1e-5)

--- a/tests/unit/models/dtensor/test_grad_norm_tp.py
+++ b/tests/unit/models/dtensor/test_grad_norm_tp.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import pytest
@@ -76,10 +90,11 @@ class GradNormTPTestActor:
         )
         expected_inf = torch.cat([replicated_grad, sharded_grad]).abs().max().item()
 
+        tp_ranks = torch.distributed.get_process_group_ranks(tp_group)
         return {
             "rank": int(os.environ["RANK"]),
-            "classified_replicated": _is_tp_duplicate(replicated_param.grad, tp_group),
-            "classified_sharded": _is_tp_duplicate(sharded_param.grad, tp_group),
+            "classified_replicated": _is_tp_duplicate(replicated_param.grad, tp_ranks),
+            "classified_sharded": _is_tp_duplicate(sharded_param.grad, tp_ranks),
             "expected": expected,
             "inflated": inflated,
             "actual": actual,
@@ -132,10 +147,12 @@ def test_get_grad_norm_counts_tp_replicated_grads_once(
             workers_per_node=None,
             sharding_annotations=sharding,
         )
-        results = ray.get(
-            worker_group.run_all_workers_single_data("run_grad_norm_check")
-        )
-        worker_group.shutdown(force=True)
+        try:
+            results = ray.get(
+                worker_group.run_all_workers_single_data("run_grad_norm_check")
+            )
+        finally:
+            worker_group.shutdown(force=True)
     finally:
         cluster.shutdown()
 


### PR DESCRIPTION
## Problem

`get_grad_norm` accumulates each rank's local `sum(|g|^p)` and then reduces it with `SUM` twice, first over `dp_cp_group` and then over `tp_group`:

```python
for grad in grads_for_norm:
    grad_norm = torch.linalg.vector_norm(grad, ord=norm_type, dtype=dtype)
    total_norm_cuda += torch.pow(grad_norm, norm_type)

torch.distributed.all_reduce(total_norm_cuda, op=SUM, group=dp_cp_group)
torch.distributed.all_reduce(total_norm_cuda, op=SUM, group=tp_group)
```

The second reduction is only valid for gradients that are genuinely sharded across the TP group. Tensor parallelism shards only the parameters named in the parallel plan (attention and MLP projections, embeddings, `lm_head`). Everything else stays replicated: RMSNorm/LayerNorm weights, biases, router weights, and any module the plan does not cover. Every TP rank computes an identical gradient for those parameters, so summing their squared norms over `tp_group` counts each of them `tp_size` times.

Two consequences:

1. The logged `grad_norm` is systematically over-reported, and the error grows with `tp_size`.
2. `clip_grad_by_total_norm_` is driven by that same value, so gradient clipping fires more aggressively than `policy.max_grad_norm` asks for. The effective clip threshold shrinks by the same factor.

Megatron's `clip_grads.py`, which this function is adapted from, excludes duplicates before the reduction via `param_is_not_tensor_parallel_duplicate`. That filter was not carried over when the function was ported.

## Fix

Split the gradients by whether they are sharded on the mesh dimension backed by `tp_group`:

- both halves are reduced over `dp_cp_group`, since FSDP shards every parameter across DP and each DP rank therefore owns a distinct piece of both;
- only the sharded half is reduced over `tp_group`; the replicated half is added once.

The TP mesh dimension is located by comparing process-group ranks rather than object identity, so a mesh slice such as `mesh["tp"]` resolves correctly. A plain `torch.Tensor` gradient, or a `DTensor` that does not live on the TP mesh, is treated as replicated.

The infinity-norm path is left as it was, because a `MAX` reduction is idempotent and duplicates are harmless there. The new test covers that path too so the behaviour stays locked in.

## Evidence

`tests/unit/models/dtensor/test_grad_norm_tp.py` builds one TP-replicated gradient (4096 elements, identical on every rank) and one TP-sharded gradient (8192 elements) on a 2-rank TP mesh, then compares `get_grad_norm` against the exact norm of the concatenated full gradients.

On the current `main` the test fails:

```
tests/unit/models/dtensor/test_grad_norm_tp.py::test_get_grad_norm_counts_tp_replicated_grads_once[2]

>           assert result["actual"] == pytest.approx(result["expected"], rel=1e-5)
E           assert 130.01957484836657 == 112.023248812...9 +- 0.00112023
E
E             comparison failed
E             Obtained: 130.01957484836657
E             Expected: 112.02324881294129 +- 0.00112023

1 failed
```

That is a 16.1% over-report at `tp_size=2`, consistent with `sqrt((2*||g_repl||^2 + ||g_shard||^2) / (||g_repl||^2 + ||g_shard||^2))` for this split.

With the fix applied the same test passes:

```
tests/unit/models/dtensor/test_grad_norm_tp.py::test_get_grad_norm_counts_tp_replicated_grads_once[2] PASSED

1 passed
```

A reduced form of the same check, run directly against `get_grad_norm` on a 2-rank TP mesh with a single parameter, isolates the factor exactly:

```
before:
  true ||g||                       = 31.032419
  get_grad_norm, SHARDED param     = 31.032418  ratio=1.0000
  get_grad_norm, REPLICATED param  = 43.886468  ratio=1.4142   <- sqrt(2)

after:
  true ||g||                       = 31.032419
  get_grad_norm, SHARDED param     = 31.032418  ratio=1.0000
  get_grad_norm, REPLICATED param  = 31.032419  ratio=1.0000
```

The sharded parameter was already correct in both cases, which confirms the regression is confined to replicated parameters.

## Note on the extra file

`tests/unit/models/dtensor/__init__.py` is added because the test spawns a Ray actor defined in the test module and Ray resolves the actor by its fully qualified module name. Without it the module is collected under a bare top-level name that the worker process cannot import. Every sibling test directory already ships one.

## Placement handling

Only `Replicate` counts as a duplicate. A `Partial` gradient on the TP mesh dimension is neither sharded nor duplicated, since each rank holds a different addend of the true gradient, so bucketing it either way would be wrong and would leave TP ranks with different clip coefficients. `_is_tp_duplicate` raises on it instead. It is not reachable on the current path, because FSDP redistributes non-DP mesh dimensions back to the parameter placements before exposing `.grad`, but the invariant is now enforced rather than assumed.

## Behaviour change worth calling out

When `tp_group` is `None`, every gradient now lands in the replicated bucket and skips the second all-reduce. Previously `all_reduce(..., group=None)` fell through to the WORLD group. Nothing in the training path passes `None` (`dtensor_policy_worker` always passes a real group), and the one caller that does is `test_get_grad_norm_precision`, which monkeypatches `all_reduce` to a no-op.

## Test run

The new test and the pre-existing `test_get_grad_norm_precision` parametrizations pass together, so the change does not regress the single-process path:

```
tests/unit/models/dtensor/test_grad_norm_tp.py::test_get_grad_norm_counts_tp_replicated_grads_once[2] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype0-norm_dtype0-1] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype1-norm_dtype1-2] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype2-norm_dtype2-inf] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype3-norm_dtype3-1] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype4-norm_dtype4-2] PASSED
tests/unit/models/dtensor/test_parallelize.py::test_get_grad_norm_precision[grad_dtype5-norm_dtype5-inf] PASSED

7 passed
```

## Scope

This PR only fixes the TP axis, which is the axis that demonstrably double-counts today. The `dp_cp_group` reduction keeps its existing assumption that FSDP shards every parameter across DP.
