### PR TITLE
fix(grpo): pass rewards into the GRPO train batch for VAPO's NLL term

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2141,6 +2141,10 @@ def _build_async_grpo_train_data(
             "generation_logprobs": flat_messages["generation_logprobs"],
             "token_mask": flat_messages["token_loss_mask"],
             "sample_mask": repeated_batch["loss_multiplier"],
+            # Consumed by ClippedPGLossFn's VAPO positive-example NLL term
+            # (loss_fn.positive_example_nll_weight); without this key that
+            # term silently evaluates to zero regardless of the config.
+            "rewards": repeated_batch["total_reward"],
         }
     )
     _preserve_router_replay_routed_experts(train_data, flat_messages, policy_config)
@@ -3169,6 +3173,15 @@ def grpo_train(
                             "generation_logprobs": flat_messages["generation_logprobs"],
                             "token_mask": flat_messages["token_loss_mask"],
                             "sample_mask": repeated_batch["loss_multiplier"],
+                            # Consumed by ClippedPGLossFn's VAPO positive-example
+                            # NLL term (loss_fn.positive_example_nll_weight);
+                            # without this key that term silently evaluates to
+                            # zero regardless of the config. `rewards` tracks
+                            # `repeated_batch` row-for-row here: dynamic sampling
+                            # has already filtered it above, and neither
+                            # overlong filtering nor the mask-sample filter below
+                            # drop rows, they only zero loss_multiplier.
+                            "rewards": rewards,
                         }
                     )
                     # this will be mini-batched inside the policy, so maintain the packed multimodal structure

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,7 @@ from nemo_rl.algorithms.grpo import (
     RewardScalingConfig,
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
+    _build_async_grpo_train_data,
     _apply_message_level_advantage_penalties,
     _get_grpo_save_state,
     _initial_grpo_save_state,
@@ -83,6 +85,7 @@ from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
 from nemo_rl.utils.timer import Timer
 from tests.unit.algorithms.utils import (
     create_mock_batch,
+    create_mock_batch_with_responses,
 )
 
 
@@ -184,6 +187,115 @@ class TestMaskSampleFilter:
         assert torch.equal(
             repeated_batch["loss_multiplier"], torch.tensor([1.0, 0.5, 1.0])
         )
+
+
+class TestBuildAsyncGrpoTrainData:
+    """positive_example_nll_weight (VAPO) reads data["rewards"] and silently
+    no-ops without it, so the async no-TQ train batch must carry the key."""
+
+    def _flat_messages(self, batch_size: int, seq_len: int) -> BatchedDataDict:
+        return BatchedDataDict(
+            {
+                "token_ids": torch.arange(
+                    batch_size * seq_len, dtype=torch.long
+                ).reshape(batch_size, seq_len),
+                "generation_logprobs": torch.zeros(batch_size, seq_len),
+                "token_loss_mask": torch.ones(batch_size, seq_len, dtype=torch.long),
+            }
+        )
+
+    def test_train_data_carries_rewards(self):
+        batch_size, seq_len = 4, 3
+        repeated_batch = create_mock_batch_with_responses(
+            num_samples=batch_size,
+            response_lengths=[seq_len] * batch_size,
+            initial_rewards=[1.0, 0.0, 1.0, 1.0],
+        )
+        flat_messages = self._flat_messages(batch_size, seq_len)
+
+        train_data = _build_async_grpo_train_data(
+            flat_messages,
+            input_lengths=torch.full((batch_size,), seq_len, dtype=torch.long),
+            repeated_batch=repeated_batch,
+            policy_config={"precision": "float32"},
+        )
+
+        assert "rewards" in train_data
+        assert torch.equal(train_data["rewards"], repeated_batch["total_reward"])
+
+    def test_rewards_row_matches_reward_hungry_loss_term(self):
+        """End-to-end: the key this function adds is exactly what
+        ClippedPGLossFn's VAPO term needs to activate."""
+        batch_size, seq_len = 4, 3
+        repeated_batch = create_mock_batch_with_responses(
+            num_samples=batch_size,
+            response_lengths=[seq_len] * batch_size,
+            initial_rewards=[1.0, 0.0, 1.0, 1.0],
+        )
+        flat_messages = self._flat_messages(batch_size, seq_len)
+        train_data = _build_async_grpo_train_data(
+            flat_messages,
+            input_lengths=torch.full((batch_size,), seq_len, dtype=torch.long),
+            repeated_batch=repeated_batch,
+            policy_config={"precision": "float32"},
+        )
+        train_data["advantages"] = torch.zeros(batch_size, seq_len)
+        train_data["prev_logprobs"] = -torch.rand(batch_size, seq_len)
+        train_data["reference_policy_logprobs"] = train_data["prev_logprobs"]
+        train_data["sample_mask"] = torch.ones(batch_size)
+
+        loss_fn = ClippedPGLossFn(
+            ClippedPGLossConfig(
+                reference_policy_kl_penalty=0.0,
+                positive_example_nll_weight=0.5,
+            )
+        )
+        _, metrics = loss_fn(
+            next_token_logprobs=train_data["prev_logprobs"][:, 1:],
+            data=train_data,
+            global_valid_seqs=train_data["sample_mask"].sum(),
+            global_valid_toks=(
+                train_data["token_mask"][:, 1:]
+                * train_data["sample_mask"].unsqueeze(-1)
+            ).sum(),
+        )
+
+        assert metrics["positive_nll_loss"] != 0.0
+
+
+def _extract_balanced_call(source: str, marker: str) -> str:
+    """Return `marker` plus everything up to its matching closing paren."""
+    start = source.index(marker)
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "(":
+            depth += 1
+        elif source[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced parens after {marker!r}")
+
+
+def test_grpo_train_sync_train_data_carries_rewards():
+    """grpo_train's in-process training batch must expose data["rewards"].
+
+    ClippedPGLossFn's VAPO positive_example_nll_weight term reads
+    data["rewards"] and silently no-ops without it (see
+    TestBuildAsyncGrpoTrainData for the equivalent async-path test and the
+    end-to-end loss check). grpo_train builds this dict inline rather than
+    through an extracted, directly callable helper, so this test locks the
+    literal in place via source inspection instead of invoking the function,
+    which would require standing up rollout, policy, and generation actors.
+    """
+    source = inspect.getsource(grpo_train)
+    train_data_call = _extract_balanced_call(
+        source, "train_data = BatchedDataDict[ClippedPGLossDataDict]("
+    )
+    assert '"rewards"' in train_data_call, (
+        "grpo_train's train_data dict lost the 'rewards' key; "
+        "loss_fn.positive_example_nll_weight would silently no-op again"
+    )
 
 
 def test_initial_policy_generation_stale() -> None:


### PR DESCRIPTION
## Problem

`ClippedPGLossFn`'s VAPO positive-example NLL term is gated like this:

```python
nll_loss = torch.tensor(0.0, device=mask.device)
if self.positive_example_nll_weight > 0 and "rewards" in data:
    ...
loss = actor_loss + kl + self.positive_example_nll_weight * nll_loss
```

If `"rewards"` is absent from the data dict passed to the loss, the term is silently zero regardless of `positive_example_nll_weight`, with no warning.

`ppo.py` already carries this key: `"rewards": repeated_batch["total_reward"]` is part of its `train_data` dict. GRPO's two in-process training paths do not:

- `grpo_train()` builds `train_data` inline without a `rewards` key.
- the async no-TQ path's `_build_async_grpo_train_data()` builds the same shape of dict, also without it.

So setting `loss_fn.positive_example_nll_weight` on a GRPO run is a silent no-op. The config accepts the value, training runs normally, and the loss is bit-identical to leaving the weight at 0.

## Fix

Add `"rewards"` to both dict-construction sites, mirroring PPO's existing pattern exactly:

- In `_build_async_grpo_train_data()`: `"rewards": repeated_batch["total_reward"]`.
- In `grpo_train()`'s inline `train_data` dict: `"rewards": rewards`, where `rewards` is the same batch-aligned reward tensor already computed a few lines above (`repeated_batch["total_reward"]`, or `repeated_batch["filtered_reward"]` under DAPO dynamic sampling) and used to build `advantages`. It stays row-aligned with `repeated_batch` through this section: dynamic sampling has already filtered `repeated_batch` to match by the time `train_data` is built, and neither overlong filtering nor the mask-sample filter that follow drop rows, they only zero `loss_multiplier`.

## Evidence

Three tests, from the API boundary up to the actual loss activating:

1. `TestBuildAsyncGrpoTrainData::test_train_data_carries_rewards` calls `_build_async_grpo_train_data()` directly and asserts `"rewards"` is present and equals `repeated_batch["total_reward"]`.
2. `TestBuildAsyncGrpoTrainData::test_rewards_row_matches_reward_hungry_loss_term` feeds the resulting `train_data` straight into `ClippedPGLossFn` with `positive_example_nll_weight=0.5` and asserts `metrics["positive_nll_loss"] != 0`, i.e. the fix actually turns the feature on end-to-end.
3. `test_grpo_train_sync_train_data_carries_rewards` locks the synchronous path's inline dict literal via source inspection (`grpo_train()` builds this dict inline rather than through an extracted, directly callable helper, so invoking the real function would require standing up rollout, policy, and generation actors).

On the current `main`, all three fail:

```
FAILED tests/unit/algorithms/test_grpo.py::TestBuildAsyncGrpoTrainData::test_train_data_carries_rewards
FAILED tests/unit/algorithms/test_grpo.py::TestBuildAsyncGrpoTrainData::test_rewards_row_matches_reward_hungry_loss_term
FAILED tests/unit/algorithms/test_grpo.py::test_grpo_train_sync_train_data_carries_rewards

AssertionError: assert 'rewards' in {'input_ids': ..., 'sample_mask': tensor([1., 1., 1., 1.])}
...
AssertionError: grpo_train's train_data dict lost the 'rewards' key; loss_fn.positive_example_nll_weight would silently no-op again

3 failed
```

With the fix applied, all three pass:

```
3 passed
```

The full `test_grpo.py` suite (144 tests, covering dynamic sampling, mask/reward-penalty filtering, config validation, refit handshakes, and rollout-metric aggregation) passes on the fix branch, so the change does not regress any other GRPO path:

```
144 passed
```

## Known related gap, out of scope here

The data-plane (TQ) synchronous path (`grpo_sync.py`, a documented sibling of `grpo_train()` for `data_plane.enabled=true`) has the identical gap, traced end to end:

- `DP_TRAIN_FIELDS` (`nemo_rl/data_plane/schema.py`), the column list workers fetch for `train_from_meta`, does not include a rewards-shaped field.
- The rollout actor's TQ bulk write (`nemo_rl/experience/sync_rollout_actor.py`, `bulk_batch = BatchedDataDict[Any](...)` built from `DP_TRAIN_FIELDS` plus multimodal extras) does not write one either, even though `total_reward` is already one of the `PROMOTE_1D_FIELDS` the schema knows how to carry through the Mooncake adapter, so the reward is available in the data plane, just not under a name or field list this fetch reads.
- The driver's own `write_to_dataplane` call in `grpo_sync.py` writes only `{"advantages", "sample_mask"}`.

So `"rewards" in data` is always `False` in `ClippedPGLossFn` on this path too. Fixing it means adding a fetched column and aliasing it to `rewards` for the loss call, in a materially different fetch mechanism (a distributed column store, not a literal dict) that this PR does not touch and that deserves its own focused change and testing.

## Scope

This only adds the `rewards` key to the two in-process GRPO training paths. Everything else about how `train_data` is built, and the loss function itself, is unchanged.
