### PR TITLE
fix(async-grpo): eliminate prompt skips across checkpoint save/restore

### DIFF
--- a/docs/design-docs/nemo-gym-integration.md
+++ b/docs/design-docs/nemo-gym-integration.md
@@ -234,7 +234,7 @@ This pattern maximizes throughput by keeping the CPU busy while waiting for netw
 The async GRPO collector uses the same prompt-group contract for Gym and native environments:
 
 - One batch worker owns each reserved target weight until all expected prompt groups are buffered or the batch fails.
-- Gym prompts receive a monotonic `_ng_task_index`. The counter is checkpointed, restored, and cross-checked against buffered trajectories so task identities are not reused after restart.
+- Every yielded prompt (Gym and native) receives a monotonic `_ng_task_index` equal to its position in the dataloader stream. The counter is checkpointed, restored, and cross-checked against buffered trajectories. On a legacy resume, task identities are never reused after restart; on a frontier-aligned resume, the counter is deliberately rewound to the saved base ordinal so the covered window re-yields under its original indices (rows already trained or retained are dropped before dispatch, and per-batch uniqueness is still enforced).
 - A partial Gym stream can be retried without duplicating groups that were already accepted by the replay buffer.
 - Native rollouts still execute as one batch. Their per-sample metrics are aggregated separately for each prompt group before buffering, so batch-level metrics are not duplicated across groups.
 - Gym rows are validated for range, uniqueness, completeness, and single-agent grouping. Results are restored to input order within a prompt group before post-processing.

--- a/docs/guides/async-grpo.md
+++ b/docs/guides/async-grpo.md
@@ -161,6 +161,8 @@ Async GRPO checkpoints the replay buffer alongside the rest of training state so
 
 On each checkpoint, a `replay_buffer.pt` file is written next to the other checkpoint artifacts. It contains all trajectories currently in the buffer together with their weight and target versions, and the `last_target_weight_already_generated` watermark.
 
+The dataloader state saved alongside it is **frontier-aligned**: it captures the position of the first prompt that training has not yet consumed, rather than the collector's live cursor (which has already advanced past prompts that are still generating or sitting in the buffer). Every yielded prompt carries a monotonic ordinal, and the saved replay buffer records which ordinals its groups cover.
+
 ### Restore behaviour
 
 On resume, the buffer is restored before the trajectory collector starts, then cleaned up as follows:
@@ -170,13 +172,27 @@ On resume, the buffer is restored before the trajectory collector starts, then c
 3. **Incomplete targets kept** — target steps that still lack a full batch are kept in the buffer. The collector will *gap-fill* only the missing trajectories for those targets before moving on.
 4. **Buffer truncated** — if the restored count exceeds `max_size`, the buffer is truncated, prioritising entries closest to the resume step.
 
+The dataloader then re-yields the window between the trained frontier and the old cursor. Prompts already trained or retained in the restored buffer are dropped; everything else — in-flight work lost at the save, groups evicted during cleanup — is regenerated in order, so **no prompt is skipped and none is duplicated as a result of the save/restore itself** (prompts trained above a conservatively-cut checkpoint's threshold — see the target-interleaving note below — are carried in the checkpoint and stay covered on resume).
+
+The guarantee is scoped to frontier-aligned checkpoints. A run falls back to the previous live-cursor checkpoints — which can skip prompts that were in flight at the save — under any of these conditions, each of which is logged when it occurs:
+
+- **Legacy checkpoints.** Resuming from a checkpoint written before frontier alignment disables it for the run, and because that run's checkpoints then carry no frontier metadata, for every run descended from them. A run only regains frontier alignment by starting fresh.
+- **Unstampable batches.** Prompts whose `extra_env_info` rows are not dicts cannot carry stream ordinals; the first such batch permanently disables frontier alignment for the run.
+- **Snapshot-ring eviction.** If no retained dataloader snapshot sits at or below the trained frontier, that checkpoint alone falls back to the live cursor.
+
+Independently of checkpointing, prompt groups whose generation fails a tolerated number of times (`max_generation_failures > 0`) are dropped during normal operation and are not recovered by a resume.
+
+**Target interleaving and the conservative cut.** A target refilled from later prompts — after a tolerated failure, or routinely when a resume gap-fills an incomplete restored target — interleaves targets' ordinals: training the refilled target can advance the frontier past another target's still-generating groups. Checkpoints written in that window conservatively cut below the trained frontier, at the lowest ordinal still in flight (logged when it happens), and persist the ordinals already trained at or above the cut. A resume from such a checkpoint regenerates the in-flight prompts and drops the persisted trained ones — no skip, no re-training.
+
 ### Gap-filling after restore
 
 After a restore, `last_target_weight_already_generated` is reset to `current_training_step - 1` so the collector re-evaluates every target from the resume step onward. For each target it queries `get_trajectories_needed` and spawns only the workers required to complete the batch — previously buffered trajectories are reused and the collector does not regenerate them.
 
 ### Disabling replay-buffer restore
 
-If no `replay_buffer.pt` file is found in the latest checkpoint directory, training starts with an empty buffer and waits for the collector to fill it before the first training step.
+Set `checkpointing.load_replay_buffer: false` to skip the restore: the buffer starts empty and, on a frontier-aligned checkpoint, the whole buffered window is regenerated fresh from the rewound dataloader. This trades resume compute for an unbiased step composition — a prompt group completes only when its *longest* rollout finishes, so the groups sitting in the buffer at a save boundary systematically skew toward short rollouts; regenerating the window removes that bias. Restoration remains enabled by default and for legacy configs that omit the field. The conservative cut (target interleaving, above) also accounts for buffered-but-untrained groups — the checkpoint cut never sits above an ordinal whose only record is the buffer — so discarding the buffer is safe even on a cut-lowered checkpoint: the resume regenerates those groups from the rewound stream.
+
+If no `replay_buffer.pt` file is found in the latest checkpoint directory, training likewise starts with an empty buffer and waits for the collector to fill it before the first training step.
 
 ## Usage Tips
 

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -118,6 +118,10 @@ checkpointing:
   keep_top_k: 3
   save_period: 10
   checkpoint_must_save_by: null
+  # Async GRPO: restore replay-buffer state on resume. Set false to regenerate
+  # the buffered window fresh instead of reusing completed groups (which skew
+  # toward short rollouts at a save boundary).
+  load_replay_buffer: true
   model_save_format: "safetensors"
   save_consolidated: false
   save_optimizer: true

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -30,6 +30,7 @@ from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
+    RETAINED_TASK_INDICES_KEY,
     PromptGroupRecord,
 )
 from nemo_rl.experience.payload import pack_payload, record_to_train_batch
@@ -333,6 +334,22 @@ class ReplayBufferImpl(ReplayBufferProtocol):
         with self._lock:
             return len(self.trajectories)
 
+    def get_held_task_indices(self) -> list[int]:
+        """Ordinals of every prompt group currently held in the buffer.
+
+        All held groups are untrained (sampling removes trained ones). The
+        checkpoint cut must not exceed any of these ordinals: with
+        ``checkpointing.load_replay_buffer=false`` the buffer is discarded on
+        resume, and ordinals below the cut are never re-yielded.
+        """
+        with self._lock:
+            return sorted(
+                int(trajectory[NEMO_GYM_TASK_INDEX_KEY])
+                for trajectory in self.trajectories
+                if isinstance(trajectory, dict)
+                and trajectory.get(NEMO_GYM_TASK_INDEX_KEY) is not None
+            )
+
     def clear(self) -> None:
         """Clear the buffer."""
         with self._lock:
@@ -368,8 +385,20 @@ class ReplayBufferImpl(ReplayBufferProtocol):
         num_prompts_per_step: int | None = None,
         current_training_step: int | None = None,
         max_age_steps: int | None = None,
-    ) -> dict[str, int]:
-        """Restore inside the actor and return only compact coordination metadata."""
+    ) -> dict[str, Any]:
+        """Restore inside the actor and return only compact coordination metadata.
+
+        Returns:
+            Mapping with ``num_trajectories`` (pre-filter count),
+            ``NEXT_NEMO_GYM_TASK_INDEX_KEY`` (one past the highest saved task
+            index, computed before age/step filtering; on a legacy resume this
+            keeps used indices from being re-issued, while a frontier-aligned
+            resume deliberately rewinds the counter to the saved base ordinal
+            so the covered window re-yields under its original indices), and
+            ``RETAINED_TASK_INDICES_KEY`` (the sorted task indices of the
+            groups that survived filtering — what a frontier-aligned resume
+            must not regenerate).
+        """
         state = torch.load(path, weights_only=False)
         saved_task_indices = [
             int(trajectory[NEMO_GYM_TASK_INDEX_KEY])
@@ -386,9 +415,17 @@ class ReplayBufferImpl(ReplayBufferProtocol):
         )
         del state
         gc.collect()
+        with self._lock:
+            retained_task_indices = sorted(
+                int(trajectory[NEMO_GYM_TASK_INDEX_KEY])
+                for trajectory in self.trajectories
+                if isinstance(trajectory, dict)
+                and trajectory.get(NEMO_GYM_TASK_INDEX_KEY) is not None
+            )
         return {
             "num_trajectories": num_trajectories,
             NEXT_NEMO_GYM_TASK_INDEX_KEY: next_task_index,
+            RETAINED_TASK_INDICES_KEY: retained_task_indices,
         }
 
     def load_state_dict(

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -18,7 +18,7 @@ import asyncio
 import concurrent.futures
 import threading as _threading
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import AsyncGenerator
 from typing import Any, Optional, cast
 
@@ -51,6 +51,7 @@ from nemo_rl.environments.nemo_gym import should_use_nemo_gym
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
+    PENDING_PROMPTS_KEY,
 )
 from nemo_rl.experience.rollouts import (
     RolloutGroupResult,
@@ -72,6 +73,39 @@ _NEMO_GYM_RETRY_DELAY_BASE_SECONDS = 1.0
 _REPLAY_BUFFER_MAX_BACKOFF_SECONDS = 0.5
 
 
+def _stamped_task_indices(batch: BatchedDataDict[DatumSpec]) -> list[int]:
+    """Stamped per-group ordinals of a pre-repeat slice ([] when unstamped)."""
+    rows = batch.get("extra_env_info")
+    if not isinstance(rows, list):
+        return []
+    raw_ordinals = [
+        row.get(NEMO_GYM_TASK_INDEX_KEY) if isinstance(row, dict) else None
+        for row in rows
+    ]
+    if not raw_ordinals or any(ordinal is None for ordinal in raw_ordinals):
+        return []
+    return [int(ordinal) for ordinal in cast("list[int]", raw_ordinals)]
+
+
+def _unanimous_task_index(rows: list[Any]) -> Optional[int]:
+    """Return the task index every row agrees on, or ``None``.
+
+    A prompt group is one prompt repeated ``num_generations`` times, so its
+    stamped rows all carry the same ordinal. Returns ``None`` for unstamped
+    rows (legacy runs) rather than guessing.
+    """
+    if not rows:
+        return None
+    ordinals = {
+        row.get(NEMO_GYM_TASK_INDEX_KEY) if isinstance(row, dict) else None
+        for row in rows
+    }
+    if len(ordinals) != 1:
+        return None
+    (ordinal,) = ordinals
+    return int(ordinal) if ordinal is not None else None
+
+
 @ray.remote  # pragma: no cover
 class AsyncTrajectoryCollector:
     """Collects trajectories asynchronously and adds them to replay buffer."""
@@ -89,6 +123,10 @@ class AsyncTrajectoryCollector:
         on_policy_distillation_cfg: Optional[dict[str, Any]] = None,
         next_nemo_gym_task_index: int = 0,
         processor: Any = None,
+        pending_batch: Optional[BatchedDataDict[DatumSpec]] = None,
+        ordinals_frontier_aligned: bool = True,
+        resume_frontier_ordinal: Optional[int] = None,
+        resume_covered_task_indices: Optional[list[int]] = None,
     ) -> None:
         self.policy_generation = policy_generation
         self.tokenizer = tokenizer
@@ -178,6 +216,39 @@ class AsyncTrajectoryCollector:
         # Track which target weights are currently being generated (globally)
         self._generating_targets: set[int] = set()
         self._next_nemo_gym_task_index = next_nemo_gym_task_index
