### PR TITLE
feat: Pass tokenizer_kwargs to AutoTokenizer.from_pretrained

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -127,6 +127,7 @@ policy:
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
     chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+    tokenizer_kwargs: null # extra kwargs forwarded to tokenizer loading, e.g., {fix_mistral_regex: false}
     use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens-b10 wheel. NRL_USE_FASTOKENS overrides at runtime.
   hf_config_overrides: {} 
   train_global_batch_size: 512

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -300,6 +300,10 @@ def get_tokenizer(
                     - "default": Uses the tokenizer's default template
                     - A custom jinja2 template string
                     If not specified, the tokenizer's default template will be used.
+                - tokenizer_kwargs: Extra keyword arguments forwarded to tokenizer
+                  loading, e.g. {"fix_mistral_regex": False}. When
+                  get_processor=True, these are passed through
+                  AutoProcessor.from_pretrained().
         get_processor: Whether to return a processor (via AutoProcessor) instead of a tokenizer.
 
     Returns:
@@ -359,17 +363,21 @@ def get_tokenizer(
     maybe_patch_fastokens(bool(tokenizer_config.get("use_fastokens")))
 
     processor = None
+    tokenizer_kwargs = dict(tokenizer_config.get("tokenizer_kwargs") or {})
 
     if get_processor:
         processor = AutoProcessor.from_pretrained(
-            tokenizer_config["name"], trust_remote_code=True, use_fast=True
+            tokenizer_config["name"],
+            trust_remote_code=True,
+            use_fast=tokenizer_kwargs.pop("use_fast", True),
+            **tokenizer_kwargs,
         )
         tokenizer = processor.tokenizer
     else:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_config["name"],
             trust_remote_code=True,
-            **(tokenizer_config.get("tokenizer_kwargs") or {}),
+            **tokenizer_kwargs,
         )
 
     if tokenizer.pad_token is None:

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -367,7 +367,9 @@ def get_tokenizer(
         tokenizer = processor.tokenizer
     else:
         tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_config["name"], trust_remote_code=True
+            tokenizer_config["name"],
+            trust_remote_code=True,
+            **(tokenizer_config.get("tokenizer_kwargs") or {}),
         )
 
     if tokenizer.pad_token is None:

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -190,7 +190,9 @@ def get_tokenizer(
         tokenizer = processor.tokenizer
     else:
         tokenizer = NeMoAutoTokenizer.from_pretrained(
-            tokenizer_config["name"], trust_remote_code=True
+            tokenizer_config["name"],
+            trust_remote_code=True,
+            **(tokenizer_config.get("tokenizer_kwargs") or {}),
         )
 
     if tokenizer.pad_token is None:

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -176,23 +176,31 @@ def get_tokenizer(
                     - A custom jinja2 template string
                     If not specified, the tokenizer's default template will be used.
                 - chat_template_kwargs: Arguments passed to tokenizer.apply_chat_template()
+                - tokenizer_kwargs: Extra keyword arguments forwarded to
+                  NeMoAutoTokenizer.from_pretrained(), e.g.
+                  {"fix_mistral_regex": False}. When get_processor=True, these
+                  are passed through AutoProcessor.from_pretrained().
         get_processor: Whether to return a processor (via AutoProcessor) instead of a tokenizer.
 
     Returns:
         The configured tokenizer or processor instance.
     """
     processor = None
+    tokenizer_kwargs = dict(tokenizer_config.get("tokenizer_kwargs") or {})
 
     if get_processor:
         processor = AutoProcessor.from_pretrained(
-            tokenizer_config["name"], trust_remote_code=True, use_fast=True
+            tokenizer_config["name"],
+            trust_remote_code=True,
+            use_fast=tokenizer_kwargs.pop("use_fast", True),
+            **tokenizer_kwargs,
         )
         tokenizer = processor.tokenizer
     else:
         tokenizer = NeMoAutoTokenizer.from_pretrained(
             tokenizer_config["name"],
             trust_remote_code=True,
-            **(tokenizer_config.get("tokenizer_kwargs") or {}),
+            **tokenizer_kwargs,
         )
 
     if tokenizer.pad_token is None:

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -509,6 +509,8 @@ class TokenizerConfig(TypedDict):
     chat_template: NotRequired[str | None]
     # Arguments to pass to tokenizer.apply_chat_template(...). This can be used to pass kwargs like enable_thinking=true
     chat_template_kwargs: NotRequired[dict[str, Any] | None]
+    # Arguments forwarded to AutoTokenizer.from_pretrained(...) via get_tokenizer.
+    tokenizer_kwargs: NotRequired[dict[str, Any] | None]
     # Multimodal configs
     audio: NotRequired[dict[str, Any]]
     video: NotRequired[dict[str, Any]]

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -509,7 +509,7 @@ class TokenizerConfig(TypedDict):
     chat_template: NotRequired[str | None]
     # Arguments to pass to tokenizer.apply_chat_template(...). This can be used to pass kwargs like enable_thinking=true
     chat_template_kwargs: NotRequired[dict[str, Any] | None]
-    # Arguments forwarded to AutoTokenizer.from_pretrained(...) via get_tokenizer.
+    # Arguments forwarded to tokenizer loading via get_tokenizer.
     tokenizer_kwargs: NotRequired[dict[str, Any] | None]
     # Multimodal configs
     audio: NotRequired[dict[str, Any]]

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -14,6 +14,7 @@
 
 import math
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -150,12 +151,37 @@ def test_get_tokenizer_forwards_tokenizer_kwargs():
     """Test get_tokenizer unpacks tokenizer_kwargs into from_pretrained."""
     config = {
         "name": "meta-llama/Llama-3.2-1B-Instruct",
-        "tokenizer_kwargs": {"use_fast": False},
+        "tokenizer_kwargs": {"model_max_length": 123},
     }
-    tokenizer = get_tokenizer(config)
-    # use_fast=False produces the slow Python tokenizer; is_fast is True
-    # only for the HuggingFace fast (Rust-backed) variant.
-    assert not tokenizer.is_fast
+    with patch("nemo_rl.algorithms.utils.AutoTokenizer") as mock_auto_tokenizer:
+        get_tokenizer(config)
+
+    mock_auto_tokenizer.from_pretrained.assert_called_once_with(
+        "meta-llama/Llama-3.2-1B-Instruct",
+        trust_remote_code=True,
+        model_max_length=123,
+    )
+
+
+def test_get_processor_forwards_tokenizer_kwargs():
+    """Test get_tokenizer forwards tokenizer_kwargs through AutoProcessor."""
+    config = {
+        "name": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "tokenizer_kwargs": {"model_max_length": 123, "use_fast": False},
+    }
+    with patch("nemo_rl.algorithms.utils.AutoProcessor") as mock_auto_processor:
+        get_tokenizer(config, get_processor=True)
+
+    mock_auto_processor.from_pretrained.assert_called_once_with(
+        "Qwen/Qwen2.5-VL-3B-Instruct",
+        trust_remote_code=True,
+        use_fast=False,
+        model_max_length=123,
+    )
+    assert config["tokenizer_kwargs"] == {
+        "model_max_length": 123,
+        "use_fast": False,
+    }
 
 
 def test_maybe_pad_last_batch():

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -146,6 +146,18 @@ def test_get_tokenizer_custom_jinja_template(conversation_messages):
     assert formatted == expected
 
 
+def test_get_tokenizer_forwards_tokenizer_kwargs():
+    """Test get_tokenizer unpacks tokenizer_kwargs into from_pretrained."""
+    config = {
+        "name": "meta-llama/Llama-3.2-1B-Instruct",
+        "tokenizer_kwargs": {"use_fast": False},
+    }
+    tokenizer = get_tokenizer(config)
+    # use_fast=False produces the slow Python tokenizer; is_fast is True
+    # only for the HuggingFace fast (Rust-backed) variant.
+    assert not tokenizer.is_fast
+
+
 def test_maybe_pad_last_batch():
     """Test maybe_pad_last_batch function for various scenarios"""
     # Test case 1: No padding needed

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -1836,6 +1836,19 @@ class TestGetTokenizer:
         assert result is mock_tokenizer
 
     @patch("nemo_rl.models.automodel.setup.NeMoAutoTokenizer")
+    def test_forwards_tokenizer_kwargs(self, mock_nemo_auto_tokenizer):
+        """Test tokenizer_kwargs are forwarded to NeMoAutoTokenizer."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.pad_token = "<pad>"
+        mock_nemo_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        get_tokenizer({"name": "gpt2", "tokenizer_kwargs": {"model_max_length": 123}})
+
+        mock_nemo_auto_tokenizer.from_pretrained.assert_called_once_with(
+            "gpt2", trust_remote_code=True, model_max_length=123
+        )
+
+    @patch("nemo_rl.models.automodel.setup.NeMoAutoTokenizer")
     def test_sets_pad_token_from_eos(self, mock_nemo_auto_tokenizer):
         """Test that pad_token is set to eos_token when None."""
         mock_tokenizer = MagicMock()
@@ -2014,6 +2027,30 @@ class TestGetTokenizer:
         assert mock_processor.eos_token_id == 1
         assert mock_processor.bos_token_id == 2
         assert mock_processor.name_or_path == "test-model"
+
+    @patch("nemo_rl.models.automodel.setup.AutoProcessor")
+    def test_get_processor_forwards_tokenizer_kwargs(self, mock_auto_processor):
+        """Test tokenizer_kwargs are forwarded through AutoProcessor."""
+        mock_processor = MagicMock()
+        mock_processor.tokenizer.pad_token = "<pad>"
+        mock_auto_processor.from_pretrained.return_value = mock_processor
+        config = {
+            "name": "test-vlm",
+            "tokenizer_kwargs": {"model_max_length": 123, "use_fast": False},
+        }
+
+        get_tokenizer(config, get_processor=True)
+
+        mock_auto_processor.from_pretrained.assert_called_once_with(
+            "test-vlm",
+            trust_remote_code=True,
+            use_fast=False,
+            model_max_length=123,
+        )
+        assert config["tokenizer_kwargs"] == {
+            "model_max_length": 123,
+            "use_fast": False,
+        }
 
     @patch("nemo_rl.models.automodel.setup.AutoProcessor")
     def test_get_processor_sets_pad_from_eos(self, mock_auto_processor):

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -133,6 +133,7 @@ policy:
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
     chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+    tokenizer_kwargs: null # extra kwargs forwarded to tokenizer loading, e.g., {fix_mistral_regex: false}
     use_fastokens: false # opt-in Rust-backed BPE tokenizer (~10x faster encode); requires the fastokens-b10 wheel. NRL_USE_FASTOKENS overrides at runtime.
   hf_config_overrides: {}
   train_global_batch_size: 512


### PR DESCRIPTION
Adds `tokenizer_kwargs` to `TokenizerConfig`

`get_tokenizer()` currently constructs tokenizers with only the model name and `trust_remote_code=True`:

```python
tokenizer = AutoTokenizer.from_pretrained(
    tokenizer_config["name"], trust_remote_code=True
)
```

There is no config route for passing additional `from_pretrained` kwargs — for example `fix_mistral_regex=False` for tokenizer artifacts that already carry a corrected Mistral regex pretokenizer. A caller that needs this must monkeypatch `AutoTokenizer.from_pretrained` in every process, including inside isolated Ray workers where tokenizers are constructed after the actor has started.

This PR adds `tokenizer_kwargs` to `TokenizerConfig` and threads it through both `get_tokenizer()` implementations. When `tokenizer_kwargs` is absent or `None`, behaviour is unchanged: `.get("tokenizer_kwargs") or {}` produces an empty unpacking.