### PR TITLE
fix(megatron): install finalizer on runtime model config

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -67,6 +67,7 @@ from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.enums import AttnBackend, InferenceCudaGraphScope
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import get_model_config
 from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.distributed.model_utils import patch_gpt_model_forward_for_linear_ce_fusion
@@ -2190,7 +2191,7 @@ def finalize_megatron_setup(
     """
     _update_model_config_funcs(
         [model],
-        megatron_cfg.model,
+        get_model_config(model),
         megatron_cfg.ddp,
         optimizer,
         align_grad_reduce=megatron_cfg.dist.align_grad_reduce,

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -3051,8 +3051,10 @@ class TestFinalizeMegatronSetup:
     @patch("nemo_rl.models.megatron.setup._update_model_config_funcs")
     @patch("nemo_rl.models.megatron.setup.build_tokenizer")
     @patch("nemo_rl.models.megatron.setup.AutoBridge")
+    @patch("nemo_rl.models.megatron.setup.get_model_config")
     def test_basic_finalize_setup(
         self,
+        mock_get_model_config,
         mock_auto_bridge,
         mock_build_tokenizer,
         mock_update_model_config,
@@ -3066,6 +3068,8 @@ class TestFinalizeMegatronSetup:
         mock_megatron_cfg.model.make_vocab_size_divisible_by = 128
 
         mock_model = MagicMock()
+        runtime_model_config = MagicMock()
+        mock_get_model_config.return_value = runtime_model_config
         mock_optimizer = MagicMock()
 
         mock_worker_sharding = MagicMock()
@@ -3107,6 +3111,8 @@ class TestFinalizeMegatronSetup:
 
         # Verify function calls
         mock_update_model_config.assert_called_once()
+        mock_get_model_config.assert_called_once_with(mock_model)
+        assert mock_update_model_config.call_args.args[1] is runtime_model_config
         mock_build_tokenizer.assert_called_once()
         mock_auto_bridge.from_hf_pretrained.assert_called_once_with(
             "test-model", trust_remote_code=True


### PR DESCRIPTION
# What does this PR do?

Installs Megatron training callbacks on the config attached to the built model. This ensures that gradient finalization runs when a model provider copies its config during model construction.

## Problem

`NemotronOmniModelProvider.provide()` builds the language model with a deep copy of the provider config:

```python
language_cfg = copy.deepcopy(self)
model = NemotronOmniModel(language_transformer_config=language_cfg, ...)
```

The config returned by `get_model_config(model)` is therefore a different object from `ConfigContainer.model`. NeMo RL passed `megatron_cfg.model` to `_update_model_config_funcs()`, so `finalize_model_grads_func` was installed on the provider config instead of the runtime config used by the training schedule.

This caused two different symptoms:

- V1 SFT silently skipped gradient finalization.
- V2 SFT (private) failed with an error.

Skipping the callback can skip data-parallel gradient reduce or reduce-scatter, sequence-parallel gradient reductions, shared embedding reductions, and the MoE expert-bias update.

## Fix

Use Megatron Core's model helper to select the runtime config:

```diff
 _update_model_config_funcs(
     [model],
-    megatron_cfg.model,
+    get_model_config(model),
     megatron_cfg.ddp,
```

This is unchanged for providers where the provider and runtime configs are the same object. The regression test uses distinct objects and verifies that `_update_model_config_funcs()` receives the runtime config.

## Debug validation

The following temporary diagnostics were used during the Nemotron V1 run. They are intentionally excluded from this PR:

```python
runtime_config = get_model_config(model)
print("[MODEL_CONFIG_DIAG] same config:", runtime_config is megatron_cfg.model)
print("[MODEL_CONFIG_DIAG] provider finalizer:", megatron_cfg.model.finalize_model_grads_func)
print("[MODEL_CONFIG_DIAG] runtime finalizer:", runtime_config.finalize_model_grads_func)

print(
    "[FINALIZE_MODEL_GRADS_DIAG] enter "
    f"rank={rank} num_tokens={num_tokens} force_all_reduce={force_all_reduce}"
)
result = finalize_model_grads_func(*args, **kwargs)
print(f"[FINALIZE_MODEL_GRADS_DIAG] exit rank={rank}")
```

Observed output after the fix:

```text
[MODEL_CONFIG_DIAG] same config: False
[MODEL_CONFIG_DIAG] provider finalizer: None
[MODEL_CONFIG_DIAG] runtime finalizer: functools.partial(<function finalize_model_grads ...>, pg_collection=ProcessGroupCollection(..., dp(2), ...))
[FINALIZE_MODEL_GRADS_DIAG] enter rank=0 num_tokens=0 force_all_reduce=False [repeated 8x across cluster]
[FINALIZE_MODEL_GRADS_DIAG] exit rank=0 [repeated 8x across cluster]
```

Matching enter and exit messages appeared on all eight ranks for each recorded optimizer step. The V1 loss also decreased from `8.0193` to `6.1847` over the visible completed steps.

# Issues

None.

# Testing

- `uvx --from ruff==0.9.9 ruff check nemo_rl/models/megatron/setup.py tests/unit/models/megatron/test_megatron_setup.py`
- `uvx --from ruff==0.9.9 ruff format --check nemo_rl/models/megatron/setup.py tests/unit/models/megatron/test_megatron_setup.py`
- Python AST parsing for both changed Python files
- One-node, eight-GPU Nemotron V1 training run with temporary callback diagnostics
- Focused pytest was not run on the host because the clean worktree does not have the Megatron/PyTorch test environment; the new regression test is included for CI.

# Before your PR is ready for review

- [x] Followed the contributor guidelines
- [x] Added a regression test
- [x] Ran focused lint and formatting checks
- [x] No documentation update is needed for this bug fix