+
+        # Unconsumed suffix of the last gap-fill batch, consumed before the
+        # next dataloader pull and serialized into fallback checkpoints.
+        # Written by the collection thread, read at checkpoint time from the
+        # actor thread, hence the lock.
+        self._pending_lock: _threading.Lock = _threading.Lock()
+        self._pending_batch: Optional[BatchedDataDict[DatumSpec]] = pending_batch
+
+        # Frontier-aligned checkpointing. Every yielded prompt is stamped
+        # with a monotonic ordinal equal to its position in the dataloader
+        # stream; this ring of pre-pull dataloader snapshots, keyed by that
+        # ordinal, is what checkpoints save instead of the live cursor. On a
+        # frontier restore, re-yielded rows that are already covered (below
+        # the cut, or in resume_covered_task_indices) are dropped at yield
+        # and the gap-fill path regenerates the rest.
+        self._snapshot_lock: _threading.Lock = _threading.Lock()
+        self._dataloader_snapshots: deque[tuple[int, dict]] = deque(maxlen=512)
+        # False when ordinals cannot be trusted to equal the trained-prompt
+        # position (legacy-checkpoint resume, or unstampable batches); the
+        # checkpoint then falls back to saving the live dataloader cursor.
+        self._ordinals_frontier_aligned = ordinals_frontier_aligned
+        self._resume_frontier_ordinal = resume_frontier_ordinal
+        self._covered_task_indices: set[int] = set(resume_covered_task_indices or [])
+        self._skip_horizon = max(
+            [*self._covered_task_indices, (resume_frontier_ordinal or 0) - 1]
+        )
+
+        # Group ordinals dispatched to a rollout worker and not yet buffered.
+        # Target interleaving can leave ordinals below the trained frontier
+        # in flight; the checkpoint cut must not sit above the minimum of
+        # this set (see get_checkpoint_state).
+        self._outstanding_lock: _threading.Lock = _threading.Lock()
+        self._outstanding_task_indices: set[int] = set()
 
         # Timer for efficiency metrics
         self._efficiency_timer = ThreadSafeTimer(context={"worker": "collector"})
@@ -366,18 +437,21 @@ class AsyncTrajectoryCollector:
                 self.collection_error = f"{type(error).__name__}: {error}"
 
     def _collection_loop(self):
-        """Run the collection loop in background thread."""
+        """Run the collection loop in background thread.
+
+        Prompts left over from a gap-fill slice (``_pending_batch``) are
+        consumed before the next dataloader pull, so a partially used batch is
+        never discarded. The dataloader counts as exhausted only when the
+        iterator drains with no pending prompts remaining.
+        """
         dataloader_exhausted = False
         if self.dataloader is None:
             raise RuntimeError(
                 "start_collection must set a dataloader before collection"
             )
-        dataloader = self.dataloader
+        dataloader_iter = iter(self.dataloader)
         try:
-            for batch in dataloader:
-                if not self.running:
-                    break
-
+            while self.running:
                 # Check if manually paused and wait
                 if not self._manual_pause_cleared.is_set() and self.running:
                     self._manual_pause_cleared.wait()
@@ -415,10 +489,40 @@ class AsyncTrajectoryCollector:
                 if not self.running:
                     break
 
-                self._process_batch(batch)
-            else:
-                # for-loop completed without break → dataloader iterator exhausted
-                dataloader_exhausted = True
+                # Carried-over prompts take priority over a fresh pull so the
+                # dataloader stream stays strictly ordered and lossless. They
+                # were stamped when first pulled, so only fresh batches are
+                # stamped and snapshotted here.
+                with self._pending_lock:
+                    batch = self._pending_batch
+                    self._pending_batch = None
+                if batch is None:
+                    pre_pull_state = self._capture_dataloader_state()
+                    try:
+                        batch = next(dataloader_iter)
+                    except StopIteration:
+                        dataloader_exhausted = True
+                        break
+                    first_ordinal = self._next_nemo_gym_task_index
+                    if self._stamp_task_indices(batch) and pre_pull_state is not None:
+                        with self._snapshot_lock:
+                            self._dataloader_snapshots.append(
+                                (first_ordinal, pre_pull_state)
+                            )
+                    batch = self._filter_covered_rows(batch)
+                    if batch is None:
+                        continue
+
+                leftover = self._process_batch(batch)
+                if leftover is not None:
+                    with self._pending_lock:
+                        self._pending_batch = leftover
+                    if leftover is batch:
+                        # Nothing was consumed (e.g. no target needed
+                        # generation). Yield briefly so the retry does not
+                        # busy-spin against the replay buffer.
+                        time.sleep(0.05)
+
         except Exception as e:
             print(f"❌ Error in trajectory collection: {e}")
             import traceback
@@ -437,27 +541,230 @@ class AsyncTrajectoryCollector:
             else:
                 print("🛑 Trajectory collection stopped")
 
-    def _stamp_nemo_gym_task_indices(self, batch: BatchedDataDict[DatumSpec]) -> None:
-        """Assign one stable, monotonic task index to every prompt in a batch."""
+    def _stamp_task_indices(self, batch: BatchedDataDict[DatumSpec]) -> bool:
+        """Assign one stable, monotonic task index to every prompt in a batch.
+
+        The ordinal equals the prompt's global position in the dataloader
+        stream, which is what frontier-aligned checkpointing keys on. Batches
+        whose ``extra_env_info`` rows are not dicts cannot carry a stamp; the
+        collector then permanently falls back to live-cursor checkpoints.
+
+        Returns:
+            Whether the batch was stamped.
+        """
+        rows = batch.get("extra_env_info")
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            if self._ordinals_frontier_aligned:
+                self._ordinals_frontier_aligned = False
+                print(
+                    "⚠️ Batch rows cannot carry task indices; checkpoints "
+                    "fall back to the live dataloader cursor."
+                )
+            return False
+
         stamped_rows = []
         first_task_index = self._next_nemo_gym_task_index
-        for offset, row in enumerate(batch["extra_env_info"]):
-            if not isinstance(row, dict):
-                raise TypeError(
-                    "Expected NeMo-Gym extra_env_info row to be a dict, "
-                    f"got {type(row).__name__}"
-                )
+        for offset, row in enumerate(rows):
             stamped_row = dict(row)
             stamped_row[NEMO_GYM_TASK_INDEX_KEY] = first_task_index + offset
             stamped_rows.append(stamped_row)
 
         batch["extra_env_info"] = stamped_rows
         self._next_nemo_gym_task_index += len(stamped_rows)
+        return True
 
-    def _process_batch(self, batch: BatchedDataDict[DatumSpec]) -> None:
-        """Process a single batch and generate for one target weight."""
+    def _capture_dataloader_state(self) -> Optional[dict]:
+        """Snapshot the dataloader state, or None when it has no state_dict."""
+        if self.dataloader is not None and hasattr(self.dataloader, "state_dict"):
+            return self.dataloader.state_dict()
+        return None
+
+    def _filter_covered_rows(
+        self, batch: BatchedDataDict[DatumSpec]
+    ) -> Optional[BatchedDataDict[DatumSpec]]:
+        """Drop re-yielded rows a frontier restore already accounts for.
+
+        After a frontier-aligned restore the dataloader re-yields the window
+        between the cut and the old cursor. Rows already covered (ordinal
+        below the cut, or in the covered set) are dropped; the normal
+        gap-fill path regenerates the rest.
+
+        Returns:
+            The (possibly row-filtered) batch, or ``None`` when every row was
+            already covered.
+        """
+        if self._resume_frontier_ordinal is None:
+            return batch
+
+        rows = batch.get("extra_env_info")
+        raw_ordinals = [
+            row.get(NEMO_GYM_TASK_INDEX_KEY) if isinstance(row, dict) else None
+            for row in (rows if isinstance(rows, list) else [])
+        ]
+        if not raw_ordinals or any(ordinal is None for ordinal in raw_ordinals):
+            raise ValueError(
+                "Frontier-aligned resume requires task indices on every row, "
+                "but a re-yielded batch is missing them. The checkpoint was "
+                "written by a run whose batches carried task indices, so this "
+                "indicates the dataset or task-data processor changed since "
+                "the checkpoint was written; silently continuing could "
+                "re-train retained prompts. Resume with the original data "
+                "configuration, or start a fresh run."
+            )
+        ordinals = cast(list[int], raw_ordinals)
+
+        if min(ordinals) > self._skip_horizon:
+            # The covered window has been fully re-yielded; stop filtering.
+            self._resume_frontier_ordinal = None
+            self._covered_task_indices = set()
+            return batch
+
+        frontier = self._resume_frontier_ordinal
+        keep = [
+            position
+            for position, ordinal in enumerate(ordinals)
+            if ordinal >= frontier and ordinal not in self._covered_task_indices
+        ]
+        if len(keep) == len(ordinals):
+            return batch
+        dropped = len(ordinals) - len(keep)
+        print(
+            f"🔁 Frontier restore: dropping {dropped} already-covered prompts "
+            f"(ordinals {ordinals[0]}–{ordinals[-1]}), regenerating {len(keep)}"
+        )
+        if not keep:
+            return None
+        return batch.select_indices(keep)
+
+    def get_checkpoint_dataloader_state(self, frontier_ordinal: int) -> dict[str, Any]:
+        """Return the dataloader state a checkpoint should persist.
+
+        Returns the newest ring snapshot at or below ``frontier_ordinal``, so
+        a resume re-yields everything past it. Falls back to the live cursor
+        when ordinals are not frontier-aligned or the snapshot ring no longer
+        covers the frontier.
+
+        Args:
+            frontier_ordinal: The trained-prompt count (consumed_samples).
+
+        Returns:
+            Mapping with ``dataloader_state``, ``base_ordinal`` (the ordinal
+            the saved state resumes yielding from; ``None`` on fallback), and
+            ``frontier_aligned``.
+        """
+        if self._ordinals_frontier_aligned:
+            best: Optional[tuple[int, dict]] = None
+            with self._snapshot_lock:
+                ring_bases = [base for base, _ in self._dataloader_snapshots]
+                for base_ordinal, state in self._dataloader_snapshots:
+                    if base_ordinal <= frontier_ordinal and (
+                        best is None or base_ordinal > best[0]
+                    ):
+                        best = (base_ordinal, state)
+            if best is not None:
+                return {
+                    "dataloader_state": best[1],
+                    "base_ordinal": best[0],
+                    "frontier_aligned": True,
+                }
+            print(
+                "⚠️ No dataloader snapshot at or below frontier ordinal "
+                f"{frontier_ordinal} (snapshot ring covers "
+                f"{f'[{min(ring_bases)}, {max(ring_bases)}]' if ring_bases else 'nothing'}); "
+                "this checkpoint falls back to the live cursor and a resume "
+                "from it may skip in-flight prompts."
+            )
+        return {
+            "dataloader_state": self.get_dataloader_state(),
+            "base_ordinal": None,
+            "frontier_aligned": False,
+        }
+
+    def get_checkpoint_state(self, frontier_ordinal: int) -> dict[str, Any]:
+        """Return the dataloader snapshot and rollout state as one consistent pair.
+
+        Both are read while holding the pending lock so the collection loop
+        cannot consume or replace the pending batch in between; a torn pair
+        (cursor newer than its pending suffix) would duplicate prompts on a
+        fallback resume.
+
+        The pending remainder is only included on fallback snapshots. On a
+        frontier-aligned snapshot the rewound dataloader re-yields it (the
+        restore path forces ``pending_batch=None``), so persisting it would
+        be dead weight in every frontier checkpoint.
+
+        The snapshot is taken at the conservative **cut** — the minimum of
+        the trained frontier, the lowest ordinal still out with a rollout
+        worker, and the lowest ordinal held in the replay buffer (buffered-
+        but-untrained groups are covered only by the buffer, which a
+        ``load_replay_buffer=false`` resume discards). Normally everything
+        in flight or buffered sits at or above the frontier and the cut
+        equals it; when a target is refilled from later prompts (after a
+        tolerated generation failure, or when gap-filling an incomplete
+        target restored from a checkpoint), training it can advance past
+        another target's in-flight groups, and cutting at the frontier
+        would strand those prompts. Cutting below the frontier instead
+        re-yields a window that includes already-trained prompts; the
+        driver persists those trained ordinals in the checkpoint
+        (``TRAINED_TASK_INDICES_KEY``) so the resume covers them like
+        retained groups — nothing is skipped and nothing is re-trained.
+
+        Returns:
+            Mapping with ``dataloader`` (shape of
+            :meth:`get_checkpoint_dataloader_state`, plus ``frontier_ordinal``
+            = the cut, which the checkpoint must persist as its filter
+            threshold) and ``rollouts`` (shape of :meth:`get_rollouts_state`).
+        """
+        with self._outstanding_lock:
+            outstanding_min = min(self._outstanding_task_indices, default=None)
+        # The cut is also bounded by buffered-untrained ordinals: their only
+        # record is the buffer, which load_replay_buffer=false discards on
+        # resume. Read after the outstanding set — an ordinal leaves it only
+        # once its buffer add succeeded, so no group is missed by both reads.
+        held_task_indices = ray.get(self.replay_buffer.get_held_task_indices.remote())
+        buffered_min = min(held_task_indices, default=None)
+        cut = frontier_ordinal
+        for candidate in (outstanding_min, buffered_min):
+            if candidate is not None and candidate < cut:
+                cut = candidate
+        if cut < frontier_ordinal:
+            print(
+                f"⚠️ Checkpoint cut lowered from trained frontier "
+                f"{frontier_ordinal} to {cut}: ordinals below the frontier "
+                "are still in flight or buffered-untrained (a gap-filled "
+                "target was refilled from later prompts — after a tolerated "
+                "generation failure, or when resuming with an incomplete "
+                "restored target). A resume from this checkpoint regenerates "
+                "the window instead of skipping it; trained prompts above "
+                "the cut are persisted in rollouts.pt and stay covered."
+            )
+        with self._pending_lock:
+            dataloader_snapshot = self.get_checkpoint_dataloader_state(cut)
+            dataloader_snapshot["frontier_ordinal"] = cut
+            rollouts_state = self._build_rollouts_state(
+                include_pending=not dataloader_snapshot["frontier_aligned"]
+            )
+        return {"dataloader": dataloader_snapshot, "rollouts": rollouts_state}
+
+    def _process_batch(
+        self, batch: BatchedDataDict[DatumSpec]
+    ) -> Optional[BatchedDataDict[DatumSpec]]:
+        """Process a batch, generating for one target weight.
+
+        Args:
+            batch: Prompt batch pulled from the dataloader (or carried over
+                from a previous gap-fill remainder).
+
+        Returns:
+            The unconsumed remainder of ``batch`` — the whole batch when no
+            target currently needs generation, the sliced-off suffix when this
+            target needed fewer prompts than the batch holds, or ``None`` when
+            every prompt was consumed. The caller re-queues it so no yielded
+            prompt is ever discarded.
+        """
         target_weight: Optional[int] = None
         worker_started = False
