### PR TITLE
perf(recipes): deduplicate Super Omni multimodal payloads

### DIFF
--- a/examples/configs/recipes/vlm/vlm_grpo-nemotron-super-omni-120ba12b-32n4g-megatron-tp2ep16cp1-async-gym.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-nemotron-super-omni-120ba12b-32n4g-megatron-tp2ep16cp1-async-gym.v1.yaml
@@ -1,4 +1,6 @@
 defaults: ./vlm_grpo-nemotron-super-omni-120ba12b-16n8g-megatron-tp8ep16cp2-async-gym.v1.yaml
+grpo:
+  deduplicate_multimodal_data: true
 policy:
   sequence_packing:
     logprob_mb_tokens: 32768


### PR DESCRIPTION
## What

Enable `grpo.deduplicate_multimodal_data` in the optimized 32n4g Nemotron Super Omni async-Gym recipe introduced by #3805.

This keeps one physical policy-media payload for the 16 logical generations of each prompt and reconstructs the logical rows at the existing NeMo-Gym/replay boundaries. The underlying deduplication and dynamic-image-shape support are already implemented and tested; this PR only enables that path for the validated recipe.

## Full-scale validation

Matched 32-node x 4-GPU, 10-step runs used the same TP2/EP16/CP1 full-recompute learner, 256 prompts x 16 generations, GBS 4096, 16K sequence limit, `max_num_seqs=64`, seed/data, container, and instrumentation. The only resolved semantic delta was this flag.

| Metric (Steps 3-10) | dedup=false, job 6503788 | dedup=true, job 6504722 | Delta |
|---|---:|---:|---:|
| Slurm elapsed | 01:22:33 | 01:16:50 | -6.9% |
| Mean step time | 376.87 s | 345.98 s | -8.2% |
| Successful replay-return time | 38.13 s | 4.66 s | -87.8% |
| NeMo-Gym actor postprocess time | 78.74 s | 8.96 s | -88.6% |
| Ray stream materialization time | 23.46 s | 2.69 s | -88.5% |
| Generated-token load | 92.22M | 91.61M | -0.7% |

Both jobs completed all 10 steps with exit 0:0, finite training/correctness metrics, and no OOM, Ray actor, refit, or NCCL failure.

The runs also show that multimodal deduplication removes the 30-50 second replay payload-return cost but does not remove the separate strict-target generation-tail wait. This PR intentionally claims only the validated payload-path improvement.

W&B: [dedup=false](https://wandb.ai/nvidia/youngeunk-super-omni-perf-study/runs/xs5dl2j5), [dedup=true](https://wandb.ai/nvidia/youngeunk-super-omni-perf-study/runs/jwrpxbk2).

## Validation

- `tools/config_cli.py minimize-check` passed.
- Fully resolved config diff contains exactly `grpo.deduplicate_multimodal_data: false -> true`.
- `git diff --check` passed.

Depends on #3805.
