### PR TITLE
feat(workers): Add config-driven worker extension FQNs

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -393,7 +393,7 @@ policy:
     # null = topology default (IPC colocated, NCCL non-colocated).
     # Non-colocated vLLM also supports vllm_s3_sparse, vllm_zmq_sparse, and nixl.
     refit_transport: null
-    # vLLM backend only - sglang/trtllm/dynamo inherit this exemplar and ignore it.
+    # vLLM backend only - sglang/megatron/trtllm/dynamo require this to remain null.
     # Selects the NeMo-RL Ray actor class, NOT vLLM's own `worker_extension_cls`.
     worker_extension_cls_fqn: null # optional registered vLLM generation-worker subclass; mutually exclusive with quant_cfg
     # Keep real-quant export tensors on CPU by default. Set false only for

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -393,7 +393,9 @@ policy:
     # null = topology default (IPC colocated, NCCL non-colocated).
     # Non-colocated vLLM also supports vllm_s3_sparse, vllm_zmq_sparse, and nixl.
     refit_transport: null
-    worker_extension_cls_fqn: null # optional registered vLLM-worker subclass; mutually exclusive with quant_cfg
+    # vLLM backend only - sglang/trtllm/dynamo inherit this exemplar and ignore it.
+    # Selects the NeMo-RL Ray actor class, NOT vLLM's own `worker_extension_cls`.
+    worker_extension_cls_fqn: null # optional registered vLLM generation-worker subclass; mutually exclusive with quant_cfg
     # Keep real-quant export tensors on CPU by default. Set false only for
     # colocated CUDA-IPC refit to avoid a GPU -> CPU -> GPU round trip.
     real_quant_export_cpu_offload: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -146,6 +146,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  worker_extension_cls_fqn: null # optional registered policy-worker subclass; mutually exclusive with quant_cfg
 
   dtensor_cfg:
     _v2: true
@@ -392,6 +393,7 @@ policy:
     # null = topology default (IPC colocated, NCCL non-colocated).
     # Non-colocated vLLM also supports vllm_s3_sparse, vllm_zmq_sparse, and nixl.
     refit_transport: null
+    worker_extension_cls_fqn: null # optional registered vLLM-worker subclass; mutually exclusive with quant_cfg
     # Keep real-quant export tensors on CPU by default. Set false only for
     # colocated CUDA-IPC refit to avoid a GPU -> CPU -> GPU round trip.
     real_quant_export_cpu_offload: true

--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -64,6 +64,16 @@ def configure_generation_config(
     trains_mtp: bool = False,
 ) -> GenerationConfig:
     """Apply specific configurations to generation config."""