+        leftover: Optional[BatchedDataDict[DatumSpec]] = None
         try:
             generation_weight_version = self.current_weight_version
             num_generations = self._num_generations_per_prompt
@@ -474,7 +781,7 @@ class AsyncTrajectoryCollector:
                 print(
                     f"🔄 No targets need generation for weight {generation_weight_version}"
                 )
-                return
+                return batch
             reserved_target = target_weight
 
             print(
@@ -492,13 +799,18 @@ class AsyncTrajectoryCollector:
                     f"🔄 Target {reserved_target} already has enough trajectories, skipping"
                 )
                 self._release_target(reserved_target)
-                return
+                return batch
 
             if num_prompts_to_generate < num_prompts_in_batch:
+                # Keep the unused suffix instead of discarding it: the caller
+                # re-queues it ahead of the next dataloader pull.
+                leftover = batch.slice(num_prompts_to_generate, num_prompts_in_batch)
                 print(
                     f"🎯 Gap-filling for target weight {reserved_target}: "
                     f"generating {num_prompts_to_generate}/{num_prompts_in_batch} "
-                    f"prompts (need {trajectories_needed} more trajectories)"
+                    f"prompts (need {trajectories_needed} more trajectories); "
+                    f"carrying over the remaining "
+                    f"{num_prompts_in_batch - num_prompts_to_generate}"
                 )
 
             # Generate all prompt groups needed for this target in one batched worker.
@@ -515,15 +827,18 @@ class AsyncTrajectoryCollector:
                     self._refit_pause_cleared.wait()
                 generation_weight_version = self.current_weight_version
 
+            # Task indices are stamped at yield time in _collection_loop, so
+            # slices and carried-over remainders keep their original ordinals.
             rollout_batch = batch.slice(0, num_prompts_to_generate)
-            if use_nemo_gym:
-                self._stamp_nemo_gym_task_indices(rollout_batch)
-                if self._deduplicate_multimodal_data:
-                    attach_initial_nemo_gym_image_payloads(
-                        rollout_batch,
-                        self.processor,
-                        env_config=self.master_config.env,
-                    )
+            # Rows are stamped at yield time, so this slice carries its
+            # original stream ordinals; record them for the outstanding set.
+            dispatched_task_indices = _stamped_task_indices(rollout_batch)
+            if use_nemo_gym and self._deduplicate_multimodal_data:
+                attach_initial_nemo_gym_image_payloads(
+                    rollout_batch,
+                    self.processor,
+                    env_config=self.master_config.env,
+                )
             repeated_batch = rollout_batch.repeat_interleave(
                 num_generations,
                 share_immutable_media=self._deduplicate_multimodal_data,
@@ -544,6 +859,7 @@ class AsyncTrajectoryCollector:
                         target_weight_version=reserved_target,
                         num_generations=num_generations,
                         use_nemo_gym=use_nemo_gym,
+                        dispatched_task_indices=dispatched_task_indices,
                     )
                 )
 
@@ -551,11 +867,19 @@ class AsyncTrajectoryCollector:
             try:
                 with self._threads_lock:
                     self._inflight_threads.add(worker)
+                if dispatched_task_indices:
+                    with self._outstanding_lock:
+                        self._outstanding_task_indices.update(dispatched_task_indices)
                 worker.start()
                 worker_started = True
             except Exception:
                 with self._threads_lock:
                     self._inflight_threads.discard(worker)
+                if dispatched_task_indices:
+                    with self._outstanding_lock:
+                        self._outstanding_task_indices.difference_update(
+                            dispatched_task_indices
+                        )
                 raise
 
             backend = "NeMo-Gym" if use_nemo_gym else "native"
@@ -566,6 +890,7 @@ class AsyncTrajectoryCollector:
             )
 
             self._cleanup_finished_threads()
+            return leftover
 
         except Exception as e:
             if target_weight is not None and not worker_started:
@@ -574,6 +899,9 @@ class AsyncTrajectoryCollector:
             import traceback
 
             traceback.print_exc()
+            # No worker was started, so nothing in `batch` was consumed: hand
+            # the whole batch back rather than only the gap-fill tail.
+            return batch if not worker_started else leftover
 
     def get_weight_version(self) -> int:
         return self.current_weight_version
