### PR TITLE
fix(venvs): quote the repo root in PY_EXECUTABLES so a path with a space works

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -14,6 +14,7 @@
 import logging
 import os
 import random
+import shlex
 import socket
 import sys
 import time
@@ -65,22 +66,22 @@ class PY_EXECUTABLES:
     SYSTEM = sys.executable
 
     # Use NeMo-RL direct dependencies.
-    BASE = f"uv run --locked --directory {git_root}"
+    BASE = f"uv run --locked --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and vllm.
-    VLLM = f"uv run --locked --extra vllm --directory {git_root}"
+    VLLM = f"uv run --locked --extra vllm --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and fsdp.
-    FSDP = f"uv run --locked --extra fsdp --directory {git_root}"
+    FSDP = f"uv run --locked --extra fsdp --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and nemo-automodel.
-    AUTOMODEL = f"uv run --locked --extra automodel --directory {git_root}"
+    AUTOMODEL = f"uv run --locked --extra automodel --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and Megatron.
-    MCORE = f"uv run --locked --extra mcore --directory {git_root}"
+    MCORE = f"uv run --locked --extra mcore --directory {shlex.quote(git_root)}"
 
     # Use NeMo-Gym dependencies
-    NEMO_GYM = f"uv run --locked --extra nemo_gym --directory {git_root}"
+    NEMO_GYM = f"uv run --locked --extra nemo_gym --directory {shlex.quote(git_root)}"
 
     # Default env for the vLLM generation workers (see
     # ray_actor_environment_registry.py). It carries nemo_gym so the worker can
@@ -88,23 +89,29 @@ class PY_EXECUTABLES:
     # worker's env at runtime: worker venvs are cached by actor class name, so
     # a venv prebuilt with plain `--extra vllm` would be reused as-is and the
     # nemo_gym import would fail.
-    VLLM_GYM = f"uv run --locked --extra vllm --extra nemo_gym --directory {git_root}"
+    VLLM_GYM = (
+        f"uv run --locked --extra vllm --extra nemo_gym "
+        f"--directory {shlex.quote(git_root)}"
+    )
 
     # Use NeMo-RL direct dependencies and SGLang.
-    SGLANG = f"uv run --locked --extra sglang --directory {git_root}"
+    SGLANG = f"uv run --locked --extra sglang --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and TRT-LLM.
-    TRTLLM = f"uv run --locked --extra trtllm --directory {git_root}"
+    TRTLLM = f"uv run --locked --extra trtllm --directory {shlex.quote(git_root)}"
 
     # Use NeMo-RL direct dependencies and ModelOpt.
     MODELOPT_VLLM = (
-        f"uv run --locked --extra modelopt --extra vllm --directory {git_root}"
+        f"uv run --locked --extra modelopt --extra vllm "
+        f"--directory {shlex.quote(git_root)}"
     )
     MODELOPT_AUTOMODEL = (
-        f"uv run --locked --extra modelopt --extra automodel --directory {git_root}"
+        f"uv run --locked --extra modelopt --extra automodel "
+        f"--directory {shlex.quote(git_root)}"
     )
     MODELOPT_MCORE = (
-        f"uv run --locked --extra modelopt --extra mcore --directory {git_root}"
+        f"uv run --locked --extra modelopt --extra mcore "
+        f"--directory {shlex.quote(git_root)}"
     )
 
     @classmethod
@@ -129,7 +136,7 @@ def uv_py_executable(extras: Sequence[str]) -> str:
     if os.environ.get("NEMO_RL_PY_EXECUTABLES_SYSTEM", "0") == "1":
         return PY_EXECUTABLES.SYSTEM
     extra_flags = "".join(f"--extra {extra} " for extra in extras)
-    return f"uv run --locked {extra_flags}--directory {git_root}"
+    return f"uv run --locked {extra_flags}--directory {shlex.quote(git_root)}"
 
 
 # Default port ranges — kept below the OS ephemeral range.  On some DGX/GB200