+    if (
+        config["backend"] != "vllm"
+        and config.get("worker_extension_cls_fqn") is not None
+    ):
+        raise ValueError(
+            "generation.worker_extension_cls_fqn is only supported by the vLLM backend, "
+            f"got backend={config['backend']!r}. Use policy.worker_extension_cls_fqn to "
+            "extend the training worker instead."
+        )
+
     # tokenizer setting
     if "_pad_token_id" in config:
         warnings.warn(

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -194,6 +194,12 @@ class VllmConfig(GenerationConfig):
     real_quant_export_cpu_offload: NotRequired[bool]
     real_quant_ignore: NotRequired[list[str]]
 
+    # FQN of a worker extension class to use instead of the resolved default
+    # generation worker. Must be a subclass of the resolved worker and cannot
+    # be combined with quant_cfg. Its runtime environment must already be in
+    # ACTOR_ENVIRONMENT_REGISTRY.
+    worker_extension_cls_fqn: NotRequired[str | None]
+
 
 def resolve_vllm_video_config(config: VllmConfig) -> VllmVideoConfig | None:
     """Validate and return the optional vLLM video sampling contract."""

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -30,6 +30,7 @@ from ray.util.placement_group import PlacementGroup
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict, SlicedDataDict
 from nemo_rl.distributed.named_sharding import NamedSharding
+from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import NVLINK_DOMAIN_UNKNOWN, RayVirtualCluster
 from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
 from nemo_rl.models.generation.fleet_health import (
@@ -223,6 +224,10 @@ class VllmGeneration(GenerationInterface):
                 "a custom generation worker cannot be combined with ModelOpt "
                 "quantization"
             )
+        if extension_fqn is not None:
+            # Validate registration before allocating workers or placement groups.
+            get_actor_python_env(extension_fqn)
+
         self.sharding_annotations = NamedSharding(
             layout=np.arange(cluster.world_size()).reshape(
                 self.dp_size, self.pp_size, self.tp_size

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -216,6 +216,13 @@ class VllmGeneration(GenerationInterface):
 
         assert_reload_refit_config_supported(self.cfg)
 
+        extension_fqn = self.cfg.get("worker_extension_cls_fqn")
+        if extension_fqn is not None and self.cfg.get("quant_cfg") is not None:
+            raise ValueError(
+                "worker_extension_cls_fqn and quant_cfg are mutually exclusive: "
+                "a custom generation worker cannot be combined with ModelOpt "
+                "quantization"
+            )
         self.sharding_annotations = NamedSharding(
             layout=np.arange(cluster.world_size()).reshape(
                 self.dp_size, self.pp_size, self.tp_size
@@ -247,6 +254,8 @@ class VllmGeneration(GenerationInterface):
                 "nemo_rl.models.generation.vllm.vllm_worker.VllmGenerationWorker"
             )
         worker_cls = resolve_generation_worker_cls(worker_cls, self.cfg)
+        if extension_fqn is not None:
+            worker_cls = extension_fqn
         if self.cfg["vllm_cfg"]["async_engine"]:
             worker_builder = RayWorkerBuilder(
                 worker_cls, config, defer_model_load=defer_model_load

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -634,3 +634,9 @@ class PolicyConfig(TypedDict):
     disable_modelopt_layer_spec: NotRequired[bool]
 
     is_vlm: NotRequired[bool]
+
+    # FQN of a worker extension class to use instead of the resolved default
+    # policy worker. Must be a subclass of the resolved worker and cannot be
+    # combined with quant_cfg. Its runtime environment must already be in
+    # ACTOR_ENVIRONMENT_REGISTRY.
+    worker_extension_cls_fqn: NotRequired[str | None]

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -105,6 +105,27 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         reserved_http_server_port: Optional[int] = None,
     ):
         self.debug_payload_metrics = False
+        configured_extension_fqn = config.get("worker_extension_cls_fqn")
+        if (
+            configured_extension_fqn is not None
+            and worker_extension_cls_fqn is not None
+            and configured_extension_fqn != worker_extension_cls_fqn
+        ):
+            raise ValueError(
+                "worker_extension_cls_fqn was set to different values in the "
+                "policy config and Policy constructor"
+            )
+        extension_fqn = (
+            configured_extension_fqn
+            if configured_extension_fqn is not None
+            else worker_extension_cls_fqn
+        )
+        if extension_fqn is not None and config.get("quant_cfg") is not None:
+            raise ValueError(
+                "worker_extension_cls_fqn and quant_cfg are mutually exclusive: "
+                "a custom policy worker cannot be combined with ModelOpt quantization"
+            )
+
         if weights_path:
             weights_path = os.path.abspath(weights_path)
         if optimizer_path:
@@ -237,11 +258,11 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             env_vars = config["dtensor_cfg"].get("env_vars", {})
 
         # If a worker extension class is provided, use it instead of the default worker builder class
-        if worker_extension_cls_fqn is not None:
+        if extension_fqn is not None:
             print(
-                f"Using worker extension class: {worker_extension_cls_fqn}, please make sure it is a subclass of {worker_builder_cls_fqn}."
+                f"Using worker extension class: {extension_fqn}, please make sure it is a subclass of {worker_builder_cls_fqn}."
             )
-            worker_builder_cls_fqn = worker_extension_cls_fqn
+            worker_builder_cls_fqn = extension_fqn
 
         # Validate world_size compatibility with parallelism configuration
         model_parallel_size = pp_size * cp_size * tp_size

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -120,7 +120,12 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             if configured_extension_fqn is not None
             else worker_extension_cls_fqn
         )
-        if extension_fqn is not None and config.get("quant_cfg") is not None:
+        # Only the config-supplied FQN is mutually exclusive with quant_cfg: a config
+        # author cannot know which worker quant_cfg resolves to, so silently replacing
+        # it would be a footgun. The constructor argument is exempt because callers
+        # passing it already see the resolved class name and are expected to subclass
+        # it, which has always been supported alongside quantization.
+        if configured_extension_fqn is not None and config.get("quant_cfg") is not None:
             raise ValueError(
                 "worker_extension_cls_fqn and quant_cfg are mutually exclusive: "
                 "a custom policy worker cannot be combined with ModelOpt quantization"

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -31,6 +31,7 @@ from nemo_rl.distributed.batched_data_dict import (
     SlicedDataDict,
 )
 from nemo_rl.distributed.named_sharding import NamedSharding
+from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
 from nemo_rl.models.generation.interfaces import (
@@ -130,6 +131,9 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "worker_extension_cls_fqn and quant_cfg are mutually exclusive: "
                 "a custom policy worker cannot be combined with ModelOpt quantization"
             )
+        if extension_fqn is not None:
+            # Validate registration before allocating workers or placement groups.
+            get_actor_python_env(extension_fqn)
 
         if weights_path:
             weights_path = os.path.abspath(weights_path)

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -160,6 +160,10 @@ def test_vllm_generation_selects_worker_extension(
     cluster.num_gpus_per_node = 1
 
     with (
+        patch.dict(
+            "nemo_rl.distributed.ray_actor_environment_registry.ACTOR_ENVIRONMENT_REGISTRY",
+            {extension_fqn: "python"},
+        ),
         patch(
             "nemo_rl.models.generation.vllm.vllm_generation.RayWorkerBuilder"
         ) as worker_builder,
@@ -195,6 +199,65 @@ def test_vllm_generation_rejects_worker_extension_with_quantization() -> None:
         VllmGeneration(cluster, config, defer_model_load=True)
 
     cluster._init_placement_groups.assert_not_called()
+
+
+@pytest.mark.parametrize("async_engine", [False, True])
+def test_vllm_generation_rejects_unregistered_worker_extension(
+    async_engine: bool,
+) -> None:
+    config = deepcopy(basic_vllm_test_config)
+    config["vllm_cfg"]["async_engine"] = async_engine
+    config["worker_extension_cls_fqn"] = "tests.extensions.UnregisteredGenerationWorker"
+    cluster = MagicMock()
+    cluster.world_size.return_value = 1
+    cluster.num_gpus_per_node = 1
+
+    with (
+        patch(
+            "nemo_rl.models.generation.vllm.vllm_generation.RayWorkerGroup"
+        ) as worker_group,
+        pytest.raises(ValueError, match="No actor environment registered"),
+    ):
+        VllmGeneration(cluster, config, defer_model_load=True)
+
+    worker_group.assert_not_called()
+    cluster._init_placement_groups.assert_not_called()
+
+
+@pytest.mark.parametrize("backend", ["sglang", "megatron", "trtllm", "dynamo"])
+def test_generation_config_rejects_worker_extension_for_other_backends(
+    backend: str,
+) -> None:
+    config = deepcopy(basic_vllm_test_config)
+    config["backend"] = backend
+    config["worker_extension_cls_fqn"] = "tests.extensions.CustomGenerationWorker"
+
+    with pytest.raises(ValueError, match="only supported by the vLLM backend"):
+        configure_generation_config(config, MagicMock())
+
+
+@pytest.mark.parametrize("backend", ["vllm", "sglang", "megatron", "trtllm", "dynamo"])
+@pytest.mark.parametrize("include_null", [False, True])
+def test_generation_config_allows_no_worker_extension(
+    backend: str,
+    include_null: bool,
+) -> None:
+    config = deepcopy(basic_vllm_test_config)
+    config["backend"] = backend
+    if include_null:
+        config["worker_extension_cls_fqn"] = None
+
+    configure_generation_config(config, MagicMock())
+
+
+def test_generation_config_allows_vllm_worker_extension() -> None:
+    config = deepcopy(basic_vllm_test_config)
+    extension_fqn = "tests.extensions.CustomGenerationWorker"
+    config["worker_extension_cls_fqn"] = extension_fqn
+
+    configured = configure_generation_config(config, MagicMock())
+
+    assert configured["worker_extension_cls_fqn"] == extension_fqn
 
 
 def test_context_capped_max_new_tokens():

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -21,7 +21,7 @@ import threading
 import types
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import ray
@@ -144,6 +144,57 @@ basic_dtensor_test_config: PolicyConfig = {
     "make_sequence_length_divisible_by": 1,
     "generation": deepcopy(basic_vllm_test_config),
 }
+
+
+@pytest.mark.parametrize("async_engine", [False, True])
+def test_vllm_generation_selects_worker_extension(
+    async_engine,
+) -> None:
+    config = deepcopy(basic_vllm_test_config)
+    config["vllm_cfg"]["async_engine"] = async_engine
+    extension_fqn = "tests.extensions.CustomGenerationWorker"
+    config["worker_extension_cls_fqn"] = extension_fqn
+
+    cluster = MagicMock()
+    cluster.world_size.return_value = 1
+    cluster.num_gpus_per_node = 1
+
+    with (
+        patch(
+            "nemo_rl.models.generation.vllm.vllm_generation.RayWorkerBuilder"
+        ) as worker_builder,
+        patch(
+            "nemo_rl.models.generation.vllm.vllm_generation.RayWorkerGroup"
+        ) as worker_group,
+        patch(
+            "nemo_rl.models.generation.vllm.vllm_generation.ray.get",
+            return_value=[None],
+        ),
+    ):
+        worker_group.return_value.dp_size = 1
+        VllmGeneration(cluster, config, defer_model_load=True)
+
+    assert worker_builder.call_args.args[:2] == (extension_fqn, config)
+    assert worker_builder.call_args.kwargs == (
+        {"defer_model_load": True} if async_engine else {}
+    )
+
+
+def test_vllm_generation_rejects_worker_extension_with_quantization() -> None:
+    config = deepcopy(basic_vllm_test_config)
+    config["worker_extension_cls_fqn"] = "tests.extensions.CustomGenerationWorker"
+    config["quant_cfg"] = "NVFP4"
+    cluster = MagicMock()
+    cluster.world_size.return_value = 1
+    cluster.num_gpus_per_node = 1
+
+    with pytest.raises(
+        ValueError,
+        match="worker_extension_cls_fqn and quant_cfg are mutually exclusive",
+    ):
+        VllmGeneration(cluster, config, defer_model_load=True)
+
+    cluster._init_placement_groups.assert_not_called()
 
 
 def test_context_capped_max_new_tokens():

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -207,15 +207,20 @@ def test_policy_flops_tracker_uses_hf_config_overrides() -> None:
     ],
 )
 def test_policy_selects_worker_extension_from_config_or_constructor(
-    tiny_llama_model_path,
-    configured_extension_fqn,
-    explicit_extension_fqn,
+    configured_extension_fqn: str | None,
+    explicit_extension_fqn: str | None,
 ) -> None:
-    config = create_dtensor_config(tiny_llama_model_path, tp=1)
+    config = create_dtensor_config("test-model", tp=1)
     if configured_extension_fqn is not None:
         config["worker_extension_cls_fqn"] = configured_extension_fqn
     with (
+        patch("nemo_rl.models.policy.lm_policy.get_hf_config"),
+        patch("nemo_rl.models.policy.lm_policy.FLOPTracker"),
         patch("nemo_rl.models.policy.lm_policy.RayQueue"),
+        patch.dict(
+            "nemo_rl.distributed.ray_actor_environment_registry.ACTOR_ENVIRONMENT_REGISTRY",
+            {"tests.extensions.CustomPolicyWorker": "python"},
+        ),
         patch("nemo_rl.models.policy.lm_policy.RayWorkerBuilder") as worker_builder,
         patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup"),
     ):
@@ -236,9 +241,13 @@ def test_policy_constructor_worker_extension_allows_quantization() -> None:
 
     with (
         patch("nemo_rl.models.policy.lm_policy.RayQueue"),
+        patch.dict(
+            "nemo_rl.distributed.ray_actor_environment_registry.ACTOR_ENVIRONMENT_REGISTRY",
+            {"tests.extensions.CustomPolicyWorker": "python"},
+        ),
         patch("nemo_rl.models.policy.lm_policy.RayWorkerBuilder") as worker_builder,
         patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup"),
-        patch("nemo_rl.models.policy.lm_policy.get_default_hf_config"),
+        patch("nemo_rl.models.policy.lm_policy.get_hf_config"),
         patch("nemo_rl.models.policy.lm_policy.FLOPTracker"),
     ):
         Policy(
@@ -284,6 +293,29 @@ def test_policy_rejects_invalid_worker_extension_config(
             tokenizer=create_mock_tokenizer(),
             worker_extension_cls_fqn=explicit_extension_fqn,
         )
+
+
+@pytest.mark.parametrize("from_config", [False, True])
+def test_policy_rejects_unregistered_worker_extension(from_config: bool) -> None:
+    extension_fqn = "tests.extensions.UnregisteredPolicyWorker"
+    config = create_dtensor_config("test-model", tp=1)
+    if from_config:
+        config["worker_extension_cls_fqn"] = extension_fqn
+    cluster = create_mock_cluster(world_size=1)
+
+    with (
+        patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup") as worker_group,
+        pytest.raises(ValueError, match="No actor environment registered"),
+    ):
+        Policy(
+            cluster=cluster,
+            config=config,
+            tokenizer=create_mock_tokenizer(),
+            worker_extension_cls_fqn=None if from_config else extension_fqn,
+        )
+
+    worker_group.assert_not_called()
+    cluster._init_placement_groups.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -200,6 +200,10 @@ def test_policy_flops_tracker_uses_hf_config_overrides() -> None:
     [
         ("tests.extensions.CustomPolicyWorker", None),
         (None, "tests.extensions.CustomPolicyWorker"),
+        (
+            "tests.extensions.CustomPolicyWorker",
+            "tests.extensions.CustomPolicyWorker",
+        ),
     ],
 )
 def test_policy_selects_worker_extension_from_config_or_constructor(
@@ -220,6 +224,28 @@ def test_policy_selects_worker_extension_from_config_or_constructor(
             config=config,
             tokenizer=create_mock_tokenizer(),
             worker_extension_cls_fqn=explicit_extension_fqn,
+        )
+
+    assert worker_builder.call_args.args[0] == "tests.extensions.CustomPolicyWorker"
+
+
+def test_policy_constructor_worker_extension_allows_quantization() -> None:
+    """The constructor argument may extend the quant-resolved worker; the config field may not."""
+    config = create_dtensor_config("test-model", tp=1)
+    config["quant_cfg"] = "NVFP4"
+
+    with (
+        patch("nemo_rl.models.policy.lm_policy.RayQueue"),
+        patch("nemo_rl.models.policy.lm_policy.RayWorkerBuilder") as worker_builder,
+        patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup"),
+        patch("nemo_rl.models.policy.lm_policy.get_default_hf_config"),
+        patch("nemo_rl.models.policy.lm_policy.FLOPTracker"),
+    ):
+        Policy(
+            cluster=create_mock_cluster(world_size=1),
+            config=config,
+            tokenizer=create_mock_tokenizer(),
+            worker_extension_cls_fqn="tests.extensions.CustomPolicyWorker",
         )
 
     assert worker_builder.call_args.args[0] == "tests.extensions.CustomPolicyWorker"

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -196,6 +196,71 @@ def test_policy_flops_tracker_uses_hf_config_overrides() -> None:
 
 
 @pytest.mark.parametrize(
+    ("configured_extension_fqn", "explicit_extension_fqn"),
+    [
+        ("tests.extensions.CustomPolicyWorker", None),
+        (None, "tests.extensions.CustomPolicyWorker"),
+    ],
+)
+def test_policy_selects_worker_extension_from_config_or_constructor(
+    tiny_llama_model_path,
+    configured_extension_fqn,
+    explicit_extension_fqn,
+) -> None:
+    config = create_dtensor_config(tiny_llama_model_path, tp=1)
+    if configured_extension_fqn is not None:
+        config["worker_extension_cls_fqn"] = configured_extension_fqn
+    with (
+        patch("nemo_rl.models.policy.lm_policy.RayQueue"),
+        patch("nemo_rl.models.policy.lm_policy.RayWorkerBuilder") as worker_builder,
+        patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup"),
+    ):
+        Policy(
+            cluster=create_mock_cluster(world_size=1),
+            config=config,
+            tokenizer=create_mock_tokenizer(),
+            worker_extension_cls_fqn=explicit_extension_fqn,
+        )
+
+    assert worker_builder.call_args.args[0] == "tests.extensions.CustomPolicyWorker"
+
+
+@pytest.mark.parametrize(
+    ("config_updates", "explicit_extension_fqn", "error_match"),
+    [
+        (
+            {
+                "worker_extension_cls_fqn": "tests.extensions.CustomPolicyWorker",
+                "quant_cfg": "NVFP4",
+            },
+            None,
+            "worker_extension_cls_fqn and quant_cfg are mutually exclusive",
+        ),
+        (
+            {"worker_extension_cls_fqn": "tests.extensions.ConfigWorker"},
+            "tests.extensions.ArgumentWorker",
+            "different values",
+        ),
+    ],
+)
+def test_policy_rejects_invalid_worker_extension_config(
+    config_updates,
+    explicit_extension_fqn,
+    error_match,
+) -> None:
+    config = create_dtensor_config("test-model", tp=1)
+    config.update(config_updates)
+
+    with pytest.raises(ValueError, match=error_match):
+        Policy(
+            cluster=create_mock_cluster(world_size=1),
+            config=config,
+            tokenizer=create_mock_tokenizer(),
+            worker_extension_cls_fqn=explicit_extension_fqn,
+        )
+
+
+@pytest.mark.parametrize(
     "world_size,tp,cp,should_pass,expected_error_type,description",
     [
         # Valid cases - DTensor backend (PP is always 1 for DTensor)

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -149,6 +149,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  worker_extension_cls_fqn: null
 
   dtensor_cfg:
     _v2: true
@@ -374,6 +375,7 @@ policy:
     # null = topology default (IPC colocated, NCCL non-colocated).
     # Non-colocated vLLM also supports vllm_s3_sparse, vllm_zmq_sparse, and nixl.
     refit_transport: null
+    worker_extension_cls_fqn: null
     # Keep real-quant export tensors on CPU by default. Set false only for
     # colocated CUDA-IPC refit to avoid a GPU -> CPU -> GPU round trip.
     real_quant_export_cpu_offload: true


### PR DESCRIPTION
This change is to make it easier to plug in custom workers and policies.

`Policy.__init__` already accepts a `worker_extension_cls_fqn`, but standard policy configs cannot set it. The vLLM generation path has no equivalent extension hook. A caller that needs custom policy and vLLM workers therefore has to wrap or replace Policy and monkeypatch the vLLM worker resolver.

This PR adds one optional `worker_extension_cls_fqn` field to `PolicyConfig` and `VllmConfig.` 

`Policy` reads the field directly from its config, so normal construction paths honor it without algorithm-specific forwarding. The existing constructor argument remains supported. 

If config and the constructor provide different FQNs, construction fails rather than choosing one silently. `VllmGeneration` applies its configured FQN after the existing worker resolver for both synchronous and asynchronous engines. 

On both paths, `worker_extension_cls_fqn` is mutually exclusive with `quant_cfg`, because both settings replace the backend’s resolved worker. Invalid combinations fail before worker or placement-group allocation. The canonical GRPO exemplar and its reference config include the two optional entries, as required for the existing TypedDict config schema.