### PR TITLE
fix(loss): normalize the VAPO positive-example NLL by the global token count

### DIFF
--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -500,9 +500,9 @@ The table below covers the metrics reported by `ClippedPGLossFn` (the GRPO/PPO f
 | Behavior | Metrics |
 | --- | --- |
 | **Follows `token_level_loss`** — token-normalized when `true`, sequence-normalized when `false` | `loss`, `kl_penalty` |
-| **Always token-normalized**, regardless of the setting | `probs_ratio`, `probs_ratio_clamped`, `token_mult_prob_error`, `gen_kl_error`, `policy_kl_error`, `js_divergence_error`, `approx_entropy` |
+| **Always token-normalized**, regardless of the setting | `probs_ratio`, `probs_ratio_clamped`, `token_mult_prob_error`, `gen_kl_error`, `policy_kl_error`, `js_divergence_error`, `approx_entropy`, `positive_nll_loss` |
 | **Keyed on a different parameter** | `sampling_importance_ratio` follows `sequence_level_importance_ratios`; `is_oob_ratio` is sequence-normalized only for `truncated_importance_sampling_type: seq-mask-tis` |
-| **Not normalized** — raw counts, per-microbatch means, or extrema combined with min/max | `num_valid_samples`, `positive_nll_loss`, `probs_ratio_min`, `probs_ratio_max`, `probs_ratio_clamped_min`, `probs_ratio_clamped_max` |
+| **Not normalized** — raw counts, or extrema combined with min/max | `num_valid_samples`, `probs_ratio_min`, `probs_ratio_max`, `probs_ratio_clamped_min`, `probs_ratio_clamped_max` |
 
 The authoritative list is the [`metric_normalizations` table in `ClippedPGLossFn`](https://github.com/NVIDIA-NeMo/RL/blob/4a1454bf430624786251d14ba0197169c8e68a5c/nemo_rl/algorithms/loss/loss_functions.py#L335-L371), which is kept in sync with the metrics the loss returns.
 

--- a/docs/guides/ppo.md
+++ b/docs/guides/ppo.md
@@ -225,7 +225,7 @@ where $V_{\text{clipped}} = \text{clamp}(V_\theta,\; V_{\text{old}} - \epsilon_v
 Key parameters:
 - **`value_loss_fn.scale`**: Scaling factor for the value loss (default: 1.0; reference recipe overrides to 0.4)
 - **`value_loss_fn.cliprange`**: Clip range $\epsilon_v$ for value predictions (default: `null` / disabled; reference recipe overrides to 0.2). Set to `null` to disable clipping.
-- **`loss_fn.positive_example_nll_weight`**: VAPO NLL auxiliary loss weight on correct samples (0 = disabled)
+- **`loss_fn.positive_example_nll_weight`**: VAPO NLL auxiliary loss weight on correct samples (0 = disabled). The NLL term is averaged over the same global valid-token count as the policy loss, so the weight is defined relative to all valid tokens and does not change when the microbatch size or the DP/CP world size changes.
 
 ## Configuration
 

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -160,6 +160,10 @@ class ClippedPGLossConfig(BaseModel, extra="allow"):
     use_cispo: bool = False
     # VAPO: weight μ for positive-example NLL loss on correct samples.
     # L = L_PPO + μ·L_NLL(correct)   (arXiv:2504.05118, Eq. 10)
+    # The NLL term is averaged over the same global valid-token count as the
+    # policy loss, so μ is defined relative to all valid tokens rather than to
+    # the correct-sample tokens alone. That keeps the term invariant to the
+    # microbatch split and to the DP/CP world size.
     # Set to 0 to disable.
     positive_example_nll_weight: float = 0.0
 
@@ -353,9 +357,8 @@ class ClippedPGLossFn(LossFunction):
             ),
             # Raw count — the downstream per-microbatch sum IS the value.
             "num_valid_samples": MetricNormalizer.NONE,
-            # Normalized by the microbatch's own correct-token count, not a
-            # global factor — already a per-microbatch mean.
-            "positive_nll_loss": MetricNormalizer.NONE,
+            # Token-normalized like the loss term it reports.
+            "positive_nll_loss": MetricNormalizer.TOKENS,
             # Extrema — combined downstream with min/max, never scaled.
             "probs_ratio_min": MetricNormalizer.NONE,
             "probs_ratio_max": MetricNormalizer.NONE,
@@ -724,13 +727,18 @@ class ClippedPGLossFn(LossFunction):
         if self.positive_example_nll_weight > 0 and "rewards" in data:
             correct_sample_mask = (data["rewards"] > 0).float()  # [batch]
             correct_mask = mask * correct_sample_mask.unsqueeze(-1)
-            correct_valid_toks = correct_mask.sum()
-            if correct_valid_toks > 0:
-                nll_loss = masked_mean(
-                    -curr_logprobs,
-                    correct_mask,
-                    global_normalization_factor=correct_valid_toks,
-                )
+            # Normalize by the same global token count the policy loss uses.
+            # correct_mask.sum() is a microbatch-local quantity, and the trainers
+            # sum the per-microbatch losses (then rescale by the DP/CP world
+            # size), so a local denominator makes each microbatch contribute a
+            # full mean instead of its share of one. The effective weight would
+            # then scale with the number of microbatches and with dp_size and
+            # cp_size, none of which should change the objective.
+            nll_loss = masked_mean(
+                -curr_logprobs,
+                correct_mask,
+                global_normalization_factor=global_valid_toks,
+            )
 
         loss = actor_loss + kl + self.positive_example_nll_weight * nll_loss
         with torch.no_grad():

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -2040,6 +2040,71 @@ def test_clipped_pg_loss_sequence_importance_ratio_averages_per_sample():
     assert metrics["sampling_importance_ratio"] == pytest.approx(3.0)
 
 
+@pytest.mark.parametrize("nll_weight", [0.0, 0.5])
+def test_clipped_pg_positive_nll_is_microbatch_invariant(nll_weight):
+    """Splitting the global batch into microbatches must not change the loss.
+
+    Trainers call the loss once per microbatch, sum the results and rescale by
+    the DP/CP world size, so every term has to be normalized by a global count.
+    Normalizing the VAPO positive-example NLL term by the microbatch's own
+    correct-token count made each microbatch contribute a full mean instead of
+    its share of one, so the term's effective weight scaled with the number of
+    microbatches and with the DP/CP world size.
+    """
+    torch.manual_seed(0)
+    batch_size, seq_len = 4, 6
+    data, _, _, _ = _setup_clipped_pg_test_data(
+        batch_size=batch_size, seq_len=seq_len, device="cpu"
+    )
+    data["advantages"] = torch.randn(batch_size, seq_len)
+    data["prev_logprobs"] = -torch.rand(batch_size, seq_len)
+    data["generation_logprobs"] = data["prev_logprobs"].clone()
+    # Two thirds of the samples are correct, so the NLL term is active but does
+    # not cover the whole batch.
+    data["rewards"] = torch.tensor([1.0, 0.0, 1.0, 1.0])
+
+    global_valid_seqs = data["sample_mask"].sum()
+    global_valid_toks = (
+        data["token_mask"][:, 1:] * data["sample_mask"].unsqueeze(-1)
+    ).sum()
+
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(
+            reference_policy_kl_penalty=0.0,
+            positive_example_nll_weight=nll_weight,
+            use_importance_sampling_correction=False,
+        )
+    )
+
+    def run(curr_logprobs, sample_slice):
+        return loss_fn(
+            next_token_logprobs=curr_logprobs[sample_slice],
+            data=BatchedDataDict(
+                {key: value[sample_slice] for key, value in data.items()}
+            ),
+            global_valid_seqs=global_valid_seqs,
+            global_valid_toks=global_valid_toks,
+        )
+
+    single = data["prev_logprobs"][:, 1:].clone().requires_grad_(True)
+    single_loss, single_metrics = run(single, slice(None))
+    single_loss.backward()
+
+    split = data["prev_logprobs"][:, 1:].clone().requires_grad_(True)
+    first_loss, _ = run(split, slice(0, 2))
+    second_loss, _ = run(split, slice(2, 4))
+    (first_loss + second_loss).backward()
+
+    if nll_weight > 0:
+        # Guard against passing vacuously: the term has to actually be active.
+        assert single_metrics["positive_nll_loss"] != 0.0
+
+    assert (first_loss + second_loss).item() == pytest.approx(
+        single_loss.item(), abs=1e-6
+    )
+    torch.testing.assert_close(split.grad, single.grad, atol=1e-6, rtol=1e-5)
+
+
 def test_clipped_pg_loss_gspo_importance_sampling_correction():
     """Tests GSPO w/ importance sampling correction in ClippedPGLossFn."""
     if not torch.cuda.is_available():
@@ -2730,11 +2795,12 @@ class TestMetricNormalizationAdvertisement:
             "policy_kl_error",
             "js_divergence_error",
             "approx_entropy",
+            # normalized by global_valid_toks like the loss term it reports
+            "positive_nll_loss",
         ):
             assert norms[key] is MetricNormalizer.TOKENS