--- a/tests/unit/distributed/test_py_executable_quoting.py
+++ b/tests/unit/distributed/test_py_executable_quoting.py
@@ -21,7 +21,11 @@ argument boundary and ``uv run --directory`` receives only the first half.
 shapes on WSL and macOS, so this is ordinary rather than exotic.
 """
 
+import contextlib
+import importlib
+import os
 import shlex
+from unittest.mock import patch
 
 import pytest
 
@@ -91,3 +95,68 @@ def test_raw_interpolation_truncates_where_quoting_does_not(root):
 
     quoted = f"uv run --locked --extra vllm --directory {shlex.quote(root)}"
     assert _directory_arg(quoted) == root
+
+
+# ============================================================================
+# The tests above are vacuous on a space-free checkout, which is every CI
+# runner: `shlex.quote` is the identity on a path that needs no quoting, so
+# both assertions hold with or without it. These rebuild the constants against
+# a repo root that does contain a space, which is what actually fails on a
+# revert.
+# ============================================================================
+
+_SPACEY_SUFFIX = " with space"
+
+# The three modelopt constants are built the same way but live in their own
+# module, and nothing in this file reached them before.
+_MODELOPT_EXECUTABLES = [
+    "MODELOPT_VLLM_EXECUTABLE",
+    "MODELOPT_AUTOMODEL_EXECUTABLE",
+    "MODELOPT_MCORE_EXECUTABLE",
+]
+
+
+@contextlib.contextmanager
+def _repo_root_with_a_space():
+    """Re-import the executable modules as if the checkout path had a space.
+
+    ``git_root`` is computed at module scope from ``os.path.abspath``, and the
+    executable strings are f-strings evaluated at the same time, so the only
+    way to see the un-quoted behaviour is to re-execute both with a different
+    root. Both modules are reloaded again on the way out.
+    """
+    import nemo_rl.distributed.virtual_cluster as vc
+    import nemo_rl.modelopt.registry as registry
+
+    real_abspath = os.path.abspath
+    try:
+        with patch("os.path.abspath", lambda p: real_abspath(p) + _SPACEY_SUFFIX):
+            importlib.reload(vc)
+            importlib.reload(registry)
+            yield vc, registry
+    finally:
+        importlib.reload(vc)
+        importlib.reload(registry)
+
+
+@pytest.mark.parametrize("attr", _UV_EXECUTABLES)
+def test_a_repo_root_with_a_space_survives_uv_argument_parsing(attr):
+    with _repo_root_with_a_space() as (vc, _):
+        assert _SPACEY_SUFFIX in vc.git_root, "the fixture did not take effect"
+        assert _directory_arg(getattr(vc.PY_EXECUTABLES, attr)) == vc.git_root
+
+
+@pytest.mark.parametrize("name", _MODELOPT_EXECUTABLES)
+def test_the_modelopt_executables_quote_the_repo_root_too(name):
+    """Three of the eleven interpolation sites live in ``nemo_rl/modelopt``.
+    Reverting that file alone left the rest of this suite green."""
+    with _repo_root_with_a_space() as (_, registry):
+        assert _directory_arg(getattr(registry, name)) == registry.git_root
+
+
+def test_the_fixture_itself_would_catch_an_unquoted_root():
+    """Guards the guard: if reloading ever stopped changing the root, every
+    assertion above would go quiet again rather than fail."""
+    with _repo_root_with_a_space() as (vc, _):
+        unquoted = f"uv run --locked --directory {vc.git_root}"
+        assert _directory_arg(unquoted) != vc.git_root

--- a/tests/unit/distributed/test_py_executable_quoting.py
+++ b/tests/unit/distributed/test_py_executable_quoting.py
@@ -107,56 +107,44 @@ def test_raw_interpolation_truncates_where_quoting_does_not(root):
 
 _SPACEY_SUFFIX = " with space"
 
-# The three modelopt constants are built the same way but live in their own
-# module, and nothing in this file reached them before.
-_MODELOPT_EXECUTABLES = [
-    "MODELOPT_VLLM_EXECUTABLE",
-    "MODELOPT_AUTOMODEL_EXECUTABLE",
-    "MODELOPT_MCORE_EXECUTABLE",
-]
-
 
 @contextlib.contextmanager
 def _repo_root_with_a_space():
-    """Re-import the executable modules as if the checkout path had a space.
+    """Re-import the executable module as if the checkout path had a space.
 
     ``git_root`` is computed at module scope from ``os.path.abspath``, and the
     executable strings are f-strings evaluated at the same time, so the only
-    way to see the un-quoted behaviour is to re-execute both with a different
-    root. Both modules are reloaded again on the way out.
+    way to see the unquoted behaviour is to re-execute it with a different
+    root. The module is reloaded again on the way out.
     """
     import nemo_rl.distributed.virtual_cluster as vc
-    import nemo_rl.modelopt.registry as registry
 
     real_abspath = os.path.abspath
     try:
         with patch("os.path.abspath", lambda p: real_abspath(p) + _SPACEY_SUFFIX):
             importlib.reload(vc)
-            importlib.reload(registry)
-            yield vc, registry
+            yield vc
     finally:
         importlib.reload(vc)
-        importlib.reload(registry)
 
 
 @pytest.mark.parametrize("attr", _UV_EXECUTABLES)
 def test_a_repo_root_with_a_space_survives_uv_argument_parsing(attr):
-    with _repo_root_with_a_space() as (vc, _):
+    with _repo_root_with_a_space() as vc:
         assert _SPACEY_SUFFIX in vc.git_root, "the fixture did not take effect"
         assert _directory_arg(getattr(vc.PY_EXECUTABLES, attr)) == vc.git_root
 
 