@@ -748,9 +1076,33 @@ class AsyncTrajectoryCollector:
         """
         return drain_multimodal_payload_metrics()
 
-    def get_rollouts_state(self) -> dict[str, int]:
-        """Get collector-side rollout state for checkpointing."""
-        return {NEXT_NEMO_GYM_TASK_INDEX_KEY: self._next_nemo_gym_task_index}
+    def _build_rollouts_state(self, *, include_pending: bool) -> dict[str, Any]:
+        """Build the rollout-state mapping. Caller must hold ``_pending_lock``.
+
+        The mapping carries the next task index and, when requested and
+        present, the pending prompt batch under ``PENDING_PROMPTS_KEY``.
+        Serializing the remainder keeps yielded prompts recoverable on
+        live-cursor checkpoints: the dataloader cursor has already advanced
+        past them, so a checkpoint that dropped them would skip those prompts
+        for the rest of the run.
+        """
+        state: dict[str, Any] = {
+            NEXT_NEMO_GYM_TASK_INDEX_KEY: self._next_nemo_gym_task_index
+        }
+        if include_pending and self._pending_batch is not None:
+            state[PENDING_PROMPTS_KEY] = self._pending_batch
+        return state
+
+    def get_rollouts_state(self) -> dict[str, Any]:
+        """Get collector-side rollout state (always including any pending batch).
+
+        The driver's save path reads this through
+        :meth:`get_checkpoint_state`, which pairs it with the dataloader
+        snapshot under one lock; this standalone accessor serves tests and
+        diagnostics.
+        """
+        with self._pending_lock:
+            return self._build_rollouts_state(include_pending=True)
 
     def _cleanup_finished_threads(self) -> None:
         with self._threads_lock:
@@ -977,6 +1329,7 @@ class AsyncTrajectoryCollector:
         target_weight_version: int,
         num_generations: int,
         use_nemo_gym: bool,
+        dispatched_task_indices: Optional[list[int]] = None,
     ) -> None:
         """Own one target reservation while collecting its rollout batch."""
         worker_start = time.perf_counter()
@@ -1034,6 +1387,13 @@ class AsyncTrajectoryCollector:
                     flush=True,
                 )
         finally:
+            if dispatched_task_indices:
+                # This worker's unbuffered ordinals are a permanent loss and
+                # must not keep holding the checkpoint cut down.
+                with self._outstanding_lock:
+                    self._outstanding_task_indices.difference_update(
+                        dispatched_task_indices
+                    )
             self._release_target(target_weight_version)
             with self._threads_lock:
                 self._inflight_threads.discard(_threading.current_thread())
@@ -1079,6 +1439,7 @@ class AsyncTrajectoryCollector:
         expected_prompt_groups: int,
         buffered_group_indices: set[int],
         collection_started_at: float,
+        input_task_index: Optional[int] = None,
     ) -> None:
         """Push one prompt group to the replay buffer with bounded backoff."""
         final_batch_cpu = rollout_result.final_batch.to("cpu")
@@ -1124,8 +1485,15 @@ class AsyncTrajectoryCollector:
             "rollout_metrics": rollout_metrics,
             "timestamp": time.time(),
         }
-        if rollout_result.task_index is not None:
-            trajectory_group[NEMO_GYM_TASK_INDEX_KEY] = rollout_result.task_index
+        group_task_index = rollout_result.task_index
+        if group_task_index is None:
+            # Native groups carry their ordinal on the stamped *input* rows,
+            # captured before the rollout ran; recording it on the group lets
+            # a frontier restore report which prompts the retained buffer
+            # already covers.
+            group_task_index = input_task_index
+        if group_task_index is not None:
+            trajectory_group[NEMO_GYM_TASK_INDEX_KEY] = group_task_index
         backoff_delay = 0.01
         backoff_started_at: float | None = None
         try:
@@ -1149,6 +1517,13 @@ class AsyncTrajectoryCollector:
                 )
                 if status == "success":
                     buffered_group_indices.add(rollout_result.group_index)
+                    if group_task_index is not None:
+                        # The cut now covers this ordinal via the buffer's
+                        # held-ordinal report instead of the outstanding set.
+                        with self._outstanding_lock:
+                            self._outstanding_task_indices.discard(
+                                int(group_task_index)
+                            )
                     group_description = f"group_index={rollout_result.group_index}"
                     if rollout_result.task_index is not None:
                         group_description = (
@@ -1201,6 +1576,21 @@ class AsyncTrajectoryCollector:
             if use_nemo_gym
             else {}
         )
+        # Capture each group's ordinal from the *input* rows up front: the
+        # rollout may replace extra_env_info wholesale (multi-turn envs can
+        # build fresh metadata dicts), so the output rows are not a reliable
+        # carrier for the stamp.
+        input_rows = repeated_batch.get("extra_env_info")
+        group_input_task_indices: list[Optional[int]] = [
+            _unanimous_task_index(
+                input_rows[
+                    group_index * num_generations : (group_index + 1) * num_generations
+                ]
+                if isinstance(input_rows, list)
+                else []
+            )
+            for group_index in range(expected_prompt_groups)
+        ]
         buffered_group_indices: set[int] = set()
         last_error: Exception | None = None
         max_attempts = 1 + (_MAX_NEMO_GYM_STREAM_RETRIES if use_nemo_gym else 0)
@@ -1240,6 +1630,7 @@ class AsyncTrajectoryCollector:
                                 expected_prompt_groups=expected_prompt_groups,
                                 buffered_group_indices=buffered_group_indices,
                                 collection_started_at=collection_started_at,
+                                input_task_index=group_input_task_indices[group_index],
                             )
                         )
                     )

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -87,7 +87,13 @@ from nemo_rl.distributed.virtual_cluster import (
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_actor
 from nemo_rl.experience.interfaces import (
+    FRONTIER_ORDINAL_KEY,
+    NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
+    PENDING_PROMPTS_KEY,
+    RESUME_BASE_ORDINAL_KEY,
+    RETAINED_TASK_INDICES_KEY,
+    TRAINED_TASK_INDICES_KEY,
 )
 from nemo_rl.experience.metric_utils import is_histogram_metric
 from nemo_rl.experience.rollouts import (
@@ -150,6 +156,56 @@ from nemo_rl.weight_sync.factory import create_weight_synchronizer
 # Configuration
 # ===============================================================================
 TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
+
+
+def _maybe_restore_async_replay_buffer_checkpoint(
+    replay_buffer: Any,
+    checkpoint_path: str,
+    *,
+    load_replay_buffer: bool | None,
+    num_prompts_per_step: int,
+    current_training_step: int,
+    max_age_steps: int,
+) -> dict[str, Any] | None:
+    """Restore async replay state unless the config explicitly opts out.
+
+    With ``checkpointing.load_replay_buffer=false`` the buffer starts empty
+    and, on a frontier-aligned checkpoint, the whole buffered window is
+    regenerated fresh from the rewound dataloader — the empty-retained-set
+    case of the same resume path. This trades resume compute for an unbiased
+    step composition: retained groups are the ones whose longest rollout
+    happened to finish before the save, so reusing them skews the next steps
+    toward short-rollout prompts.
+
+    Returns:
+        The restore metadata from ``load_from_path``, or ``None`` when the
+        restore was skipped or no checkpoint file exists.
+    """
+    if load_replay_buffer is False:
+        print(
+            "📦 Skipping replay buffer restore (checkpointing.load_replay_buffer=false)"
+        )
+        return None
+
+    replay_buffer_path = os.path.join(checkpoint_path, "replay_buffer.pt")
+    if not os.path.exists(replay_buffer_path):
+        print(
+            f"⚠️ No replay buffer checkpoint found at {replay_buffer_path}. "
+            "Starting with an empty replay buffer."
+        )
+        return None
+
+    print(f"📦 Restoring replay buffer from checkpoint: {replay_buffer_path}")
+    restore_metadata = ray.get(
+        replay_buffer.load_from_path.remote(
+            replay_buffer_path,
+            num_prompts_per_step=num_prompts_per_step,
+            current_training_step=current_training_step,
+            max_age_steps=max_age_steps,
+        )
+    )
+    print("✅ Replay buffer restored from checkpoint")
+    return restore_metadata
 
 
 def _save_async_replay_buffer_checkpoint(
@@ -4225,26 +4281,17 @@ def async_grpo_train(
     )
 
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
-    replay_buffer_restore_metadata: dict[str, int] | None = None
+    replay_buffer_restore_metadata: dict[str, Any] | None = None
     rollouts_state = None
     if last_checkpoint_path is not None:
-        replay_buffer_path = os.path.join(last_checkpoint_path, "replay_buffer.pt")
-        if os.path.exists(replay_buffer_path):
-            print(f"📦 Restoring replay buffer from checkpoint: {replay_buffer_path}")
-            replay_buffer_restore_metadata = ray.get(
-                replay_buffer.load_from_path.remote(
-                    replay_buffer_path,
-                    num_prompts_per_step=num_prompts_per_step,
-                    current_training_step=step,
-                    max_age_steps=max_trajectory_age_steps,
-                )
-            )
-            print("✅ Replay buffer restored from checkpoint")
-        else:
-            print(
-                f"⚠️ No replay buffer checkpoint found at {replay_buffer_path}. "
-                "Starting with an empty replay buffer."
-            )
+        replay_buffer_restore_metadata = _maybe_restore_async_replay_buffer_checkpoint(
+            replay_buffer,
+            last_checkpoint_path,
+            load_replay_buffer=master_config.checkpointing.get("load_replay_buffer"),
+            num_prompts_per_step=num_prompts_per_step,
+            current_training_step=step,
+            max_age_steps=max_trajectory_age_steps,
+        )
 
         rollouts_path = os.path.join(last_checkpoint_path, "rollouts.pt")
         if os.path.exists(rollouts_path):
@@ -4256,6 +4303,72 @@ def async_grpo_train(
         int(
             (replay_buffer_restore_metadata or {}).get(NEXT_NEMO_GYM_TASK_INDEX_KEY, 0)
         ),
+    )
+
+    # Frontier-aligned resume: the checkpoint saved the dataloader state at
+    # the trained frontier rather than the live cursor, so the collector
+    # re-yields the covered window and regenerates every prompt that is
+    # neither trained nor retained in the restored buffer. Legacy checkpoints
+    # (no frontier metadata) keep today's behavior.
+    frontier_ordinal = (rollouts_state or {}).get(FRONTIER_ORDINAL_KEY)
+    resume_base_ordinal = (rollouts_state or {}).get(RESUME_BASE_ORDINAL_KEY)
+    frontier_restore = frontier_ordinal is not None and resume_base_ordinal is not None
+    if frontier_restore:
+        retained_task_indices = list(
+            (replay_buffer_restore_metadata or {}).get(RETAINED_TASK_INDICES_KEY, [])
+        )
+        # Ordinals trained at/above the cut, covered like retained groups so
+        # the re-yielded window regenerates only what was lost.
+        trained_task_indices = [
+            int(ordinal)
+            for ordinal in (rollouts_state or {}).get(TRAINED_TASK_INDICES_KEY, [])
+        ]
+        covered_task_indices = sorted(
+            set(retained_task_indices) | set(trained_task_indices)
+        )
+        collector_start_kwargs: dict[str, Any] = {
+            "next_nemo_gym_task_index": int(resume_base_ordinal),
+            "resume_frontier_ordinal": int(frontier_ordinal),
+            "resume_covered_task_indices": covered_task_indices,
+            # The rewound dataloader re-yields any carried-over remainder.
+            "pending_batch": None,
+            "ordinals_frontier_aligned": True,
+        }
+        print(
+            "📦 Frontier-aligned resume: dataloader rewound to ordinal "
+            f"{resume_base_ordinal}, trained frontier {frontier_ordinal}, "
+            f"{len(retained_task_indices)} retained prompt groups, "
+            f"{len(trained_task_indices)} trained above the cut"
+        )
+    else:
+        collector_start_kwargs = {
+            "next_nemo_gym_task_index": next_nemo_gym_task_index,
+            "pending_batch": (rollouts_state or {}).get(PENDING_PROMPTS_KEY),
+            # Ordinal == stream position only holds for runs that have used
+            # frontier-aligned checkpoints from the start; a legacy resume
+            # keeps live-cursor checkpoints.
+            "ordinals_frontier_aligned": last_checkpoint_path is None,
+        }
+        if last_checkpoint_path is not None:
+            print(
+                "⚠️ Legacy checkpoint resume: frontier-aligned checkpointing "
+                "is disabled for this run and every checkpoint descended from "
+                "it. Checkpoints will save the live dataloader cursor, so a "
+                "resume may skip prompts that were in flight at the save."
+            )
+
+    # High-water mark of trained group ordinals, exclusive — the checkpoint
+    # frontier. consumed_samples cannot serve here: tolerated generation
+    # failures leave stream holes it never sees, so it lags the true stream
+    # position.
+    trained_frontier_ordinal = (
+        int(frontier_ordinal) if frontier_ordinal is not None else consumed_samples
+    )
+    # Trained ordinals at/above the last checkpoint cut, persisted so a
+    # resume covers them instead of re-training them. Pruned at each save;
+    # the cut never decreases, so pruning is safe.
+    recent_trained_task_indices: set[int] = (
+        set(trained_task_indices) if frontier_restore else set()
     )
 
     _tc_py_exec = get_actor_python_env(
@@ -4293,8 +4406,8 @@ def async_grpo_train(
         teacher_worker_groups=teacher_worker_groups,
         alias_to_group_alias=alias_to_group_alias,
         on_policy_distillation_cfg=opd_module._opd_cfg(master_config),
-        next_nemo_gym_task_index=next_nemo_gym_task_index,
         processor=processor,
+        **collector_start_kwargs,
     )
 
     print(
@@ -4612,6 +4725,24 @@ def async_grpo_train(
                     # Extract trajectories and metadata from sample result
                     trajectories = sample_result["trajectories"]
                     avg_trajectory_age = sample_result["avg_trajectory_age"]
+
+                    # Advance the trained frontier from the sampled groups'
+                    # own stream ordinals.
+                    sampled_ordinals = [
+                        trajectory.get(NEMO_GYM_TASK_INDEX_KEY)
+                        for trajectory in trajectories
+                        if isinstance(trajectory, dict)
+                    ]
+                    if sampled_ordinals and all(
+                        ordinal is not None for ordinal in sampled_ordinals
+                    ):
+                        trained_frontier_ordinal = max(
+                            trained_frontier_ordinal,
+                            max(int(ordinal) for ordinal in sampled_ordinals) + 1,
+                        )
+                        recent_trained_task_indices.update(
+                            int(ordinal) for ordinal in sampled_ordinals
+                        )
 
                     print(
                         f"✅ Sampled {len(trajectories)} trajectory groups from buffer (avg age: {avg_trajectory_age:.2f} steps)"
@@ -5194,21 +5325,47 @@ def async_grpo_train(
                             ),
                             checkpointing_cfg=master_config.checkpointing,
                         )
-                        # Get dataloader state from trajectory collector
-                        actual_dataloader_state = ray.get(
-                            trajectory_collector.get_dataloader_state.remote()
+                        # Save the dataloader state at the checkpoint cut
+                        # rather than the live cursor; a resume re-yields the
+                        # covered window and regenerates what the restored
+                        # buffer does not account for. One actor call returns
+                        # the snapshot and rollout state as a consistent pair
+                        # (separate reads would race the collection loop).
+                        collector_checkpoint = ray.get(
+                            trajectory_collector.get_checkpoint_state.remote(
+                                trained_frontier_ordinal
+                            )
                         )
+                        dataloader_snapshot = collector_checkpoint["dataloader"]
+                        rollouts_state = collector_checkpoint["rollouts"]
                         torch.save(
-                            actual_dataloader_state,
+                            dataloader_snapshot["dataloader_state"],
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
                         _save_async_replay_buffer_checkpoint(
                             replay_buffer,
                             checkpoint_path,
                         )
-                        rollouts_state = ray.get(
-                            trajectory_collector.get_rollouts_state.remote()
-                        )
+                        if dataloader_snapshot["frontier_aligned"]:
+                            # Persist the (possibly lowered) cut as the
+                            # resume filter threshold, not the trained
+                            # frontier.
+                            cut_ordinal = int(dataloader_snapshot["frontier_ordinal"])
+                            rollouts_state[FRONTIER_ORDINAL_KEY] = cut_ordinal
+                            rollouts_state[RESUME_BASE_ORDINAL_KEY] = (
+                                dataloader_snapshot["base_ordinal"]
+                            )
+                            # Ordinals trained at/above the cut: the resume
+                            # must not regenerate these. Prune below the cut
+                            # (it never decreases).
+                            recent_trained_task_indices = {
+                                ordinal
+                                for ordinal in recent_trained_task_indices
+                                if ordinal >= cut_ordinal
+                            }
+                            rollouts_state[TRAINED_TASK_INDICES_KEY] = sorted(
+                                recent_trained_task_indices
+                            )
                         torch.save(
                             rollouts_state,
                             os.path.join(checkpoint_path, "rollouts.pt"),

--- a/nemo_rl/experience/interfaces.py
+++ b/nemo_rl/experience/interfaces.py
@@ -19,6 +19,23 @@ from nemo_rl.data.interfaces import LLMMessageLogType, VLMMessageLogType
 
 NEMO_GYM_TASK_INDEX_KEY = "_ng_task_index"
 NEXT_NEMO_GYM_TASK_INDEX_KEY = "next_ng_task_index"
+# Unconsumed suffix of a gap-fill dataloader batch, carried in the async
+# collector's rollouts state so a checkpoint cannot strand yielded prompts.
+PENDING_PROMPTS_KEY = "pending_prompt_batch"
+# Frontier-aligned async checkpoint metadata (rollouts.pt). The frontier key
+# holds the checkpoint cut — the resume filter threshold — and the base is
+# the ordinal the saved dataloader snapshot resumes yielding from. Together
+# they let a resume regenerate every unaccounted prompt instead of skipping
+# it.
+FRONTIER_ORDINAL_KEY = "frontier_ordinal"
+RESUME_BASE_ORDINAL_KEY = "resume_base_ordinal"
+# Post-restore replay-buffer metadata: ordinals of the retained prompt groups,
+# reported after age/step filtering so the collector can regenerate the rest.
+RETAINED_TASK_INDICES_KEY = "retained_task_indices"
+# Ordinals already trained but at or above the checkpoint cut (rollouts.pt).
+# The resume folds them into the covered set so the re-yielded window drops
+# them instead of training them a second time.
+TRAINED_TASK_INDICES_KEY = "trained_task_indices"
 
 
 @dataclass

--- a/nemo_rl/utils/checkpoint.py
+++ b/nemo_rl/utils/checkpoint.py
@@ -116,6 +116,11 @@ class CheckpointingConfig(TypedDict):
     model_repo_id (str): Repository ID for the model (for safetensors format).
     is_peft (bool): Whether the model uses PEFT.
     save_optimizer (bool): Whether to save optimizer state with checkpoints.
+    load_replay_buffer (bool): Whether async GRPO restores replay-buffer state
+        when resuming from a checkpoint. Defaults to True. When False the
+        buffer starts empty and a frontier-aligned resume regenerates the
+        whole buffered window fresh instead of reusing completed (and
+        therefore short-rollout-biased) groups.
     """
 
     enabled: bool
@@ -129,6 +134,7 @@ class CheckpointingConfig(TypedDict):
     checkpoint_must_save_by: NotRequired[str | None]
     pretrained_checkpoint: NotRequired[PretrainedCheckpointConfig]
     save_optimizer: NotRequired[bool]  # Default: True
+    load_replay_buffer: NotRequired[bool]  # Default: True (async GRPO only)
     # New nemo-automodel integration fields
     model_save_format: NotRequired[str | None]  # Default: "safetensors"
     save_consolidated: NotRequired[bool]  # Default: False

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -37,6 +37,10 @@ from nemo_rl.algorithms.async_utils import (
     ReplayBuffer,
 )
 from nemo_rl.algorithms.async_utils.replay_buffer import ReplayBufferImpl
