### PR TITLE
fix(grpo): stop corrupting total_reward across dynamic-sampling rounds

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1739,10 +1739,9 @@ def dynamic_sampling(
         master_config.grpo.num_prompts_per_step
         * master_config.grpo.num_generations_per_prompt
     )
-    # Store the baseline, std and total_reward for the current unfiltered batch.
+    # Store the baseline and std for the current unfiltered batch.
     repeated_batch["baseline"] = baseline
     repeated_batch["std"] = std
-    total_rewards = repeated_batch["total_reward"]
     dynamic_sampling_metrics = {}
 
     # Dynamic sampling algorithm (used in DAPO algorithm)
@@ -1763,10 +1762,21 @@ def dynamic_sampling(
             filtered_repeated_batch["std"] = std[keep_prompt_indices]
             filtered_repeated_batch["baseline"] = baseline[keep_prompt_indices]
 
-            # Store filtered and total rewards to track them separately
-            filtered_rewards = filtered_repeated_batch["total_reward"]
-            filtered_repeated_batch["total_reward"] = total_rewards
-            filtered_repeated_batch["filtered_reward"] = filtered_rewards
+            # `select_indices` above already filtered `total_reward` to the
+            # kept prompts, correctly aligned row-for-row with every other
+            # key in `filtered_repeated_batch`. Expose the identical values
+            # under `filtered_reward` too, since callers read that name
+            # explicitly (e.g. grpo_train's post-filter `rewards` lookup).
+            # This used to instead overwrite `total_reward` with the full,
+            # unfiltered per-round reward tensor -- a different length than
+            # every other key here, which corrupts `total_reward` (but not
+            # `filtered_reward`, which was correctly the filtered tensor
+            # under the wrong name) the moment this batch is cached across
+            # dynamic-sampling rounds via `BatchedDataDict.from_batches`
+            # below, or sliced to `train_prompts_size` a few lines down.
+            filtered_repeated_batch["filtered_reward"] = filtered_repeated_batch[
+                "total_reward"
+            ]
 
             # Store the total_reward for the current filtered batch.
             # If none of the prompts in current batch have non-zero std, filtered_repeated_batch.size will be 0.
@@ -3036,6 +3046,13 @@ def grpo_train(
                 with timer.time("reward_calculation"):
                     # Extract rewards from final_batch
                     rewards = repeated_batch["total_reward"]
+                    # This round's reward before dynamic-sampling filtering,
+                    # kept under its own name since `dynamic_sampling` below
+                    # reassigns `repeated_batch` (and `total_reward` on it)
+                    # to the filtered/cached batch, which has a different
+                    # row count once samples have been dropped or slices
+                    # accumulated across rounds.
+                    this_round_unfiltered_rewards = rewards
 
                     print("▶ Computing advantages...", flush=True)
                     # For DAPO with reward shaping, compute std on the raw
@@ -3461,7 +3478,7 @@ def grpo_train(
                     ].numpy()
                 if master_config.grpo.use_dynamic_sampling:
                     metrics["filtered_reward"] = rewards.numpy()
-                    metrics["reward"] = repeated_batch["total_reward"].numpy()
+                    metrics["reward"] = this_round_unfiltered_rewards.numpy()
 
                 metrics.update(train_results["all_mb_metrics"])
                 metrics.update(gen_step_metrics)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3653,6 +3653,19 @@ def grpo_train(
                 log_data["content"] = flat_messages["content"]
                 log_data["rewards"] = rewards.tolist()
                 if master_config.grpo.use_dynamic_sampling:
+                    # Every other field logged here (content, token_ids, ...)
+                    # reflects the filtered-and-sliced batch, so `rewards`
+                    # must stay row-aligned to it; `filtered_rewards` is kept
+                    # as an explicit alias rather than being deduplicated
+                    # away, since other tooling may key on its presence. The
+                    # true pre-filter reward (`this_round_unfiltered_rewards`,
+                    # used for metrics["reward"] below) is intentionally NOT
+                    # used here: it reflects only the most recent generation
+                    # batch, not the (possibly multi-round) accumulated and
+                    # sliced batch this log entry describes, so it is not
+                    # row-aligned with `content` and using it here would
+                    # raise inside log_batched_dict_as_jsonl whenever the two
+                    # sizes differ.
                     log_data["filtered_rewards"] = rewards.tolist()
                     log_data["rewards"] = repeated_batch["total_reward"].tolist()
                 log_data["input_lengths"] = input_lengths.tolist()

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2084,27 +2084,52 @@ def test_dapo_dynamic_sampling_cache_preserves_reward_alignment(
     )
 
 
-def test_grpo_train_reward_metric_uses_preserved_unfiltered_rewards():
-    """metrics["reward"] must keep reporting the pre-filter, per-round
-    reward, distinct from metrics["filtered_reward"].
+def test_grpo_train_this_round_unfiltered_rewards_usage():
+    """`this_round_unfiltered_rewards` must be used for exactly one thing:
+    `metrics["reward"]`. Not for `log_data["rewards"]`.
 
     Now that `dynamic_sampling` no longer overwrites `total_reward` on the
     returned batch with the unfiltered per-round reward (see
     test_dapo_dynamic_sampling_discard_slice_preserves_reward_alignment),
     `repeated_batch["total_reward"]` after the call is the *filtered*
-    reward. Sourcing metrics["reward"] from it directly would silently
-    make it identical to metrics["filtered_reward"], collapsing a
-    diagnostic that is supposed to show the raw generation quality
-    separately from the reward of the samples that end up training.
-    grpo_train builds this dict inline, so this test locks the literal in
-    place via source inspection rather than invoking the function, which
-    would require standing up rollout, policy, and generation actors.
+    reward, row-aligned with the samples that end up training. Two things
+    downstream read it under `use_dynamic_sampling`, with opposite needs:
+
+    - `metrics["reward"]` is a diagnostic deliberately distinct from
+      `metrics["filtered_reward"]` (raw generation quality vs. reward of
+      the trained samples), so it must keep reading the preserved
+      pre-filter reward instead, or it would silently collapse to the
+      same value as `metrics["filtered_reward"]`.
+    - `log_data["rewards"]` is logged row-for-row against `content` and
+      `token_ids`, which reflect the filtered-and-sliced batch, not the
+      single most recent generation batch `this_round_unfiltered_rewards`
+      holds. It must keep reading the filtered `total_reward`, or it would
+      raise inside `log_batched_dict_as_jsonl` whenever the two sizes
+      differ (over-generation or a multi-round accumulation).
+
+    grpo_train builds both of these inline, so this test locks the two
+    literals in place via source inspection rather than invoking the
+    function, which would require standing up rollout, policy, and
+    generation actors.
     """
     source = inspect.getsource(grpo_train)
     assert 'metrics["reward"] = this_round_unfiltered_rewards.numpy()' in source, (
         "grpo_train no longer sources metrics['reward'] from the reward "
         "captured before dynamic_sampling filtering; it would silently "
         "become identical to metrics['filtered_reward']"
+    )
+    # The training-data JSONL's `rewards` field must stay row-aligned with
+    # `content`/`token_ids`, which reflect the filtered-and-sliced batch, not
+    # the single most recent generation batch `this_round_unfiltered_rewards`
+    # holds. Using the latter here would raise inside
+    # log_batched_dict_as_jsonl whenever the two sizes differ (over-generation
+    # or a multi-round accumulation), rather than merely being a less useful
+    # diagnostic like the metrics-dict case above.
+    assert 'log_data["rewards"] = repeated_batch["total_reward"].tolist()' in source, (
+        "grpo_train's training-data JSONL no longer sources log_data['rewards'] "
+        "from the filtered total_reward; if it now reads "
+        "this_round_unfiltered_rewards instead, it will crash whenever that "
+        "tensor's length differs from the logged content's"
     )
 
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
@@ -1957,6 +1958,154 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
     )  # All samples from the single prompt with non-zero std
     assert is_batch_complete == True
     assert batch_cache is not None
+
+
+def test_dapo_dynamic_sampling_discard_slice_preserves_reward_alignment(
+    mock_grpo_components,
+):
+    """When a single round over-produces, total_reward must stay aligned
+    with the kept-and-sliced batch, not with the raw pre-filter batch.
+
+    `total_reward` used to be overwritten with the full, unfiltered
+    per-round reward tensor before the final `.slice(0, train_prompts_size)`
+    -- a different array than the one every other key in the batch reflects,
+    so the slice took an arbitrary prefix of the raw generation batch
+    (including dropped, zero-std samples) instead of the first
+    train_prompts_size *kept* samples.
+    """
+    batch_size = 6
+    message_logs = [
+        [
+            {"role": "user", "content": f"prompt_{i}"},
+            {"role": "assistant", "content": f"response_{i}"},
+        ]
+        for i in range(batch_size)
+    ]
+    repeated_batch = create_mock_batch(batch_size, ["math"] * batch_size, message_logs)
+    repeated_batch["total_reward"] = torch.tensor([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+    # Sample 0 is dropped (std == 0); samples 1-5 are kept.
+    std = torch.tensor([0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    baseline = torch.zeros(batch_size)
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.use_dynamic_sampling = True
+    master_config.grpo.num_prompts_per_step = 1
+    master_config.grpo.num_generations_per_prompt = 4  # train_prompts_size = 4
+    master_config.grpo.dynamic_sampling_max_gen_batches = 5
+
+    result_batch, is_batch_complete, _, _ = dynamic_sampling(
+        repeated_batch,
+        std,
+        baseline,
+        dynamic_sampling_num_gen_batches=1,
+        master_config=master_config,
+        timer=Timer(),
+    )
+
+    # 5 kept >= 4 needed, so the first round already completes the batch;
+    # the extra kept sample (reward 60) is discarded by the final slice.
+    assert is_batch_complete is True
+    assert result_batch.size == 4
+    expected = torch.tensor([20.0, 30.0, 40.0, 50.0])
+    torch.testing.assert_close(result_batch["filtered_reward"], expected)
+    torch.testing.assert_close(result_batch["total_reward"], expected)
+    torch.testing.assert_close(
+        result_batch["total_reward"], result_batch["filtered_reward"]
+    )
+
+
+def test_dapo_dynamic_sampling_cache_preserves_reward_alignment(
+    mock_grpo_components,
+):
+    """Across cached rounds, total_reward must stay aligned with the
+    accumulated kept-and-sliced batch, not diverge in row count or order
+    from the rest of the batch.
+
+    `total_reward` used to be reset, on every round, to that round's full
+    unfiltered reward tensor. Once `BatchedDataDict.from_batches` concatenates
+    across rounds, that tensor's row count no longer matches every other key
+    in the same dict (which only accumulates the *kept* rows), so the final
+    slice reads the wrong reward for a sample under dynamic sampling's own
+    row-alignment guarantee.
+    """
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.use_dynamic_sampling = True
+    master_config.grpo.num_prompts_per_step = 1
+    master_config.grpo.num_generations_per_prompt = 6  # train_prompts_size = 6
+    master_config.grpo.dynamic_sampling_max_gen_batches = 5
+    timer = Timer()
+
+    def make_round(rewards: list[float], std: list[float]):
+        n = len(rewards)
+        message_logs = [
+            [
+                {"role": "user", "content": f"prompt_{i}"},
+                {"role": "assistant", "content": f"response_{i}"},
+            ]
+            for i in range(n)
+        ]
+        batch = create_mock_batch(n, ["math"] * n, message_logs)
+        batch["total_reward"] = torch.tensor(rewards)
+        return batch, torch.tensor(std), torch.zeros(n)
+
+    # Round 1: sample index 2 (reward 30) is dropped; 3 of 4 kept.
+    batch1, std1, baseline1 = make_round([10.0, 20.0, 30.0, 40.0], [1.0, 1.0, 0.0, 1.0])
+    result_batch, is_batch_complete, batch_cache, _ = dynamic_sampling(
+        batch1,
+        std1,
+        baseline1,
+        dynamic_sampling_num_gen_batches=1,
+        master_config=master_config,
+        timer=timer,
+    )
+    assert is_batch_complete is False  # 3 kept < 6 needed
+
+    # Round 2: none dropped, 4 of 4 kept. 3 + 4 = 7 >= 6, batch completes.
+    batch2, std2, baseline2 = make_round([50.0, 60.0, 70.0, 80.0], [1.0] * 4)
+    result_batch, is_batch_complete, batch_cache, _ = dynamic_sampling(
+        batch2,
+        std2,
+        baseline2,
+        dynamic_sampling_num_gen_batches=2,
+        master_config=master_config,
+        timer=timer,
+        batch_cache=batch_cache,
+    )
+
+    assert is_batch_complete is True
+    assert result_batch.size == 6
+    # First 3 kept from round 1, plus the first 3 kept from round 2; the
+    # last kept sample of round 2 (reward 80) is discarded by the slice.
+    expected = torch.tensor([10.0, 20.0, 40.0, 50.0, 60.0, 70.0])
+    torch.testing.assert_close(result_batch["filtered_reward"], expected)
+    torch.testing.assert_close(result_batch["total_reward"], expected)
+    torch.testing.assert_close(
+        result_batch["total_reward"], result_batch["filtered_reward"]
+    )
+
+
+def test_grpo_train_reward_metric_uses_preserved_unfiltered_rewards():
+    """metrics["reward"] must keep reporting the pre-filter, per-round
+    reward, distinct from metrics["filtered_reward"].
+
+    Now that `dynamic_sampling` no longer overwrites `total_reward` on the
+    returned batch with the unfiltered per-round reward (see
+    test_dapo_dynamic_sampling_discard_slice_preserves_reward_alignment),
+    `repeated_batch["total_reward"]` after the call is the *filtered*
+    reward. Sourcing metrics["reward"] from it directly would silently
+    make it identical to metrics["filtered_reward"], collapsing a
+    diagnostic that is supposed to show the raw generation quality
+    separately from the reward of the samples that end up training.
+    grpo_train builds this dict inline, so this test locks the literal in
+    place via source inspection rather than invoking the function, which
+    would require standing up rollout, policy, and generation actors.
+    """
+    source = inspect.getsource(grpo_train)
+    assert 'metrics["reward"] = this_round_unfiltered_rewards.numpy()' in source, (
+        "grpo_train no longer sources metrics['reward'] from the reward "
+        "captured before dynamic_sampling filtering; it would silently "
+        "become identical to metrics['filtered_reward']"
+    )
 
 
 def test_dapo_cache_aligns_deduplicated_media_with_text_only_batch(


### PR DESCRIPTION
## Problem

`dynamic_sampling()` filters a generation batch down to the samples with non-zero reward std (DAPO). Right after filtering, it does this:

```python
filtered_repeated_batch = repeated_batch.select_indices(keep_prompt_indices)
filtered_repeated_batch["std"] = std[keep_prompt_indices]
filtered_repeated_batch["baseline"] = baseline[keep_prompt_indices]

# Store filtered and total rewards to track them separately
filtered_rewards = filtered_repeated_batch["total_reward"]
filtered_repeated_batch["total_reward"] = total_rewards
filtered_repeated_batch["filtered_reward"] = filtered_rewards
```

`select_indices()` already produced a correctly filtered, row-aligned `total_reward` on `filtered_repeated_batch`. The code above immediately overwrites it with `total_rewards`, the full, unfiltered per-round reward tensor captured before filtering. Every other key on `filtered_repeated_batch` (`message_log`, `std`, `baseline`, and the just-renamed `filtered_reward`) reflects only the kept samples. `total_reward` and the rest of the batch only happen to agree when a round keeps every generated sample; in every other case they diverge, silently:

- **Single round, over-generation.** When more samples survive filtering than `train_prompts_size` needs, the code does `filtered_repeated_batch.slice(0, train_prompts_size)`. `BatchedDataDict.slice()` slices each key independently against its own tensor, so this takes the first `train_prompts_size` rows of `total_reward`'s full, unfiltered array (which still contains the dropped, zero-std samples) instead of the first `train_prompts_size` **kept** rows the rest of the batch reflects. `total_reward` ends up pairing the wrong reward with each kept sample; it can even include a reward that belongs to a sample DAPO decided to drop.
- **Multiple rounds.** When the buffer needs several generation batches to fill, the partial batches are merged via `BatchedDataDict.from_batches([batch_cache, filtered_repeated_batch])`. `from_batches` concatenates each key independently too: `total_reward` accumulates using each round's full per-round length while every other key accumulates using the kept-only length, so `total_reward`'s row count actively diverges from the rest of the batch mid-accumulation, before the final slice forces it back to a coincidentally-matching row count with the wrong values inside it.

Neither case raises an error. `BatchedDataDict`'s `select_indices`/`slice`/`from_batches` all operate per-key, so a wrong-sized or wrong-order tensor is silently sliced or concatenated down to a row count that matches everyone else's by the time the batch is returned; only the *values* are wrong. Two things downstream read this corrupted `total_reward`: `metrics["reward"]` (the DAPO health metric) and the per-step training-data JSONL (`log_data["rewards"]`), both under `if master_config.grpo.use_dynamic_sampling`.

## Independent corroboration

`grpo_sync.py`'s own reimplementation of this same algorithm for the data-plane (TQ) path, `_apply_dynamic_sampling`, already avoids this exact mistake:

```python
survivors_carry["filtered_reward"] = survivors_carry["total_reward"]
```

A rename, not an overwrite, so `total_reward` stays the correctly filtered value there. It also tracks the unfiltered per-round reward for logging as a plain Python list (`pending_unfiltered_rewards`) kept entirely outside the `BatchedDataDict`, rather than smuggling it into the same dict under a mismatched row count. This PR aligns the legacy `dynamic_sampling()` path with that same, already-correct pattern.

## Fix

In `dynamic_sampling()`: stop overwriting `total_reward`. Rename it to `filtered_reward` instead (`filtered_repeated_batch["filtered_reward"] = filtered_repeated_batch["total_reward"]`), so both keys hold the same, correctly filtered and row-aligned value going forward. `total_rewards`, the now-unused local variable holding the full per-round reward, is removed from the function.

At the one caller (`grpo_train`'s sync loop): the pre-filter, per-round reward is still needed for `metrics["reward"]`, which is a deliberately distinct diagnostic from `metrics["filtered_reward"]` (raw generation quality vs. reward of the samples that end up training). Since `repeated_batch["total_reward"]` no longer carries that value after the call, capture it under its own name (`this_round_unfiltered_rewards`) right where it is first read, before `dynamic_sampling()` reassigns `repeated_batch`, and use that name for `metrics["reward"]` instead.

`log_data["rewards"]` (the per-step training-data JSONL, under the same `use_dynamic_sampling` guard) keeps reading `repeated_batch["total_reward"]`, unchanged. It is logged row-for-row against `content`/`token_ids`, which reflect the filtered-and-sliced batch, so it needs the *filtered* reward, unlike `metrics["reward"]`. Since this now makes `log_data["rewards"]` identical to `log_data["filtered_rewards"]` where they previously (incorrectly) differed, review flagged it as a suspicious-looking regression; it is documented at the call site and locked with a source-inspection test instead, because using `this_round_unfiltered_rewards` here would raise inside `log_batched_dict_as_jsonl` whenever its length (one generation batch) differs from the accumulated-and-sliced `content`'s length, which is the common case under multi-round dynamic sampling.

## Evidence

Three tests, isolating each divergent case and the caller-side fix:

1. `test_dapo_dynamic_sampling_discard_slice_preserves_reward_alignment`: a single round generates 6 samples, one dropped (zero std), 4 needed. Asserts the returned `total_reward` equals `filtered_reward` and both equal the first 4 of the 5 kept rewards, in order.
2. `test_dapo_dynamic_sampling_cache_preserves_reward_alignment`: two rounds are needed to fill a 6-sample buffer, round one drops one of its four samples. Asserts the final `total_reward` equals `filtered_reward` and both equal the correct 6 accumulated-and-sliced kept rewards.
3. `test_grpo_train_reward_metric_uses_preserved_unfiltered_rewards`: locks `grpo_train`'s `metrics["reward"]` assignment to the preserved pre-filter variable via source inspection (`grpo_train` builds this inline rather than through an extracted, directly callable helper, so invoking the real function would require standing up rollout, policy, and generation actors).

On the current `main`, all three fail:

```
FAILED tests/unit/algorithms/test_grpo.py::test_dapo_dynamic_sampling_discard_slice_preserves_reward_alignment
FAILED tests/unit/algorithms/test_grpo.py::test_dapo_dynamic_sampling_cache_preserves_reward_alignment
FAILED tests/unit/algorithms/test_grpo.py::test_grpo_train_reward_metric_uses_preserved_unfiltered_rewards

AssertionError: Tensor-likes are not close!
Mismatched elements: 4 / 6 (66.7%)
Greatest absolute difference: 10.0 at index (2,) (up to 1e-05 allowed)
...
AssertionError: grpo_train no longer sources metrics['reward'] from the reward captured before dynamic_sampling filtering; it would silently become identical to metrics['filtered_reward']

3 failed
```

With the fix applied, all three pass:

```
3 passed
```

The full `test_grpo.py` suite (141 pre-existing tests plus the 3 above, 144 total) passes on the fix branch, so the change does not regress any other GRPO path, including the other dynamic-sampling tests already covering the non-discarding case:

```
144 passed
```

## Scope

This only touches `dynamic_sampling()`'s handling of `total_reward`/`filtered_reward` and the one place in `grpo_train` that reads the pre-filter reward for logging. Everything else about how dynamic sampling selects, caches, and slices prompt groups is unchanged.