-@pytest.mark.parametrize("name", _MODELOPT_EXECUTABLES)
-def test_the_modelopt_executables_quote_the_repo_root_too(name):
-    """Three of the eleven interpolation sites live in ``nemo_rl/modelopt``.
-    Reverting that file alone left the rest of this suite green."""
-    with _repo_root_with_a_space() as (_, registry):
-        assert _directory_arg(getattr(registry, name)) == registry.git_root
+def test_dynamic_environment_survives_a_repo_root_with_a_space():
+    with _repo_root_with_a_space() as vc:
+        command = vc.uv_py_executable(("vllm", "nemo_gym"))
+
+        assert _directory_arg(command) == vc.git_root
 
 
 def test_the_fixture_itself_would_catch_an_unquoted_root():
     """Guards the guard: if reloading ever stopped changing the root, every
     assertion above would go quiet again rather than fail."""
-    with _repo_root_with_a_space() as (vc, _):
+    with _repo_root_with_a_space() as vc:
         unquoted = f"uv run --locked --directory {vc.git_root}"
         assert _directory_arg(unquoted) != vc.git_root

--- a/tests/unit/distributed/test_py_executable_quoting.py
+++ b/tests/unit/distributed/test_py_executable_quoting.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PY_EXECUTABLES must survive a repo path containing a space.
+
+``create_local_venv`` re-parses these command strings with ``shlex.split``
+(`nemo_rl/utils/venvs.py`), so a space in the interpolated repo root becomes an
+argument boundary and ``uv run --directory`` receives only the first half.
+``/mnt/c/Users/First Last/...`` and ``/Users/First Last/...`` are the default
+shapes on WSL and macOS, so this is ordinary rather than exotic.
+"""
+
+import shlex
+
+import pytest
+
+from nemo_rl.distributed.virtual_cluster import (
+    PY_EXECUTABLES,
+    git_root,
+    uv_py_executable,
+)
+
+_UV_EXECUTABLES = [
+    "BASE",
+    "VLLM",
+    "FSDP",
+    "AUTOMODEL",
+    "MCORE",
+    "NEMO_GYM",
+    "VLLM_GYM",
+    "SGLANG",
+    "TRTLLM",
+    "MODELOPT_VLLM",
+    "MODELOPT_AUTOMODEL",
+    "MODELOPT_MCORE",
+]
+
+
+def _directory_arg(command: str) -> str:
+    """The value `uv run` actually receives for --directory."""
+    parts = shlex.split(command)
+    return parts[parts.index("--directory") + 1]
+
+
+@pytest.mark.parametrize("attr", _UV_EXECUTABLES)
+def test_directory_survives_the_shlex_split_in_venvs(attr):
+    """Vacuous on a space-free checkout, and the whole point on one with a space."""
+    assert _directory_arg(getattr(PY_EXECUTABLES, attr)) == git_root
+
+
+@pytest.mark.parametrize("attr", _UV_EXECUTABLES)
+def test_the_repo_root_is_quoted_rather_than_interpolated_raw(attr):
+    """Holds regardless of where the checkout happens to live.
+
+    ``shlex.quote`` is a no-op on a path that needs no quoting, so asserting the
+    quoted form is present is what makes this independent of the CI path.
+    """
+    assert shlex.quote(git_root) in getattr(PY_EXECUTABLES, attr)
+
+
+def test_dynamic_actor_environment_quotes_the_repo_root():
+    command = uv_py_executable(("vllm", "nemo_gym"))
+
+    assert _directory_arg(command) == git_root
+    assert shlex.quote(git_root) in command
+
+
+@pytest.mark.parametrize(
+    "root",
+    [
+        "/mnt/c/Users/First Last/src/NeMo-RL",  # WSL, Windows account with a space
+        "/Users/First Last/src/NeMo-RL",  # macOS default home
+        "/home/u/NeMo RL",  # space in the repo directory itself
+    ],
+)
+def test_raw_interpolation_truncates_where_quoting_does_not(root):
+    """Pins the mechanism, so a future rewrite cannot silently reintroduce it."""
+    raw = f"uv run --locked --extra vllm --directory {root}"
+    assert _directory_arg(raw) != root, "expected the unquoted form to truncate"
+
+    quoted = f"uv run --locked --extra vllm --directory {shlex.quote(root)}"
+    assert _directory_arg(quoted) == root


### PR DESCRIPTION
## What does this PR do?

Fixes #3800 by quoting the repository root in every environment command that is later parsed with `shlex.split`.

Without quoting, a checkout such as `/mnt/c/Users/First Last/RL` turns one `--directory` value into two arguments and worker startup fails. Current main moved the ModelOpt environments into `PY_EXECUTABLES` and added dynamic `uv_py_executable(...)`; this refresh covers those current entry points as well as the static commands.

The regression tests reload the module against a synthetic root containing a space, so they remain meaningful on CI's normal space-free checkout. They also pin the final `shlex.split` argument seen by `uv`.

## Validation

Current head `3f296b8e80c1acb9a71ab2c9797a1b3533a99a21`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- `tests/unit/distributed/test_py_executable_quoting.py` + `tests/unit/distributed/test_actor_environments.py`: **106 passed**
- covers every current static command and the dynamic environment builder under a space-containing root
- Ruff check, Ruff format check, and `git diff --check`: passed

No GPU is required.