-        # raw counts / local means / extrema are never rescaled
+        # raw counts / extrema are never rescaled
         assert norms["num_valid_samples"] is MetricNormalizer.NONE
-        assert norms["positive_nll_loss"] is MetricNormalizer.NONE
         assert norms["probs_ratio_min"] is MetricNormalizer.NONE
         assert norms["probs_ratio_max"] is MetricNormalizer.NONE
         # no TIS configured → the metric is never emitted, so not advertised


### PR DESCRIPTION
## Problem

`ClippedPGLossFn` implements VAPO's positive-example NLL term (arXiv:2504.05118, Eq. 10). Every other term in the same loss function is normalized by `global_valid_toks`, a count all-reduced across the DP/CP world before the loss call, so that summing the per-microbatch losses on each rank reproduces the correct global mean. The NLL term instead normalized by `correct_mask.sum()`, the current microbatch's own count of correct-sample tokens:

```python
nll_loss = torch.tensor(0.0, device=mask.device)
if self.positive_example_nll_weight > 0 and "rewards" in data:
    correct_sample_mask = (data["rewards"] > 0).float()
    correct_mask = mask * correct_sample_mask.unsqueeze(-1)
    correct_valid_toks = correct_mask.sum()
    if correct_valid_toks > 0:
        nll_loss = masked_mean(
            -curr_logprobs, correct_mask,
            global_normalization_factor=correct_valid_toks,
        )
```