+from nemo_rl.algorithms.async_utils.trajectory_collector import (
+    _stamped_task_indices,
+    _unanimous_task_index,
+)
 from nemo_rl.algorithms.grpo import (
     AsyncGRPOConfig,
     GRPOConfig,
@@ -50,6 +54,12 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
+)
+from nemo_rl.experience.interfaces import (
+    NEMO_GYM_TASK_INDEX_KEY,
+    NEXT_NEMO_GYM_TASK_INDEX_KEY,
+    PENDING_PROMPTS_KEY,
+    RETAINED_TASK_INDICES_KEY,
 )
 
 
@@ -440,10 +450,13 @@ class TestReplayBufferImplCheckpointing:
         )
 
         # Metadata accounts for every saved task index, including trajectories
-        # discarded during resume cleanup, so an index is never reused.
+        # discarded during resume cleanup, so an index is never reused. The
+        # retained list reflects only post-filter survivors, so a frontier
+        # resume regenerates the dropped stale group instead of skipping it.
         assert metadata == {
             "num_trajectories": 2,
             "next_ng_task_index": 42,
+            RETAINED_TASK_INDICES_KEY: [7],
         }
         assert restored.size() == 1
         restored_state = restored.state_dict()
@@ -1191,6 +1204,7 @@ class TestReplayBuffer:
         assert restore_metadata == {
             "num_trajectories": 1,
             "next_ng_task_index": 12,
+            RETAINED_TASK_INDICES_KEY: [11],
         }
         assert ray.get(buffer2.size.remote()) == 1
         debug_info = ray.get(buffer2.get_debug_info.remote())
@@ -1282,6 +1296,10 @@ class TestAsyncTrajectoryCollector:
         replay_buffer=None,
         next_nemo_gym_task_index: int = 0,
         max_generation_failures: int = 0,
+        pending_batch=None,
+        ordinals_frontier_aligned: bool = True,
+        resume_frontier_ordinal=None,
+        resume_covered_task_indices=None,
     ):
         """Create a non-Ray collector instance for unit-testing local state."""
         collector_cls = AsyncTrajectoryCollector.__ray_metadata__.modified_class
@@ -1292,6 +1310,7 @@ class TestAsyncTrajectoryCollector:
         master_config.grpo.async_grpo.max_generation_failures = max_generation_failures
         if replay_buffer is None:
             replay_buffer = mock.MagicMock()
+            replay_buffer.get_held_task_indices.remote.return_value = []
 
         return collector_cls(
             policy_generation=mock_generation,
@@ -1301,6 +1320,10 @@ class TestAsyncTrajectoryCollector:
             replay_buffer=replay_buffer,
             start_step=0,
             next_nemo_gym_task_index=next_nemo_gym_task_index,
+            pending_batch=pending_batch,
+            ordinals_frontier_aligned=ordinals_frontier_aligned,
+            resume_frontier_ordinal=resume_frontier_ordinal,
+            resume_covered_task_indices=resume_covered_task_indices,
         )
 
     def _prime_collection_loop(self, collector):
@@ -1394,6 +1417,742 @@ class TestAsyncTrajectoryCollector:
 
         assert collector.data_exhausted is False
         assert collector.collection_failed is False
