### PR TITLE
fix(grpo): preserve params across checkpoint wake

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -5457,10 +5457,15 @@ def async_grpo_train(
                         or should_save_by_timeout
                         or early_stop_message is not None
                     ):
-                        # The save onloaded model+optimizer;
-                        # generation windows must start from the offloaded state.
-                        policy.offload_after_refit()
-                        policy_generation.prepare_for_generation()
+                        # Preserve the backend's wake and offload semantics.
+                        assert (
+                            getattr(policy_generation, "weight_synchronizer", None)
+                            is not None
+                        ), "defer_wake_for_save requires a weight synchronizer"
+                        with timer.time("post_checkpoint_refit"):
+                            refit_policy_generation(
+                                policy, policy_generation, colocated_inference
+                            )
                         ray.get(trajectory_collector.resume_after_refit.remote())
 
             # Logging

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3478,6 +3478,13 @@ def test_async_grpo_colocated_save_defers_wake_until_after_checkpoint(
     policy.offload_after_refit.side_effect = lambda *a, **k: events.append(
         "offload_after_refit"
     )
+    post_save_refits = []
+
+    def record_refit(*args: Any, **kwargs: Any) -> dict[str, float]:
+        if ("save", 2) in events:
+            events.append("backend_refit")
+            post_save_refits.append((args, kwargs))
+        return {}
 
     def record_save(step, *args, **kwargs):
         events.append(("save", step))
@@ -3491,6 +3498,10 @@ def test_async_grpo_colocated_save_defers_wake_until_after_checkpoint(
             mock_batch, mock_rollout_metrics, collector_events=events
         ),
         _patched_logprob_phase(policy),
+        patch(
+            "nemo_rl.algorithms.grpo.refit_policy_generation",
+            side_effect=record_refit,
+        ),
         patch("nemo_rl.algorithms.grpo.torch.save"),
     ):
         async_grpo_train(
@@ -3523,8 +3534,7 @@ def test_async_grpo_colocated_save_defers_wake_until_after_checkpoint(
         "offload_before_refit",
         "set_weight_version",
         ("save", 2),
-        "offload_after_refit",
-        "wake_engine",
+        "backend_refit",
         "resume_after_refit",
         # Step 3 (last step saves): same deferral, but no wake — the loop exits.
         ("finish_generation", True),
@@ -3532,6 +3542,9 @@ def test_async_grpo_colocated_save_defers_wake_until_after_checkpoint(
         "set_weight_version",
         ("save", 3),
     ]
+    assert post_save_refits == [((policy, policy_generation, True), {})]
+    policy.offload_after_refit.assert_not_called()
+    policy_generation.prepare_for_generation.assert_not_called()
 
 
 @pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])


### PR DESCRIPTION
# Summary

Route the deferred post-checkpoint wake through the configured weight synchronizer so shared parameters remain valid for CUDA graphs.

# Issue fixed
Async GRPO with colocated Megatron generation can crash on the first generation
request after a checkpoint. The checkpoint finishes successfully, but the resumed
CUDA-graph engine then reports 

`CUDA error: an illegal memory access was encountered`.

- Original run: <https://wandb.ai/adlr/nano-v3-megatron-inference/runs/otxj6kf2/overview>

## Trigger

- async colocated Megatron generation
- `transformer_impl=inference_optimized`
- local, block-scope CUDA graphs
- KV-cache offload

## Reproduction recipe

Launch the following command through `ray.sub` with 4 nodes and 4 GPUs per node:
```bash
uv run examples/run_grpo.py \
  --config examples/configs/recipes/llm/grpo-nanov3-30BA3B-4n4g-megatron_async_colocated.yaml \
  grpo.max_num_steps=2 \
  grpo.val_period=0 \
  grpo.val_at_end=false \
  policy.generation.mcore_generation_config.kv_cache_management_mode=offload \
  +policy.megatron_cfg.transformer_impl=inference_optimized \
  policy.megatron_cfg.moe_router_dtype=fp32 \
  policy.megatron_cfg.cuda_graph_impl=local \
  +policy.megatron_cfg.inference_cuda_graph_scope=block \
  checkpointing.enabled=true \
  checkpointing.save_period=1 \
  checkpointing.save_optimizer=false \
  checkpointing.metric_name=null \
  checkpointing.checkpoint_dir="$RUN_ROOT/checkpoints" \
  logger.wandb_enabled=false \
  logger.tensorboard_enabled=false \
  logger.monitor_gpus=false \
  logger.log_dir="$RUN_ROOT/training-logs"
```

Cluster launch settings used for the reproduced run:

```bash
export NRL_FORCE_REBUILD_VENVS=true
export GPUS_PER_NODE=4
export NCCL_GRAPH_MIXING_SUPPORT=1
export WANDB_MODE=disabled

sbatch --nodes=4 --gres=gpu:4 --time=01:00:00 ray.sub
```

Expected sequence:

1. Step 1 trains and schedules an async checkpoint.
2. The checkpoint is finalized synchronously.
3. `prepare_for_generation()` resumes the cached inference engine.
4. The first new generation request fails in the dynamic engine, surfacing at
   `step_end_event.synchronize()`.


## Cause and fix

The affected post-checkpoint path calls `policy.offload_after_refit()`, which can
replace the shared model's parameter storage. Cached decode CUDA graphs retain
the old device addresses, so replay after the wake dereferences stale pointers.

The fix routes the deferred wake through `refit_policy_generation()`. Its
Megatron weight synchronizer preserves parameter storage while offloading the
optimizer and gradients, matching the normal colocated refit path.

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
