### PR TITLE
fix(logging): aggregate rollout histograms before logging

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -89,6 +89,7 @@ from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_a
 from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
 )
+from nemo_rl.experience.metric_utils import is_histogram_metric
 from nemo_rl.experience.rollouts import (
     EffortLevelsConfig,
     attach_initial_nemo_gym_image_payloads,
@@ -3686,20 +3687,6 @@ def grpo_train(
                     logger,
                 )
 
-            # Plot ISL/OSL/ISL+OSL histograms to wandb
-            if (
-                master_config.policy["generation"]
-                .get("vllm_cfg", {})
-                .get("async_engine", False)
-            ):
-                for metric_name in metrics.keys():
-                    if metric_name.startswith("histogram/"):
-                        logger.log_histogram(
-                            metrics[metric_name],
-                            total_steps + 1,
-                            f"generation_metrics/{metric_name}",
-                        )
-
             print("\n📊 Training Results:")
 
             print(f"  • Loss: {metrics['loss']:.4f}")
@@ -4036,6 +4023,7 @@ def aggregate_rollout_metrics(
     """Aggregate rollout metrics from multiple trajectory groups.
 
     Different metric types are aggregated according to their semantics:
+    - Histogram observations: flattened into one step-level distribution
     - Metrics ending with "/min" or starting with "min_" (excluding "_rate" suffix): take the minimum
     - Metrics ending with "/max" or starting with "max_" (excluding "_rate" suffix): take the maximum
     - "total_turns": summed
@@ -4050,7 +4038,9 @@ def aggregate_rollout_metrics(
     """
     aggregated = {}
     for k, v in per_group_metrics.items():
-        if not isinstance(v[0], (int, float)):
+        if is_histogram_metric(k):
+            aggregated[k] = [observation for group in v for observation in group]
+        elif not isinstance(v[0], (int, float)):
             aggregated[k] = v
         elif k.endswith("/min") or (k.startswith("min_") and not k.endswith("_rate")):
             aggregated[k] = min(v)
@@ -5305,20 +5295,6 @@ def async_grpo_train(
                     ],
                     logger,
                 )
-
-            # Plot ISL/OSL/ISL+OSL histograms to wandb
-            if (
-                master_config.policy["generation"]
-                .get("vllm_cfg", {})
-                .get("async_engine", False)
-            ):
-                for metric_name in metrics.keys():
-                    if metric_name.startswith("histogram/"):
-                        logger.log_histogram(
-                            metrics[metric_name],
-                            step + 1,
-                            f"generation_metrics/{metric_name}",
-                        )
 
             print("\n📊 Training Results:")
             print(f"  • Loss: {metrics['loss']:.4f}")

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -1283,19 +1283,6 @@ def grpo_train_sync(
                     logger,
                 )
 
-            if (
-                master_config.policy["generation"]
-                .get("vllm_cfg", {})
-                .get("async_engine", False)
-            ):
-                for metric_name in metrics.keys():
-                    if metric_name.startswith("histogram/"):
-                        logger.log_histogram(
-                            metrics[metric_name],
-                            total_steps + 1,
-                            f"generation_metrics/{metric_name}",
-                        )
-
             print("\n📊 Training Results:")
             print(f"  • Loss: {metrics['loss']:.4f}")
             if "draft_loss" in metrics:

--- a/nemo_rl/experience/metric_utils.py
+++ b/nemo_rl/experience/metric_utils.py
@@ -18,7 +18,10 @@ import math
 import statistics
 from collections.abc import Sequence
 
-from wandb import Histogram
+
+def is_histogram_metric(name: str) -> bool:
+    """Return whether a metric key represents raw histogram observations."""
+    return name.startswith("histogram/") or name.endswith("/histogram")
 
 
 def calculate_single_metric(
@@ -32,7 +35,9 @@ def calculate_single_metric(
         key_name: Prefix for the returned metric keys (e.g. "total_reward").
 
     Returns:
-        Dict mapping "{key_name}/{stat}" to its value for stat in mean, max, min, median, stddev (nan for a single value), and histogram (a wandb.Histogram).
+        Dict mapping "{key_name}/{stat}" to its value for stat in mean, max, min,
+        median, stddev (nan for a single value), and histogram. Histogram values
+        remain backend-agnostic raw observations until the logger serializes them.
     """
     return {
         f"{key_name}/mean": sum(values) / batch_size,
@@ -40,7 +45,7 @@ def calculate_single_metric(
         f"{key_name}/min": min(values),
         f"{key_name}/median": statistics.median(values),
         f"{key_name}/stddev": statistics.stdev(values) if len(values) > 1 else math.nan,
-        f"{key_name}/histogram": Histogram(values),
+        f"{key_name}/histogram": list(values),
     }
 
 

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -42,6 +42,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from nemo_rl.data.interfaces import LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.metric_utils import is_histogram_metric
 
 # Flag to track if rich logging has been configured
 _rich_logging_configured = False
@@ -191,7 +192,8 @@ class TensorboardLogger(LoggerInterface):
 
     def log_histogram(self, histogram: list[Any], step: int, name: str) -> None:
         """Log histogram metrics to Tensorboard."""
-        return
+        if len(histogram) > 0:
+            self.writer.add_histogram(name, np.asarray(histogram), step)
 
     def log_hyperparams(self, params: Mapping[str, Any]) -> None:
         """Log hyperparameters to Tensorboard.
@@ -1048,9 +1050,38 @@ class Logger(LoggerInterface):
             prefix: Optional prefix for metric names
             step_metric: Optional name of a field in metrics to use as step instead
                          of the provided step value (currently only needed for wandb)
+
+        Note:
+            Metrics identified by :func:`is_histogram_metric` are routed through
+            :meth:`log_histogram` instead of each backend's ``log_metrics``.
+            ``histogram/*`` keys retain their established
+            ``generation_metrics/`` namespace; other distributions inherit
+            ``prefix``.
         """
+        histogram_metrics = {
+            name: value for name, value in metrics.items() if is_histogram_metric(name)
+        }
+        metrics_to_log = {
+            name: value
+            for name, value in metrics.items()
+            if name not in histogram_metrics
+        }
+
+        for name, values in histogram_metrics.items():
+            # Preserve the established namespace for per-turn generation
+            # histograms; other distributions inherit the caller's prefix.
+            if name.startswith("histogram/"):
+                histogram_name = (
+                    f"generation_metrics/{name}"
+                    if prefix in ("", None, "train")
+                    else f"generation_metrics/{prefix}/{name}"
+                )
+            else:
+                histogram_name = f"{prefix}/{name}" if prefix else name
+            self.log_histogram(values, step, histogram_name)
+
         for logger in self.loggers:
-            logger.log_metrics(metrics, step, prefix, step_metric, step_finished)
+            logger.log_metrics(metrics_to_log, step, prefix, step_metric, step_finished)
 
     def log_hyperparams(self, params: Mapping[str, Any]) -> None:
         """Log hyperparameters to all enabled backends.

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -5199,6 +5199,45 @@ class TestAggregateRolloutMetrics:
         result = aggregate_rollout_metrics(metrics)
         assert result["some_list_metric"] == [["a", "b"], ["c", "d"]]
 
+    def test_histogram_observations_are_flattened(self):
+        """Per-group observations become one bounded step-level distribution."""
+        metrics = {
+            "agent/reward/histogram": [[0.1], [0.2, 0.3]],
+            "histogram/gen_tokens_length": [[10, 20], [30]],
+        }
+        result = aggregate_rollout_metrics(metrics)
+
+        assert result["agent/reward/histogram"] == [0.1, 0.2, 0.3]
+        assert result["histogram/gen_tokens_length"] == [10, 20, 30]
+
+    def test_histogram_substring_keys_still_average(self):
+        """Histogram-like substrings do not identify distributions."""
+        metrics = {
+            "histogram_bucket_count": [8, 10],
+            "reward/histogram_p95": [1.0, 3.0],
+        }
+        result = aggregate_rollout_metrics(metrics)
+
+        assert result["histogram_bucket_count"] == 9
+        assert result["reward/histogram_p95"] == 2.0
+
+    def test_per_agent_histogram_stats_are_not_flattened(self):
+        """An env field named histogram still produces scalar stat keys."""
+        metrics = {
+            "myagent/histogram/mean": [1.0, 2.0],
+            "myagent/histogram/histogram": [[1.0], [2.0]],
+        }
+        result = aggregate_rollout_metrics(metrics)
+
+        assert result["myagent/histogram/mean"] == 1.5
+        assert result["myagent/histogram/histogram"] == [1.0, 2.0]
+
+    def test_empty_histogram_groups_flatten_to_empty(self):
+        """Groups without observations produce an empty, loggable histogram."""
+        result = aggregate_rollout_metrics({"histogram/gen_tokens_length": [[], []]})
+
+        assert result["histogram/gen_tokens_length"] == []
+
     def test_mixed_metrics(self):
         """Full integration test with a realistic mix of metric types."""
         metrics = {

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -463,6 +463,7 @@ class TestCalculateSingleMetric:
         assert result["test/max"] == 42.0
         assert result["test/min"] == 42.0
         assert result["test/median"] == 42.0
+        assert result["test/histogram"] == [42.0]
         assert math.isnan(result["test/stddev"]), (
             "stddev should be nan for single value"
         )
@@ -476,6 +477,7 @@ class TestCalculateSingleMetric:
         assert result["test/min"] == 1.0
         assert result["test/median"] == 2.0
         assert abs(result["test/stddev"] - 1.0) < 1e-9  # stdev of [1,2,3] is 1.0
+        assert result["test/histogram"] == [1.0, 2.0, 3.0]
 
     def test_two_identical_values_returns_zero_stddev(self):
         """Test that stddev is 0 when all values are identical."""

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -21,6 +21,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
+import numpy as np
 import pytest
 import torch
 
@@ -179,6 +180,31 @@ class TestTensorboardLogger:
         assert mock_writer.add_scalar.call_count == 2
         mock_writer.add_scalar.assert_any_call("loss", 0.5, 10)
         mock_writer.add_scalar.assert_any_call("accuracy", 0.8, 10)
+
+    @patch("nemo_rl.utils.logger.SummaryWriter")
+    def test_log_histogram(self, mock_summary_writer, temp_dir):
+        """TensorBoard receives numeric histogram observations."""
+        logger = TensorboardLogger({"log_dir": temp_dir}, log_dir=temp_dir)
+
+        logger.log_histogram([1.0, 2.0, 3.0], step=10, name="train/reward")
+
+        name, values, step = (
+            mock_summary_writer.return_value.add_histogram.call_args.args
+        )
+        assert name == "train/reward"
+        np.testing.assert_array_equal(values, np.asarray([1.0, 2.0, 3.0]))
+        assert step == 10
+
+    @patch("nemo_rl.utils.logger.SummaryWriter")
+    def test_log_histogram_skips_empty_observations(
+        self, mock_summary_writer, temp_dir
+    ):
+        """An empty distribution does not fail TensorBoard logging."""
+        logger = TensorboardLogger({"log_dir": temp_dir}, log_dir=temp_dir)
+
+        logger.log_histogram([], step=10, name="train/reward")
+
+        mock_summary_writer.return_value.add_histogram.assert_not_called()
 
     def test_json_dump_requires_tag_prefix_across_plugin_categories(self, tmp_path):
         """The functional gate accepts image tags and rejects missing prefixes."""
@@ -1708,6 +1734,108 @@ class TestLogger:
         )
         mock_tb_instance.log_metrics.assert_called_once_with(
             metrics, step, "", None, False
+        )
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_log_metrics_routes_histograms(
+        self,
+        mock_tb_logger,
+        mock_wandb_logger,
+        temp_dir,
+    ):
+        """Histogram metrics use the typed logger API."""
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": True,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "tensorboard": {"log_dir": "test_logs"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        metrics = {
+            "loss": 0.5,
+            "agent/reward/histogram": [0.1, 0.2],
+            "histogram/gen_tokens_length": [10, 20],
+        }
+        logger.log_metrics(metrics, step=10)
+
+        mock_wandb_logger.return_value.log_metrics.assert_called_once_with(
+            {"loss": 0.5}, 10, "", None, False
+        )
+        mock_tb_logger.return_value.log_metrics.assert_called_once_with(
+            {"loss": 0.5}, 10, "", None, False
+        )
+        for backend in (
+            mock_wandb_logger.return_value,
+            mock_tb_logger.return_value,
+        ):
+            assert backend.log_histogram.call_args_list == [
+                call([0.1, 0.2], 10, "agent/reward/histogram"),
+                call(
+                    [10, 20],
+                    10,
+                    "generation_metrics/histogram/gen_tokens_length",
+                ),
+            ]
+        assert metrics == {
+            "loss": 0.5,
+            "agent/reward/histogram": [0.1, 0.2],
+            "histogram/gen_tokens_length": [10, 20],
+        }
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    def test_log_metrics_prefixes_non_generation_histograms(
+        self, mock_wandb_logger, temp_dir
+    ):
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        logger.log_metrics(
+            {"agent/reward/histogram": [0.1, 0.2]}, step=10, prefix="train"
+        )
+
+        mock_wandb_logger.return_value.log_histogram.assert_called_once_with(
+            [0.1, 0.2], 10, "train/agent/reward/histogram"
+        )
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    def test_log_metrics_preserves_non_train_generation_histogram_prefix(
+        self, mock_wandb_logger, temp_dir
+    ):
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        logger.log_metrics(
+            {"histogram/gen_tokens_length": [10, 20]},
+            step=10,
+            prefix="validation",
+        )
+
+        mock_wandb_logger.return_value.log_histogram.assert_called_once_with(
+            [10, 20],
+            10,
+            "generation_metrics/validation/histogram/gen_tokens_length",
         )
 
     @patch("nemo_rl.utils.logger.WandbLogger")


### PR DESCRIPTION
## Summary

- Backport 10dc8e0285ff3ee4a9fe32253bbdb4ab5e96e3a7 (#3748) from main.
- Aggregate raw histogram observations at the step level and route them through each logging backend, including TensorBoard.
- Remove duplicate per-training-loop histogram logging.

## Validation

- pytest: 273 passed across tests/unit/algorithms/test_grpo.py, tests/unit/experience/test_rollouts.py, and tests/unit/utils/test_logger.py
- Ruff: all checks passed for the seven affected files
- git diff --check: passed