+
+    def test_collection_loop_consumes_carryover_before_next_pull(self):
+        """A gap-fill remainder is processed ahead of the next dataloader batch."""
+        collector = self.create_local_collector()
+        self._prime_collection_loop(collector)
+        first, second, tail = {"b": 0}, {"b": 1}, {"tail": True}
+        processed = []
+
+        def _process(batch):
+            processed.append(batch)
+            return tail if batch is first else None
+
+        collector._process_batch = _process
+        collector.dataloader = [first, second]
+
+        collector._collection_loop()
+
+        assert processed == [first, tail, second]
+        assert collector._pending_batch is None
+        assert collector.data_exhausted is True
+
+    def test_collection_loop_retries_unconsumed_batch(self):
+        """A batch nothing consumed (no target free) is retried, not discarded."""
+        collector = self.create_local_collector()
+        self._prime_collection_loop(collector)
+        batch = {"b": 0}
+        processed = []
+
+        def _process(current):
+            processed.append(current)
+            # First attempt: nothing consumed. Second attempt: consumed.
+            return current if len(processed) == 1 else None
+
+        collector._process_batch = _process
+        collector.dataloader = [batch]
+
+        collector._collection_loop()
+
+        assert processed == [batch, batch]
+        assert collector.data_exhausted is True
+
+    def test_collection_loop_starts_from_restored_pending_batch(self):
+        """A pending remainder restored from a checkpoint is processed first."""
+        restored = {"restored": True}
+        collector = self.create_local_collector(pending_batch=restored)
+        self._prime_collection_loop(collector)
+        processed = []
+        collector._process_batch = lambda batch: processed.append(batch)
+        collector.dataloader = [{"b": 0}]
+
+        collector._collection_loop()
+
+        assert processed == [restored, {"b": 0}]
+
+    def test_process_batch_carries_over_gap_fill_tail(self, monkeypatch):
+        """When the target needs fewer prompts than the batch, the tail survives."""
+        replay_buffer = mock.MagicMock()
+        replay_buffer.get_trajectories_needed.remote.return_value = 2
+        collector = self.create_local_collector(replay_buffer=replay_buffer)
+        collector._refit_pause_cleared.set()
+        collector._get_next_target_for_generation = lambda version: 1
+        monkeypatch.setattr(
+            "nemo_rl.algorithms.async_utils.trajectory_collector.ray",
+            mock.MagicMock(get=lambda ref: ref),
+        )
+        worker_calls = []
+
+        async def _fake_worker(**kwargs):
+            worker_calls.append(kwargs)
+
+        collector._run_rollout_batch_worker = _fake_worker
+
+        batch = self.create_mock_batch(size=4)
+        leftover = collector._process_batch(batch)
+        collector.wait_for_pending_generations()
+
+        assert leftover is not None
+        assert leftover.size == 2
+        assert [log[0]["content"] for log in leftover["message_log"]] == [
+            "Test prompt 2",
+            "Test prompt 3",
+        ]
+        assert len(worker_calls) == 1
+        # 2 prompts x 3 generations reached the rollout worker.
+        assert worker_calls[0]["repeated_batch"].size == 6
+
+    def test_process_batch_returns_whole_batch_when_no_target_free(self):
+        """No reservable target: the untouched batch comes back for retry."""
+        collector = self.create_local_collector()
+        collector._get_next_target_for_generation = lambda version: None
+
+        batch = self.create_mock_batch(size=2)
+        assert collector._process_batch(batch) is batch
+
+    class _FakeStatefulLoader:
+        """List-backed stand-in for StatefulDataLoader with a position cursor."""
+
+        def __init__(self, batches, start: int = 0):
+            self._batches = batches
+            self._pos = start
+
+        def state_dict(self) -> dict:
+            return {"pos": self._pos}
+
+        def __iter__(self):
+            while self._pos < len(self._batches):
+                batch = self._batches[self._pos]
+                self._pos += 1
+                yield batch
+
+    def _run_loop_collecting(self, collector, loader):
+        """Drive _collection_loop to exhaustion, returning processed batches."""
+        self._prime_collection_loop(collector)
+        processed = []
+        collector._process_batch = lambda batch: processed.append(batch)
+        collector.dataloader = loader
+        collector._collection_loop()
+        return processed
+
+    @staticmethod
+    def _ordinals(batches) -> list[int]:
+        return [
+            row[NEMO_GYM_TASK_INDEX_KEY]
+            for batch in batches
+            for row in batch["extra_env_info"]
+        ]
+
+    def test_collection_loop_stamps_ordinals_and_records_snapshots(self):
+        """Fresh batches get stream-position ordinals; the ring keys on them."""
+        collector = self.create_local_collector()
+        loader = self._FakeStatefulLoader(
+            [self.create_mock_batch(2), self.create_mock_batch(2)]
+        )
+
+        processed = self._run_loop_collecting(collector, loader)
+
+        assert self._ordinals(processed) == [0, 1, 2, 3]
+        assert [
+            (base, state["pos"]) for base, state in collector._dataloader_snapshots
+        ] == [(0, 0), (2, 1)]
+        assert collector._next_nemo_gym_task_index == 4
+
+    def test_get_checkpoint_dataloader_state_selects_frontier_snapshot(self):
+        """The snapshot just at/below the frontier wins; misaligned falls back."""
+        collector = self.create_local_collector()
+        collector._dataloader_snapshots.extend(
+            [(0, {"pos": 0}), (4, {"pos": 1}), (8, {"pos": 2})]
+        )
+
+        snapshot = collector.get_checkpoint_dataloader_state(5)
+        assert snapshot["frontier_aligned"] is True
+        assert snapshot["base_ordinal"] == 4
+        assert snapshot["dataloader_state"] == {"pos": 1}
+
+        assert collector.get_checkpoint_dataloader_state(3)["base_ordinal"] == 0
+        assert collector.get_checkpoint_dataloader_state(11)["base_ordinal"] == 8
+
+        collector._ordinals_frontier_aligned = False
+        fallback = collector.get_checkpoint_dataloader_state(5)
+        assert fallback["frontier_aligned"] is False
+        assert fallback["base_ordinal"] is None
+
+    def test_checkpoint_falls_back_when_ring_has_no_snapshot_at_frontier(self):
+        """Aligned ordinals but an evicted/empty ring still degrade cleanly."""
+        collector = self.create_local_collector()
+        assert collector._ordinals_frontier_aligned is True
+
+        # Empty ring: nothing to select from.
+        empty = collector.get_checkpoint_dataloader_state(5)
+        assert empty["frontier_aligned"] is False
+        assert empty["base_ordinal"] is None
+
+        # Every retained base sits above the frontier (older entries evicted).
+        collector._dataloader_snapshots.extend([(8, {"pos": 2}), (12, {"pos": 3})])
+        evicted = collector.get_checkpoint_dataloader_state(5)
+        assert evicted["frontier_aligned"] is False
+        assert evicted["base_ordinal"] is None
+
+    def test_get_checkpoint_state_omits_pending_on_frontier_snapshots(
+        self, monkeypatch
+    ):
+        """One call returns the cursor/pending pair; pending only on fallback."""
+        monkeypatch.setattr(trajectory_collector_mod.ray, "get", lambda ref: ref)
+        collector = self.create_local_collector(next_nemo_gym_task_index=4)
+        collector._dataloader_snapshots.append((0, {"pos": 0}))
+        collector._pending_batch = self.create_mock_batch(2)
+
+        aligned = collector.get_checkpoint_state(4)
+        assert aligned["dataloader"]["frontier_aligned"] is True
+        assert aligned["dataloader"]["frontier_ordinal"] == 4
+        assert aligned["rollouts"] == {NEXT_NEMO_GYM_TASK_INDEX_KEY: 4}
+
+        collector._ordinals_frontier_aligned = False
+        fallback = collector.get_checkpoint_state(4)
+        assert fallback["dataloader"]["frontier_aligned"] is False
+        assert fallback["rollouts"][NEXT_NEMO_GYM_TASK_INDEX_KEY] == 4
+        assert fallback["rollouts"][PENDING_PROMPTS_KEY] is collector._pending_batch
+
+    def test_stamped_task_indices_extraction(self):
+        stamped = BatchedDataDict[DatumSpec](
+            {
+                "extra_env_info": [
+                    {NEMO_GYM_TASK_INDEX_KEY: 5},
+                    {NEMO_GYM_TASK_INDEX_KEY: 6},
+                ]
+            }
+        )
+        unstamped = BatchedDataDict[DatumSpec]({"extra_env_info": [{}, {}]})
+        no_rows = BatchedDataDict[DatumSpec]({"value": [1]})
+
+        assert _stamped_task_indices(stamped) == [5, 6]
+        assert _stamped_task_indices(unstamped) == []
+        assert _stamped_task_indices(no_rows) == []
+
+    def test_checkpoint_cut_lowered_by_outstanding_ordinals(self, monkeypatch):
+        """A target refilled past another target's in-flight groups must not
+        strand them: 24 prompts in 8-batches, target 0 lost {3..7} to a
+        tolerated failure and was refilled with {16..20}; training it moved
+        the frontier to 21 while target 1's {8..15} are still generating.
+        The checkpoint must cut at 8 — not 21 — or those never-failed
+        prompts sit below the resume base and are silently lost.
+        """
+        monkeypatch.setattr(trajectory_collector_mod.ray, "get", lambda ref: ref)
+        collector = self.create_local_collector()
+        collector._dataloader_snapshots.extend(
+            [(0, {"pos": 0}), (8, {"pos": 1}), (16, {"pos": 2})]
+        )
+        collector._outstanding_task_indices = set(range(8, 16))
+
+        poisoned = collector.get_checkpoint_state(21)
+        assert poisoned["dataloader"]["frontier_ordinal"] == 8
+        assert poisoned["dataloader"]["base_ordinal"] == 8
+        assert poisoned["dataloader"]["frontier_aligned"] is True
+
+        # Healthy path: outstanding work at/above the frontier changes nothing.
+        collector._outstanding_task_indices = {21, 22, 23}
+        healthy = collector.get_checkpoint_state(21)
+        assert healthy["dataloader"]["frontier_ordinal"] == 21
+        assert healthy["dataloader"]["base_ordinal"] == 16
+
+        # No outstanding work at all: also unchanged.
+        collector._outstanding_task_indices = set()
+        idle = collector.get_checkpoint_state(21)
+        assert idle["dataloader"]["frontier_ordinal"] == 21
+
+        # Buffered-but-untrained groups below the frontier lower the cut
+        # too: their only record is the buffer, which a
+        # load_replay_buffer=false resume discards. Here target 1's {8..12}
+        # completed (left the outstanding set) while {13..15} still run.
+        collector._outstanding_task_indices = {13, 14, 15}
+        collector.replay_buffer.get_held_task_indices.remote.return_value = [
+            8,
+            9,
+            10,
+            11,
+            12,
+        ]
+        partially_buffered = collector.get_checkpoint_state(21)
+        assert partially_buffered["dataloader"]["frontier_ordinal"] == 8
+        assert partially_buffered["dataloader"]["base_ordinal"] == 8
+
+        # Healthy buffer contents (at/above the frontier) change nothing.
+        collector._outstanding_task_indices = set()
+        collector.replay_buffer.get_held_task_indices.remote.return_value = [
+            21,
+            22,
+            23,
+        ]
+        healthy_buffered = collector.get_checkpoint_state(21)
+        assert healthy_buffered["dataloader"]["frontier_ordinal"] == 21
+
+    def test_failure_interleaving_resume_regenerates_stranded_window(self):
+        """Resume from a lowered cut regenerates exactly what was lost.
+
+        Cut = 8; the checkpoint covers retained groups {11, 12} AND the
+        already-trained refill {16..20} (persisted as trained-above-cut by
+        the driver). The resumed stream must contain the stranded prompts
+        {8, 9, 10, 13, 14, 15} and continue at 21+ — the trained refill is
+        dropped by the filter, never re-trained.
+        """
+        batches = [self.create_mock_batch(8) for _ in range(3)]
+        phase_a = self.create_local_collector()
+        self._run_loop_collecting(phase_a, self._FakeStatefulLoader(batches))
+
+        resumed = self.create_local_collector(
+            next_nemo_gym_task_index=8,
+            resume_frontier_ordinal=8,
+            # retained ∪ trained-above-cut, as async_grpo_train unions them
+            resume_covered_task_indices=[11, 12, 16, 17, 18, 19, 20],
+        )
+        stream = self._run_loop_collecting(
+            resumed, self._FakeStatefulLoader(batches, start=1)
+        )
+
+        assert self._ordinals(stream) == [8, 9, 10, 13, 14, 15, 21, 22, 23]
+
+    def test_lowered_cut_resume_without_buffer_regenerates_buffered_window(self):
+        """load_replay_buffer=false on a cut-lowered checkpoint.
+
+        Cut = 8 (lowered to the buffered-untrained minimum), no retained set
+        (the buffer was discarded), covered = trained {16..20} only. The
+        whole [8, 16) window must regenerate — including {8..12}, whose
+        finished rollouts were thrown away with the buffer.
+        """
+        batches = [self.create_mock_batch(8) for _ in range(3)]
+        phase_a = self.create_local_collector()
+        self._run_loop_collecting(phase_a, self._FakeStatefulLoader(batches))
+
+        resumed = self.create_local_collector(
+            next_nemo_gym_task_index=8,
+            resume_frontier_ordinal=8,
+            resume_covered_task_indices=[16, 17, 18, 19, 20],
+        )
+        stream = self._run_loop_collecting(
+            resumed, self._FakeStatefulLoader(batches, start=1)
+        )
+
+        assert self._ordinals(stream) == list(range(8, 16)) + [21, 22, 23]
+
+    def test_process_batch_tracks_dispatched_outstanding(self, monkeypatch):
+        """Dispatch adds stamped group ordinals; a failed start removes them."""
+        replay_buffer = mock.MagicMock()
+        replay_buffer.get_trajectories_needed.remote.return_value = 2
+        collector = self.create_local_collector(replay_buffer=replay_buffer)
+        collector._refit_pause_cleared.set()
+        collector._get_next_target_for_generation = lambda version: 1
+        monkeypatch.setattr(
+            "nemo_rl.algorithms.async_utils.trajectory_collector.ray",
+            mock.MagicMock(get=lambda ref: ref),
+        )
+        worker_calls = []
+
+        async def _fake_worker(**kwargs):
+            worker_calls.append(kwargs)
+
+        collector._run_rollout_batch_worker = _fake_worker
+
+        batch = self.create_mock_batch(size=4)
+        collector._stamp_task_indices(batch)
+        collector._process_batch(batch)
+        collector.wait_for_pending_generations()
+
+        # The fake worker bypasses the real finally-discard, so the dispatch
+        # registration is observable here.
+        assert collector._outstanding_task_indices == {0, 1}
+        assert worker_calls[0]["dispatched_task_indices"] == [0, 1]
+
+        # A worker that fails to start must roll its registration back.
+        collector._outstanding_task_indices = set()
+        monkeypatch.setattr(
+            "nemo_rl.algorithms.async_utils.trajectory_collector._threading.Thread",
+            mock.MagicMock(side_effect=RuntimeError("no threads")),
+        )
+        remainder = collector._process_batch(batch)
+        assert remainder is batch  # nothing consumed
+        assert collector._outstanding_task_indices == set()
+
+    def test_worker_clears_outstanding_on_success_and_tolerated_failure(
+        self, monkeypatch
+    ):
+        """Buffered groups leave the outstanding set; a tolerated failure's
+        remainder leaves it at worker exit instead of pinning the cut."""
+
+        class _ReadyResult:
+            def __await__(self):
+                async def _resolve():
+                    return "success"
+
+                return _resolve().__await__()
+
+        class _AddRemote:
+            def remote(self, *args):
+                return _ReadyResult()
+
+        class _ReplayBuffer:
+            add = _AddRemote()
+
+        def _fake_rollouts_factory(fail_after):
+            async def fake_rollouts(**kwargs):
+                for group_index in range(2):
+                    if group_index == fail_after:
+                        raise RuntimeError("worker died mid-batch")
+                    yield trajectory_collector_mod.RolloutGroupResult(
+                        group_index=group_index,
+                        final_batch=BatchedDataDict({"value": torch.tensor([1])}),
+                        rollout_metrics={},
+                    )
+
+            return fake_rollouts
+
+        for fail_after, description in ((None, "success"), (1, "tolerated failure")):
+            collector = self.create_local_collector(
+                replay_buffer=_ReplayBuffer(), max_generation_failures=5
+            )
+            collector.running = True
+            collector._generating_targets.add(3)
+            collector._outstanding_task_indices = {5, 6}
+            monkeypatch.setattr(
+                trajectory_collector_mod,
+                "run_async_multi_turn_rollout_groups",
+                _fake_rollouts_factory(fail_after),
+            )
+
+            # Stamp the input at ordinals 5-6 so group_input_task_indices
+            # carries them. This asserts only the end state (either discard
+            # mechanism suffices); the per-group discard itself is pinned by
+            # test_buffered_groups_clear_outstanding_before_worker_exit.
+            input_batch = self.create_mock_batch(size=2)
+            collector._next_nemo_gym_task_index = 5
+            collector._stamp_task_indices(input_batch)
+
+            asyncio.run(
+                collector._run_rollout_batch_worker(
+                    repeated_batch=input_batch.repeat_interleave(1),
+                    generation_weight_version=2,
+                    target_weight_version=3,
+                    num_generations=1,
+                    use_nemo_gym=False,
+                    dispatched_task_indices=[5, 6],
+                )
+            )
+
+            assert collector._outstanding_task_indices == set(), description
+            assert collector.collection_failed is False, description
+
+    class _AwaitableStatus:
+        """Awaitable stand-in for a Ray ObjectRef returned by ``add.remote``."""
+
+        def __init__(self, status="success"):
+            self._status = status
+
+        def __await__(self):
+            async def _resolve():
+                return self._status
+
+            return _resolve().__await__()
+
+    class _FakeReplayBuffer:
+        """Replay buffer whose ``add`` always succeeds immediately."""
+
+        def __init__(self, outer):
+            self._outer = outer
+
+        @property
+        def get_held_task_indices(self):
+            class _HeldRemote:
+                @staticmethod
+                def remote():
+                    return []
+
+            return _HeldRemote
+
+        @property
+        def add(self):
+            outer = self._outer
+
+            class _AddRemote:
+                @staticmethod
+                def remote(*args):
+                    return outer._AwaitableStatus()
+
+            return _AddRemote
+
+    def _fake_two_group_rollouts(self):
+        async def fake_rollouts(**kwargs):
+            for group_index in range(2):
+                yield trajectory_collector_mod.RolloutGroupResult(
+                    group_index=group_index,
+                    final_batch=BatchedDataDict({"value": torch.tensor([1])}),
+                    rollout_metrics={},
+                )
+
+        return fake_rollouts
+
+    def test_buffered_groups_clear_outstanding_before_worker_exit(self, monkeypatch):
+        """The window where every group has buffered but the worker has not
+        yet reached its ``finally``.
+
+        If only the worker-exit sweep cleared the set, a checkpoint taken in
+        this window during a perfectly healthy run would still see the just-
+        buffered ordinals outstanding and lower the cut below the frontier.
+        Driving ``_collect_rollout_batch`` directly bypasses the worker-exit
+        sweep, so only the per-group discard can empty the set here.
+        """
+        collector = self.create_local_collector(
+            replay_buffer=self._FakeReplayBuffer(self)
+        )
+        collector.running = True
+        collector._outstanding_task_indices = {5, 6}
+        monkeypatch.setattr(trajectory_collector_mod.ray, "get", lambda ref: ref)
+        monkeypatch.setattr(
+            trajectory_collector_mod,
+            "run_async_multi_turn_rollout_groups",
+            self._fake_two_group_rollouts(),
+        )
+
+        input_batch = self.create_mock_batch(size=2)
+        collector._next_nemo_gym_task_index = 5
+        collector._stamp_task_indices(input_batch)
+
+        asyncio.run(
+            collector._collect_rollout_batch(
+                repeated_batch=input_batch.repeat_interleave(1),
+                generation_weight_version=2,
+                target_weight_version=3,
+                num_generations=1,
+                use_nemo_gym=False,
+            )
+        )
+
+        assert collector._outstanding_task_indices == set()
+
+        # The healthy consequence: a frontier that just advanced past the
+        # buffered ordinals is not lowered.
+        collector._dataloader_snapshots.append((0, {"pos": 0}))
+        assert collector.get_checkpoint_state(7)["dataloader"]["frontier_ordinal"] == 7
+
+    def test_worker_sweeps_outstanding_when_stopped_mid_flight(self, monkeypatch):
+        """A worker that fails after ``running`` went False must not leak.
+
+        The failure handler returns early when the collector is shutting
+        down; the sweep lives in ``finally`` so the ordinals still clear. A
+        leak here is silent — it pins every later checkpoint's cut and shows
+        up only as mass regeneration on the next resume.
+        """
+        collector = self.create_local_collector()
+        collector.running = True
+        collector._generating_targets.add(3)
+        collector._outstanding_task_indices = {5, 6}
+
+        async def _stop_and_fail(**kwargs):
+            collector.running = False
+            raise RuntimeError("collector shut down mid-batch")
+
+        collector._collect_rollout_batch = _stop_and_fail
+
+        asyncio.run(
+            collector._run_rollout_batch_worker(
+                repeated_batch=self.create_mock_batch(size=2),
+                generation_weight_version=2,
+                target_weight_version=3,
+                num_generations=1,
+                use_nemo_gym=False,
+                dispatched_task_indices=[5, 6],
+            )
+        )
+
+        assert collector._outstanding_task_indices == set()
+        assert 3 not in collector._generating_targets
+
+    def test_healthy_dispatch_leaves_cut_at_frontier_without_warning(
+        self, monkeypatch, capsys
+    ):
+        """End-to-end healthy path: dispatch through ``_process_batch``, let
+        the real worker buffer both groups, and check the cut is untouched.
+
+        The frontier can only reach 2 once ordinals 0-1 are buffered, and the
+        next dispatch's ordinals sit at/above it — so the cut equals the
+        frontier and nothing is logged.
+        """
+        replay_buffer = self._FakeReplayBuffer(self)
+        replay_buffer.get_trajectories_needed = mock.MagicMock()
+        replay_buffer.get_trajectories_needed.remote.return_value = 2
+        collector = self.create_local_collector(replay_buffer=replay_buffer)
+        collector.running = True
+        collector._refit_pause_cleared.set()
+        collector._get_next_target_for_generation = lambda version: 1
+        collector._dataloader_snapshots.append((0, {"pos": 0}))
+        monkeypatch.setattr(trajectory_collector_mod.ray, "get", lambda ref: ref)
+        monkeypatch.setattr(
+            trajectory_collector_mod,
+            "run_async_multi_turn_rollout_groups",
+            self._fake_two_group_rollouts(),
+        )
+
+        batch = self.create_mock_batch(size=2)
+        collector._stamp_task_indices(batch)
+        assert collector._process_batch(batch) is None
+        collector.wait_for_pending_generations()
+
+        # Both groups buffered, so nothing pins the cut down.
+        assert collector._outstanding_task_indices == set()
+        capsys.readouterr()
+        state = collector.get_checkpoint_state(2)
+        assert state["dataloader"]["frontier_ordinal"] == 2
+        assert "cut lowered" not in capsys.readouterr().out
+
+    def test_stamping_falls_back_when_rows_cannot_carry_ordinals(self):
+        """Un-stampable batches disable frontier alignment instead of crashing."""
+        collector = self.create_local_collector()
+        batch = self.create_mock_batch(2)
+        batch["extra_env_info"] = [None, None]
+
+        assert collector._stamp_task_indices(batch) is False
+        assert collector._ordinals_frontier_aligned is False
+        assert collector.get_checkpoint_dataloader_state(0)["frontier_aligned"] is False
+
+    def test_frontier_restore_regenerates_exactly_the_uncovered_prompts(self):
+        """Save/restore round trip: no prompt skipped, none duplicated.
+
+        Phase A yields ordinals 0-11 and checkpoints at trained frontier 5
+        with groups {6, 7, 10} retained in the buffer. Phase B rewinds the
+        loader to the saved snapshot and must re-process exactly the ordinals
+        that are neither trained (< 5) nor retained — then drop the filter.
+        """
+        batches = [self.create_mock_batch(4) for _ in range(4)]
+
+        phase_a = self.create_local_collector()
+        loader_a = self._FakeStatefulLoader(batches[:3])
+        self._run_loop_collecting(phase_a, loader_a)
+
+        snapshot = phase_a.get_checkpoint_dataloader_state(5)
+        assert snapshot["frontier_aligned"] is True
+        assert snapshot["base_ordinal"] == 4
+
+        phase_b = self.create_local_collector(
+            next_nemo_gym_task_index=snapshot["base_ordinal"],
+            resume_frontier_ordinal=5,
+            resume_covered_task_indices=[6, 7, 10],
+        )
+        loader_b = self._FakeStatefulLoader(
+            batches, start=snapshot["dataloader_state"]["pos"]
+        )
+
+        processed = self._run_loop_collecting(phase_b, loader_b)
+
+        assert self._ordinals(processed) == [5, 8, 9, 11, 12, 13, 14, 15]
+        # The filter shuts off once the covered window has been re-yielded.
+        assert phase_b._resume_frontier_ordinal is None
+
+    def test_legacy_resume_skips_prompts_that_frontier_resume_regenerates(self):
+        """The measured failure mode in miniature, as an A/B.
+
+        16 prompts stream through in 4 batches. A checkpoint lands with
+        prompts 0-4 trained (frontier=5), groups {6, 7, 10} retained in the
+        buffer, prompts {5, 8, 9, 11} in flight, and the live cursor at
+        batch 3. The legacy resume (still in-tree as the fallback for
+        pre-frontier checkpoints) restores the live cursor and loses every
+        yielded-but-unbuffered prompt; the frontier resume regenerates all of
+        them with no duplicates.
+        """
+
+        def batch_for(prompt_ids):
+            return BatchedDataDict[DatumSpec](
+                {
+                    "task_name": ["test"] * len(prompt_ids),
+                    "message_log": [
+                        [{"role": "user", "content": f"prompt-{i}"}] for i in prompt_ids
+                    ],
+                    "extra_env_info": [{"prompt_id": i} for i in prompt_ids],
+                    "loss_multiplier": torch.ones(len(prompt_ids)),
+                }
+            )
+
+        def resume_stream(collector, loader):
+            self._prime_collection_loop(collector)
+            seen = []
+            collector._process_batch = lambda batch: seen.extend(
+                row["prompt_id"] for row in batch["extra_env_info"]
+            )
+            collector.dataloader = loader
+            collector._collection_loop()
+            return seen
+
+        all_prompts = set(range(16))
+        batches = [batch_for(range(i, i + 4)) for i in range(0, 16, 4)]
+        trained_before_save = set(range(5))  # consumed_samples = 5
+        retained = {6, 7, 10}  # completed groups in replay_buffer.pt
+        live_cursor_pos = 3  # batches 0-2 yielded at save time
+
+        phase_a = self.create_local_collector()
+        resume_stream(phase_a, self._FakeStatefulLoader(batches))
+        snapshot = phase_a.get_checkpoint_dataloader_state(5)
+
+        # Legacy semantics: live cursor restored, no rewind, no filter.
+        legacy_stream = resume_stream(
+            self.create_local_collector(),
+            self._FakeStatefulLoader(batches, start=live_cursor_pos),
+        )
+        legacy_skipped = all_prompts - (
+            trained_before_save | retained | set(legacy_stream)
+        )
+        assert sorted(legacy_skipped) == [5, 8, 9, 11]
+
+        # Frontier semantics: rewind to the saved snapshot, drop covered rows.
+        frontier = self.create_local_collector(
+            next_nemo_gym_task_index=snapshot["base_ordinal"],
+            resume_frontier_ordinal=5,
+            resume_covered_task_indices=sorted(retained),
+        )
+        frontier_stream = resume_stream(
+            frontier,
+            self._FakeStatefulLoader(
+                batches, start=snapshot["dataloader_state"]["pos"]
+            ),
+        )
+
+        assert frontier_stream == [5, 8, 9, 11, 12, 13, 14, 15]
+        frontier_skipped = all_prompts - (
+            trained_before_save | retained | set(frontier_stream)
+        )
+        duplicates = (trained_before_save | retained) & set(frontier_stream)
+        assert not frontier_skipped
+        assert not duplicates
+
+    def test_unanimous_task_index(self):
+        unanimous = [{NEMO_GYM_TASK_INDEX_KEY: 7}] * 3
+        mixed = [{NEMO_GYM_TASK_INDEX_KEY: 7}, {NEMO_GYM_TASK_INDEX_KEY: 8}]
+        unstamped = [{}, {}]
+
+        assert _unanimous_task_index(unanimous) == 7
+        assert _unanimous_task_index(mixed) is None
+        assert _unanimous_task_index(unstamped) is None
+        assert _unanimous_task_index([]) is None
+
+    def test_rollouts_state_roundtrips_pending_batch(self, tmp_path):
+        """The pending remainder survives torch.save/load and collector restore."""
+        collector = self.create_local_collector()
+        assert PENDING_PROMPTS_KEY not in collector.get_rollouts_state()
+
+        pending = self.create_mock_batch(size=2)
+        collector._pending_batch = pending
+        state = collector.get_rollouts_state()
+        assert state[PENDING_PROMPTS_KEY] is pending
+
+        path = tmp_path / "rollouts.pt"
+        torch.save(state, path)
+        loaded = torch.load(path, weights_only=False)
+
+        restored = self.create_local_collector(
+            pending_batch=loaded[PENDING_PROMPTS_KEY]
+        )
+        assert restored._pending_batch.size == 2
+        assert [
+            log[0]["content"] for log in restored._pending_batch["message_log"]
+        ] == ["Test prompt 0", "Test prompt 1"]
         status = collector.get_status()
         assert status["data_exhausted"] is False
         assert status["errored"] is False