Trainers call the loss function once per microbatch and sum the results (`dtensor_policy_worker.py` also multiplies by `dp_size * cp_size` to undo FSDP's gradient averaging). A term normalized by a local count contributes a full local mean on every microbatch instead of its share of one global mean, so:

- the term's effective weight scales with the number of microbatches the global batch is split into, a value that has nothing to do with the objective (`train_micro_batch_size` is a hardware knob);
- it further scales with `dp_size * cp_size`, since that factor is applied uniformly to the whole loss including this now-inflated term.

Changing `train_micro_batch_size`, `dp_size`, or `cp_size` therefore silently changes what `mu` in `L = L_PPO + mu * L_NLL(correct)` actually means, with no error or warning.

## Fix

Normalize by `global_valid_toks`, the same denominator `actor_loss` and `kl` use. `mu` is now defined relative to all valid tokens in the batch rather than to correct-sample tokens alone; that is a constant rescaling of the weight (correct-token count / total valid-token count, roughly the training accuracy), not a change to what the term computes, and it is now invariant to how the batch is split into microbatches or across DP/CP.

`positive_nll_loss` moves from `MetricNormalizer.NONE` to `TOKENS` in `metric_normalizations`, since it is now normalized the same way as the loss term it reports, and the metric-normalization table in `docs/guides/grpo.md` and the config comment in `ClippedPGLossConfig` are updated to match.

## Evidence

`tests/unit/algorithms/test_loss_functions.py::test_clipped_pg_positive_nll_is_microbatch_invariant` builds one batch of 4 samples (3 correct, 1 incorrect) and compares the loss and the input gradient computed in a single call against the same computation split into two microbatches of 2, summed. This is exactly the microbatch pattern `dtensor_policy_worker.py` and `megatron_policy_worker.py` use.

On the current `main`, with `positive_example_nll_weight` disabled the two computations agree, and with it enabled they diverge:

```
tests/unit/algorithms/test_loss_functions.py::test_clipped_pg_positive_nll_is_microbatch_invariant[0.0] PASSED
tests/unit/algorithms/test_loss_functions.py::test_clipped_pg_positive_nll_is_microbatch_invariant[0.5] FAILED

>       assert (first_loss + second_loss).item() == pytest.approx(single_loss.item(), abs=1e-6)
E       assert 0.2159305214881897 == -0.0661458671092987 ± 1.0e-06
E
E         comparison failed
E         Obtained: 0.2159305214881897
E         Expected: -0.0661458671092987 ± 1.0e-06

1 failed, 1 passed
```

`mu=0.0` passing on unpatched main and `mu=0.5` failing isolates the bug to the VAPO term specifically: everything else in the loss is already microbatch-invariant.

With the fix applied, both parametrizations pass:

```
tests/unit/algorithms/test_loss_functions.py::test_clipped_pg_positive_nll_is_microbatch_invariant[0.0] PASSED
tests/unit/algorithms/test_loss_functions.py::test_clipped_pg_positive_nll_is_microbatch_invariant[0.5] PASSED

2 passed
```

The full `test_loss_functions.py` suite (79 tests, covering GRPO/PPO clipping, GSPO, CISPO, dual-clip, TIS variants, DPO, distillation, and the metric-normalization advertisement) passes on the fix branch, so the change does not regress any other loss path:

```
79 passed, 4 warnings
```

## Scope

This only touches the VAPO NLL term's normalization and its metric classification. The rest of `ClippedPGLossFn`, the PPO/GRPO/GSPO/CISPO ratio computation, KL penalty, and truncated importance sampling, is unchanged.