@@ -1877,7 +2636,11 @@ class TestAsyncTrajectoryCollector:
             trajectory_collector_mod._threading, "Thread", RecordingThread
         )
 
-        collector._process_batch(self.create_mock_batch(size=2))
+        # Stamping happens at yield time in _collection_loop; _process_batch
+        # must preserve the ordinals through slicing and repetition.
+        batch = self.create_mock_batch(size=2)
+        assert collector._stamp_task_indices(batch) is True
+        collector._process_batch(batch)
 
         assert len(started_threads) == 1
         assert captured["use_nemo_gym"] is True

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,7 @@ from nemo_rl.algorithms.grpo import (
     _get_grpo_save_state,
     _initial_grpo_save_state,
     _initial_policy_generation_stale,
+    _maybe_restore_async_replay_buffer_checkpoint,
     _needs_hf_refit_handshake,
     _raise_if_reward_penalties_enabled_without_nemo_gym,
     _resolve_logprob_skip_flags,
@@ -73,7 +75,15 @@ from nemo_rl.environments.interfaces import (
     EnvironmentReturn,
 )
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym
-from nemo_rl.experience.interfaces import NEXT_NEMO_GYM_TASK_INDEX_KEY
+from nemo_rl.experience.interfaces import (
+    FRONTIER_ORDINAL_KEY,
+    NEMO_GYM_TASK_INDEX_KEY,
+    NEXT_NEMO_GYM_TASK_INDEX_KEY,
+    PENDING_PROMPTS_KEY,
+    RESUME_BASE_ORDINAL_KEY,
+    RETAINED_TASK_INDICES_KEY,
+    TRAINED_TASK_INDICES_KEY,
+)
 from nemo_rl.experience.rollouts import calculate_rewards
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.models.generation.dynamo import DynamoConfig
@@ -113,6 +123,69 @@ def test_save_async_replay_buffer_checkpoint(tmp_path):
     replay_buffer.save_to_path.remote.assert_called_once_with(
         str(tmp_path / "replay_buffer.pt")
     )
+
+
+@pytest.mark.parametrize("load_replay_buffer", [True, None])
+def test_restore_async_replay_buffer_checkpoint_by_default(
+    tmp_path, load_replay_buffer
+):
+    """True and the legacy absent-key case both restore the buffer."""
+    (tmp_path / "replay_buffer.pt").touch()
+    replay_buffer = MagicMock()
+    replay_buffer.load_from_path.remote.return_value = {"restored": 7}
+
+    with patch("nemo_rl.algorithms.grpo.ray.get", side_effect=lambda value: value):
+        metadata = _maybe_restore_async_replay_buffer_checkpoint(
+            replay_buffer,
+            str(tmp_path),
+            load_replay_buffer=load_replay_buffer,
+            num_prompts_per_step=32,
+            current_training_step=4,
+            max_age_steps=1,
+        )
+
+    assert metadata == {"restored": 7}
+    replay_buffer.load_from_path.remote.assert_called_once_with(
+        str(tmp_path / "replay_buffer.pt"),
+        num_prompts_per_step=32,
+        current_training_step=4,
+        max_age_steps=1,
+    )
+
+
+def test_restore_async_replay_buffer_checkpoint_can_be_disabled(tmp_path):
+    """load_replay_buffer=false skips the restore even when the file exists."""
+    (tmp_path / "replay_buffer.pt").touch()
+    replay_buffer = MagicMock()
+
+    metadata = _maybe_restore_async_replay_buffer_checkpoint(
+        replay_buffer,
+        str(tmp_path),
+        load_replay_buffer=False,
+        num_prompts_per_step=32,
+        current_training_step=4,
+        max_age_steps=1,
+    )
+
+    assert metadata is None
+    replay_buffer.load_from_path.remote.assert_not_called()
+
+
+def test_restore_async_replay_buffer_checkpoint_missing_file(tmp_path):
+    """A missing replay_buffer.pt starts empty without calling the actor."""
+    replay_buffer = MagicMock()
+
+    metadata = _maybe_restore_async_replay_buffer_checkpoint(
+        replay_buffer,
+        str(tmp_path),
+        load_replay_buffer=None,
+        num_prompts_per_step=32,
+        current_training_step=4,
+        max_age_steps=1,
+    )
+
+    assert metadata is None
+    replay_buffer.load_from_path.remote.assert_not_called()
 
 
 @patch("nemo_rl.algorithms.grpo.ray")
@@ -828,11 +901,18 @@ class StubReplayBuffer:
     Each method returns a MagicMock with a 'remote' attribute that can be called.
     """
 
-    def __init__(self, initial_size=10, mock_batch=None, mock_rollout_metrics=None):
+    def __init__(
+        self,
+        initial_size=10,
+        mock_batch=None,
+        mock_rollout_metrics=None,
+        retained_task_indices=None,
+    ):
         self._size = initial_size
         self._trajectories = []
         self._mock_batch = mock_batch
         self._mock_rollout_metrics = mock_rollout_metrics or {}
+        self._retained_task_indices = list(retained_task_indices or [])
 
     @property
     def size(self):
@@ -846,13 +926,16 @@ class StubReplayBuffer:
         """Return a mock that returns sample result when .remote() is called"""
 
         def _sample(num_prompt_groups, current_weight_version, max_age_steps):
-            # Return proper trajectory structure expected by async GRPO
+            # Return proper trajectory structure expected by async GRPO. Each
+            # group carries its stream ordinal, like real buffered groups, so
+            # the driver's trained-frontier tracker is exercised.
             trajectories = [
                 {
                     "batch": self._mock_batch,
                     "rollout_metrics": self._mock_rollout_metrics,
+                    NEMO_GYM_TASK_INDEX_KEY: group_index,
                 }
-                for _ in range(num_prompt_groups)
+                for group_index in range(num_prompt_groups)
             ]
             return {
                 "trajectories": trajectories,
@@ -928,6 +1011,7 @@ class StubReplayBuffer:
             return_value={
                 "num_trajectories": self._size,
                 "next_ng_task_index": 0,
+                RETAINED_TASK_INDICES_KEY: list(self._retained_task_indices),
             }
         )
         return mock
@@ -967,6 +1051,8 @@ class StubAsyncTrajectoryCollector:
         health_side_effect=None,
         remote_error_event=None,
         remote_error_ref=None,
+        checkpoint_frontier_aligned=False,
+        checkpoint_cut_ordinal=None,
     ):
         self._events = events
         self._remote_error_event = remote_error_event
@@ -975,6 +1061,10 @@ class StubAsyncTrajectoryCollector:
         self.check_health.remote = MagicMock(
             return_value=None, side_effect=health_side_effect
         )
+        self._checkpoint_frontier_aligned = checkpoint_frontier_aligned
+        # When set, stands in for a collector that lowered the cut below the
+        # trained frontier because prompts below it were still in flight.
+        self._checkpoint_cut_ordinal = checkpoint_cut_ordinal
 
     def _remote_method(self, event):
         mock = MagicMock()
@@ -1062,10 +1152,29 @@ class StubAsyncTrajectoryCollector:
         return mock
 
     @property
-    def get_rollouts_state(self):
-        """Return a remote-callable mock yielding collector rollout state."""
+    def get_checkpoint_state(self):
+        """Return a remote-callable mock yielding the checkpoint pair.
+
+        Mirrors both snapshot shapes: the frontier-aligned one (ring snapshot
+        found at the frontier) and the live-cursor fallback, selected by the
+        ``checkpoint_frontier_aligned`` constructor flag.
+        """
+        aligned = self._checkpoint_frontier_aligned
+        cut = self._checkpoint_cut_ordinal
         mock = MagicMock()
-        mock.remote = MagicMock(return_value={NEXT_NEMO_GYM_TASK_INDEX_KEY: 0})
+        mock.remote = MagicMock(
+            side_effect=lambda frontier_ordinal: {
+                "dataloader": {
+                    "dataloader_state": {},
+                    "base_ordinal": 0 if aligned else None,
+                    "frontier_aligned": aligned,
+                    # the real collector returns the (possibly lowered) cut;
+                    # with no outstanding work it echoes the frontier
+                    "frontier_ordinal": (frontier_ordinal if cut is None else cut),
+                },
+                "rollouts": {NEXT_NEMO_GYM_TASK_INDEX_KEY: 0},
+            }
+        )
         return mock
 
 
@@ -1077,6 +1186,9 @@ def mock_async_grpo_infrastructure(
     collector_events=None,
     refit_side_effect=None,
     collector_remote_error_event=None,
+    checkpoint_frontier_aligned=False,
+    retained_task_indices=None,
+    checkpoint_cut_ordinal=None,
 ):
     """
     Context manager that mocks all async GRPO infrastructure (Ray actors, venv, etc).
@@ -1092,6 +1204,7 @@ def mock_async_grpo_infrastructure(
         initial_size=10,
         mock_batch=mock_batch,
         mock_rollout_metrics=mock_rollout_metrics,
+        retained_task_indices=retained_task_indices,
     )
     collector_remote_error_ref = object()
     stub_collector = StubAsyncTrajectoryCollector(
@@ -1099,6 +1212,8 @@ def mock_async_grpo_infrastructure(
         health_side_effect=collector_health_side_effect,
         remote_error_event=collector_remote_error_event,
         remote_error_ref=collector_remote_error_ref,
+        checkpoint_frontier_aligned=checkpoint_frontier_aligned,
+        checkpoint_cut_ordinal=checkpoint_cut_ordinal,
     )
 
     # Patch venv creation
@@ -1321,6 +1436,221 @@ def test_async_grpo_propagates_main_loop_collector_failure(mock_grpo_components)
 
     mock_grpo_components["checkpointer"].shutdown.assert_called_once()
     mock_grpo_components["policy"].shutdown.assert_called_once()
+
+
+@pytest.mark.parametrize("frontier_aligned", [True, False])
+def test_async_checkpoint_rollouts_state_frontier_key_contract(
+    mock_grpo_components, tmp_path, frontier_aligned
+):
+    """rollouts.pt carries the frontier keys iff the snapshot is aligned.
+
+    Pins both halves of the checkpoint-file contract at the driver level: the
+    frontier ordinal written under FRONTIER_ORDINAL_KEY comes from the trained
+    groups' own ordinals (max + 1), and RESUME_BASE_ORDINAL_KEY mirrors the
+    snapshot's base; a fallback snapshot writes neither key.
+    """
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    master_config.checkpointing["enabled"] = True
+    master_config.checkpointing["save_period"] = 1
+    master_config.checkpointing["metric_name"] = None
+    checkpointer = mock_grpo_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = str(tmp_path)
+    checkpointer.checkpoint_dir = tmp_path
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_rollout_metrics = {"mean_gen_tokens_per_sample": 2.0}
+
+    with (
+        mock_async_grpo_infrastructure(
+            mock_batch,
+            mock_rollout_metrics,
+            checkpoint_frontier_aligned=frontier_aligned,
+        ),
+        patch("nemo_rl.algorithms.grpo.torch.save") as mock_torch_save,
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            checkpointer,
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    saved_by_name = {
+        os.path.basename(call.args[1]): call.args[0]
+        for call in mock_torch_save.call_args_list
+    }
+    assert "rollouts.pt" in saved_by_name
+    assert "train_dataloader.pt" in saved_by_name
+    rollouts_state = saved_by_name["rollouts.pt"]
+    assert rollouts_state[NEXT_NEMO_GYM_TASK_INDEX_KEY] == 0
+    if frontier_aligned:
+        # StubReplayBuffer stamps sampled groups 0..P-1, so the trained
+        # frontier is P; the stub snapshot reports base_ordinal 0.
+        expected_frontier = master_config.grpo.num_prompts_per_step
+        assert rollouts_state[FRONTIER_ORDINAL_KEY] == expected_frontier
+        # cut == frontier here, so no trained ordinal sits at/above the cut
+        assert rollouts_state[TRAINED_TASK_INDICES_KEY] == []
+        assert rollouts_state[RESUME_BASE_ORDINAL_KEY] == 0
+    else:
+        assert FRONTIER_ORDINAL_KEY not in rollouts_state
+        assert RESUME_BASE_ORDINAL_KEY not in rollouts_state
+
+
+def test_async_checkpoint_persists_lowered_cut_not_trained_frontier(
+    mock_grpo_components, tmp_path
+):
+    """rollouts.pt must carry the collector's cut, not the trained frontier.
+
+    When the collector lowers the cut because prompts below the frontier are
+    still in flight, the persisted filter threshold has to follow it down. If
+    the driver wrote ``trained_frontier_ordinal`` instead, the rewound
+    dataloader would re-yield the stranded window and the resume filter would
+    immediately drop it as already-trained — re-stranding the prompts one
+    layer down, with no warning.
+    """
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    master_config.checkpointing["enabled"] = True
+    master_config.checkpointing["save_period"] = 1
+    master_config.checkpointing["metric_name"] = None
+    checkpointer = mock_grpo_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = str(tmp_path)
+    checkpointer.checkpoint_dir = tmp_path
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    # The stub trains groups 0..P-1, so the trained frontier is P. Stand the
+    # cut strictly below it and require the cut to win.
+    trained_frontier = master_config.grpo.num_prompts_per_step
+    lowered_cut = trained_frontier - 1
+    assert lowered_cut < trained_frontier
+
+    with (
+        mock_async_grpo_infrastructure(
+            mock_batch,
+            {"mean_gen_tokens_per_sample": 2.0},
+            checkpoint_frontier_aligned=True,
+            checkpoint_cut_ordinal=lowered_cut,
+        ),
+        patch("nemo_rl.algorithms.grpo.torch.save") as mock_torch_save,
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            checkpointer,
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    saved_by_name = {
+        os.path.basename(call.args[1]): call.args[0]
+        for call in mock_torch_save.call_args_list
+    }
+    rollouts_state = saved_by_name["rollouts.pt"]
+    assert rollouts_state[FRONTIER_ORDINAL_KEY] == lowered_cut
+    # the stub trained groups 0..P-1; those at/above the lowered cut must be
+    # persisted so the resume covers them instead of re-training them
+    assert rollouts_state[TRAINED_TASK_INDICES_KEY] == list(
+        range(lowered_cut, trained_frontier)
+    )
+    assert rollouts_state[RESUME_BASE_ORDINAL_KEY] == 0
+
+
+def test_async_resume_plumbs_frontier_metadata_into_collector(
+    mock_grpo_components, tmp_path
+):
+    """rollouts.pt frontier keys drive the collector's resume kwargs.
+
+    The read-back half of the checkpoint-file contract: base_ordinal feeds
+    next_nemo_gym_task_index, the frontier and the buffer's retained indices
+    feed the row filter, and the pending batch is dropped (the rewound
+    dataloader re-yields it).
+    """
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    checkpointer = mock_grpo_components["checkpointer"]
+    checkpointer.get_latest_checkpoint_path.return_value = str(tmp_path)
+    checkpointer.checkpoint_dir = tmp_path
+
+    torch.save(
+        {
+            NEXT_NEMO_GYM_TASK_INDEX_KEY: 12,
+            FRONTIER_ORDINAL_KEY: 8,
+            RESUME_BASE_ORDINAL_KEY: 4,
+            PENDING_PROMPTS_KEY: {"should": "be dropped"},
+            TRAINED_TASK_INDICES_KEY: [15],
+        },
+        tmp_path / "rollouts.pt",
+    )
+    torch.save({}, tmp_path / "replay_buffer.pt")  # existence gates the restore
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_rollout_metrics = {"mean_gen_tokens_per_sample": 2.0}
+
+    collector_cls = MagicMock()
+    collector_cls.options.return_value.remote.return_value = (
+        StubAsyncTrajectoryCollector()
+    )
+    with (
+        mock_async_grpo_infrastructure(
+            mock_batch,
+            mock_rollout_metrics,
+            retained_task_indices=[9, 10],
+        ),
+        patch("nemo_rl.algorithms.async_utils.AsyncTrajectoryCollector", collector_cls),
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            checkpointer,
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    collector_kwargs = collector_cls.options.return_value.remote.call_args.kwargs
+    assert collector_kwargs["next_nemo_gym_task_index"] == 4
+    assert collector_kwargs["resume_frontier_ordinal"] == 8
+    # retained (from the buffer) ∪ trained-above-cut (from rollouts.pt)
+    assert collector_kwargs["resume_covered_task_indices"] == [9, 10, 15]
+    assert collector_kwargs["pending_batch"] is None
+    assert collector_kwargs["ordinals_frontier_aligned"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -124,6 +124,10 @@ checkpointing:
   keep_top_k: 3
   save_period: 10
   checkpoint_must_save_by: null
+  # Async GRPO: restore replay-buffer state on resume. Set false to regenerate
+  # the buffered window fresh instead of reusing completed groups (which skew
+  # toward short rollouts at a save boundary).
+  load_replay_buffer: true
   model_save_format: "safetensors"
   save_consolidated: false
   save_optimizer: true


### PR DESCRIPTION
## Summary

- Backport 05c6e8a901d7b103d06caae9bfb8292da89234a3 (#3599) from main.
- Align async-GRPO dataloader checkpoints to the trained prompt frontier and persist coverage metadata so in-flight or evicted prompts are regenerated without skips or duplicate training.
- Add replay-buffer restore control, legacy-checkpoint fallbacks, documentation, and regression coverage.

## Compatibility

- Existing legacy checkpoints remain loadable and explicitly fall back to the previous live-cursor behavior.
- Replay-buffer restore remains enabled by default; it can be disabled to regenerate the buffered window.

## Validation

- Focused async collector, GRPO, config-v2, and config-validation suites: 853 passed, 6 expected config skips
- Targeted pre-commit hooks: passed, including Ruff, Ruff format, Pyrefly, whitespace, and recipe minimization checks
- Backport patch ID matches the source commit exactly
- git diff --check: passed

## Known limitations

- No distributed end-to-end training run was performed locally.