### PR TITLE
test(sc): checkpoint save/restore must not drop prompt groups

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -520,6 +520,7 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
+  checkpointing_enabled: false       # save TQ state inside algorithm checkpoints
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -520,7 +520,10 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
-  checkpointing_enabled: false       # SingleController only: save required shadow TQ state
+  # SingleController only: save native TQ state. Required when trainer
+  # checkpointing is enabled with a replay-checkpoint-capable sampler;
+  # supported samplers restore from metadata-only replay indexes.
+  checkpointing_enabled: false
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -520,7 +520,7 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
-  checkpointing_enabled: false       # save TQ state inside algorithm checkpoints
+  checkpointing_enabled: false       # SingleController only: save required shadow TQ state
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -58,6 +58,7 @@ logger:
 
 data_plane:
   enabled: true
+  # Required shadow snapshot: a save failure aborts checkpoint finalization.
   checkpointing_enabled: true
 
 cluster:

--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -58,6 +58,7 @@ logger:
 
 data_plane:
   enabled: true
+  checkpointing_enabled: true
 
 cluster:
   gpus_per_node: 2

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -16,19 +16,21 @@ import asyncio
 import gc
 import hashlib
 import json
+import math
 import statistics
 import threading as _threading
 import uuid
 from collections import Counter
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
+from numbers import Integral, Real
 from typing import Any, Iterable, Literal, Optional, TypedDict
 
 import ray
 import torch
 
 from nemo_rl.algorithms.async_utils.interfaces import ReplayBufferProtocol
-from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION, KVBatchMeta
 from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.experience.interfaces import (
@@ -39,13 +41,17 @@ from nemo_rl.experience.interfaces import (
 from nemo_rl.experience.payload import pack_payload, record_to_train_batch
 from nemo_rl.utils.r3_trace import trace_rollout_payload
 
-
 DATA_PLANE_CHECKPOINT_DIR = "data_plane"
-DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 2
 REPLAY_BUFFER_METADATA_FILENAME = "replay_buffer_metadata.pt"
 LEGACY_REPLAY_BUFFER_FILENAME = "replay_buffer.pt"
 REPLAY_BUFFER_METADATA_SCHEMA_VERSION = 1
 REPLAY_BUFFER_METADATA_STORAGE: Literal["tq_checkpoint"] = "tq_checkpoint"
+
+# These TypedDicts describe the versioned, plain-mapping checkpoint wire
+# format. They are intentionally not dataclass instances: persisting a
+# dataclass would couple recovery to its Python import path and class layout.
+# Runtime objects such as KVBatchMeta remain explicitly represented as fields
+# inside this schema.
 
 
 class TQReplayGroupMetadata(TypedDict):
@@ -67,6 +73,38 @@ class TQReplayMetadataState(TypedDict):
     saved_capacity: int
     manifest_digest: str
     groups: list[TQReplayGroupMetadata]
+
+
+def _canonical_manifest_value(value: Any, *, path: str) -> Any:
+    """Return a deterministic JSON value or reject unsupported metadata."""
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        float_value = float(value)
+        if not math.isfinite(float_value):
+            raise TypeError(f"Replay metadata at {path} must be finite")
+        return float_value
+    if isinstance(value, Mapping):
+        canonical: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Replay metadata at {path} has non-string key {key!r}")
+            canonical[key] = _canonical_manifest_value(
+                item,
+                path=f"{path}.{key}",
+            )
+        return canonical
+    if isinstance(value, (list, tuple)):
+        return [
+            _canonical_manifest_value(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    raise TypeError(
+        f"Replay metadata at {path} has unsupported type "
+        f"{type(value).__name__}; expected JSON-compatible primitive values"
+    )
 
 
 def replay_manifest_digest(groups: list[TQReplayGroupMetadata]) -> str:
@@ -91,20 +129,35 @@ def replay_manifest_digest(groups: list[TQReplayGroupMetadata]) -> str:
                     if group["meta"].sequence_lengths is not None
                     else None
                 ),
-                "tags": group["meta"].tags,
-                "extra_info": group["meta"].extra_info,
+                "tags": _canonical_manifest_value(
+                    group["meta"].tags,
+                    path=f"groups[{group_index}].meta.tags",
+                ),
+                "extra_info": _canonical_manifest_value(
+                    group["meta"].extra_info,
+                    path=f"groups[{group_index}].meta.extra_info",
+                ),
             },
         }
-        for group in groups
+        for group_index, group in enumerate(groups)
     ]
-    encoded = json.dumps(digest_input, sort_keys=True, separators=(",", ":")).encode(
-        "utf-8"
-    )
+    encoded = json.dumps(
+        digest_input,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 
 class DataPlaneCheckpointBarrier:
-    """Allow concurrent mutations while giving checkpoints exclusive access."""
+    """Allow concurrent mutations while giving live checkpoints exclusivity.
+
+    At most one checkpoint holder is active. New mutations queue behind it,
+    and a checkpoint waits for all active mutations before yielding. Every
+    live canonical TQ commit/clear and native save must use this barrier so the
+    snapshot and controller replay index describe the same rows.
+    """
 
     def __init__(self) -> None:
         self._condition = asyncio.Condition()

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -707,6 +707,13 @@ class TQReplayBuffer:
         self.target_step_list: list[Optional[int]] = []
         self.ready_list: list[bool] = []
         self._group_ids: list[str] = []
+        self._data_plane_checkpoint_lock: Optional[asyncio.Lock] = None
+
+    def set_data_plane_checkpoint_lock(self, lock: asyncio.Lock) -> None:
+        """Serialize replay-buffer-owned clears with SC checkpoints."""
+        if self._data_plane_checkpoint_lock is not None:
+            raise RuntimeError("data-plane checkpoint lock is already configured")
+        self._data_plane_checkpoint_lock = lock
 
     def reserve(
         self,
@@ -806,10 +813,8 @@ class TQReplayBuffer:
             # put_samples may have written rows before raising. Roll back by the
             # deterministic IDs known here; the caller removes the reserved slot.
             try:
-                await self._call_dp(
-                    "clear_samples",
+                await self._clear_samples(
                     sample_ids=list(sample_ids),
-                    partition_id=self._partition_id,
                 )
             except BaseException as rollback_error:
                 if isinstance(commit_error, asyncio.CancelledError):
@@ -872,10 +877,8 @@ class TQReplayBuffer:
             del self._group_ids[i]
 
         if remove_in_dp:
-            await self._call_dp(
-                "clear_samples",
+            await self._clear_samples(
                 sample_ids=dropped_sample_ids,
-                partition_id=self._partition_id,
             )
 
         return len(drop_idxs)
@@ -1102,3 +1105,17 @@ class TQReplayBuffer:
         if asyncio.iscoroutine(result):
             return await result
         return result
+
+    async def _clear_samples(self, *, sample_ids: list[str]) -> None:
+        """Clear rows without overlapping a bound data-plane checkpoint."""
+        if self._data_plane_checkpoint_lock is None:
+            raise RuntimeError(
+                "TQReplayBuffer must be bound to the controller data-plane "
+                "checkpoint lock before clearing samples"
+            )
+        async with self._data_plane_checkpoint_lock:
+            await self._call_dp(
+                "clear_samples",
+                sample_ids=sample_ids,
+                partition_id=self._partition_id,
+            )

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -14,12 +14,15 @@
 
 import asyncio
 import gc
+import hashlib
+import json
 import statistics
 import threading as _threading
 import uuid
 from collections import Counter
-from collections.abc import Mapping
-from typing import Any, Iterable, Optional
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from typing import Any, Iterable, Literal, Optional, TypedDict
 
 import ray
 import torch
@@ -35,6 +38,111 @@ from nemo_rl.experience.interfaces import (
 )
 from nemo_rl.experience.payload import pack_payload, record_to_train_batch
 from nemo_rl.utils.r3_trace import trace_rollout_payload
+
+
+DATA_PLANE_CHECKPOINT_DIR = "data_plane"
+DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 2
+REPLAY_BUFFER_METADATA_FILENAME = "replay_buffer_metadata.pt"
+LEGACY_REPLAY_BUFFER_FILENAME = "replay_buffer.pt"
+REPLAY_BUFFER_METADATA_SCHEMA_VERSION = 1
+REPLAY_BUFFER_METADATA_STORAGE: Literal["tq_checkpoint"] = "tq_checkpoint"
+
+
+class TQReplayGroupMetadata(TypedDict):
+    """Controller-local index for one training-ready group stored in TQ."""
+
+    meta: KVBatchMeta
+    start_weight: int
+    end_weight: int
+    target_step: Optional[int]
+    group_id: str
+
+
+class TQReplayMetadataState(TypedDict):
+    """Versioned metadata-only replay sidecar paired with a TQ snapshot."""
+
+    schema_version: int
+    storage: Literal["tq_checkpoint"]
+    partition_id: str
+    saved_capacity: int
+    manifest_digest: str
+    groups: list[TQReplayGroupMetadata]
+
+
+def replay_manifest_digest(groups: list[TQReplayGroupMetadata]) -> str:
+    """Return a stable digest binding replay metadata to a TQ checkpoint."""
+    digest_input = [
+        {
+            "group_id": group["group_id"],
+            "start_weight": group["start_weight"],
+            "end_weight": group["end_weight"],
+            "target_step": group["target_step"],
+            "meta": {
+                "partition_id": group["meta"].partition_id,
+                "task_name": group["meta"].task_name,
+                "sample_ids": list(group["meta"].sample_ids),
+                "fields": (
+                    list(group["meta"].fields)
+                    if group["meta"].fields is not None
+                    else None
+                ),
+                "sequence_lengths": (
+                    list(group["meta"].sequence_lengths)
+                    if group["meta"].sequence_lengths is not None
+                    else None
+                ),
+                "tags": group["meta"].tags,
+                "extra_info": group["meta"].extra_info,
+            },
+        }
+        for group in groups
+    ]
+    encoded = json.dumps(digest_input, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class DataPlaneCheckpointBarrier:
+    """Allow concurrent mutations while giving checkpoints exclusive access."""
+
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self._checkpoint_active = False
+        self._active_mutations = 0
+
+    @asynccontextmanager
+    async def mutation(self) -> AsyncIterator[None]:
+        """Enter a commit/clear section, waiting only for an active checkpoint."""
+        async with self._condition:
+            await self._condition.wait_for(lambda: not self._checkpoint_active)
+            self._active_mutations += 1
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._active_mutations -= 1
+                if self._active_mutations == 0:
+                    self._condition.notify_all()
+
+    @asynccontextmanager
+    async def checkpoint(self) -> AsyncIterator[None]:
+        """Block new mutations and wait for active ones before snapshotting."""
+        async with self._condition:
+            await self._condition.wait_for(lambda: not self._checkpoint_active)
+            self._checkpoint_active = True
+            try:
+                await self._condition.wait_for(lambda: self._active_mutations == 0)
+            except BaseException:
+                self._checkpoint_active = False
+                self._condition.notify_all()
+                raise
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._checkpoint_active = False
+                self._condition.notify_all()
 
 
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
@@ -708,18 +816,20 @@ class TQReplayBuffer:
         self.target_step_list: list[Optional[int]] = []
         self.ready_list: list[bool] = []
         self._group_ids: list[str] = []
-        self._data_plane_checkpoint_lock: Optional[asyncio.Lock] = None
+        self._data_plane_checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
 
-    def set_data_plane_checkpoint_lock(self, lock: asyncio.Lock) -> None:
-        """Bind the controller's shared checkpoint/clear barrier exactly once.
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        """Bind the controller's shared checkpoint/mutation barrier once.
 
-        A private fallback lock would not coordinate with controller-owned
+        A private fallback barrier would not coordinate with controller-owned
         saves and clears, so destructive operations fail loudly until the SC
-        actor supplies its lock.
+        actor supplies its barrier.
         """
-        if self._data_plane_checkpoint_lock is not None:
-            raise RuntimeError("data-plane checkpoint lock is already configured")
-        self._data_plane_checkpoint_lock = lock
+        if self._data_plane_checkpoint_barrier is not None:
+            raise RuntimeError("data-plane checkpoint barrier is already configured")
+        self._data_plane_checkpoint_barrier = barrier
 
     def reserve(
         self,
@@ -778,6 +888,11 @@ class TQReplayBuffer:
                 f"commit called with unknown group_id={group_id!r}; "
                 f"reserve() must precede commit() (or the slot was already removed)"
             )
+        if self._data_plane_checkpoint_barrier is None:
+            raise RuntimeError(
+                "TQReplayBuffer must be bound to the controller data-plane "
+                "checkpoint barrier before committing samples"
+            )
         train_batch = record_to_train_batch(record, pad_value_dict=self._pad_value_dict)
         sample_ids, fields, tags = pack_payload(
             train_batch, weight_version=start_weight_version, group_id=group_id
@@ -790,47 +905,48 @@ class TQReplayBuffer:
                 "the async message-log flattening path."
             )
         trace_rollout_payload(keys=sample_ids, data=train_batch)
-        try:
-            await call_data_plane(
-                self._dp_client,
-                "put_samples",
-                sample_ids=sample_ids,
-                partition_id=self._partition_id,
-                fields=fields,
-                tags=tags,
-            )
-
-            # mirrors kv_first_write
-            lengths = train_batch["input_lengths"]
-            meta = KVBatchMeta(
-                partition_id=self._partition_id,
-                task_name="train",
-                sample_ids=list(sample_ids),
-                fields=list(fields.keys()),
-                sequence_lengths=[int(s) for s in lengths.tolist()],
-                tags=[dict(t) for t in tags],
-            )
-
-            idx = self._group_ids.index(group_id)
-            self.meta_list[idx] = meta
-            self.end_weight_list[idx] = end_weight_version
-            self.ready_list[idx] = True
-            return meta
-        except BaseException as commit_error:
-            # put_samples may have written rows before raising. Roll back by the
-            # deterministic IDs known here; the caller removes the reserved slot.
+        async with self._data_plane_checkpoint_barrier.mutation():
             try:
-                await self._clear_samples(
+                await call_data_plane(
+                    self._dp_client,
+                    "put_samples",
+                    sample_ids=sample_ids,
+                    partition_id=self._partition_id,
+                    fields=fields,
+                    tags=tags,
+                )
+
+                # mirrors kv_first_write
+                lengths = train_batch["input_lengths"]
+                meta = KVBatchMeta(
+                    partition_id=self._partition_id,
+                    task_name="train",
                     sample_ids=list(sample_ids),
+                    fields=list(fields.keys()),
+                    sequence_lengths=[int(s) for s in lengths.tolist()],
+                    tags=[dict(t) for t in tags],
                 )
-            except BaseException as rollback_error:
-                if isinstance(commit_error, asyncio.CancelledError):
-                    raise commit_error from rollback_error
-                raise BaseExceptionGroup(
-                    f"commit and rollback both failed for group_id={group_id!r}",
-                    [commit_error, rollback_error],
-                )
-            raise
+
+                idx = self._group_ids.index(group_id)
+                self.meta_list[idx] = meta
+                self.end_weight_list[idx] = end_weight_version
+                self.ready_list[idx] = True
+                return meta
+            except BaseException as commit_error:
+                # put_samples may have written rows before raising. Roll back by the
+                # deterministic IDs while retaining the barrier mutation slot.
+                try:
+                    await self._clear_samples_unlocked(
+                        sample_ids=list(sample_ids),
+                    )
+                except BaseException as rollback_error:
+                    if isinstance(commit_error, asyncio.CancelledError):
+                        raise commit_error from rollback_error
+                    raise BaseExceptionGroup(
+                        f"commit and rollback both failed for group_id={group_id!r}",
+                        [commit_error, rollback_error],
+                    )
+                raise
 
     async def remove_group(self, group_id: str, *, remove_in_dp: bool = False) -> int:
         """Remove the live slot identified by ``group_id``.
@@ -845,11 +961,17 @@ class TQReplayBuffer:
         Raises:
             ValueError: ``group_id`` has no live slot.
         """
-        try:
-            idx = self._group_ids.index(group_id)
-        except ValueError as error:
-            raise ValueError(f"unknown group_id={group_id!r}") from error
-        return await self.remove([idx], remove_in_dp=remove_in_dp)
+        if self._data_plane_checkpoint_barrier is None:
+            raise RuntimeError(
+                "TQReplayBuffer must be bound to the controller data-plane "
+                "checkpoint barrier before removing a group"
+            )
+        async with self._data_plane_checkpoint_barrier.mutation():
+            try:
+                idx = self._group_ids.index(group_id)
+            except ValueError as error:
+                raise ValueError(f"unknown group_id={group_id!r}") from error
+            return await self._remove_unlocked([idx], clear_data_plane=remove_in_dp)
 
     async def remove(self, idxs: list[int], remove_in_dp: bool) -> int:
         """Drop entries at the given indices and optionally clear them from DataPlane.
@@ -863,14 +985,24 @@ class TQReplayBuffer:
         """
         if len(idxs) == 0:
             return 0
-
-        drop_idxs = sorted(idxs, reverse=True)
-        if drop_idxs[0] >= len(self.meta_list):
-            raise IndexError(
-                f"TQReplayBuffer.remove: indices out of range: {drop_idxs[0]}; "
-                f"size={len(self.meta_list)}"
+        if self._data_plane_checkpoint_barrier is None:
+            raise RuntimeError(
+                "TQReplayBuffer must be bound to the controller data-plane "
+                "checkpoint barrier before removing groups"
             )
+        async with self._data_plane_checkpoint_barrier.mutation():
+            drop_idxs = sorted(idxs, reverse=True)
+            if drop_idxs[0] >= len(self.meta_list):
+                raise IndexError(
+                    f"TQReplayBuffer.remove: indices out of range: {drop_idxs[0]}; "
+                    f"size={len(self.meta_list)}"
+                )
+            return await self._remove_unlocked(drop_idxs, clear_data_plane=remove_in_dp)
 
+    async def _remove_unlocked(
+        self, drop_idxs: list[int], *, clear_data_plane: bool
+    ) -> int:
+        """Remove validated indices while the caller owns any required lock."""
         dropped_sample_ids: list[str] = []
         for i in drop_idxs:
             meta = self.meta_list[i]
@@ -883,71 +1015,48 @@ class TQReplayBuffer:
             del self.ready_list[i]
             del self._group_ids[i]
 
-        if remove_in_dp:
-            await self._clear_samples(
+        if clear_data_plane:
+            await self._clear_samples_unlocked(
                 sample_ids=dropped_sample_ids,
             )
 
         return len(drop_idxs)
 
-    async def state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
-        """Serialize ready groups (meta + DataPlane payloads) for checkpointing.
+    def metadata_state_dict(self, *, saved_capacity: int) -> TQReplayMetadataState:
+        """Capture the controller index for ready groups without tensor payloads.
 
-        Snapshots the ready slots synchronously on the event loop first, then
-        fetches each group's rows from the DataPlane. Unready reservations are
-        in-flight rollouts and are dropped, matching legacy semantics. The
-        snapshot stays consistent during the async fetch: concurrent commits
-        only append/flip *other* slots, and the train pump — the only
-        remover — is the caller itself; groups committed mid-save land in the
-        next checkpoint.
-
-        Args:
-            saved_capacity: max_buffered_rollouts at save time, recorded so
-                load_state_dict can report capacity changes across restarts.
-
-        Returns:
-            Envelope: ``{"partition_id": ..., "saved_capacity": ...,
-            "groups": [{"meta", "start_weight", "end_weight", "target_step",
-            "group_id", "fields_data"}, ...]}``.
+        The caller must hold the exclusive side of the shared data-plane
+        checkpoint barrier through this capture and the matching TQ save.
+        Commits and destructive clears use shared mutation slots, so the sidecar
+        and native snapshot describe one exact set of training-ready groups.
+        Every operation that mutates the canonical rollout partition or its
+        controller-local replay membership must participate in that barrier
+        across the complete publish/index or clear/remove transition. This
+        includes future finalizer paths; canonical writes are not required to
+        originate specifically from :meth:`commit`.
+        In-flight reservations are intentionally omitted.
         """
-        snapshot: list[tuple[KVBatchMeta, int, int, Optional[int], str]] = []
+        groups: list[TQReplayGroupMetadata] = []
         for i, ready in enumerate(self.ready_list):
             if not ready:
                 continue
             meta = self.meta_list[i]
             assert meta is not None  # commit sets meta before ready=True
-            snapshot.append(
-                (
-                    meta,
-                    self.start_weight_list[i],
-                    self.end_weight_list[i],
-                    self.target_step_list[i],
-                    self._group_ids[i],
-                )
-            )
-
-        groups: list[dict[str, Any]] = []
-        for meta, start_weight, end_weight, target_step, group_id in snapshot:
-            fields_data = await call_data_plane(
-                self._dp_client,
-                "get_samples",
-                sample_ids=meta.sample_ids,
-                partition_id=self._partition_id,
-                select_fields=meta.fields,
-            )
             groups.append(
                 {
                     "meta": meta,
-                    "start_weight": start_weight,
-                    "end_weight": end_weight,
-                    "target_step": target_step,
-                    "group_id": group_id,
-                    "fields_data": fields_data,
+                    "start_weight": self.start_weight_list[i],
+                    "end_weight": self.end_weight_list[i],
+                    "target_step": self.target_step_list[i],
+                    "group_id": self._group_ids[i],
                 }
             )
         return {
+            "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "storage": REPLAY_BUFFER_METADATA_STORAGE,
             "partition_id": self._partition_id,
             "saved_capacity": saved_capacity,
+            "manifest_digest": replay_manifest_digest(groups),
             "groups": groups,
         }
 
@@ -958,16 +1067,14 @@ class TQReplayBuffer:
         max_groups: int,
         expected_partition_id: str,
         expected_group_size: int,
+        expected_manifest_digest: str,
     ) -> int:
-        """Validate and re-put checkpointed groups into the buffer.
+        """Restore the local replay index for an already-restored TQ snapshot.
 
-        The preflight runs entirely before any DataPlane write (legacy
-        precedent: validate, then truncate):
-          1. Validate the envelope and raise ValueError on malformed state.
-          2. Truncate to ``max_groups``, keeping the freshest groups, so the
-             restored count can never exceed the buffer's capacity. Groups
-             carrying a ``target_step`` are never truncated — an over-capacity
-             in-order checkpoint raises instead (see Raises).
+        The sidecar never contains tensor payloads and this method never writes
+        to the DataPlane. TQ must be restored first; the caller binds the two
+        artifacts by passing the manifest digest returned by TQ checkpoint
+        loading.
 
         Staleness is intentionally NOT handled here — load only loads. The
         train pump's first ``sampler.evict`` drops any restored group that is
@@ -975,7 +1082,7 @@ class TQReplayBuffer:
         eviction in one place.
 
         Args:
-            state: Envelope produced by ``state_dict``.
+            state: Envelope produced by ``metadata_state_dict``.
             max_groups: Current max_buffered_rollouts; the restored count
                 never exceeds it.
             expected_partition_id: Partition this buffer writes to; must
@@ -983,6 +1090,8 @@ class TQReplayBuffer:
             expected_group_size: num_generations_per_prompt; every group must
                 hold exactly this many rows (a changed group size silently
                 breaks the group-relative baseline).
+            expected_manifest_digest: Digest returned by the matching native
+                TQ checkpoint load. It must match the metadata sidecar.
 
         Returns:
             Number of groups restored into the buffer.
@@ -990,13 +1099,34 @@ class TQReplayBuffer:
         Raises:
             ValueError: If the envelope is malformed (missing keys, partition
                 mismatch, misaligned or wrongly sized groups, duplicate
-                sample_ids), or if target-stamped groups exceed ``max_groups``.
+                sample_ids), disagrees with the native TQ snapshot, or exceeds
+                ``max_groups``.
         """
-        required_keys = {"partition_id", "saved_capacity", "groups"}
+        if self.meta_list or self._group_ids:
+            raise RuntimeError(
+                "Replay-buffer checkpoint loading requires an empty local buffer"
+            )
+        required_keys = {
+            "schema_version",
+            "storage",
+            "partition_id",
+            "saved_capacity",
+            "manifest_digest",
+            "groups",
+        }
         missing_keys = required_keys - set(state)
         if missing_keys:
             raise ValueError(
                 f"Replay buffer checkpoint missing required keys: {missing_keys}"
+            )
+        if state["schema_version"] != REPLAY_BUFFER_METADATA_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported replay-buffer metadata schema version: "
+                f"{state['schema_version']!r}"
+            )
+        if state["storage"] != REPLAY_BUFFER_METADATA_STORAGE:
+            raise ValueError(
+                f"Replay-buffer metadata has unsupported storage: {state['storage']!r}"
             )
         if state["partition_id"] != expected_partition_id:
             raise ValueError(
@@ -1012,16 +1142,25 @@ class TQReplayBuffer:
             "end_weight",
             "target_step",
             "group_id",
-            "fields_data",
         }
         seen_sample_ids: set[str] = set()
         for group in groups:
+            if "fields_data" in group:
+                raise ValueError(
+                    "Metadata-only replay checkpoint must not contain fields_data"
+                )
             missing_group_keys = group_keys - set(group)
             if missing_group_keys:
                 raise ValueError(
                     f"Replay buffer checkpoint group missing keys: {missing_group_keys}"
                 )
             meta = group["meta"]
+            if meta.partition_id != expected_partition_id:
+                raise ValueError(
+                    "Replay buffer checkpoint group partition_id mismatch: "
+                    f"checkpoint={meta.partition_id!r}, "
+                    f"expected={expected_partition_id!r}"
+                )
             num_tags = len(meta.tags) if meta.tags is not None else -1
             num_lengths = (
                 len(meta.sequence_lengths) if meta.sequence_lengths is not None else -1
@@ -1042,44 +1181,30 @@ class TQReplayBuffer:
                     )
                 seen_sample_ids.add(sid)
 
+        actual_digest = replay_manifest_digest(groups)
+        if state["manifest_digest"] != actual_digest:
+            raise ValueError(
+                "Replay-buffer metadata digest does not match its contents"
+            )
+        if expected_manifest_digest != actual_digest:
+            raise ValueError(
+                "Replay-buffer metadata does not match the loaded TQ checkpoint"
+            )
+
         if state["saved_capacity"] != max_groups:
             print(
                 "TQReplayBuffer capacity changed: "
                 f"checkpoint={state['saved_capacity']}, current={max_groups}. "
                 "Using current config value."
             )
-        num_truncated = 0
         if len(groups) > max_groups:
-            if any(group["target_step"] is not None for group in groups):
-                raise ValueError(
-                    f"Replay buffer checkpoint holds {len(groups)} group(s) "
-                    f"but async_rl.max_buffered_rollouts is {max_groups}. "
-                    "These groups carry target_step stamps (in-order "
-                    "sampling) and are selected as whole per-step batches, so "
-                    "dropping any of them would deadlock the resumed run. "
-                    "Resume with async_rl.max_buffered_rollouts >= "
-                    f"{len(groups)}, or delete replay_buffer.pt from the "
-                    "checkpoint to resume with an empty buffer."
-                )
-            num_truncated = len(groups) - max_groups
-            # Keep the freshest max_groups groups, preserving original order.
-            prioritized = sorted(
-                range(len(groups)),
-                key=lambda i: (groups[i]["start_weight"], i),
+            raise ValueError(
+                "Native TQ checkpoint contains more replay groups than the current "
+                f"buffer capacity: checkpoint={len(groups)}, current={max_groups}"
             )
-            indices_to_keep = sorted(prioritized[num_truncated:])
-            groups = [groups[i] for i in indices_to_keep]
 
         for group in groups:
             meta = group["meta"]
-            await call_data_plane(
-                self._dp_client,
-                "put_samples",
-                sample_ids=list(meta.sample_ids),
-                partition_id=self._partition_id,
-                fields=group["fields_data"],
-                tags=[dict(t) for t in meta.tags],
-            )
             self.meta_list.append(meta)
             self.start_weight_list.append(group["start_weight"])
             self.end_weight_list.append(group["end_weight"])
@@ -1087,10 +1212,10 @@ class TQReplayBuffer:
             self.ready_list.append(True)
             self._group_ids.append(group["group_id"])
 
-        summary = f"📦 Restored {len(groups)} replay group(s) from checkpoint"
-        if num_truncated:
-            summary += f"; truncated {num_truncated} group(s) over capacity"
-        print(summary, flush=True)
+        print(
+            f"📦 Restored {len(groups)} replay group(s) from checkpoint",
+            flush=True,
+        )
         return len(groups)
 
     def count_for_target_step(self, target_step: int) -> int:
@@ -1106,16 +1231,20 @@ class TQReplayBuffer:
 
     async def _clear_samples(self, *, sample_ids: list[str]) -> None:
         """Clear rows without overlapping a bound data-plane checkpoint."""
-        if self._data_plane_checkpoint_lock is None:
+        if self._data_plane_checkpoint_barrier is None:
             raise RuntimeError(
                 "TQReplayBuffer must be bound to the controller data-plane "
-                "checkpoint lock before clearing samples"
+                "checkpoint barrier before clearing samples"
             )
-        async with self._data_plane_checkpoint_lock:
-            await call_data_plane(
-                self._dp_client,
-                "clear_samples",
-                offload_sync=True,
-                sample_ids=sample_ids,
-                partition_id=self._partition_id,
-            )
+        async with self._data_plane_checkpoint_barrier.mutation():
+            await self._clear_samples_unlocked(sample_ids=sample_ids)
+
+    async def _clear_samples_unlocked(self, *, sample_ids: list[str]) -> None:
+        """Clear rows while the caller holds a barrier mutation slot."""
+        await call_data_plane(
+            self._dp_client,
+            "clear_samples",
+            offload_sync=True,
+            sample_ids=sample_ids,
+            partition_id=self._partition_id,
+        )

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -30,7 +30,7 @@ import ray
 import torch
 
 from nemo_rl.algorithms.async_utils.interfaces import ReplayBufferProtocol
-from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION, KVBatchMeta
+from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.experience.interfaces import (

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -26,6 +26,7 @@ import torch
 
 from nemo_rl.algorithms.async_utils.interfaces import ReplayBufferProtocol
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
@@ -790,7 +791,8 @@ class TQReplayBuffer:
             )
         trace_rollout_payload(keys=sample_ids, data=train_batch)
         try:
-            await self._call_dp(
+            await call_data_plane(
+                self._dp_client,
                 "put_samples",
                 sample_ids=sample_ids,
                 partition_id=self._partition_id,
@@ -926,7 +928,8 @@ class TQReplayBuffer:
 
         groups: list[dict[str, Any]] = []
         for meta, start_weight, end_weight, target_step, group_id in snapshot:
-            fields_data = await self._call_dp(
+            fields_data = await call_data_plane(
+                self._dp_client,
                 "get_samples",
                 sample_ids=meta.sample_ids,
                 partition_id=self._partition_id,
@@ -1069,7 +1072,8 @@ class TQReplayBuffer:
 
         for group in groups:
             meta = group["meta"]
-            await self._call_dp(
+            await call_data_plane(
+                self._dp_client,
                 "put_samples",
                 sample_ids=list(meta.sample_ids),
                 partition_id=self._partition_id,
@@ -1100,17 +1104,6 @@ class TQReplayBuffer:
     def __len__(self) -> int:
         return len(self.meta_list)
 
-    async def _call_dp(self, method_name: str, **kwargs: Any) -> Any:
-        """Call a DataPlaneClient method, awaiting Ray remotes if needed."""
-        method = getattr(self._dp_client, method_name)
-        remote = getattr(method, "remote", None)
-        if remote is not None:
-            return await remote(**kwargs)
-        result = method(**kwargs)
-        if asyncio.iscoroutine(result):
-            return await result
-        return result
-
     async def _clear_samples(self, *, sample_ids: list[str]) -> None:
         """Clear rows without overlapping a bound data-plane checkpoint."""
         if self._data_plane_checkpoint_lock is None:
@@ -1119,8 +1112,10 @@ class TQReplayBuffer:
                 "checkpoint lock before clearing samples"
             )
         async with self._data_plane_checkpoint_lock:
-            await self._call_dp(
+            await call_data_plane(
+                self._dp_client,
                 "clear_samples",
+                offload_sync=True,
                 sample_ids=sample_ids,
                 partition_id=self._partition_id,
             )

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -710,7 +710,12 @@ class TQReplayBuffer:
         self._data_plane_checkpoint_lock: Optional[asyncio.Lock] = None
 
     def set_data_plane_checkpoint_lock(self, lock: asyncio.Lock) -> None:
-        """Serialize replay-buffer-owned clears with SC checkpoints."""
+        """Bind the controller's shared checkpoint/clear barrier exactly once.
+
+        A private fallback lock would not coordinate with controller-owned
+        saves and clears, so destructive operations fail loudly until the SC
+        actor supplies its lock.
+        """
         if self._data_plane_checkpoint_lock is not None:
             raise RuntimeError("data-plane checkpoint lock is already configured")
         self._data_plane_checkpoint_lock = lock

--- a/nemo_rl/algorithms/async_utils/staleness_sampler.py
+++ b/nemo_rl/algorithms/async_utils/staleness_sampler.py
@@ -110,16 +110,14 @@ class PromptGroupSampler(Protocol):
         """True when the policy admits zero staleness (sync mode)."""
         ...
 
-    @property
-    def supports_buffer_checkpoint(self) -> bool:
-        """Whether completed buffered groups can be restored safely."""
-        ...
+    supports_buffer_checkpoint: ClassVar[bool]
+    """Whether completed buffered groups can be restored safely."""
 
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         """Buffer-capacity the policy needs, or ``None`` if unconstrained."""
         ...
 
-    def set_dispatch_index(self, resume_from_step: int) -> None:
+    def set_dispatch_index(self, resume_from_trainer_version: int) -> None:
         """Seed the dispatch cursor when resuming from a checkpoint."""
         ...
 
@@ -132,28 +130,30 @@ class BaseSampler(abc.ABC):
     select-finalize / weight-window-evict helpers.
     """
 
+    supports_buffer_checkpoint: ClassVar[bool] = False
+
     def __init__(self, buffer: TQReplayBuffer) -> None:
         self._buffer = buffer
         # Pre-incremented before each admitted batch, so -1 lets the first
         # batch through a zero-staleness gate.
         self._dispatch_index: int = -1
 
-    def set_dispatch_index(self, resume_from_step: int) -> None:
+    def set_dispatch_index(self, resume_from_trainer_version: int) -> None:
         """Seed the dispatch cursor when resuming from a checkpoint.
 
         Args:
-            resume_from_step: Trainer step this run starts from — 0 for a
-                fresh run, the restored ``current_step`` when resuming. Sets
-                the cursor to ``resume_from_step - 1`` so gated ``admit`` and
-                ``InOrderSampler``'s target_step stamps line up with the
-                restored trainer version exactly as at step 0 of a fresh run.
-                Call before the first ``admit``.
+            resume_from_trainer_version: Trainer weight version this run starts
+                from — 0 for a fresh run, the restored trainer version when
+                resuming. Sets the cursor to one before that version so gated
+                ``admit`` and ``InOrderSampler`` target-step stamps line up with
+                the restored trainer version. Call before the first ``admit``.
         """
-        if resume_from_step < 0:
+        if resume_from_trainer_version < 0:
             raise ValueError(
-                f"resume_from_step must be non-negative, got {resume_from_step}"
+                "resume_from_trainer_version must be non-negative, got "
+                f"{resume_from_trainer_version}"
             )
-        self._dispatch_index = resume_from_step - 1
+        self._dispatch_index = resume_from_trainer_version - 1
 
     # ── rollout-pump side ────────────────────────────────────────────────
     @abc.abstractmethod
@@ -201,10 +201,6 @@ class BaseSampler(abc.ABC):
     @property
     def is_on_policy(self) -> bool:
         return self._eviction_window() == 0
-
-    @property
-    def supports_buffer_checkpoint(self) -> bool:
-        return False
 
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         return None
@@ -257,6 +253,9 @@ class WindowedSampler(BaseSampler):
     freshest-first.
     """
 
+    # Ungated restored groups are ordinary in-window candidates.
+    supports_buffer_checkpoint: ClassVar[bool] = True
+
     def __init__(
         self,
         buffer: TQReplayBuffer,
@@ -275,11 +274,6 @@ class WindowedSampler(BaseSampler):
 
     def _eviction_window(self) -> int:
         return self.max_staleness_versions
-
-    @property
-    def supports_buffer_checkpoint(self) -> bool:
-        # Ungated restored groups are ordinary in-window candidates.
-        return True
 
     def should_abort_inflight(
         self,
@@ -458,7 +452,6 @@ class InOrderSampler(_GatedSampler):
 
 
 class WindowedSamplerConfig(BaseModel, extra="allow"):
-    supports_buffer_checkpoint: ClassVar[bool] = True
     name: Literal["windowed"] = "windowed"
     # Max weight-version gap a selected group may have from the trainer.
     max_staleness_versions: NonNegativeInt = 1
@@ -467,25 +460,24 @@ class WindowedSamplerConfig(BaseModel, extra="allow"):
 
 
 class WeightFifoSamplerConfig(BaseModel, extra="allow"):
-    supports_buffer_checkpoint: ClassVar[bool] = False
     name: Literal["weight_fifo"] = "weight_fifo"
     # Lookahead + selectable weight window, in trainer versions.
     max_staleness_versions: NonNegativeInt = 1
 
 
 class InOrderSamplerConfig(BaseModel, extra="allow"):
-    supports_buffer_checkpoint: ClassVar[bool] = False
     name: Literal["in_order"] = "in_order"
     # How far generation may run ahead of the trainer, in dispatch batches.
     max_lookahead_versions: NonNegativeInt = 1
 
 
 class CustomSamplerConfig(BaseModel, extra="allow"):
-    # A custom implementation's capability is known only after construction.
-    supports_buffer_checkpoint: ClassVar[Optional[bool]] = None
     name: Literal["custom"] = "custom"
     # "module:ClassName" of a PromptGroupSampler defined outside this repo.
-    # Extra keys are forwarded to the constructor (after ``buffer``).
+    # Extra keys are forwarded to the constructor (after ``buffer``). The
+    # target class must declare a boolean ``supports_buffer_checkpoint`` class
+    # attribute so setup can validate recovery requirements before allocating
+    # cluster resources.
     target: str
 
 
@@ -521,6 +513,46 @@ def required_buffer_capacity_for_config(
     return None
 
 
+def _custom_sampler_class(cfg: CustomSamplerConfig) -> type:
+    """Import and return a custom sampler class without constructing it."""
+    module_name, sep, class_name = cfg.target.partition(":")
+    if not sep:
+        raise ValueError(
+            f"custom sampler target must be 'module:ClassName', got {cfg.target!r}"
+        )
+    sampler_cls = getattr(importlib.import_module(module_name), class_name)
+    if not isinstance(sampler_cls, type):
+        raise TypeError(f"custom sampler target is not a class: {cfg.target!r}")
+    return sampler_cls
+
+
+def sampler_supports_buffer_checkpoint(cfg: SamplerConfig) -> bool:
+    """Return a sampler class's static replay-checkpoint capability.
+
+    Custom classes are imported but not instantiated, allowing setup to fail
+    before allocating cluster resources or triggering constructor side effects.
+    """
+    sampler_cls: type
+    if isinstance(cfg, WindowedSamplerConfig):
+        sampler_cls = WindowedSampler
+    elif isinstance(cfg, WeightFifoSamplerConfig):
+        sampler_cls = WeightFifoSampler
+    elif isinstance(cfg, InOrderSamplerConfig):
+        sampler_cls = InOrderSampler
+    elif isinstance(cfg, CustomSamplerConfig):
+        sampler_cls = _custom_sampler_class(cfg)
+    else:
+        raise ValueError(f"unknown sampler config {type(cfg).__name__}")
+
+    capability = getattr(sampler_cls, "supports_buffer_checkpoint", None)
+    if not isinstance(capability, bool):
+        raise TypeError(
+            f"{sampler_cls.__name__}.supports_buffer_checkpoint must be a "
+            f"boolean class attribute, got {capability!r}"
+        )
+    return capability
+
+
 def create_sampler(
     buffer: TQReplayBuffer,
     cfg: SamplerConfig,
@@ -549,30 +581,16 @@ def create_sampler(
             max_lookahead_versions=cfg.max_lookahead_versions,
         )
     elif isinstance(cfg, CustomSamplerConfig):
-        module_name, sep, class_name = cfg.target.partition(":")
-        if not sep:
-            raise ValueError(
-                f"custom sampler target must be 'module:ClassName', got {cfg.target!r}"
-            )
-        sampler_cls = getattr(importlib.import_module(module_name), class_name)
+        sampler_cls = _custom_sampler_class(cfg)
+        sampler_supports_buffer_checkpoint(cfg)
         sampler = sampler_cls(buffer, **(cfg.model_extra or {}))
         if not isinstance(sampler, PromptGroupSampler):
             raise TypeError(
                 f"{cfg.target} does not implement the PromptGroupSampler "
                 f"interface (needs admit/select/evict/should_abort_inflight, "
-                f"set_dispatch_index, is_on_policy, required_buffer_capacity)"
+                f"set_dispatch_index, is_on_policy, supports_buffer_checkpoint, "
+                f"required_buffer_capacity)"
             )
     else:
         raise ValueError(f"unknown sampler config {type(cfg).__name__}")
-
-    expected_capability = cfg.supports_buffer_checkpoint
-    if (
-        expected_capability is not None
-        and sampler.supports_buffer_checkpoint != expected_capability
-    ):
-        raise RuntimeError(
-            f"{type(cfg).__name__}.supports_buffer_checkpoint="
-            f"{expected_capability} disagrees with {type(sampler).__name__}."
-            f"supports_buffer_checkpoint={sampler.supports_buffer_checkpoint}"
-        )
     return sampler

--- a/nemo_rl/algorithms/async_utils/staleness_sampler.py
+++ b/nemo_rl/algorithms/async_utils/staleness_sampler.py
@@ -44,6 +44,7 @@ import importlib
 from typing import (
     Annotated,
     Callable,
+    ClassVar,
     Literal,
     Optional,
     Protocol,
@@ -107,6 +108,11 @@ class PromptGroupSampler(Protocol):
     @property
     def is_on_policy(self) -> bool:
         """True when the policy admits zero staleness (sync mode)."""
+        ...
+
+    @property
+    def supports_buffer_checkpoint(self) -> bool:
+        """Whether completed buffered groups can be restored safely."""
         ...
 
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
@@ -196,6 +202,10 @@ class BaseSampler(abc.ABC):
     def is_on_policy(self) -> bool:
         return self._eviction_window() == 0
 
+    @property
+    def supports_buffer_checkpoint(self) -> bool:
+        return False
+
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         return None
 
@@ -265,6 +275,11 @@ class WindowedSampler(BaseSampler):
 
     def _eviction_window(self) -> int:
         return self.max_staleness_versions
+
+    @property
+    def supports_buffer_checkpoint(self) -> bool:
+        # Ungated restored groups are ordinary in-window candidates.
+        return True
 
     def should_abort_inflight(
         self,
@@ -443,6 +458,7 @@ class InOrderSampler(_GatedSampler):
 
 
 class WindowedSamplerConfig(BaseModel, extra="allow"):
+    supports_buffer_checkpoint: ClassVar[bool] = True
     name: Literal["windowed"] = "windowed"
     # Max weight-version gap a selected group may have from the trainer.
     max_staleness_versions: NonNegativeInt = 1
@@ -451,18 +467,22 @@ class WindowedSamplerConfig(BaseModel, extra="allow"):
 
 
 class WeightFifoSamplerConfig(BaseModel, extra="allow"):
+    supports_buffer_checkpoint: ClassVar[bool] = False
     name: Literal["weight_fifo"] = "weight_fifo"
     # Lookahead + selectable weight window, in trainer versions.
     max_staleness_versions: NonNegativeInt = 1
 
 
 class InOrderSamplerConfig(BaseModel, extra="allow"):
+    supports_buffer_checkpoint: ClassVar[bool] = False
     name: Literal["in_order"] = "in_order"
     # How far generation may run ahead of the trainer, in dispatch batches.
     max_lookahead_versions: NonNegativeInt = 1
 
 
 class CustomSamplerConfig(BaseModel, extra="allow"):
+    # A custom implementation's capability is known only after construction.
+    supports_buffer_checkpoint: ClassVar[Optional[bool]] = None
     name: Literal["custom"] = "custom"
     # "module:ClassName" of a PromptGroupSampler defined outside this repo.
     # Extra keys are forwarded to the constructor (after ``buffer``).
@@ -505,20 +525,30 @@ def create_sampler(
     buffer: TQReplayBuffer,
     cfg: SamplerConfig,
 ) -> PromptGroupSampler:
-    """Build a sampler from its config (or import one by FQN)."""
+    """Build a sampler from its config (or import one by FQN).
+
+    Args:
+        buffer: Shared TQReplayBuffer holding the candidate slots.
+        cfg: Discriminated sampler config selecting the policy.
+    """
+    sampler: PromptGroupSampler
     if isinstance(cfg, WindowedSamplerConfig):
-        return WindowedSampler(
+        sampler = WindowedSampler(
             buffer,
             max_staleness_versions=cfg.max_staleness_versions,
             sample_freshest_first=cfg.sample_freshest_first,
         )
-    if isinstance(cfg, WeightFifoSamplerConfig):
-        return WeightFifoSampler(
-            buffer, max_staleness_versions=cfg.max_staleness_versions
+    elif isinstance(cfg, WeightFifoSamplerConfig):
+        sampler = WeightFifoSampler(
+            buffer,
+            max_staleness_versions=cfg.max_staleness_versions,
         )
-    if isinstance(cfg, InOrderSamplerConfig):
-        return InOrderSampler(buffer, max_lookahead_versions=cfg.max_lookahead_versions)
-    if isinstance(cfg, CustomSamplerConfig):
+    elif isinstance(cfg, InOrderSamplerConfig):
+        sampler = InOrderSampler(
+            buffer,
+            max_lookahead_versions=cfg.max_lookahead_versions,
+        )
+    elif isinstance(cfg, CustomSamplerConfig):
         module_name, sep, class_name = cfg.target.partition(":")
         if not sep:
             raise ValueError(
@@ -532,5 +562,17 @@ def create_sampler(
                 f"interface (needs admit/select/evict/should_abort_inflight, "
                 f"set_dispatch_index, is_on_policy, required_buffer_capacity)"
             )
-        return sampler
-    raise ValueError(f"unknown sampler config {type(cfg).__name__}")
+    else:
+        raise ValueError(f"unknown sampler config {type(cfg).__name__}")
+
+    expected_capability = cfg.supports_buffer_checkpoint
+    if (
+        expected_capability is not None
+        and sampler.supports_buffer_checkpoint != expected_capability
+    ):
+        raise RuntimeError(
+            f"{type(cfg).__name__}.supports_buffer_checkpoint="
+            f"{expected_capability} disagrees with {type(sampler).__name__}."
+            f"supports_buffer_checkpoint={sampler.supports_buffer_checkpoint}"
+        )
+    return sampler

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -315,6 +315,9 @@ class GRPOSaveState:
     total_steps: int
     total_valid_tokens: int  # Track total number of non-padding tokens during training
     val_reward: float  # May be removed when no validation metrics are available
+    # SC may advance the policy version independently from the optimizer-step
+    # counter. None preserves compatibility with checkpoints predating it.
+    trainer_version: Optional[int] = None
     # SingleController only: name of the sampler that wrote the replay buffer,
     # used to gate the SC buffer restore. None on checkpoints from the other
     # algorithms and from SC runs that predate this field.
@@ -329,6 +332,7 @@ def _initial_grpo_save_state() -> GRPOSaveState:
         total_steps=0,
         total_valid_tokens=0,
         val_reward=-99999999.0,
+        trainer_version=None,
         sampler_name=None,
     )
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -174,8 +174,11 @@ class SingleControllerActor:
         # ── asyncio state ──────────────────────────────────────────────────
         # TQ snapshots permit concurrent puts but not destructive clears. All
         # clears currently owned by async SC use this lock, including rollback
-        # and eviction through TQReplayBuffer. A future staging/finalizer path
-        # must join the same barrier before native restore can be authoritative.
+        # and eviction through TQReplayBuffer. Clear-dependent eviction waits
+        # during a save; _buffer_capacity bounds new rollout groups and
+        # eventually stalls dispatch instead of allowing unbounded TQ growth.
+        # A future staging/finalizer path must join the same barrier before
+        # native restore can be authoritative.
         self._data_plane_checkpoint_lock: asyncio.Lock = asyncio.Lock()
         if self._buffer is not None:
             self._buffer.set_data_plane_checkpoint_lock(
@@ -320,13 +323,33 @@ class SingleControllerActor:
         """Await a Ray ObjectRef without blocking the asyncio event loop."""
         return await obj_ref
 
-    async def _call_dp(self, method_name: str, **kwargs) -> Any:
-        """Call a DataPlaneClient method or a Ray actor exposing that method."""
+    async def _call_dp(
+        self,
+        method_name: str,
+        *,
+        offload_sync: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Call a local DataPlaneClient or a Ray actor exposing its methods.
+
+        Args:
+            method_name: DataPlaneClient method to invoke.
+            offload_sync: Run a synchronous local implementation in a worker
+                thread. Use for blocking filesystem or RPC operations; Ray
+                methods are already asynchronous and ignore this setting.
+            **kwargs: Keyword arguments forwarded to the data-plane method.
+
+        Returns:
+            The method result after awaiting Ray or coroutine results.
+        """
         method = getattr(self._dp_client, method_name)
         remote = getattr(method, "remote", None)
         if remote is not None:
             return await self._ray_get(remote(**kwargs))
-        result = method(**kwargs)
+        if offload_sync:
+            result = await asyncio.to_thread(method, **kwargs)
+        else:
+            result = method(**kwargs)
         if asyncio.iscoroutine(result):
             return await result
         return result
@@ -341,7 +364,13 @@ class SingleControllerActor:
             )
 
     async def _save_data_plane_checkpoint(self, checkpoint_path: str) -> None:
-        """Save a shadow TQ snapshot inside an SC checkpoint bundle."""
+        """Save a required shadow TQ snapshot inside an SC checkpoint bundle.
+
+        Although native TQ restore is not wired into SC yet, opting into this
+        shadow snapshot is intentionally fail-closed: any failure propagates so
+        a finalized bundle never silently omits the advertised data-plane
+        component.
+        """
         checkpoint_dir = os.path.join(
             checkpoint_path,
             DATA_PLANE_CHECKPOINT_DIR,
@@ -359,20 +388,12 @@ class SingleControllerActor:
         started = time.monotonic()
         print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
         try:
-            method = getattr(self._dp_client, "save_checkpoint")
-            remote = getattr(method, "remote", None)
-            if remote is not None:
-                await self._ray_get(
-                    remote(checkpoint_dir=checkpoint_dir, metadata=metadata)
-                )
-            else:
-                result = await asyncio.to_thread(
-                    method,
-                    checkpoint_dir=checkpoint_dir,
-                    metadata=metadata,
-                )
-                if asyncio.iscoroutine(result):
-                    await result
+            await self._call_dp(
+                "save_checkpoint",
+                offload_sync=True,
+                checkpoint_dir=checkpoint_dir,
+                metadata=metadata,
+            )
         except Exception as error:
             print(
                 "data-plane checkpoint save failed: "

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -73,6 +73,9 @@ from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
 
+DATA_PLANE_CHECKPOINT_DIR = "data_plane"
+DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 1
+
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
 class SingleControllerActor:
@@ -169,6 +172,16 @@ class SingleControllerActor:
         )
 
         # ── asyncio state ──────────────────────────────────────────────────
+        # TQ snapshots permit concurrent puts but not destructive clears. All
+        # clears currently owned by async SC use this lock, including rollback
+        # and eviction through TQReplayBuffer. A future staging/finalizer path
+        # must join the same barrier before native restore can be authoritative.
+        self._data_plane_checkpoint_lock: asyncio.Lock = asyncio.Lock()
+        if self._buffer is not None:
+            self._buffer.set_data_plane_checkpoint_lock(
+                self._data_plane_checkpoint_lock
+            )
+
         # Gate: cleared during _sync_weights, set when generation may proceed
         self._rollout_permitted: asyncio.Event = asyncio.Event()
         self._rollout_permitted.set()
@@ -317,6 +330,61 @@ class SingleControllerActor:
         if asyncio.iscoroutine(result):
             return await result
         return result
+
+    async def _clear_data_plane_samples(self, sample_ids: list[str]) -> None:
+        """Clear consumed rows without overlapping a data-plane checkpoint."""
+        async with self._data_plane_checkpoint_lock:
+            await self._call_dp(
+                "clear_samples",
+                sample_ids=sample_ids,
+                partition_id=self._partition_id,
+            )
+
+    async def _save_data_plane_checkpoint(self, checkpoint_path: str) -> None:
+        """Save a shadow TQ snapshot inside an SC checkpoint bundle."""
+        checkpoint_dir = os.path.join(
+            checkpoint_path,
+            DATA_PLANE_CHECKPOINT_DIR,
+        )
+        metadata = {
+            "data_plane_checkpoint_schema_version": (
+                DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+            ),
+            "single_controller_train_steps": self._train_steps,
+            "single_controller_trainer_version": self._trainer_version,
+            "single_controller_epoch": self._current_epoch,
+            "partition_id": self._partition_id,
+            "mode": "shadow",
+        }
+        started = time.monotonic()
+        print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
+        try:
+            method = getattr(self._dp_client, "save_checkpoint")
+            remote = getattr(method, "remote", None)
+            if remote is not None:
+                await self._ray_get(
+                    remote(checkpoint_dir=checkpoint_dir, metadata=metadata)
+                )
+            else:
+                result = await asyncio.to_thread(
+                    method,
+                    checkpoint_dir=checkpoint_dir,
+                    metadata=metadata,
+                )
+                if asyncio.iscoroutine(result):
+                    await result
+        except Exception as error:
+            print(
+                "data-plane checkpoint save failed: "
+                f"{checkpoint_dir} ({type(error).__name__}: {error})",
+                flush=True,
+            )
+            raise
+        print(
+            "data-plane checkpoint save completed: "
+            f"{checkpoint_dir} ({time.monotonic() - started:.2f}s)",
+            flush=True,
+        )
 
     # ── the three pumps + the inline advantage stage ───────────────────────
 
@@ -590,11 +658,7 @@ class SingleControllerActor:
                         min_sample_version = curr_min_sample_version
 
                     # Remove consumed sample_ids from the buffer
-                    await self._call_dp(
-                        "clear_samples",
-                        sample_ids=list(train_meta.sample_ids),
-                        partition_id=self._partition_id,
-                    )
+                    await self._clear_data_plane_samples(list(train_meta.sample_ids))
 
                     groups_dispatched += num_groups
 
@@ -799,14 +863,28 @@ class SingleControllerActor:
             dataloader_state,
             os.path.join(checkpoint_path, "train_dataloader.pt"),
         )
-        buffer_state = await self._buffer.state_dict(
-            saved_capacity=self._async_cfg.max_buffered_rollouts
-        )
-        await asyncio.to_thread(
-            torch.save,
-            buffer_state,
-            os.path.join(checkpoint_path, "replay_buffer.pt"),
-        )
+        buffer_state: Optional[dict[str, Any]] = None
+        if self._master_config.data_plane.get("checkpointing_enabled"):
+            # Capture the legacy replay payload and the native TQ snapshot
+            # under one clear barrier. Generation puts may continue, so TQ can
+            # contain a superset of the groups named by replay_buffer.pt.
+            async with self._data_plane_checkpoint_lock:
+                if self._sampler.supports_buffer_checkpoint:
+                    buffer_state = await self._buffer.state_dict(
+                        saved_capacity=self._async_cfg.max_buffered_rollouts
+                    )
+                await self._save_data_plane_checkpoint(checkpoint_path)
+        elif self._sampler.supports_buffer_checkpoint:
+            buffer_state = await self._buffer.state_dict(
+                saved_capacity=self._async_cfg.max_buffered_rollouts
+            )
+
+        if buffer_state is not None:
+            await asyncio.to_thread(
+                torch.save,
+                buffer_state,
+                os.path.join(checkpoint_path, "replay_buffer.pt"),
+            )
         # Rename happens in the background once the async weight writes
         # finish; flushed at the next save or on exit.
         self._checkpointer.begin_finalization(

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -62,6 +62,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
 )
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
@@ -319,46 +320,13 @@ class SingleControllerActor:
         for _ in range(restored):
             await self._buffer_capacity.acquire()
 
-    async def _ray_get(self, obj_ref: Any) -> Any:
-        """Await a Ray ObjectRef without blocking the asyncio event loop."""
-        return await obj_ref
-
-    async def _call_dp(
-        self,
-        method_name: str,
-        *,
-        offload_sync: bool = False,
-        **kwargs: Any,
-    ) -> Any:
-        """Call a local DataPlaneClient or a Ray actor exposing its methods.
-
-        Args:
-            method_name: DataPlaneClient method to invoke.
-            offload_sync: Run a synchronous local implementation in a worker
-                thread. Use for blocking filesystem or RPC operations; Ray
-                methods are already asynchronous and ignore this setting.
-            **kwargs: Keyword arguments forwarded to the data-plane method.
-
-        Returns:
-            The method result after awaiting Ray or coroutine results.
-        """
-        method = getattr(self._dp_client, method_name)
-        remote = getattr(method, "remote", None)
-        if remote is not None:
-            return await self._ray_get(remote(**kwargs))
-        if offload_sync:
-            result = await asyncio.to_thread(method, **kwargs)
-        else:
-            result = method(**kwargs)
-        if asyncio.iscoroutine(result):
-            return await result
-        return result
-
     async def _clear_data_plane_samples(self, sample_ids: list[str]) -> None:
         """Clear consumed rows without overlapping a data-plane checkpoint."""
         async with self._data_plane_checkpoint_lock:
-            await self._call_dp(
+            await call_data_plane(
+                self._dp_client,
                 "clear_samples",
+                offload_sync=True,
                 sample_ids=sample_ids,
                 partition_id=self._partition_id,
             )
@@ -388,7 +356,8 @@ class SingleControllerActor:
         started = time.monotonic()
         print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
         try:
-            await self._call_dp(
+            await call_data_plane(
+                self._dp_client,
                 "save_checkpoint",
                 offload_sync=True,
                 checkpoint_dir=checkpoint_dir,
@@ -999,7 +968,8 @@ class SingleControllerActor:
             return meta
         adv_cfg = self._advantage_cfg
 
-        data = await self._call_dp(
+        data = await call_data_plane(
+            self._dp_client,
             "get_samples",
             sample_ids=meta.sample_ids,
             partition_id=meta.partition_id,
@@ -1049,7 +1019,8 @@ class SingleControllerActor:
             response_advantages.detach().cpu()
         )
 
-        await self._call_dp(
+        await call_data_plane(
+            self._dp_client,
             "put_samples",
             sample_ids=meta.sample_ids,
             partition_id=meta.partition_id,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -43,6 +43,15 @@ from typing import Any, Optional, Union, cast
 import ray
 import torch
 
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DATA_PLANE_CHECKPOINT_DIR,
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    DataPlaneCheckpointBarrier,
+    LEGACY_REPLAY_BUFFER_FILENAME,
+    REPLAY_BUFFER_METADATA_FILENAME,
+    REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    TQReplayMetadataState,
+)
 from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
 from nemo_rl.algorithms.grpo import GRPOSaveState, _write_latest_checkpoint_status
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
@@ -73,9 +82,6 @@ from nemo_rl.utils.logger import Logger
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
-
-DATA_PLANE_CHECKPOINT_DIR = "data_plane"
-DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 1
 
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
@@ -155,6 +161,9 @@ class SingleControllerActor:
         # already defaulted any fields missing from older checkpoints.
         self._save_state: GRPOSaveState = actor_args.save_state
         self._last_checkpoint_path: Optional[str] = actor_args.last_checkpoint_path
+        self._data_plane_checkpoint_metadata: Optional[dict[str, Any]] = (
+            actor_args.data_plane_checkpoint_metadata
+        )
         self._consumed_samples: int = actor_args.save_state.consumed_samples
         self._total_valid_tokens: int = actor_args.save_state.total_valid_tokens
 
@@ -162,9 +171,24 @@ class SingleControllerActor:
         self._train_cluster = actor_args.train_cluster
         self._inference_cluster = actor_args.inference_cluster
 
+        restored_trainer_version = (
+            actor_args.save_state.trainer_version
+            if actor_args.save_state.trainer_version is not None
+            else actor_args.save_state.current_step
+        )
         num_prompts_per_step = self._master_config.grpo.num_prompts_per_step
         self._sampler = create_sampler(self._buffer, self._async_cfg.sampler)
-        self._sampler.set_dispatch_index(actor_args.save_state.current_step)
+        self._sampler.set_dispatch_index(restored_trainer_version)
+        if (
+            self._master_config.checkpointing["enabled"]
+            and self._sampler.supports_buffer_checkpoint
+            and not self._master_config.data_plane.get("checkpointing_enabled")
+        ):
+            raise ValueError(
+                "SingleController checkpointing with a replay-checkpoint-capable "
+                "sampler requires data_plane.checkpointing_enabled=true so "
+                "completed, unconsumed rollouts are recoverable."
+            )
         required_capacity = self._sampler.required_buffer_capacity(num_prompts_per_step)
         validate_sampler_buffer_capacity(
             self._async_cfg,
@@ -173,17 +197,17 @@ class SingleControllerActor:
         )
 
         # ── asyncio state ──────────────────────────────────────────────────
-        # TQ snapshots permit concurrent puts but not destructive clears. All
-        # clears currently owned by async SC use this lock, including rollback
-        # and eviction through TQReplayBuffer. Clear-dependent eviction waits
-        # during a save; _buffer_capacity bounds new rollout groups and
-        # eventually stalls dispatch instead of allowing unbounded TQ growth.
+        # Commits and destructive clears use this lock with TQ snapshots. This
+        # makes the native snapshot match the controller's metadata-only replay
+        # index exactly. Generation may continue, but completed rollouts wait at
+        # commit; _buffer_capacity bounds reservations and eventually stalls
+        # dispatch instead of allowing unbounded TQ growth.
         # A future staging/finalizer path must join the same barrier before
         # native restore can be authoritative.
-        self._data_plane_checkpoint_lock: asyncio.Lock = asyncio.Lock()
+        self._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
         if self._buffer is not None:
-            self._buffer.set_data_plane_checkpoint_lock(
-                self._data_plane_checkpoint_lock
+            self._buffer.set_data_plane_checkpoint_barrier(
+                self._data_plane_checkpoint_barrier
             )
 
         # Gate: cleared during _sync_weights, set when generation may proceed
@@ -210,7 +234,7 @@ class SingleControllerActor:
             self._async_cfg.max_buffered_rollouts
         )
 
-        self._trainer_version: int = actor_args.save_state.current_step
+        self._trainer_version: int = restored_trainer_version
         self._train_steps: int = actor_args.save_state.current_step
         self._current_epoch: int = actor_args.save_state.current_epoch
         self._step_log_dict: dict[str, list] = {
@@ -276,53 +300,128 @@ class SingleControllerActor:
     # ── internal helpers ───────────────────────────────────────────────────
 
     async def _maybe_restore_replay_buffer(self) -> None:
-        """Restore replay-buffer groups from the previous run's checkpoint.
+        """Restore the local replay index for the native TQ checkpoint.
 
-        Skipped with a warning when the checkpoint was written under a
-        different sampler: restored groups carry the saving sampler's
-        weight/target-step stamps, which another policy may never select.
+        Recovery is authoritative only for samplers that explicitly support
+        buffered-group restoration. The native snapshot and metadata sidecar
+        must both be present and agree on their manifest and group count.
         """
         if self._last_checkpoint_path is None:
             return
-        buffer_path = os.path.join(self._last_checkpoint_path, "replay_buffer.pt")
-        if not os.path.exists(buffer_path):
+        metadata_path = os.path.join(
+            self._last_checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME
+        )
+        if (
+            os.path.exists(metadata_path)
+            and not self._sampler.supports_buffer_checkpoint
+        ):
+            raise RuntimeError(
+                "The checkpoint contains native replay state, but the configured "
+                f"sampler {self._async_cfg.sampler.name!r} does not support "
+                "replay-buffer recovery"
+            )
+        if not self._sampler.supports_buffer_checkpoint:
+            return
+        if not os.path.exists(metadata_path):
+            legacy_path = os.path.join(
+                self._last_checkpoint_path, LEGACY_REPLAY_BUFFER_FILENAME
+            )
+            if os.path.exists(legacy_path):
+                raise RuntimeError(
+                    "Checkpoint contains legacy replay_buffer.pt state, which "
+                    "predates authoritative native TQ replay recovery. Resume it "
+                    "with the older implementation or explicitly start without "
+                    "restoring buffered rollouts."
+                )
             print(
-                f"⚠️ No replay buffer checkpoint found at {buffer_path}. "
+                f"⚠️ No native replay metadata found at {metadata_path}. "
                 "Starting with an empty replay buffer.",
                 flush=True,
             )
             return
-        saved_sampler_name = self._save_state.sampler_name
-        current_sampler_name = self._async_cfg.sampler.name
-        if saved_sampler_name != current_sampler_name:
-            print(
-                f"⚠️ Replay buffer checkpoint was saved with sampler "
-                f"{saved_sampler_name!r} but this run uses "
-                f"{current_sampler_name!r}; skipping the buffer restore.",
-                flush=True,
-            )
-            return
-        print(f"📦 Restoring replay buffer from checkpoint: {buffer_path}")
-        # weights_only=False: groups hold pickled KVBatchMeta/TensorDicts,
-        # not plain tensors. The checkpoint is a trusted same-job artifact.
+        print(f"📦 Restoring replay buffer metadata: {metadata_path}")
+        # weights_only=False: the metadata sidecar contains pickled KVBatchMeta
+        # objects but no rollout tensor payloads. It is a trusted same-job artifact.
         buffer_state = await asyncio.to_thread(
-            torch.load, buffer_path, weights_only=False
+            torch.load, metadata_path, weights_only=False
         )
+        if self._data_plane_checkpoint_metadata is None:
+            raise RuntimeError(
+                "Found metadata-only replay checkpoint, but the matching "
+                "native TQ checkpoint was not restored during setup"
+            )
+        expected_manifest_digest_value = self._data_plane_checkpoint_metadata.get(
+            "replay_manifest_digest"
+        )
+        if not isinstance(expected_manifest_digest_value, str):
+            raise ValueError(
+                "Restored TQ checkpoint metadata is missing a replay manifest digest"
+            )
+        expected_group_count = self._data_plane_checkpoint_metadata.get(
+            "replay_group_count"
+        )
+        groups = buffer_state.get("groups")
+        if (
+            not isinstance(expected_group_count, int)
+            or not isinstance(groups, list)
+            or len(groups) != expected_group_count
+        ):
+            raise ValueError(
+                "Replay-buffer metadata group count does not match the "
+                "loaded TQ checkpoint metadata"
+            )
         restored = await self._buffer.load_state_dict(
             buffer_state,
             max_groups=self._async_cfg.max_buffered_rollouts,
             expected_partition_id=self._partition_id,
             expected_group_size=self._master_config.grpo.num_generations_per_prompt,
+            expected_manifest_digest=expected_manifest_digest_value,
         )
-        # Each buffered group holds one _buffer_capacity permit; the load
-        # truncation guarantees restored <= capacity, so this never blocks.
+        await self._validate_replay_inventory(buffer_state)
+
+        # Each buffered group holds one _buffer_capacity permit. Restore fails
+        # above if the saved group count exceeds current capacity.
         assert restored <= self._async_cfg.max_buffered_rollouts
         for _ in range(restored):
             await self._buffer_capacity.acquire()
 
+    async def _validate_replay_inventory(
+        self, replay_metadata: TQReplayMetadataState
+    ) -> None:
+        """Require the canonical TQ keys to match the SC replay index exactly."""
+        expected_sample_ids = {
+            sample_id
+            for group in replay_metadata["groups"]
+            for sample_id in group["meta"].sample_ids
+        }
+        actual_sample_ids = set(
+            await call_data_plane(
+                self._dp_client,
+                "list_sample_ids",
+                offload_sync=True,
+                partition_id=self._partition_id,
+            )
+        )
+        missing_sample_ids = sorted(expected_sample_ids - actual_sample_ids)
+        unexpected_sample_ids = sorted(actual_sample_ids - expected_sample_ids)
+        if missing_sample_ids or unexpected_sample_ids:
+            raise RuntimeError(
+                "Native TQ checkpoint inventory does not match the replay "
+                "metadata sidecar: "
+                f"missing={missing_sample_ids[:10]!r} "
+                f"(total={len(missing_sample_ids)}), "
+                f"unexpected={unexpected_sample_ids[:10]!r} "
+                f"(total={len(unexpected_sample_ids)})"
+            )
+        print(
+            "📦 Native TQ replay inventory validated: "
+            f"samples={len(actual_sample_ids)}",
+            flush=True,
+        )
+
     async def _clear_data_plane_samples(self, sample_ids: list[str]) -> None:
         """Clear consumed rows without overlapping a data-plane checkpoint."""
-        async with self._data_plane_checkpoint_lock:
+        async with self._data_plane_checkpoint_barrier.mutation():
             await call_data_plane(
                 self._dp_client,
                 "clear_samples",
@@ -331,13 +430,18 @@ class SingleControllerActor:
                 partition_id=self._partition_id,
             )
 
-    async def _save_data_plane_checkpoint(self, checkpoint_path: str) -> None:
-        """Save a required shadow TQ snapshot inside an SC checkpoint bundle.
+    async def _save_data_plane_checkpoint(
+        self,
+        checkpoint_path: str,
+        replay_metadata: Optional[TQReplayMetadataState] = None,
+    ) -> None:
+        """Save a required TQ snapshot inside an SC checkpoint bundle.
 
-        Although native TQ restore is not wired into SC yet, opting into this
-        shadow snapshot is intentionally fail-closed: any failure propagates so
-        a finalized bundle never silently omits the advertised data-plane
-        component.
+        A sampler with replay-buffer recovery writes an authoritative native
+        TQ snapshot bound to its metadata-only sidecar by a digest. Other
+        samplers retain shadow-mode snapshots until their recovery contract is
+        defined. Failures propagate so a finalized bundle never silently omits
+        the advertised data-plane component.
         """
         checkpoint_dir = os.path.join(
             checkpoint_path,
@@ -351,8 +455,19 @@ class SingleControllerActor:
             "single_controller_trainer_version": self._trainer_version,
             "single_controller_epoch": self._current_epoch,
             "partition_id": self._partition_id,
-            "mode": "shadow",
+            "sampler_name": self._async_cfg.sampler.name,
+            "mode": "authoritative" if replay_metadata is not None else "shadow",
         }
+        if replay_metadata is not None:
+            metadata.update(
+                {
+                    "replay_metadata_schema_version": (
+                        REPLAY_BUFFER_METADATA_SCHEMA_VERSION
+                    ),
+                    "replay_manifest_digest": replay_metadata["manifest_digest"],
+                    "replay_group_count": len(replay_metadata["groups"]),
+                }
+            )
         started = time.monotonic()
         print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
         try:
@@ -803,11 +918,10 @@ class SingleControllerActor:
         save_state = self._save_state
         save_state.current_step = self._train_steps
         save_state.total_steps = self._train_steps
+        save_state.trainer_version = self._trainer_version
         save_state.current_epoch = self._current_epoch
         save_state.consumed_samples = self._consumed_samples
         save_state.total_valid_tokens = self._total_valid_tokens
-        # The restore skips the replay buffer when the resuming run uses a
-        # different sampler (its stamps may never be selectable there).
         save_state.sampler_name = self._async_cfg.sampler.name
         # Snapshot before any await so it can't interleave with
         # _rollout_pump iterating this same dataloader.
@@ -853,27 +967,27 @@ class SingleControllerActor:
             dataloader_state,
             os.path.join(checkpoint_path, "train_dataloader.pt"),
         )
-        buffer_state: Optional[dict[str, Any]] = None
+        replay_metadata: Optional[TQReplayMetadataState] = None
         if self._master_config.data_plane.get("checkpointing_enabled"):
-            # Capture the legacy replay payload and the native TQ snapshot
-            # under one clear barrier. Generation puts may continue, so TQ can
-            # contain a superset of the groups named by replay_buffer.pt.
-            async with self._data_plane_checkpoint_lock:
+            # Commits and destructive clears take the same barrier. Generation
+            # may continue while a snapshot is written, but completed groups
+            # wait at commit, so TQ and the metadata sidecar describe exactly
+            # the same set of training-ready groups.
+            async with self._data_plane_checkpoint_barrier.checkpoint():
                 if self._sampler.supports_buffer_checkpoint:
-                    buffer_state = await self._buffer.state_dict(
+                    replay_metadata = self._buffer.metadata_state_dict(
                         saved_capacity=self._async_cfg.max_buffered_rollouts
                     )
-                await self._save_data_plane_checkpoint(checkpoint_path)
-        elif self._sampler.supports_buffer_checkpoint:
-            buffer_state = await self._buffer.state_dict(
-                saved_capacity=self._async_cfg.max_buffered_rollouts
-            )
-
-        if buffer_state is not None:
+                await self._save_data_plane_checkpoint(
+                    checkpoint_path, replay_metadata=replay_metadata
+                )
+                if replay_metadata is not None:
+                    await self._validate_replay_inventory(replay_metadata)
+        if replay_metadata is not None:
             await asyncio.to_thread(
                 torch.save,
-                buffer_state,
-                os.path.join(checkpoint_path, "replay_buffer.pt"),
+                replay_metadata,
+                os.path.join(checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME),
             )
         # Rename happens in the background once the async weight writes
         # finish; flushed at the next save or on exit.

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -45,11 +45,10 @@ import torch
 
 from nemo_rl.algorithms.async_utils.replay_buffer import (
     DATA_PLANE_CHECKPOINT_DIR,
-    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
-    DataPlaneCheckpointBarrier,
     LEGACY_REPLAY_BUFFER_FILENAME,
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    DataPlaneCheckpointBarrier,
     TQReplayMetadataState,
 )
 from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
@@ -70,7 +69,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
     tensor_field,
 )
 from nemo_rl.data.interfaces import DatumSpec
-from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION, KVBatchMeta
 from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -388,7 +387,12 @@ class SingleControllerActor:
     async def _validate_replay_inventory(
         self, replay_metadata: TQReplayMetadataState
     ) -> None:
-        """Require the canonical TQ keys to match the SC replay index exactly."""
+        """Require the canonical TQ keys to match the SC replay index exactly.
+
+        Live checkpoint callers must hold the exclusive data-plane barrier so
+        commits and clears cannot race this inventory read. Restore calls are
+        also safe before the rollout and train pumps start any live writers.
+        """
         expected_sample_ids = {
             sample_id
             for group in replay_metadata["groups"]
@@ -978,11 +982,11 @@ class SingleControllerActor:
                     replay_metadata = self._buffer.metadata_state_dict(
                         saved_capacity=self._async_cfg.max_buffered_rollouts
                     )
+                if replay_metadata is not None:
+                    await self._validate_replay_inventory(replay_metadata)
                 await self._save_data_plane_checkpoint(
                     checkpoint_path, replay_metadata=replay_metadata
                 )
-                if replay_metadata is not None:
-                    await self._validate_replay_inventory(replay_metadata)
         if replay_metadata is not None:
             await asyncio.to_thread(
                 torch.save,

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -32,7 +32,14 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
-from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DATA_PLANE_CHECKPOINT_DIR,
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    LEGACY_REPLAY_BUFFER_FILENAME,
+    REPLAY_BUFFER_METADATA_FILENAME,
+    REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    TQReplayBuffer,
+)
 from nemo_rl.algorithms.grpo import (
     GRPOSaveState,
     _create_advantage_estimator,
@@ -98,6 +105,94 @@ class SingleControllerActorArgs:
     partition_id: str
     save_state: GRPOSaveState
     last_checkpoint_path: Optional[str]
+    data_plane_checkpoint_metadata: Optional[dict[str, Any]] = None
+
+
+def _maybe_restore_native_data_plane_checkpoint(
+    policy: TQPolicy,
+    *,
+    last_checkpoint_path: Optional[str],
+    save_state: GRPOSaveState,
+    partition_id: str,
+    sampler_name: str,
+) -> Optional[dict[str, Any]]:
+    """Load and validate an authoritative native TQ checkpoint when present.
+
+    The metadata-only replay sidecar is the format marker. Checkpoints without
+    any replay artifact resume trainer state with an empty replay buffer;
+    legacy tensor-bearing replay files are rejected rather than silently
+    ignored. Rollout tensors are never serialized into a controller-side
+    replay checkpoint.
+    """
+    if last_checkpoint_path is None:
+        return None
+    checkpoint_path = Path(last_checkpoint_path)
+    replay_metadata_path = checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME
+    if not replay_metadata_path.is_file():
+        legacy_replay_path = checkpoint_path / LEGACY_REPLAY_BUFFER_FILENAME
+        if legacy_replay_path.is_file():
+            raise RuntimeError(
+                "Checkpoint contains legacy replay_buffer.pt state, which "
+                "predates authoritative native TQ replay recovery. Resume it "
+                "with the older implementation or explicitly start without "
+                "restoring buffered rollouts."
+            )
+        return None
+
+    data_plane_path = checkpoint_path / DATA_PLANE_CHECKPOINT_DIR
+    if not data_plane_path.is_dir():
+        raise FileNotFoundError(
+            "Metadata-only replay checkpoint requires a matching native TQ "
+            f"checkpoint at {data_plane_path}"
+        )
+
+    print(f"📦 Restoring native TQ checkpoint: {data_plane_path}", flush=True)
+    metadata = policy.load_data_plane_checkpoint(data_plane_path)
+    if not isinstance(metadata, dict):
+        raise TypeError(
+            "Native TQ checkpoint load must return a metadata dictionary, "
+            f"got {type(metadata).__name__}"
+        )
+    expected_values: dict[str, Any] = {
+        "data_plane_checkpoint_schema_version": (DATA_PLANE_CHECKPOINT_SCHEMA_VERSION),
+        "single_controller_train_steps": save_state.current_step,
+        "single_controller_trainer_version": (
+            save_state.trainer_version
+            if save_state.trainer_version is not None
+            else save_state.current_step
+        ),
+        "single_controller_epoch": save_state.current_epoch,
+        "partition_id": partition_id,
+        "sampler_name": sampler_name,
+        "mode": "authoritative",
+        "replay_metadata_schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    }
+    mismatches = {
+        key: {"checkpoint": metadata.get(key), "expected": expected}
+        for key, expected in expected_values.items()
+        if metadata.get(key) != expected
+    }
+    if mismatches:
+        raise ValueError(
+            "Native TQ checkpoint metadata does not match the trainer "
+            f"checkpoint: {mismatches}"
+        )
+    manifest_digest = metadata.get("replay_manifest_digest")
+    if not isinstance(manifest_digest, str) or not manifest_digest:
+        raise ValueError(
+            "Native TQ checkpoint metadata is missing replay_manifest_digest"
+        )
+    group_count = metadata.get("replay_group_count")
+    if not isinstance(group_count, int) or group_count < 0:
+        raise ValueError(
+            "Native TQ checkpoint metadata has invalid replay_group_count: "
+            f"{group_count!r}"
+        )
+    print(
+        f"📦 Native TQ checkpoint restored and validated: groups={group_count}",
+        flush=True,
+    )
+    return metadata
 
 
 def _build_clusters(
@@ -400,6 +495,16 @@ def setup_single_controller(
             "data_plane.backend='simple'; Mooncake storage cannot be restored "
             "by TQ v0.1.9."
         )
+    if (
+        master_config.checkpointing["enabled"]
+        and master_config.async_rl.sampler.supports_buffer_checkpoint is True
+        and not dp_config.get("checkpointing_enabled")
+    ):
+        raise ValueError(
+            "SingleController checkpointing with a replay-checkpoint-capable "
+            "sampler requires data_plane.checkpointing_enabled=true so "
+            "completed, unconsumed rollouts are recoverable."
+        )
 
     assert generation_config is not None, (
         "single_controller_utils.setup requires policy.generation in master_config"
@@ -580,6 +685,17 @@ def setup_single_controller(
         setup_timing_metrics.policy_init_time_s = trainer_time
     setup_timing_metrics.generation_init_time_s = gen_reserve_time + gen_load_time
 
+    # Native TQ restore must run through the trainer's bootstrap client before
+    # the normal SC data-plane client is created or any rollout/train data-plane
+    # operation starts.
+    data_plane_checkpoint_metadata = _maybe_restore_native_data_plane_checkpoint(
+        trainer,
+        last_checkpoint_path=last_checkpoint_path,
+        save_state=save_state,
+        partition_id=partition_id,
+        sampler_name=master_config.async_rl.sampler.name,
+    )
+
     if use_nemo_gym:
         env_handles["nemo_gym"], gym_time = results["nemo_gym"]
         setup_timing_metrics.nemo_gym_init_time_s = gym_time
@@ -660,5 +776,6 @@ def setup_single_controller(
         partition_id=partition_id,
         save_state=save_state,
         last_checkpoint_path=last_checkpoint_path,
+        data_plane_checkpoint_metadata=data_plane_checkpoint_metadata,
     )
     return actor_args, setup_timing_metrics

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -34,11 +34,13 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.async_utils.replay_buffer import (
     DATA_PLANE_CHECKPOINT_DIR,
-    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
     LEGACY_REPLAY_BUFFER_FILENAME,
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
     TQReplayBuffer,
+)
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    sampler_supports_buffer_checkpoint,
 )
 from nemo_rl.algorithms.grpo import (
     GRPOSaveState,
@@ -60,7 +62,11 @@ from nemo_rl.algorithms.single_controller_utils.config import (
 from nemo_rl.algorithms.utils import set_seed
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.utils import load_dataloader_state, setup_response_data
-from nemo_rl.data_plane import DataPlaneClient, build_data_plane_client
+from nemo_rl.data_plane import (
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    DataPlaneClient,
+    build_data_plane_client,
+)
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
@@ -497,7 +503,7 @@ def setup_single_controller(
         )
     if (
         master_config.checkpointing["enabled"]
-        and master_config.async_rl.sampler.supports_buffer_checkpoint is True
+        and sampler_supports_buffer_checkpoint(master_config.async_rl.sampler)
         and not dp_config.get("checkpointing_enabled")
     ):
         raise ValueError(

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -394,6 +394,12 @@ def setup_single_controller(
             "master_config.data_plane.enabled=True. The async-RL "
             "SingleController path is built on the TransferQueue data plane."
         )
+    if dp_config.get("checkpointing_enabled") and dp_config["backend"] != "simple":
+        raise NotImplementedError(
+            "SingleController data-plane checkpointing currently requires "
+            "data_plane.backend='simple'; Mooncake storage cannot be restored "
+            "by TQ v0.1.9."
+        )
 
     assert generation_config is not None, (
         "single_controller_utils.setup requires policy.generation in master_config"

--- a/nemo_rl/data_plane/__init__.py
+++ b/nemo_rl/data_plane/__init__.py
@@ -21,6 +21,7 @@ detail of a specific adapter.
 from nemo_rl.data_plane.codec import materialize
 from nemo_rl.data_plane.factory import build_data_plane_client
 from nemo_rl.data_plane.interfaces import (
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
     DataPlaneClient,
     DataPlaneConfig,
     KVBatchMeta,
@@ -28,6 +29,7 @@ from nemo_rl.data_plane.interfaces import (
 from nemo_rl.data_plane.observability import MetricsDataPlaneClient, log_event
 
 __all__ = [
+    "DATA_PLANE_CHECKPOINT_SCHEMA_VERSION",
     "DataPlaneClient",
     "DataPlaneConfig",
     "KVBatchMeta",

--- a/nemo_rl/data_plane/adapters/noop.py
+++ b/nemo_rl/data_plane/adapters/noop.py
@@ -25,7 +25,10 @@ fallback (see ``factory.py``).
 
 from __future__ import annotations
 
+import pickle
+import shutil
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -236,6 +239,59 @@ class NoOpDataPlaneClient(DataPlaneClient):
             rec.tags.pop(sid, None)
             for s in rec.consumed.values():
                 s.discard(sid)
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist the trusted in-memory fixture for adapter contract tests.
+
+        This test-only adapter uses pickle; callers must not load checkpoints
+        from untrusted paths.
+        """
+        checkpoint_dir = Path(checkpoint_dir)
+        tmp_dir = checkpoint_dir.with_name(f"{checkpoint_dir.name}.tmp")
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+        tmp_dir.mkdir(parents=True)
+        try:
+            with (tmp_dir / "noop_state.pkl").open("wb") as checkpoint_file:
+                pickle.dump(
+                    {
+                        "partitions": self._partitions,
+                        "metadata": metadata or {},
+                    },
+                    checkpoint_file,
+                    protocol=pickle.HIGHEST_PROTOCOL,
+                )
+            if checkpoint_dir.exists():
+                shutil.rmtree(checkpoint_dir)
+            tmp_dir.rename(checkpoint_dir)
+        except Exception:
+            if tmp_dir.exists():
+                shutil.rmtree(tmp_dir)
+            raise
+
+    def load_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
+        """Restore the in-memory fixture into a clean client."""
+        if self._partitions:
+            raise RuntimeError(
+                "load_checkpoint requires a clean data-plane client with no "
+                "registered partitions"
+            )
+        checkpoint_file = Path(checkpoint_dir) / "noop_state.pkl"
+        if not checkpoint_file.is_file():
+            raise FileNotFoundError(f"NoOp checkpoint not found: {checkpoint_file}")
+        with checkpoint_file.open("rb") as state_file:
+            state = pickle.load(state_file)
+        metadata = state.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError("NoOp checkpoint metadata must be a dictionary")
+        self._partitions = state["partitions"]
+        self._closed = False
+        return dict(metadata)
 
     def close(self) -> None:
         if self._closed:

--- a/nemo_rl/data_plane/adapters/noop.py
+++ b/nemo_rl/data_plane/adapters/noop.py
@@ -223,6 +223,11 @@ class NoOpDataPlaneClient(DataPlaneClient):
         stacked = {f: _stack_or_nest(out[f]) for f in select_fields}
         return TensorDict(stacked, batch_size=(len(sample_ids),))
 
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        """List stored sample IDs without reading their tensor payloads."""
+        rec = self._partitions.get(partition_id)
+        return sorted(rec.rows) if rec is not None else []
+
     def clear_samples(self, sample_ids: list[str] | None, partition_id: str) -> None:
         rec = self._partitions.get(partition_id)
         if rec is None:

--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -23,12 +23,14 @@ business logic. Backend init is lifted from
 from __future__ import annotations
 
 import ipaddress
+import json
 import os
 import socket
 import subprocess
 import time
 import warnings
 from importlib import resources
+from pathlib import Path
 from typing import Any, cast
 
 import torch
@@ -469,6 +471,7 @@ class TQDataPlaneClient(DataPlaneClient):
         # is unaffected). Writer unsqueezes 1D → (N, 1) on put; reader
         # squeezes the trailing 1 back on get. Drop when upstream TQ
         # unifies the schema/data shapes for 1D fields.
+        self._backend = cfg["backend"]
         self._promote_1d = cfg["backend"] == "mooncake_cpu"
 
         if bootstrap:
@@ -705,6 +708,39 @@ class TQDataPlaneClient(DataPlaneClient):
         tq.kv_clear(keys=list(sample_ids), partition_id=partition_id)
 
     # ── (C) lifecycle ──────────────────────────────────────────────────
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Save TQ controller metadata and storage data."""
+        if self._backend == "mooncake_cpu":
+            raise NotImplementedError(
+                "TQ checkpointing is not supported for the mooncake_cpu "
+                "backend: MooncakeStorageManager cannot persist its in-memory "
+                "rows, so TQ would silently create a metadata-only checkpoint."
+            )
+        _connect_existing()
+        tq.save_checkpoint(checkpoint_dir, metadata=metadata)
+
+    def load_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
+        """Restore TQ state after initialization and before data operations."""
+        if self._backend == "mooncake_cpu":
+            raise NotImplementedError(
+                "TQ checkpoint restore is not supported for the mooncake_cpu "
+                "backend because its in-memory rows cannot be restored."
+            )
+        _connect_existing()
+        tq.load_checkpoint(checkpoint_dir)
+        metadata_path = Path(checkpoint_dir) / "metadata.json"
+        with metadata_path.open() as metadata_file:
+            checkpoint_metadata = json.load(metadata_file)
+        user_metadata = checkpoint_metadata.get("user_metadata", {})
+        if not isinstance(user_metadata, dict):
+            raise ValueError("TQ checkpoint user_metadata must be a dictionary")
+        return dict(user_metadata)
 
     def close(self) -> None:
         if self._closed:

--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -480,6 +480,22 @@ class TQDataPlaneClient(DataPlaneClient):
             _connect_existing()
         self._poll_interval_s = cfg["claim_meta_poll_interval_s"]
         self._closed = False
+        # TQ restore is non-transactional and requires a globally clean system.
+        # This process-local guard catches incorrect ordering through this
+        # adapter; setup must still ensure no other client has touched TQ.
+        self._data_operations_started = False
+
+    def _mark_data_operation_started(self) -> None:
+        """Make a later checkpoint load fail instead of mixing TQ states."""
+        self._data_operations_started = True
+
+    def _require_clean_for_load(self) -> None:
+        """Reject restore after this client has performed a data operation."""
+        if self._data_operations_started:
+            raise RuntimeError(
+                "load_checkpoint requires a clean TQ client before any "
+                "register, claim, get, put, clear, or consumption operation"
+            )
 
     # ── (A) task-mediated ───────────────────────────────────────────────
 
@@ -512,6 +528,7 @@ class TQDataPlaneClient(DataPlaneClient):
         # stale metadata from a previous registration.
         if not fields:
             return
+        self._mark_data_operation_started()
         schema_key = (
             f"__schema__:{partition_id}:{os.getpid()}:{id(self)}:{time.time_ns()}"
         )
@@ -537,6 +554,7 @@ class TQDataPlaneClient(DataPlaneClient):
         blocking: bool = True,
         timeout_s: float = 60.0,
     ) -> KVBatchMeta:
+        self._mark_data_operation_started()
         client = tq.get_client()
         deadline = time.time() + max(0.0, timeout_s)
         sampling_config: dict[str, Any] = {}
@@ -608,6 +626,7 @@ class TQDataPlaneClient(DataPlaneClient):
     def check_consumption_status(
         self, partition_id: str, task_names: list[str]
     ) -> bool:
+        self._mark_data_operation_started()
         client = tq.get_client()
         for t in task_names:
             if not client.check_consumption_status(
@@ -649,6 +668,7 @@ class TQDataPlaneClient(DataPlaneClient):
             wire_fields = detached_fields
             field_names = [str(key) for key in detached_fields.keys()]
 
+        self._mark_data_operation_started()
         # TQ's wire vocabulary is `keys=` — translation point.
         tq.kv_batch_put(
             keys=list(sample_ids),
@@ -673,6 +693,7 @@ class TQDataPlaneClient(DataPlaneClient):
     ) -> TensorDict:
         if not sample_ids:
             return TensorDict({}, batch_size=(0,))
+        self._mark_data_operation_started()
         td = tq.kv_batch_get(
             keys=list(sample_ids),
             partition_id=partition_id,
@@ -683,6 +704,7 @@ class TQDataPlaneClient(DataPlaneClient):
     def clear_samples(self, sample_ids: list[str] | None, partition_id: str) -> None:
         cleared_via_none = sample_ids is None
         if sample_ids is None:
+            self._mark_data_operation_started()
             # No local state — ask TQ's controller for the current key
             # set in this partition. ``kv_list`` errors propagate; we
             # don't want a network blip to silently turn into "cleared
@@ -704,6 +726,7 @@ class TQDataPlaneClient(DataPlaneClient):
                     stacklevel=2,
                 )
             return
+        self._mark_data_operation_started()
         # TQ's wire vocabulary is `keys=` — translation point.
         tq.kv_clear(keys=list(sample_ids), partition_id=partition_id)
 
@@ -726,20 +749,31 @@ class TQDataPlaneClient(DataPlaneClient):
         tq.save_checkpoint(checkpoint_dir, metadata=metadata)
 
     def load_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
-        """Restore TQ state after initialization and before data operations."""
+        """Restore TQ state after initialization and before data operations.
+
+        The local lifecycle guard cannot observe operations issued by another
+        TQ client, so the recovery coordinator must also guarantee globally
+        clean setup ordering.
+        """
         if self._backend == "mooncake_cpu":
             raise NotImplementedError(
                 "TQ checkpoint restore is not supported for the mooncake_cpu "
                 "backend because its in-memory rows cannot be restored."
             )
-        _connect_existing()
-        tq.load_checkpoint(checkpoint_dir)
+        self._require_clean_for_load()
+        # Validate the adapter-owned metadata before starting TQ's
+        # non-transactional storage/controller restore.
         metadata_path = Path(checkpoint_dir) / "metadata.json"
         with metadata_path.open() as metadata_file:
             checkpoint_metadata = json.load(metadata_file)
         user_metadata = checkpoint_metadata.get("user_metadata", {})
         if not isinstance(user_metadata, dict):
             raise ValueError("TQ checkpoint user_metadata must be a dictionary")
+        _connect_existing()
+        # A failed TQ load may have partially modified distributed storage, so
+        # this client is no longer safe for a retry even when an error escapes.
+        self._mark_data_operation_started()
+        tq.load_checkpoint(checkpoint_dir)
         return dict(user_metadata)
 
     def close(self) -> None:

--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -494,7 +494,7 @@ class TQDataPlaneClient(DataPlaneClient):
         if self._data_operations_started:
             raise RuntimeError(
                 "load_checkpoint requires a clean TQ client before any "
-                "register, claim, get, put, clear, or consumption operation"
+                "register, claim, get, list, put, clear, or consumption operation"
             )
 
     # ── (A) task-mediated ───────────────────────────────────────────────
@@ -700,6 +700,12 @@ class TQDataPlaneClient(DataPlaneClient):
             select_fields=select_fields,
         )
         return _from_wire(td)
+
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        """List TQ keys in ``partition_id`` without fetching tensor payloads."""
+        self._mark_data_operation_started()
+        listing = tq.kv_list(partition_id=partition_id)
+        return sorted(listing.get(partition_id, {}).keys())
 
     def clear_samples(self, sample_ids: list[str] | None, partition_id: str) -> None:
         cleared_via_none = sample_ids is None

--- a/nemo_rl/data_plane/async_utils.py
+++ b/nemo_rl/data_plane/async_utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async dispatch helpers for local and Ray data-plane clients."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+async def call_data_plane(
+    client: Any,
+    method_name: str,
+    *,
+    offload_sync: bool = False,
+    **kwargs: Any,
+) -> Any:
+    """Call a local data-plane client or a Ray actor exposing its methods.
+
+    Synchronous offloading is opt-in because it allows the actor event loop to
+    issue other calls while this one is running. Callers should enable it only
+    when that concurrency is supported or externally serialized.
+
+    Args:
+        client: Local ``DataPlaneClient`` or Ray actor handle.
+        method_name: Data-plane method to invoke.
+        offload_sync: Run a synchronous local implementation in a worker
+            thread. Ray methods are already asynchronous and ignore this flag.
+        **kwargs: Keyword arguments forwarded to the data-plane method.
+
+    Returns:
+        The method result after awaiting Ray or coroutine results.
+    """
+    method = getattr(client, method_name)
+    remote = getattr(method, "remote", None)
+    if remote is not None:
+        return await remote(**kwargs)
+    if offload_sync:
+        result = await asyncio.to_thread(method, **kwargs)
+    else:
+        result = method(**kwargs)
+    if asyncio.iscoroutine(result):
+        return await result
+    return result

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -43,6 +43,9 @@ from typing import Any, Callable, Literal, NotRequired, Sequence, TypedDict
 from tensordict import TensorDict
 
 
+DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 2
+
+
 class DataPlaneConfig(TypedDict):
     """Feature-gated config; defaults to disabled.
 

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -42,7 +42,6 @@ from typing import Any, Callable, Literal, NotRequired, Sequence, TypedDict
 
 from tensordict import TensorDict
 
-
 DATA_PLANE_CHECKPOINT_SCHEMA_VERSION = 2
 
 

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -60,11 +60,12 @@ class DataPlaneConfig(TypedDict):
     They are required (not NotRequired) so the YAML carries the full
     schema and there are no hidden Python defaults.
 
-    ``checkpointing_enabled`` opts SingleController into saving required
-    shadow TQ state inside its checkpoint bundle. Other algorithm entrypoints
-    do not consume this field. It is optional because existing configs predate
-    data-plane checkpointing; exemplar configs carry the recommended default
-    explicitly.
+    ``checkpointing_enabled`` opts SingleController into saving required TQ
+    state inside its checkpoint bundle. Samplers that support replay-buffer
+    recovery pair the native snapshot with a metadata-only local index; other
+    samplers save it in shadow mode. Other algorithm entrypoints do not consume
+    this field. It is optional because existing configs predate data-plane
+    checkpointing; exemplar configs carry the recommended default explicitly.
     """
 
     enabled: bool
@@ -418,6 +419,22 @@ class DataPlaneClient(ABC):
 
         Returns:
             ``TensorDict`` keyed by field name, batched along ``sample_ids``.
+        """
+
+    @abstractmethod
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        """List the sample IDs currently stored in a partition.
+
+        This metadata-only operation is intended for recovery validation and
+        reconciliation. It must not fetch tensor payloads or advance consumer
+        cursors.
+
+        Args:
+            partition_id: Partition whose stored keys should be listed.
+
+        Returns:
+            Stable, sorted sample IDs. An unknown or empty partition returns
+            an empty list.
         """
 
     @abstractmethod

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Literal, NotRequired, Sequence, TypedDict
 
 from tensordict import TensorDict
@@ -58,6 +59,11 @@ class DataPlaneConfig(TypedDict):
     ``backend == "mooncake_cpu"``; the simple backend ignores them.
     They are required (not NotRequired) so the YAML carries the full
     schema and there are no hidden Python defaults.
+
+    ``checkpointing_enabled`` opts algorithms into saving native TQ state
+    inside their checkpoint bundle. It is optional during rollout because
+    existing configs predate data-plane checkpointing; exemplar configs carry
+    the recommended default explicitly.
     """
 
     enabled: bool
@@ -68,6 +74,7 @@ class DataPlaneConfig(TypedDict):
     claim_meta_poll_interval_s: float
     global_segment_size: int
     local_buffer_size: int
+    checkpointing_enabled: NotRequired[bool]
     controller_address: NotRequired[str]
     ack_timeout_ms: NotRequired[int]
     observability: NotRequired["ObservabilityConfig"]
@@ -259,7 +266,8 @@ class DataPlaneClient(ABC):
     B. *Direct-by-key* — used by stages that already know the exact uids
        (e.g. driver-side fan-out to DP ranks):
        :meth:`put_samples`, :meth:`get_samples`, :meth:`clear_samples`.
-    C. *Lifecycle* — :meth:`close`.
+    C. *Lifecycle* — :meth:`save_checkpoint`, :meth:`load_checkpoint`, and
+       :meth:`close`.
 
     Stage-completion signal: there is intentionally no ``mark_consumed``.
     The authoritative signal in TransferQueue is *field production* —
@@ -441,6 +449,42 @@ class DataPlaneClient(ABC):
         """
 
     # ── (C) lifecycle ──────────────────────────────────────────────────
+
+    @abstractmethod
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist the complete data-plane state to ``checkpoint_dir``.
+
+        The checkpoint must include both data and the implementation's
+        scheduling/consumption metadata. Callers must serialize checkpoint
+        saves and prevent destructive operations such as clears until this
+        method returns.
+
+        Args:
+            checkpoint_dir: New durable directory for this checkpoint.
+            metadata: Optional JSON-compatible recovery metadata.
+        """
+
+    @abstractmethod
+    def load_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
+        """Restore a complete data-plane checkpoint.
+
+        The data-plane implementation must already be initialized, but no data
+        operations may have run before restore.
+
+        Args:
+            checkpoint_dir: Directory previously written by
+                :meth:`save_checkpoint`.
+
+        Returns:
+            User metadata supplied to :meth:`save_checkpoint`. The caller may
+            validate this metadata, but restoring data-plane state does not
+            restore the surrounding controller or trainer state.
+        """
 
     @abstractmethod
     def close(self) -> None:

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -60,10 +60,11 @@ class DataPlaneConfig(TypedDict):
     They are required (not NotRequired) so the YAML carries the full
     schema and there are no hidden Python defaults.
 
-    ``checkpointing_enabled`` opts algorithms into saving native TQ state
-    inside their checkpoint bundle. It is optional during rollout because
-    existing configs predate data-plane checkpointing; exemplar configs carry
-    the recommended default explicitly.
+    ``checkpointing_enabled`` opts SingleController into saving required
+    shadow TQ state inside its checkpoint bundle. Other algorithm entrypoints
+    do not consume this field. It is optional because existing configs predate
+    data-plane checkpointing; exemplar configs carry the recommended default
+    explicitly.
     """
 
     enabled: bool
@@ -474,7 +475,9 @@ class DataPlaneClient(ABC):
         """Restore a complete data-plane checkpoint.
 
         The data-plane implementation must already be initialized, but no data
-        operations may have run before restore.
+        operations may have run before restore. Implementations must reject a
+        load after operations through the same client; callers must also ensure
+        that no other client has modified shared data-plane state.
 
         Args:
             checkpoint_dir: Directory previously written by

--- a/nemo_rl/data_plane/observability.py
+++ b/nemo_rl/data_plane/observability.py
@@ -323,6 +323,13 @@ class MetricsDataPlaneClient(DataPlaneClient):
             n_keys=len(sample_ids),
         )
 
+    def list_sample_ids(self, partition_id):
+        return self._run(
+            "list_sample_ids",
+            partition_id,
+            lambda: self._inner.list_sample_ids(partition_id),
+        )
+
     def clear_samples(self, sample_ids, partition_id):
         sample_ids_list = (
             sample_ids

--- a/nemo_rl/data_plane/observability.py
+++ b/nemo_rl/data_plane/observability.py
@@ -323,7 +323,7 @@ class MetricsDataPlaneClient(DataPlaneClient):
             n_keys=len(sample_ids),
         )
 
-    def list_sample_ids(self, partition_id):
+    def list_sample_ids(self, partition_id: str) -> list[str]:
         return self._run(
             "list_sample_ids",
             partition_id,

--- a/nemo_rl/data_plane/observability.py
+++ b/nemo_rl/data_plane/observability.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from time import monotonic
 from typing import Any, Callable, Literal, TypedDict
 
@@ -336,6 +337,28 @@ class MetricsDataPlaneClient(DataPlaneClient):
             n_keys=n_keys,
         )
         self._record_clear(partition_id, sample_ids_list)
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._run(
+            "save_checkpoint",
+            "",
+            lambda: self._inner.save_checkpoint(
+                checkpoint_dir,
+                metadata=metadata,
+            ),
+        )
+
+    def load_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
+        return self._run(
+            "load_checkpoint",
+            "",
+            lambda: self._inner.load_checkpoint(checkpoint_dir),
+        )
 
     def close(self) -> None:
         self._run(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -33,6 +33,7 @@ import warnings
 from collections import defaultdict
 from contextlib import nullcontext
 from dataclasses import replace
+from pathlib import Path
 from typing import Any, Optional
 
 import ray
@@ -133,6 +134,10 @@ class TQPolicy(Policy):
         )
 
     # ── lifecycle ──────────────────────────────────────────────────────
+
+    def load_data_plane_checkpoint(self, checkpoint_dir: str | Path) -> dict[str, Any]:
+        """Restore TQ through the clean bootstrap client during SC setup."""
+        return self.dp_client.load_checkpoint(checkpoint_dir)
 
     def shutdown(self) -> bool:  # type: ignore[override]
         """Close the TQ client before shutting down the worker group."""

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -116,6 +116,7 @@ project-includes = [
   "nemo_rl/data_plane/adapters/__init__.py",
   "nemo_rl/data_plane/adapters/noop.py",
   "nemo_rl/data_plane/adapters/transfer_queue.py",
+  "nemo_rl/data_plane/async_utils.py",
   "nemo_rl/data_plane/codec.py",
   "nemo_rl/data_plane/column_io.py",
   "nemo_rl/data_plane/factory.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -250,6 +250,7 @@ project-includes = [
   "tools/model_diagnostics/5.prefix_caching_nan.py",
   "tools/model_diagnostics/6.vllm_routed_experts_completeness.py",
   "tools/refit_bandwidth_calculator.py",
+  "tools/verify_tq_data_plane_checkpoint.py",
   "tools/x_token/__init__.py",
   "tools/x_token/reapply_exact_map.py",
   "tools/x_token/sort_and_cut_projection_matrix.py",

--- a/tests/functional/L1_Functional_Tests_SingleController.sh
+++ b/tests/functional/L1_Functional_Tests_SingleController.sh
@@ -37,6 +37,7 @@ run_test() {
 run_test fast uv run --no-sync bash ./tests/functional/grpo_dp_single_controller.sh
 run_test fast uv run --no-sync bash ./tests/functional/grpo_async_gym_single_controller.sh
 run_test uv run --no-sync bash ./tests/functional/grpo_checkpoint_single_controller.sh
+run_test uv run --no-sync bash ./tests/functional/grpo_dp_single_controller_tq_recovery.sh
 
 cd ${PROJECT_ROOT}/tests
 if compgen -G ".coverage*" > /dev/null; then

--- a/tests/functional/grpo_dp_single_controller.sh
+++ b/tests/functional/grpo_dp_single_controller.sh
@@ -22,7 +22,7 @@ rm -rf $EXP_DIR $LOG_DIR
 mkdir -p $EXP_DIR $LOG_DIR
 
 cd $PROJECT_ROOT
-uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
+uv run --group test coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
     $PROJECT_ROOT/examples/run_grpo_single_controller.py \
     policy.model_name=Qwen/Qwen3-0.6B \
     grpo.num_prompts_per_step=2 \
@@ -47,11 +47,13 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     $@ \
     2>&1 | tee $RUN_LOG
 
-uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+if [[ "${RUN_CONVERGENCE_CHECKS:-1}" == "1" ]]; then
+    uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
-uv run tests/check_metrics.py $JSON_METRICS \
-    'max(data["train/gen_kl_error"]) < 0.002' \
-    'min(data["train/probs_ratio_clamped_min"]) > 0.79' \
-    'max(data["train/probs_ratio_clamped_min"]) < 1.21' \
-    'min(data["train/probs_ratio_clamped_max"]) > 0.79' \
-    'max(data["train/probs_ratio_clamped_max"]) < 1.21'
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'max(data["train/gen_kl_error"]) < 0.002' \
+        'min(data["train/probs_ratio_clamped_min"]) > 0.79' \
+        'max(data["train/probs_ratio_clamped_min"]) < 1.21' \
+        'min(data["train/probs_ratio_clamped_max"]) > 0.79' \
+        'max(data["train/probs_ratio_clamped_max"]) < 1.21'
+fi

--- a/tests/functional/grpo_dp_single_controller_tq_recovery.sh
+++ b/tests/functional/grpo_dp_single_controller_tq_recovery.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Two-process functional test for native TQ + metadata-only replay recovery.
+
+set -eou pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BASE_TEST=$SCRIPT_DIR/grpo_dp_single_controller.sh
+TEST_DIR=$SCRIPT_DIR/grpo_dp_single_controller_tq_recovery
+CHECKPOINT_DIR=$TEST_DIR/checkpoints
+BASE_RUN_LOG=$SCRIPT_DIR/grpo_dp_single_controller/run.log
+
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+
+COMMON_OVERRIDES=(
+    checkpointing.enabled=true
+    checkpointing.checkpoint_dir="$CHECKPOINT_DIR"
+    checkpointing.save_period=1
+    data_plane.checkpointing_enabled=true
+    async_rl.sampler.name=windowed
+    '~async_rl.sampler.max_lookahead_versions'
+    '+async_rl.sampler.max_staleness_versions=1'
+    async_rl.max_inflight_prompts=8
+    async_rl.max_buffered_rollouts=8
+)
+
+echo "=== Phase 1: save an authoritative native TQ checkpoint ==="
+# Keep the two-step training horizon identical across both processes so the
+# Megatron optimizer scheduler can be restored. The timeout makes phase 1 save
+# after its first completed step and exit early, simulating an interrupted job.
+RUN_CONVERGENCE_CHECKS=0 bash "$BASE_TEST" \
+    "${COMMON_OVERRIDES[@]}" \
+    grpo.max_num_steps=2 \
+    checkpointing.checkpoint_must_save_by=0:0:0:1
+
+test -d "$CHECKPOINT_DIR/step_1/data_plane"
+test -f "$CHECKPOINT_DIR/step_1/replay_buffer_metadata.pt"
+test ! -f "$CHECKPOINT_DIR/step_1/replay_buffer.pt"
+uv run --no-sync python -c \
+    'import json, sys; metadata = json.load(open(sys.argv[1]))["user_metadata"]; assert metadata["mode"] == "authoritative"; assert metadata["replay_group_count"] > 0, metadata' \
+    "$CHECKPOINT_DIR/step_1/data_plane/metadata.json"
+
+echo "=== Phase 2: start a fresh process, restore TQ, and train one more step ==="
+RUN_CONVERGENCE_CHECKS=0 bash "$BASE_TEST" \
+    "${COMMON_OVERRIDES[@]}" grpo.max_num_steps=2
+
+grep -q "Native TQ checkpoint restored and validated" "$BASE_RUN_LOG"
+grep -q "Native TQ replay inventory validated" "$BASE_RUN_LOG"
+grep -Eq "Restored [1-9][0-9]* replay group" "$BASE_RUN_LOG"
+test -d "$CHECKPOINT_DIR/step_2/data_plane"
+test -f "$CHECKPOINT_DIR/step_2/replay_buffer_metadata.pt"
+
+echo "Native TQ recovery functional test passed."

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -392,8 +392,9 @@ def test_get_grpo_save_state_handles_legacy_checkpoint_and_filters_metrics():
         "total_steps": 13,
         "total_valid_tokens": 0,
         "val_reward": -99999999.0,
-        # SingleController-only field; None for every other algorithm.
+        # SingleController-only fields; None for every other algorithm.
         "sampler_name": None,
+        "trainer_version": None,
     }
     assert "total_valid_tokens" not in loaded_state
     assert not hasattr(save_state, "val:accuracy")

--- a/tests/unit/data_plane/test_architecture_invariants.py
+++ b/tests/unit/data_plane/test_architecture_invariants.py
@@ -80,6 +80,8 @@ def test_sync_trainer_rejects_message_level_advantage_penalties():
         "get_samples",
         "clear_samples",
         "check_consumption_status",
+        "save_checkpoint",
+        "load_checkpoint",
         "close",
     ],
 )

--- a/tests/unit/data_plane/test_architecture_invariants.py
+++ b/tests/unit/data_plane/test_architecture_invariants.py
@@ -78,6 +78,7 @@ def test_sync_trainer_rejects_message_level_advantage_penalties():
         "get_data",
         "put_samples",
         "get_samples",
+        "list_sample_ids",
         "clear_samples",
         "check_consumption_status",
         "save_checkpoint",

--- a/tests/unit/data_plane/test_async_utils.py
+++ b/tests/unit/data_plane/test_async_utils.py
@@ -61,9 +61,7 @@ def test_sync_call_can_be_offloaded() -> None:
 
 
 def test_local_coroutine_result_is_awaited() -> None:
-    result = asyncio.run(
-        call_data_plane(_LocalClient(), "async_value", value=7)
-    )
+    result = asyncio.run(call_data_plane(_LocalClient(), "async_value", value=7))
 
     assert result == 7
 

--- a/tests/unit/data_plane/test_async_utils.py
+++ b/tests/unit/data_plane/test_async_utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for local and Ray-style async data-plane dispatch."""
+
+import asyncio
+import threading
+
+from nemo_rl.data_plane.async_utils import call_data_plane
+
+
+class _LocalClient:
+    def thread_id(self) -> int:
+        return threading.get_ident()
+
+    async def async_value(self, *, value: int) -> int:
+        return value
+
+
+class _RemoteMethod:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    async def remote(self, *, value: int) -> int:
+        self.calls.append(value)
+        return value
+
+
+class _RemoteClient:
+    def __init__(self) -> None:
+        self.value = _RemoteMethod()
+
+
+def test_sync_call_stays_inline_by_default() -> None:
+    caller_thread_id = threading.get_ident()
+
+    result = asyncio.run(call_data_plane(_LocalClient(), "thread_id"))
+
+    assert result == caller_thread_id
+
+
+def test_sync_call_can_be_offloaded() -> None:
+    caller_thread_id = threading.get_ident()
+
+    result = asyncio.run(
+        call_data_plane(_LocalClient(), "thread_id", offload_sync=True)
+    )
+
+    assert result != caller_thread_id
+
+
+def test_local_coroutine_result_is_awaited() -> None:
+    result = asyncio.run(
+        call_data_plane(_LocalClient(), "async_value", value=7)
+    )
+
+    assert result == 7
+
+
+def test_ray_style_remote_result_is_awaited() -> None:
+    client = _RemoteClient()
+
+    result = asyncio.run(call_data_plane(client, "value", value=11))
+
+    assert result == 11
+    assert client.value.calls == [11]

--- a/tests/unit/data_plane/test_codec_mooncake.py
+++ b/tests/unit/data_plane/test_codec_mooncake.py
@@ -234,6 +234,7 @@ def test_get_samples_uses_static_shape_schema(monkeypatch) -> None:
     monkeypatch.setattr(tq_adapter.tq, "kv_batch_get", fake_kv_batch_get)
     client = object.__new__(tq_adapter.TQDataPlaneClient)
     client._promote_1d = True
+    client._data_operations_started = False
 
     restored = client.get_samples(
         ["a", "b", "c"], "train", ["total_reward", "input_ids"]
@@ -268,6 +269,7 @@ def test_get_samples_densifies_uniform_rows_without_1d_promotion(monkeypatch) ->
     monkeypatch.setattr(tq_adapter.tq, "kv_batch_get", fake_kv_batch_get, raising=False)
     client = object.__new__(tq_adapter.TQDataPlaneClient)
     client._promote_1d = False
+    client._data_operations_started = False
 
     restored = client.get_samples(["a", "b"], "train", ["input_ids"])
 

--- a/tests/unit/data_plane/test_interface_contract.py
+++ b/tests/unit/data_plane/test_interface_contract.py
@@ -65,8 +65,10 @@ def test_register_put_get_clear(client: DataPlaneClient):
 
     out = client.get_samples(sample_ids=keys, partition_id="p", select_fields=["x"])
     assert torch.equal(out["x"], torch.arange(4))
+    assert client.list_sample_ids("p") == keys
 
     client.clear_samples(sample_ids=None, partition_id="p")
+    assert client.list_sample_ids("p") == []
     with pytest.raises(KeyError):
         client.get_samples(sample_ids=keys, partition_id="p", select_fields=["x"])
 

--- a/tests/unit/data_plane/test_interface_contract.py
+++ b/tests/unit/data_plane/test_interface_contract.py
@@ -124,3 +124,65 @@ def test_kv_batch_put_rejects_non_tensor_leaves(client: DataPlaneClient):
 def test_close_is_idempotent(client: DataPlaneClient):
     client.close()
     client.close()
+
+
+def test_checkpoint_round_trip_restores_data_and_consumption(tmp_path) -> None:
+    checkpoint_dir = tmp_path / "data-plane"
+    source = NoOpDataPlaneClient()
+    source.register_partition(
+        partition_id="p",
+        fields=["x"],
+        num_samples=3,
+        consumer_tasks=["train"],
+    )
+    source.put_samples(
+        sample_ids=["a", "b", "c"],
+        partition_id="p",
+        fields=TensorDict({"x": torch.tensor([10, 20, 30])}, batch_size=[3]),
+    )
+    consumed = source.claim_meta(
+        partition_id="p",
+        task_name="train",
+        required_fields=["x"],
+        batch_size=1,
+    )
+    source.save_checkpoint(checkpoint_dir, metadata={"step": 7})
+
+    restored = NoOpDataPlaneClient()
+    metadata = restored.load_checkpoint(checkpoint_dir)
+    assert metadata == {"step": 7}
+    data = restored.get_samples(
+        sample_ids=["a", "b", "c"],
+        partition_id="p",
+        select_fields=["x"],
+    )
+    assert torch.equal(data["x"], torch.tensor([10, 20, 30]))
+
+    remaining = restored.claim_meta(
+        partition_id="p",
+        task_name="train",
+        required_fields=["x"],
+        batch_size=3,
+    )
+    assert consumed.sample_ids[0] not in remaining.sample_ids
+    assert set(consumed.sample_ids + remaining.sample_ids) == {"a", "b", "c"}
+    assert restored.check_consumption_status("p", ["train"])
+
+    source.close()
+    restored.close()
+
+
+def test_checkpoint_load_requires_clean_client(tmp_path) -> None:
+    checkpoint_dir = tmp_path / "data-plane"
+    source = NoOpDataPlaneClient()
+    source.save_checkpoint(checkpoint_dir)
+
+    source.register_partition(
+        partition_id="already-used",
+        fields=["x"],
+        num_samples=1,
+        consumer_tasks=["train"],
+    )
+    with pytest.raises(RuntimeError, match="clean data-plane client"):
+        source.load_checkpoint(checkpoint_dir)
+    source.close()

--- a/tests/unit/data_plane/test_observability.py
+++ b/tests/unit/data_plane/test_observability.py
@@ -89,6 +89,22 @@ def test_register_and_clear_recorded(wrapped_client):
     assert ops.count("clear") == 1
 
 
+def test_list_sample_ids_is_forwarded_and_recorded(wrapped_client):
+    client, events = wrapped_client
+    client.register_partition(
+        partition_id="p", fields=["x"], num_samples=2, consumer_tasks=["r"]
+    )
+    client.put_samples(
+        sample_ids=["b", "a"],
+        partition_id="p",
+        fields=TensorDict({"x": torch.ones(2)}, batch_size=[2]),
+    )
+
+    assert client.list_sample_ids("p") == ["a", "b"]
+    assert events[-1]["op"] == "list_sample_ids"
+    assert events[-1]["status"] == "ok"
+
+
 def test_error_status_recorded_and_reraised(wrapped_client):
     """Decorator does NOT swallow errors — re-raise after recording."""
     client, events = wrapped_client

--- a/tests/unit/data_plane/test_observability.py
+++ b/tests/unit/data_plane/test_observability.py
@@ -131,6 +131,42 @@ def test_close_propagates(wrapped_client):
     client.close()
 
 
+def test_checkpoint_lifecycle_is_forwarded_and_recorded(tmp_path) -> None:
+    checkpoint_dir = tmp_path / "data-plane"
+    source_events: list[dict] = []
+    source = MetricsDataPlaneClient(
+        NoOpDataPlaneClient(),
+        on_event=source_events.append,
+    )
+    source.register_partition(
+        partition_id="p",
+        fields=["x"],
+        num_samples=1,
+        consumer_tasks=["train"],
+    )
+    source.put_samples(
+        sample_ids=["a"],
+        partition_id="p",
+        fields=TensorDict({"x": torch.tensor([1])}, batch_size=[1]),
+    )
+    source.save_checkpoint(checkpoint_dir, metadata={"step": 3})
+
+    restore_events: list[dict] = []
+    restored = MetricsDataPlaneClient(
+        NoOpDataPlaneClient(),
+        on_event=restore_events.append,
+    )
+    metadata = restored.load_checkpoint(checkpoint_dir)
+
+    assert metadata == {"step": 3}
+    assert [event["op"] for event in source_events][-1] == "save_checkpoint"
+    assert source_events[-1]["status"] == "ok"
+    assert [event["op"] for event in restore_events] == ["load_checkpoint"]
+    assert restore_events[-1]["status"] == "ok"
+    source.close()
+    restored.close()
+
+
 def test_factory_wraps_when_observability_enabled():
     """Programmatic wrap path; factory.py uses the same MetricsDataPlaneClient."""
     inner = NoOpDataPlaneClient()

--- a/tests/unit/data_plane/test_smoke.py
+++ b/tests/unit/data_plane/test_smoke.py
@@ -89,6 +89,7 @@ def test_dataplane_client_abc_surface() -> None:
         # direct-by-key
         "put_samples",
         "get_samples",
+        "list_sample_ids",
         "clear_samples",
         # lifecycle
         "close",

--- a/tests/unit/data_plane/test_tq_lifecycle.py
+++ b/tests/unit/data_plane/test_tq_lifecycle.py
@@ -54,6 +54,7 @@ def test_register_partition_uses_unique_schema_warmup_key(monkeypatch) -> None:
     monkeypatch.setattr(tq_adapter.tq, "kv_clear", fake_clear)
 
     client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._data_operations_started = False
     client.register_partition(
         partition_id="obj-backend",
         fields=["msg_log"],
@@ -111,6 +112,7 @@ def test_checkpoint_lifecycle_forwards_to_tq(monkeypatch, tmp_path) -> None:
 
     client = object.__new__(tq_adapter.TQDataPlaneClient)
     client._backend = "simple"
+    client._data_operations_started = False
     checkpoint_dir = tmp_path / "step-7"
     checkpoint_dir.mkdir()
     (checkpoint_dir / "metadata.json").write_text(
@@ -123,6 +125,65 @@ def test_checkpoint_lifecycle_forwards_to_tq(monkeypatch, tmp_path) -> None:
     assert save_calls == [(checkpoint_dir, {"step": 7})]
     assert load_calls == [checkpoint_dir]
     assert metadata == {"step": 7}
+    assert client._data_operations_started
+
+
+def test_checkpoint_load_rejects_client_after_data_operation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+
+    connect = MagicMock()
+    load = MagicMock()
+    monkeypatch.setattr(tq_adapter, "_connect_existing", connect)
+    monkeypatch.setattr(tq_adapter.tq, "load_checkpoint", load)
+    monkeypatch.setattr(tq_adapter.tq, "kv_batch_put", MagicMock())
+
+    client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._backend = "simple"
+    client._promote_1d = False
+    client._data_operations_started = False
+    client.put_samples(
+        sample_ids=["sample-0"],
+        partition_id="rollout_data",
+        fields=TensorDict({"x": torch.tensor([1])}, batch_size=[1]),
+    )
+
+    with pytest.raises(RuntimeError, match="requires a clean TQ client"):
+        client.load_checkpoint(tmp_path / "data-plane")
+
+    connect.assert_not_called()
+    load.assert_not_called()
+
+
+def test_failed_checkpoint_load_leaves_client_in_dirty_state(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+
+    connect = MagicMock()
+    load = MagicMock(side_effect=RuntimeError("injected partial restore"))
+    monkeypatch.setattr(tq_adapter, "_connect_existing", connect)
+    monkeypatch.setattr(tq_adapter.tq, "load_checkpoint", load)
+
+    checkpoint_dir = tmp_path / "data-plane"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps({"storage_saved": True, "user_metadata": {"step": 7}})
+    )
+    client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._backend = "simple"
+    client._data_operations_started = False
+
+    with pytest.raises(RuntimeError, match="injected partial restore"):
+        client.load_checkpoint(checkpoint_dir)
+    with pytest.raises(RuntimeError, match="requires a clean TQ client"):
+        client.load_checkpoint(checkpoint_dir)
+
+    connect.assert_called_once_with()
+    load.assert_called_once_with(checkpoint_dir)
 
 
 @pytest.mark.parametrize("operation", ["save", "load"])
@@ -142,6 +203,7 @@ def test_mooncake_checkpoint_lifecycle_fails_loudly(
 
     client = object.__new__(tq_adapter.TQDataPlaneClient)
     client._backend = "mooncake_cpu"
+    client._data_operations_started = False
     checkpoint_dir = tmp_path / "step-7"
 
     with pytest.raises(NotImplementedError, match="mooncake_cpu"):

--- a/tests/unit/data_plane/test_tq_lifecycle.py
+++ b/tests/unit/data_plane/test_tq_lifecycle.py
@@ -128,6 +128,23 @@ def test_checkpoint_lifecycle_forwards_to_tq(monkeypatch, tmp_path) -> None:
     assert client._data_operations_started
 
 
+def test_list_sample_ids_uses_tq_partition_listing(monkeypatch) -> None:
+    from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+
+    list_call = MagicMock(
+        return_value={"rollout_data": {"sample-b": {}, "sample-a": {}}}
+    )
+    monkeypatch.setattr(tq_adapter.tq, "kv_list", list_call)
+    client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._data_operations_started = False
+
+    sample_ids = client.list_sample_ids("rollout_data")
+
+    assert sample_ids == ["sample-a", "sample-b"]
+    assert client._data_operations_started
+    list_call.assert_called_once_with(partition_id="rollout_data")
+
+
 def test_checkpoint_load_rejects_client_after_data_operation(
     monkeypatch,
     tmp_path,

--- a/tests/unit/data_plane/test_tq_lifecycle.py
+++ b/tests/unit/data_plane/test_tq_lifecycle.py
@@ -22,6 +22,9 @@ the data-plane extra still passes.
 
 from __future__ import annotations
 
+import json
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 import torch
@@ -80,6 +83,76 @@ def test_register_partition_uses_unique_schema_warmup_key(monkeypatch) -> None:
         {"keys": [schema_keys[0]], "partition_id": "obj-backend"},
         {"keys": [schema_keys[1]], "partition_id": "obj-backend"},
     ]
+
+
+def test_checkpoint_lifecycle_forwards_to_tq(monkeypatch, tmp_path) -> None:
+    from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+
+    connect_calls = []
+    save_calls = []
+    load_calls = []
+    monkeypatch.setattr(
+        tq_adapter,
+        "_connect_existing",
+        lambda: connect_calls.append(None),
+    )
+    monkeypatch.setattr(
+        tq_adapter.tq,
+        "save_checkpoint",
+        lambda checkpoint_dir, *, metadata=None: save_calls.append(
+            (checkpoint_dir, metadata)
+        ),
+    )
+    monkeypatch.setattr(
+        tq_adapter.tq,
+        "load_checkpoint",
+        lambda checkpoint_dir: load_calls.append(checkpoint_dir),
+    )
+
+    client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._backend = "simple"
+    checkpoint_dir = tmp_path / "step-7"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps({"storage_saved": True, "user_metadata": {"step": 7}})
+    )
+    client.save_checkpoint(checkpoint_dir, metadata={"step": 7})
+    metadata = client.load_checkpoint(checkpoint_dir)
+
+    assert connect_calls == [None, None]
+    assert save_calls == [(checkpoint_dir, {"step": 7})]
+    assert load_calls == [checkpoint_dir]
+    assert metadata == {"step": 7}
+
+
+@pytest.mark.parametrize("operation", ["save", "load"])
+def test_mooncake_checkpoint_lifecycle_fails_loudly(
+    monkeypatch,
+    tmp_path,
+    operation: str,
+) -> None:
+    from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+
+    connect = MagicMock()
+    save = MagicMock()
+    load = MagicMock()
+    monkeypatch.setattr(tq_adapter, "_connect_existing", connect)
+    monkeypatch.setattr(tq_adapter.tq, "save_checkpoint", save)
+    monkeypatch.setattr(tq_adapter.tq, "load_checkpoint", load)
+
+    client = object.__new__(tq_adapter.TQDataPlaneClient)
+    client._backend = "mooncake_cpu"
+    checkpoint_dir = tmp_path / "step-7"
+
+    with pytest.raises(NotImplementedError, match="mooncake_cpu"):
+        if operation == "save":
+            client.save_checkpoint(checkpoint_dir)
+        else:
+            client.load_checkpoint(checkpoint_dir)
+
+    connect.assert_not_called()
+    save.assert_not_called()
+    load.assert_not_called()
 
 
 # ``tq_client`` (simple) and ``tq_client_backends`` (parametrized over

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -512,6 +512,7 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
+  checkpointing_enabled: false       # save TQ state inside algorithm checkpoints
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -512,7 +512,9 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
-  checkpointing_enabled: false       # SingleController only: save required shadow TQ state
+  # SingleController only: save native TQ state. Supported samplers restore
+  # from metadata-only replay indexes.
+  checkpointing_enabled: false
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -512,7 +512,7 @@ data_plane:
   storage_capacity: 1000000          # max samples retained per partition
   num_storage_units: 2               # storage shards
   claim_meta_poll_interval_s: 0.5    # blocking-claim poll cadence
-  checkpointing_enabled: false       # save TQ state inside algorithm checkpoints
+  checkpointing_enabled: false       # SingleController only: save required shadow TQ state
   global_segment_size: 549755813888  # 512 GiB — used when backend == "mooncake_cpu"
   local_buffer_size:   68719476736   # 64 GiB  — used when backend == "mooncake_cpu"
   # observability:                    # NotRequired

--- a/tests/unit/single_controller/_checkpoint_scenarios.py
+++ b/tests/unit/single_controller/_checkpoint_scenarios.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario harness for the checkpoint no-data-loss property.
+
+The property under test, in one sentence: **pausing a run to checkpoint and
+resuming it must train on exactly the same prompt groups as never pausing at
+all.** Concretely, every prompt group the dataloader has already handed out and
+the trainer has not yet consumed must come back after a restore -- whether it
+finished generating or not. If it does not come back, that prompt is lost for
+good, because the dataloader cursor is saved where it stands and never rewinds.
+
+Everything here runs on CPU. The real ``TQReplayBuffer``, the real samplers, the
+real ``DataPlaneCheckpointBarrier`` and the real ``NoOpDataPlaneClient``
+save/load are exercised. Only two things are stubbed, and neither is on the path
+under test:
+
+* ``record_to_train_batch`` -- the tensor converter, so a scenario can use empty
+  prompt records instead of building real rollouts.
+* the trainer/generation side -- absent entirely; this harness is the buffer and
+  the samplers, which is where save/restore lives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+from nemo_rl.algorithms.async_utils import replay_buffer as _rb
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DataPlaneCheckpointBarrier,
+    TQReplayBuffer,
+)
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    InOrderSamplerConfig,
+    WeightFifoSamplerConfig,
+    WindowedSamplerConfig,
+    create_sampler,
+)
+from nemo_rl.data_plane.adapters.noop import NoOpDataPlaneClient
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.interfaces import PromptGroupRecord
+
+PARTITION = "rollout_data"
+ROLLOUTS_PER_GROUP = 2  # rollouts_per_prompt_group
+GROUPS_PER_STEP = 3  # prompt_groups per training step
+CAPACITY = 64  # max_buffered_rollouts
+_FIELDS = ["input_ids", "input_lengths", "total_reward"]
+
+SAMPLERS = ("windowed", "weight_fifo", "in_order")
+
+
+def sampler_config(name: str, lag: int):
+    """Build the real discriminated sampler config for ``name``."""
+    if name == "windowed":
+        return WindowedSamplerConfig(max_staleness_versions=lag)
+    if name == "weight_fifo":
+        return WeightFifoSamplerConfig(max_staleness_versions=lag)
+    if name == "in_order":
+        return InOrderSamplerConfig(max_lookahead_versions=lag)
+    raise ValueError(f"unknown sampler {name!r}")
+
+
+# ── scenario description ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Group:
+    """One prompt group at checkpoint time.
+
+    Args:
+        gid: Prompt-group number, matching the order the dataloader served it.
+        done: How many of its ``ROLLOUTS_PER_GROUP`` rollouts have finished.
+            ``ROLLOUTS_PER_GROUP`` means the group committed; anything less
+            means it is still in flight.
+        weight: Weight version the group was dispatched at.
+        target: ``target_step`` stamp, used by the gated samplers.
+        evicted: The sampler deliberately dropped it (too stale). An evicted
+            group is an intentional discard, not data loss, so it is excluded
+            from what a restore must return.
+    """
+
+    gid: int
+    done: int
+    weight: int = 0
+    target: Optional[int] = None
+    evicted: bool = False
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A checkpoint taken mid-run.
+
+    Args:
+        name: Short label used in test ids.
+        groups: Every prompt group the dataloader has handed out so far.
+        cursor: The next prompt-group number the dataloader would serve. Every
+            group below it has already been handed out and will never be
+            handed out again after a restore.
+        trained: Groups the trainer has already consumed. Not necessarily
+            contiguous -- some samplers train whatever is ready and leave an
+            earlier unfinished group behind.
+        lag: How far generation may run ahead, in steps.
+    """
+
+    name: str
+    groups: tuple[Group, ...]
+    cursor: int
+    trained: frozenset[int] = field(default_factory=frozenset)
+    lag: int = 1
+
+    def must_survive(self) -> set[str]:
+        """Groups a restore has to return, or data is lost.
+
+        Handed out, not trained, not deliberately evicted -- and below the
+        cursor, so the dataloader will never produce them again.
+        """
+        return {
+            _gid(g.gid)
+            for g in self.groups
+            if not g.evicted and g.gid not in self.trained and g.gid < self.cursor
+        }
+
+
+def _gid(n: int) -> str:
+    return f"g{n:02d}"
+
+
+@dataclass(frozen=True)
+class Case:
+    """One row of the test matrix: a scenario run under one sampler.
+
+    Args:
+        scenario: The buffer state at checkpoint time.
+        sampler: Which sampler the run is configured with.
+        why: For a case that fails today, the line that drops the data.
+    """
+
+    scenario: Scenario
+    sampler: str
+    why: str = ""
+
+    @property
+    def id(self) -> str:
+        return f"{self.sampler}::{self.scenario.name}"
+
+
+# ── the round trip ──────────────────────────────────────────────────────────
+
+
+def _record() -> PromptGroupRecord:
+    return PromptGroupRecord(
+        prompt_idx=0,
+        prompt=[],
+        extra_env_info=None,
+        metadata={},
+        completions=[],
+        rollout_metrics={},
+    )
+
+
+def _stub_converter(record: PromptGroupRecord, *, pad_value_dict: Any):
+    del record, pad_value_dict
+    return BatchedDataDict[Any](
+        {
+            "input_ids": torch.ones((ROLLOUTS_PER_GROUP, 3), dtype=torch.long),
+            "input_lengths": torch.full((ROLLOUTS_PER_GROUP,), 3, dtype=torch.long),
+            "total_reward": torch.zeros(ROLLOUTS_PER_GROUP, dtype=torch.float32),
+        }
+    )
+
+
+def patch_converter(monkeypatch) -> None:
+    """Swap the tensor converter so scenarios can use empty prompt records."""
+    monkeypatch.setattr(_rb, "record_to_train_batch", _stub_converter)
+
+
+def _fresh_client(register: bool) -> NoOpDataPlaneClient:
+    dp = NoOpDataPlaneClient()
+    if register:
+        dp.register_partition(
+            partition_id=PARTITION,
+            fields=list(_FIELDS),
+            num_samples=CAPACITY * ROLLOUTS_PER_GROUP,
+            consumer_tasks=["train"],
+        )
+    return dp
+
+
+def _new_buffer(dp: NoOpDataPlaneClient) -> TQReplayBuffer:
+    buf = TQReplayBuffer(
+        dp,
+        partition_id=PARTITION,
+        pad_value_dict={"input_ids": 0},
+        require_routed_experts=False,
+    )
+    buf.set_data_plane_checkpoint_barrier(DataPlaneCheckpointBarrier())
+    return buf
+
+
+async def _fill(buf: TQReplayBuffer, scenario: Scenario) -> None:
+    """Recreate the scenario through the buffer's real reserve/commit path.
+
+    Only groups still held at checkpoint time are added. A trained group is gone
+    -- ``_finalize_selection`` removes it from the buffer as it hands it to the
+    trainer -- and an evicted one was dropped by the staleness rule.
+    """
+    for g in scenario.groups:
+        if g.evicted or g.gid in scenario.trained:
+            continue
+        gid = buf.reserve(
+            weight_version=g.weight, target_step=g.target, group_id=_gid(g.gid)
+        )
+        if g.done == ROLLOUTS_PER_GROUP:
+            await buf.commit(
+                gid,
+                _record(),
+                start_weight_version=g.weight,
+                end_weight_version=g.weight,
+            )
+        # done < ROLLOUTS_PER_GROUP: still generating, so no commit yet.
+
+
+@dataclass
+class RoundTrip:
+    """What a save/restore cycle returned."""
+
+    recovered: set[str]
+    saved_sidecar: bool
+    rows_before: set[str]
+    rows_after: set[str]
+
+
+async def _round_trip(
+    scenario: Scenario, sampler_name: str, tmp_path: Path
+) -> RoundTrip:
+    dp_a = _fresh_client(register=True)
+    buf_a = _new_buffer(dp_a)
+    await _fill(buf_a, scenario)
+    sampler_a = create_sampler(buf_a, sampler_config(sampler_name, scenario.lag))
+
+    # Mirrors SingleControllerActor._save_checkpoint: the sidecar is written
+    # only when the sampler says it can restore one.
+    sidecar = (
+        buf_a.metadata_state_dict(saved_capacity=CAPACITY)
+        if sampler_a.supports_buffer_checkpoint
+        else None
+    )
+    rows_before = set(dp_a.list_sample_ids(PARTITION))
+    dp_a.save_checkpoint(tmp_path / "data_plane")
+
+    # ---- restart: brand new process, nothing carried over in memory ----
+    dp_b = _fresh_client(register=False)  # load_checkpoint demands a clean client
+    dp_b.load_checkpoint(tmp_path / "data_plane")
+    buf_b = _new_buffer(dp_b)
+    sampler_b = create_sampler(buf_b, sampler_config(sampler_name, scenario.lag))
+
+    # Mirrors SingleControllerActor._maybe_restore_replay_buffer.
+    if sidecar is not None and sampler_b.supports_buffer_checkpoint:
+        await buf_b.load_state_dict(
+            sidecar,
+            max_groups=CAPACITY,
+            expected_partition_id=PARTITION,
+            expected_group_size=ROLLOUTS_PER_GROUP,
+            expected_manifest_digest=sidecar["manifest_digest"],
+        )
+
+    return RoundTrip(
+        recovered=set(buf_b._group_ids),
+        saved_sidecar=sidecar is not None,
+        rows_before=rows_before,
+        rows_after=set(dp_b.list_sample_ids(PARTITION)),
+    )
+
+
+def round_trip(scenario: Scenario, sampler_name: str, tmp_path: Path) -> RoundTrip:
+    """Save the scenario, restore it into a fresh buffer, report what came back."""
+    return asyncio.run(_round_trip(scenario, sampler_name, tmp_path))
+
+
+def assert_no_data_loss(
+    scenario: Scenario, sampler_name: str, tmp_path: Path
+) -> RoundTrip:
+    """Fail if the restore dropped any group the run still needs."""
+    result = round_trip(scenario, sampler_name, tmp_path)
+    expected = scenario.must_survive()
+    missing = sorted(expected - result.recovered)
+    assert not missing, (
+        f"{sampler_name}/{scenario.name}: restore dropped {missing}. "
+        f"These groups were handed out by the dataloader, never trained, and sit "
+        f"below the saved cursor ({scenario.cursor}), so nothing will produce them "
+        f"again. recovered={sorted(result.recovered)}"
+    )
+    return result
+
+
+# ── the scenarios ───────────────────────────────────────────────────────────
+# Numbering follows the worked example: groups 09-11 are trained, 12+ are not.
+
+S_ALL_COMPLETE = Scenario(
+    name="lag1-next-step-complete",
+    groups=(
+        Group(9, 2, weight=0),
+        Group(10, 2, weight=0),
+        Group(11, 2, weight=0),
+        Group(12, 2, weight=1, target=5),
+        Group(13, 2, weight=1, target=5),
+        Group(14, 2, weight=1, target=5),
+    ),
+    cursor=15,
+    trained=frozenset({9, 10, 11}),
+    lag=1,
+)
+
+S_PARTIAL = Scenario(
+    name="lag1-next-step-partly-generated",
+    groups=(
+        Group(9, 2, weight=0),
+        Group(10, 2, weight=0),
+        Group(11, 2, weight=0),
+        Group(12, 1, weight=1, target=5),  # one rollout still running
+        Group(13, 2, weight=1, target=5),
+        Group(14, 0, weight=1, target=5),  # not started
+    ),
+    cursor=15,
+    trained=frozenset({9, 10, 11}),
+    lag=1,
+)
+
+S_LAG2 = Scenario(
+    name="lag2-two-batches-in-flight",
+    groups=(
+        Group(9, 2, weight=0),
+        Group(10, 2, weight=0),
+        Group(11, 2, weight=0),
+        Group(12, 1, weight=1, target=5),
+        Group(13, 2, weight=1, target=5),
+        Group(14, 0, weight=1, target=5),
+        Group(15, 2, weight=2, target=6),
+        Group(16, 1, weight=2, target=6),
+        Group(17, 0, weight=2, target=6),
+    ),
+    cursor=18,
+    trained=frozenset({9, 10, 11}),
+    lag=2,
+)
+
+S_EVICTED = Scenario(
+    name="lag1-with-an-evicted-group",
+    groups=(
+        Group(9, 2, weight=0),
+        Group(10, 2, weight=0, evicted=True),  # dropped on purpose: too stale
+        Group(11, 2, weight=0),
+        Group(12, 1, weight=1, target=5),
+        Group(13, 2, weight=1, target=5),
+        Group(14, 0, weight=1, target=5),
+    ),
+    cursor=15,
+    trained=frozenset({9, 11}),
+    lag=1,
+)
+
+S_TRAINED_OUT_OF_ORDER = Scenario(
+    name="trained-what-was-ready-leaving-a-hole",
+    groups=(
+        Group(9, 2, weight=0),
+        Group(10, 2, weight=0),
+        Group(11, 2, weight=0),
+        Group(12, 1, weight=1, target=5),  # skipped: still generating
+        Group(13, 2, weight=1, target=5),  # trained ahead of 12
+        Group(14, 0, weight=1, target=5),
+    ),
+    cursor=15,
+    trained=frozenset({9, 10, 11, 13}),
+    lag=1,
+)
+
+S_STALE_ONLY = Scenario(
+    name="one-group-far-outside-the-staleness-window",
+    groups=(
+        Group(9, ROLLOUTS_PER_GROUP, weight=0, target=1),
+        Group(10, ROLLOUTS_PER_GROUP, weight=7, target=8),
+    ),
+    cursor=11,
+    trained=frozenset(),
+    lag=1,
+)
+
+# Everything fully generated -- the case this PR set out to recover.
+FULLY_GENERATED = (S_ALL_COMPLETE, S_STALE_ONLY)
+# At least one group still generating when the snapshot was taken.
+WITH_IN_FLIGHT = (S_PARTIAL, S_LAG2, S_EVICTED, S_TRAINED_OUT_OF_ORDER)
+ALL_SCENARIOS = FULLY_GENERATED + WITH_IN_FLIGHT
+
+GATED_SAMPLERS = ("in_order", "weight_fifo")  # supports_buffer_checkpoint = False

--- a/tests/unit/single_controller/_checkpoint_scenarios.py
+++ b/tests/unit/single_controller/_checkpoint_scenarios.py
@@ -128,12 +128,36 @@ class Scenario:
         """Groups a restore has to return, or data is lost.
 
         Handed out, not trained, not deliberately evicted -- and below the
-        cursor, so the dataloader will never produce them again.
+        cursor, so the dataloader will never produce them again. This is the
+        bar the feature should eventually meet, not the bar it meets today.
         """
         return {
             _gid(g.gid)
             for g in self.groups
             if not g.evicted and g.gid not in self.trained and g.gid < self.cursor
+        }
+
+    def recoverable_before_this_pr(self) -> set[str]:
+        """What the pre-PR code would have brought back, for any sampler.
+
+        On the merge base the buffer was saved on every checkpoint with no
+        capability gate, and restored whenever the saved sampler name matched
+        the configured one -- which it always does on a same-sampler resume.
+        ``state_dict`` there saved the ready slots and said so outright:
+        *"Unready reservations are in-flight rollouts and are dropped, matching
+        legacy semantics."*
+
+        So the old behaviour is exactly: every committed group still held at
+        checkpoint time. Losing any of these is a step backwards, which is a
+        different and more serious thing than not yet closing a gap that was
+        always there.
+        """
+        return {
+            _gid(g.gid)
+            for g in self.groups
+            if not g.evicted
+            and g.gid not in self.trained
+            and g.done == ROLLOUTS_PER_GROUP
         }
 
 
@@ -238,9 +262,21 @@ async def _fill(buf: TQReplayBuffer, scenario: Scenario) -> None:
 
 @dataclass
 class RoundTrip:
-    """What a save/restore cycle returned."""
+    """What a save/restore cycle returned.
+
+    ``recovered`` is deliberately *presence*, not readiness: a group counts as
+    recovered if the restored buffer knows about it at all. That keeps the
+    assertions independent of how a future partial-group restore is built. A
+    group could come back already committed (its missing rollouts regenerated
+    before the save), or as a reserved slot waiting to be finished -- either
+    way the run has not lost the prompt, and either way these tests notice.
+    ``ready`` and ``pending`` are reported separately for diagnosis only;
+    nothing asserts on them.
+    """
 
     recovered: set[str]
+    ready: set[str]
+    pending: set[str]
     saved_sidecar: bool
     rows_before: set[str]
     rows_after: set[str]
@@ -280,8 +316,13 @@ async def _round_trip(
             expected_manifest_digest=sidecar["manifest_digest"],
         )
 
+    ready = {
+        gid for gid, is_ready in zip(buf_b._group_ids, buf_b.ready_list) if is_ready
+    }
     return RoundTrip(
         recovered=set(buf_b._group_ids),
+        ready=ready,
+        pending=set(buf_b._group_ids) - ready,
         saved_sidecar=sidecar is not None,
         rows_before=rows_before,
         rows_after=set(dp_b.list_sample_ids(PARTITION)),
@@ -296,15 +337,38 @@ def round_trip(scenario: Scenario, sampler_name: str, tmp_path: Path) -> RoundTr
 def assert_no_data_loss(
     scenario: Scenario, sampler_name: str, tmp_path: Path
 ) -> RoundTrip:
-    """Fail if the restore dropped any group the run still needs."""
+    """Fail if the restore dropped any group the run still needs.
+
+    The full bar: everything handed out and not yet trained comes back.
+    """
     result = round_trip(scenario, sampler_name, tmp_path)
-    expected = scenario.must_survive()
-    missing = sorted(expected - result.recovered)
+    missing = sorted(scenario.must_survive() - result.recovered)
     assert not missing, (
         f"{sampler_name}/{scenario.name}: restore dropped {missing}. "
         f"These groups were handed out by the dataloader, never trained, and sit "
         f"below the saved cursor ({scenario.cursor}), so nothing will produce them "
         f"again. recovered={sorted(result.recovered)}"
+    )
+    return result
+
+
+def assert_no_regression(
+    scenario: Scenario, sampler_name: str, tmp_path: Path
+) -> RoundTrip:
+    """Fail if this restore lost something the pre-PR code kept.
+
+    A weaker bar than :func:`assert_no_data_loss`, and a much sharper signal.
+    Not closing a gap that was always there is a missing feature. Dropping
+    groups the old code brought back is a step backwards, and one that no
+    config change can work around.
+    """
+    result = round_trip(scenario, sampler_name, tmp_path)
+    lost = sorted(scenario.recoverable_before_this_pr() - result.recovered)
+    assert not lost, (
+        f"{sampler_name}/{scenario.name}: {lost} came back before this change and "
+        f"do not now. These groups finished generating and committed, so the old "
+        f"save wrote them and the old restore returned them on a same-sampler "
+        f"resume. recovered={sorted(result.recovered)}"
     )
     return result
 

--- a/tests/unit/single_controller/_dp_fakes.py
+++ b/tests/unit/single_controller/_dp_fakes.py
@@ -147,6 +147,9 @@ class _SyncDPAdapter:
             )
         )
 
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        return ray.get(self._handle.list_sample_ids.remote(partition_id))
+
     @staticmethod
     def _padded(td: TensorDict) -> TensorDict:
         out: dict[str, torch.Tensor] = {}

--- a/tests/unit/single_controller/test_checkpoint_no_data_loss.py
+++ b/tests/unit/single_controller/test_checkpoint_no_data_loss.py
@@ -18,9 +18,20 @@ Pausing a run to checkpoint and resuming it should train on the same prompt
 groups as never pausing at all. The matrix below is every combination that
 holds right now.
 
-Cases that do **not** hold live in ``test_checkpoint_no_data_loss_xfail.py``,
-each marked with the line that drops the data. When a fix lands, its case moves
-from that table into ``PASSING`` here.
+Two bars, and the difference matters:
+
+* ``PASSING`` -- the full bar. Every group the run still needs comes back.
+* ``NO_REGRESSION`` -- the weaker bar. Nothing that came back *before this
+  change* was lost. This holds for every ``windowed`` row, including ones that
+  still drop in-flight groups, which is what makes the xfail file honest.
+
+The other two files split the failures by which bar they miss:
+
+* ``test_checkpoint_regressions.py`` -- misses the weaker bar. Groups that used
+  to come back and no longer do. **Not** xfail; a step backwards should be loud.
+* ``test_checkpoint_no_data_loss_xfail.py`` -- clears the weaker bar, misses the
+  full one. Gaps that were here before. ``xfail(strict=True)``, so a fix turns
+  them into failures and the row gets moved into ``PASSING`` here.
 """
 
 from __future__ import annotations
@@ -31,6 +42,7 @@ import pytest
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
 from tests.unit.single_controller._checkpoint_scenarios import (
+    ALL_SCENARIOS,
     CAPACITY,
     PARTITION,
     ROLLOUTS_PER_GROUP,
@@ -41,6 +53,7 @@ from tests.unit.single_controller._checkpoint_scenarios import (
     _fresh_client,
     _new_buffer,
     assert_no_data_loss,
+    assert_no_regression,
     patch_converter,
     round_trip,
     sampler_config,
@@ -56,6 +69,11 @@ PASSING = [
     Case(S_STALE_ONLY, "windowed"),
 ]
 
+# The weaker bar -- "nothing that used to come back was lost" -- holds for every
+# windowed row, including the ones that still drop in-flight groups. Gated
+# samplers fail this and live in test_checkpoint_regressions.py.
+NO_REGRESSION = [Case(s, "windowed") for s in ALL_SCENARIOS]
+
 
 @pytest.fixture(autouse=True)
 def _converter(monkeypatch):
@@ -68,6 +86,11 @@ def test_restore_returns_every_group_the_run_still_needs(case, tmp_path):
     assert result.recovered == case.scenario.must_survive(), (
         "restore should return exactly the outstanding groups -- no more, no less"
     )
+
+
+@pytest.mark.parametrize("case", NO_REGRESSION, ids=lambda c: c.id)
+def test_restore_still_returns_what_it_used_to(case, tmp_path):
+    assert_no_regression(case.scenario, case.sampler, tmp_path)
 
 
 # ── properties that back the matrix up ──────────────────────────────────────

--- a/tests/unit/single_controller/test_checkpoint_no_data_loss.py
+++ b/tests/unit/single_controller/test_checkpoint_no_data_loss.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpoint save/restore must not drop prompt groups -- cases that hold today.
+
+Pausing a run to checkpoint and resuming it should train on the same prompt
+groups as never pausing at all. The matrix below is every combination that
+holds right now.
+
+Cases that do **not** hold live in ``test_checkpoint_no_data_loss_xfail.py``,
+each marked with the line that drops the data. When a fix lands, its case moves
+from that table into ``PASSING`` here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
+from tests.unit.single_controller._checkpoint_scenarios import (
+    CAPACITY,
+    PARTITION,
+    ROLLOUTS_PER_GROUP,
+    S_ALL_COMPLETE,
+    S_STALE_ONLY,
+    Case,
+    _fill,
+    _fresh_client,
+    _new_buffer,
+    assert_no_data_loss,
+    patch_converter,
+    round_trip,
+    sampler_config,
+)
+
+# ── the matrix ──────────────────────────────────────────────────────────────
+# Read this as a table. Every row: restore returns every group the run still
+# needs. Only ``windowed`` appears, and only with everything fully generated --
+# that is the whole of what this PR recovers.
+
+PASSING = [
+    Case(S_ALL_COMPLETE, "windowed"),
+    Case(S_STALE_ONLY, "windowed"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _converter(monkeypatch):
+    patch_converter(monkeypatch)
+
+
+@pytest.mark.parametrize("case", PASSING, ids=lambda c: c.id)
+def test_restore_returns_every_group_the_run_still_needs(case, tmp_path):
+    result = assert_no_data_loss(case.scenario, case.sampler, tmp_path)
+    assert result.recovered == case.scenario.must_survive(), (
+        "restore should return exactly the outstanding groups -- no more, no less"
+    )
+
+
+# ── properties that back the matrix up ──────────────────────────────────────
+
+
+def test_restore_reuses_the_stored_rows_instead_of_rewriting_them(tmp_path):
+    """TransferQueue keeps the tensors; the sidecar only names the rows."""
+    result = round_trip(S_ALL_COMPLETE, "windowed", tmp_path)
+    assert result.rows_before, "scenario should have written rows"
+    assert result.rows_after == result.rows_before
+
+
+def test_restored_groups_are_selectable_by_the_sampler(tmp_path):
+    """Coming back is not enough -- they have to be usable on the next step."""
+
+    async def exercise():
+        dp = _fresh_client(register=True)
+        buf = _new_buffer(dp)
+        await _fill(buf, S_ALL_COMPLETE)
+        sidecar = buf.metadata_state_dict(saved_capacity=CAPACITY)
+
+        dp2 = _fresh_client(register=True)
+        buf2 = _new_buffer(dp2)
+        await buf2.load_state_dict(
+            sidecar,
+            max_groups=CAPACITY,
+            expected_partition_id=PARTITION,
+            expected_group_size=ROLLOUTS_PER_GROUP,
+            expected_manifest_digest=sidecar["manifest_digest"],
+        )
+        sampler = create_sampler(buf2, sampler_config("windowed", 1))
+        return await sampler.select(
+            current_train_weight=1, min_prompt_groups=1, max_prompt_groups=3
+        )
+
+    meta, count = asyncio.run(exercise())
+    assert count == 3, "the three restored groups should form the next batch"
+    assert meta is not None
+
+
+def test_a_stale_group_comes_back_so_the_sampler_can_decide_to_drop_it(tmp_path):
+    """Restoring and then evicting is a decision; dropping at restore is a bug.
+
+    Both look the same from outside, so this pins that the checkpoint hands the
+    stale group back and leaves the staleness call to the sampler.
+    """
+    result = assert_no_data_loss(S_STALE_ONLY, "windowed", tmp_path)
+    assert result.recovered == {"g09", "g10"}

--- a/tests/unit/single_controller/test_checkpoint_no_data_loss_xfail.py
+++ b/tests/unit/single_controller/test_checkpoint_no_data_loss_xfail.py
@@ -12,26 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Checkpoint cases that drop prompt groups today. Each one is real data loss.
+"""Gaps that were here before this change and are still here.
 
-Same property as ``test_checkpoint_no_data_loss.py``: pause, resume, and the run
-should train on the same prompt groups as if it had never paused. This is the
-table of combinations where it does not.
+Only one cause is left in this file: **a prompt group that has not committed is
+never saved.** That was true before this change too -- the old ``state_dict``
+said so in as many words, *"Unready reservations are in-flight rollouts and are
+dropped, matching legacy semantics"* -- so nothing here is a step backwards.
+Things this change made worse live in ``test_checkpoint_regressions.py`` and
+are **not** xfail.
 
-Marks are ``strict=True``, so the moment a fix lands the case turns into an
-XPASS failure and whoever fixed it is told to move that row into ``PASSING`` in
-the other module. Nothing here is a guess -- each row names the line that drops
-the data.
+The sharpest row is ``windowed::lag1-next-step-partly-generated``: group 13 has
+finished both of its rollouts and is dropped anyway, because the commit had not
+run when the snapshot was taken. A group is reserved or committed, with nothing
+in between, so "one rollout still running" and "not started" are the same thing
+to a checkpoint.
 
-Two independent causes:
-
-* ``IN_FLIGHT`` -- ``reserve()`` books a slot marked not-ready and only
-  ``commit()`` flips it, and ``metadata_state_dict`` skips anything not ready.
-  A group that has generated some, or even all, of its rollouts without
-  committing is skipped exactly like one that never started. Hits every sampler.
-* ``GATED`` -- ``in_order`` and ``weight_fifo`` declare
-  ``supports_buffer_checkpoint = False``, so no sidecar is written at all and
-  the restore returns early. Hits every group, finished or not.
+**Why these assert on presence, not on state.** Closing this gap needs a
+durable copy of a half-finished group's tokens, which is what the token-capture
+work in #3456 is building. How a restore then presents such a group is an open
+design question -- it might come back already committed, with the missing
+rollouts regenerated before the save, or as a reserved slot for the run to
+finish. These tests deliberately do not care. ``recovered`` counts a group if
+the restored buffer knows about it **at all**, so either design flips these to
+XPASS. ``strict=True`` then turns that XPASS into a failure, and whoever built
+it is told to move the row into ``PASSING``.
 """
 
 from __future__ import annotations
@@ -39,44 +43,33 @@ from __future__ import annotations
 import pytest
 
 from tests.unit.single_controller._checkpoint_scenarios import (
-    ALL_SCENARIOS,
-    GATED_SAMPLERS,
-    S_ALL_COMPLETE,
     S_EVICTED,
     S_LAG2,
     S_PARTIAL,
     S_TRAINED_OUT_OF_ORDER,
     Case,
     assert_no_data_loss,
+    assert_no_regression,
     patch_converter,
     round_trip,
 )
 
 IN_FLIGHT = (
-    "in-flight groups are never saved: reserve() marks the slot not-ready "
-    "(replay_buffer.py:910) and metadata_state_dict skips it (:1093)"
-)
-GATED = (
-    "gated sampler declares supports_buffer_checkpoint=False, so no sidecar is "
-    "written (single_controller.py:981) and the restore returns early (:322)"
+    "a group that has not committed is never saved: reserve() marks the slot "
+    "not-ready (replay_buffer.py:910) and metadata_state_dict skips it (:1093). "
+    "Pre-existing -- the old state_dict dropped in-flight reservations too."
 )
 
 # ── the matrix ──────────────────────────────────────────────────────────────
-# Read this as a table of setups. Left column is what the buffer held when the
-# snapshot was taken; middle is the sampler; right is what loses the data.
+# The recovering sampler only. Gated samplers are excluded on purpose: they
+# fail for a second, worse reason, and that reason is a regression, so those
+# rows belong in test_checkpoint_regressions.py.
 
 EXPECTED_TO_FAIL = [
-    # The recovering sampler still drops anything mid-generation.
-    # S_PARTIAL is the sharpest: group 13 finished both rollouts and is dropped
-    # anyway, because the commit had not run when the snapshot was taken.
     Case(S_PARTIAL, "windowed", IN_FLIGHT),
     Case(S_LAG2, "windowed", IN_FLIGHT),
     Case(S_EVICTED, "windowed", IN_FLIGHT),
     Case(S_TRAINED_OUT_OF_ORDER, "windowed", IN_FLIGHT),
-    # Gated samplers keep nothing at all, however complete. This is the
-    # behaviour change the review flagged: before this PR the buffer was saved
-    # for every sampler and restored whenever the sampler name matched.
-    *(Case(s, sampler, GATED) for sampler in GATED_SAMPLERS for s in ALL_SCENARIOS),
 ]
 
 
@@ -92,33 +85,29 @@ def _converter(monkeypatch):
 
 
 @pytest.mark.parametrize("case", [_param(c) for c in EXPECTED_TO_FAIL])
-def test_restore_drops_groups_the_run_still_needs(case, tmp_path):
+def test_restore_drops_groups_that_had_not_committed(case, tmp_path):
     assert_no_data_loss(case.scenario, case.sampler, tmp_path)
 
 
-# ── why the rows above fail ─────────────────────────────────────────────────
-# These pass on purpose. They pin the two causes, so a fix that changes either
-# one fails here and points at the table to re-check.
+@pytest.mark.parametrize("case", EXPECTED_TO_FAIL, ids=lambda c: c.id)
+def test_but_nothing_that_used_to_come_back_was_lost(case, tmp_path):
+    """The same rows, held to the weaker bar -- and they pass.
 
-
-def test_gated_samplers_write_no_sidecar_at_all(tmp_path):
-    for sampler in GATED_SAMPLERS:
-        result = round_trip(S_ALL_COMPLETE, sampler, tmp_path / sampler)
-        assert not result.saved_sidecar, f"{sampler} unexpectedly wrote a sidecar"
-        assert result.recovered == set(), f"{sampler} unexpectedly restored groups"
-
-    windowed = round_trip(S_ALL_COMPLETE, "windowed", tmp_path / "windowed")
-    assert windowed.saved_sidecar, "windowed should still write one"
-
-
-def test_the_tensors_survive_even_when_the_index_does_not(tmp_path):
-    """The loss is the index, not the rows -- so a fix can be index-only.
-
-    TransferQueue still holds every committed row after a gated-sampler restore.
-    The groups are unreachable only because nothing records which rows belong to
-    which group.
+    This is what makes the xfail above honest: under ``windowed`` every group
+    the old code returned still comes back. The only losses are ones the old
+    code lost too.
     """
-    result = round_trip(S_ALL_COMPLETE, "in_order", tmp_path)
-    assert result.rows_before, "scenario should have written rows"
-    assert result.rows_after == result.rows_before
-    assert result.recovered == set(), "but no group index came back"
+    assert_no_regression(case.scenario, case.sampler, tmp_path)
+
+
+def test_a_fully_generated_group_is_dropped_when_the_commit_had_not_run(tmp_path):
+    """Pins the exact shape of the gap, so a partial fix cannot pass by accident.
+
+    In ``S_PARTIAL`` group 13 committed and comes back; 12 and 14 did not and do
+    not. If a future change brings back 12 or 14 in any form, ``recovered``
+    grows and the xfail rows above flip to XPASS.
+    """
+    result = round_trip(S_PARTIAL, "windowed", tmp_path)
+    assert result.recovered == {"g13"}
+    assert result.ready == {"g13"}, "the one committed group comes back ready"
+    assert result.pending == set(), "nothing comes back awaiting completion yet"

--- a/tests/unit/single_controller/test_checkpoint_no_data_loss_xfail.py
+++ b/tests/unit/single_controller/test_checkpoint_no_data_loss_xfail.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpoint cases that drop prompt groups today. Each one is real data loss.
+
+Same property as ``test_checkpoint_no_data_loss.py``: pause, resume, and the run
+should train on the same prompt groups as if it had never paused. This is the
+table of combinations where it does not.
+
+Marks are ``strict=True``, so the moment a fix lands the case turns into an
+XPASS failure and whoever fixed it is told to move that row into ``PASSING`` in
+the other module. Nothing here is a guess -- each row names the line that drops
+the data.
+
+Two independent causes:
+
+* ``IN_FLIGHT`` -- ``reserve()`` books a slot marked not-ready and only
+  ``commit()`` flips it, and ``metadata_state_dict`` skips anything not ready.
+  A group that has generated some, or even all, of its rollouts without
+  committing is skipped exactly like one that never started. Hits every sampler.
+* ``GATED`` -- ``in_order`` and ``weight_fifo`` declare
+  ``supports_buffer_checkpoint = False``, so no sidecar is written at all and
+  the restore returns early. Hits every group, finished or not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.single_controller._checkpoint_scenarios import (
+    ALL_SCENARIOS,
+    GATED_SAMPLERS,
+    S_ALL_COMPLETE,
+    S_EVICTED,
+    S_LAG2,
+    S_PARTIAL,
+    S_TRAINED_OUT_OF_ORDER,
+    Case,
+    assert_no_data_loss,
+    patch_converter,
+    round_trip,
+)
+
+IN_FLIGHT = (
+    "in-flight groups are never saved: reserve() marks the slot not-ready "
+    "(replay_buffer.py:910) and metadata_state_dict skips it (:1093)"
+)
+GATED = (
+    "gated sampler declares supports_buffer_checkpoint=False, so no sidecar is "
+    "written (single_controller.py:981) and the restore returns early (:322)"
+)
+
+# ── the matrix ──────────────────────────────────────────────────────────────
+# Read this as a table of setups. Left column is what the buffer held when the
+# snapshot was taken; middle is the sampler; right is what loses the data.
+
+EXPECTED_TO_FAIL = [
+    # The recovering sampler still drops anything mid-generation.
+    # S_PARTIAL is the sharpest: group 13 finished both rollouts and is dropped
+    # anyway, because the commit had not run when the snapshot was taken.
+    Case(S_PARTIAL, "windowed", IN_FLIGHT),
+    Case(S_LAG2, "windowed", IN_FLIGHT),
+    Case(S_EVICTED, "windowed", IN_FLIGHT),
+    Case(S_TRAINED_OUT_OF_ORDER, "windowed", IN_FLIGHT),
+    # Gated samplers keep nothing at all, however complete. This is the
+    # behaviour change the review flagged: before this PR the buffer was saved
+    # for every sampler and restored whenever the sampler name matched.
+    *(Case(s, sampler, GATED) for sampler in GATED_SAMPLERS for s in ALL_SCENARIOS),
+]
+
+
+def _param(case: Case):
+    return pytest.param(
+        case, id=case.id, marks=pytest.mark.xfail(strict=True, reason=case.why)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _converter(monkeypatch):
+    patch_converter(monkeypatch)
+
+
+@pytest.mark.parametrize("case", [_param(c) for c in EXPECTED_TO_FAIL])
+def test_restore_drops_groups_the_run_still_needs(case, tmp_path):
+    assert_no_data_loss(case.scenario, case.sampler, tmp_path)
+
+
+# ── why the rows above fail ─────────────────────────────────────────────────
+# These pass on purpose. They pin the two causes, so a fix that changes either
+# one fails here and points at the table to re-check.
+
+
+def test_gated_samplers_write_no_sidecar_at_all(tmp_path):
+    for sampler in GATED_SAMPLERS:
+        result = round_trip(S_ALL_COMPLETE, sampler, tmp_path / sampler)
+        assert not result.saved_sidecar, f"{sampler} unexpectedly wrote a sidecar"
+        assert result.recovered == set(), f"{sampler} unexpectedly restored groups"
+
+    windowed = round_trip(S_ALL_COMPLETE, "windowed", tmp_path / "windowed")
+    assert windowed.saved_sidecar, "windowed should still write one"
+
+
+def test_the_tensors_survive_even_when_the_index_does_not(tmp_path):
+    """The loss is the index, not the rows -- so a fix can be index-only.
+
+    TransferQueue still holds every committed row after a gated-sampler restore.
+    The groups are unreachable only because nothing records which rows belong to
+    which group.
+    """
+    result = round_trip(S_ALL_COMPLETE, "in_order", tmp_path)
+    assert result.rows_before, "scenario should have written rows"
+    assert result.rows_after == result.rows_before
+    assert result.recovered == set(), "but no group index came back"

--- a/tests/unit/single_controller/test_checkpoint_regressions.py
+++ b/tests/unit/single_controller/test_checkpoint_regressions.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Groups that came back before this change and do not now.
+
+**These are deliberately not xfail.** A gap that was always there is a missing
+feature, and those live in ``test_checkpoint_no_data_loss_xfail.py``. Losing
+something the previous code kept is a different thing, and marking it
+"expected" would hide exactly the signal worth having.
+
+What the previous code did, on the merge base:
+
+* the buffer was saved on **every** checkpoint, with no sampler capability gate
+  (``single_controller.py:802`` -- ``self._buffer.state_dict(...)``);
+* the restore ran for **any** sampler, gated only on the saved sampler name
+  matching the configured one (``:270``), which always holds on a same-sampler
+  resume;
+* ``state_dict`` saved the committed slots and dropped in-flight ones, saying
+  so outright: *"Unready reservations are in-flight rollouts and are dropped,
+  matching legacy semantics."*
+
+So every fully generated group used to survive a restart under every sampler.
+After this change, ``in_order`` and ``weight_fifo`` declare
+``supports_buffer_checkpoint = False``, so no sidecar is written
+(``single_controller.py:981``) and the restore returns early (``:322``) --
+losing groups that used to come back.
+
+The assertion is the weaker of the two in the harness: not "everything the run
+needs" but "nothing that used to come back". Nothing here depends on the
+in-flight gap, so these fail on the fully-generated scenarios too.
+
+If dropping this is a deliberate trade -- one durable store instead of two --
+then the right resolution is not to xfail these but to decide the old
+behaviour is not coming back, and say so where a user configuring
+``in_order`` will read it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.single_controller._checkpoint_scenarios import (
+    ALL_SCENARIOS,
+    GATED_SAMPLERS,
+    S_ALL_COMPLETE,
+    Case,
+    assert_no_regression,
+    patch_converter,
+    round_trip,
+)
+
+# ── the matrix ──────────────────────────────────────────────────────────────
+# Every gated sampler, every scenario. The fully-generated rows are the
+# cleanest evidence: nothing about them is in flight, so the only reason they
+# do not come back is the capability gate.
+
+REGRESSED = [
+    Case(scenario, sampler)
+    for sampler in GATED_SAMPLERS
+    for scenario in ALL_SCENARIOS
+]
+
+
+@pytest.fixture(autouse=True)
+def _converter(monkeypatch):
+    patch_converter(monkeypatch)
+
+
+@pytest.mark.parametrize("case", REGRESSED, ids=lambda c: c.id)
+def test_restore_still_returns_what_it_used_to(case, tmp_path):
+    assert_no_regression(case.scenario, case.sampler, tmp_path)
+
+
+def test_the_rows_are_still_in_transfer_queue_after_a_gated_restore(tmp_path):
+    """The regression is the index, not the tensors -- so a fix can be index-only.
+
+    TransferQueue still holds every committed row. The groups are unreachable
+    only because nothing wrote down which rows belong to which group.
+    """
+    result = round_trip(S_ALL_COMPLETE, "in_order", tmp_path)
+    assert result.rows_before, "scenario should have written rows"
+    assert result.rows_after == result.rows_before
+    assert result.recovered == set(), "but no group index came back"

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -27,10 +27,12 @@ import asyncio
 import pytest
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    CustomSamplerConfig,
     InOrderSampler,
     InOrderSamplerConfig,
     PromptGroupSampler,
     WeightFifoSampler,
+    WeightFifoSamplerConfig,
     WindowedSampler,
     WindowedSamplerConfig,
     create_sampler,
@@ -151,6 +153,24 @@ class TestInOrderEvictMatchesSelect:
 
 
 class TestFactory:
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            (WindowedSamplerConfig(), True),
+            (WeightFifoSamplerConfig(), False),
+            (InOrderSamplerConfig(), False),
+            (
+                CustomSamplerConfig(target=f"{__name__}:EchoSampler"),
+                None,
+            ),
+        ],
+    )
+    def test_config_declares_checkpoint_capability_without_serializing_it(
+        self, config, expected
+    ):
+        assert config.supports_buffer_checkpoint is expected
+        assert "supports_buffer_checkpoint" not in config.model_dump()
+
     def test_windowed_config_builds_windowed(self):
         s = create_sampler(
             FakeBuffer(), WindowedSamplerConfig(max_staleness_versions=3)
@@ -164,24 +184,25 @@ class TestFactory:
         assert s.max_lookahead_versions == 2
 
     def test_weight_fifo_config_builds_weight_fifo(self):
-        from nemo_rl.algorithms.async_utils.staleness_sampler import (
-            WeightFifoSamplerConfig,
-        )
-
         s = create_sampler(
             FakeBuffer(), WeightFifoSamplerConfig(max_staleness_versions=4)
         )
         assert isinstance(s, WeightFifoSampler)
         assert s.max_staleness_versions == 4
 
+    def test_factory_rejects_config_implementation_capability_drift(self, monkeypatch):
+        monkeypatch.setattr(
+            WindowedSampler,
+            "supports_buffer_checkpoint",
+            property(lambda _self: False),
+        )
+        with pytest.raises(RuntimeError, match="disagrees with"):
+            create_sampler(FakeBuffer(), WindowedSamplerConfig())
+
 
 class TestCustomFqnSampler:
     def test_custom_target_loads_out_of_repo_sampler(self):
         # A user sampler defined anywhere importable; here, this test module.
-        from nemo_rl.algorithms.async_utils.staleness_sampler import (
-            CustomSamplerConfig,
-        )
-
         s = create_sampler(
             FakeBuffer(),
             CustomSamplerConfig(

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -36,6 +36,7 @@ from nemo_rl.algorithms.async_utils.staleness_sampler import (
     WindowedSampler,
     WindowedSamplerConfig,
     create_sampler,
+    sampler_supports_buffer_checkpoint,
 )
 from nemo_rl.data_plane import KVBatchMeta
 
@@ -161,14 +162,12 @@ class TestFactory:
             (InOrderSamplerConfig(), False),
             (
                 CustomSamplerConfig(target=f"{__name__}:EchoSampler"),
-                None,
+                False,
             ),
         ],
     )
-    def test_config_declares_checkpoint_capability_without_serializing_it(
-        self, config, expected
-    ):
-        assert config.supports_buffer_checkpoint is expected
+    def test_capability_comes_from_sampler_class(self, config, expected):
+        assert sampler_supports_buffer_checkpoint(config) is expected
         assert "supports_buffer_checkpoint" not in config.model_dump()
 
     def test_windowed_config_builds_windowed(self):
@@ -190,17 +189,37 @@ class TestFactory:
         assert isinstance(s, WeightFifoSampler)
         assert s.max_staleness_versions == 4
 
-    def test_factory_rejects_config_implementation_capability_drift(self, monkeypatch):
-        monkeypatch.setattr(
-            WindowedSampler,
-            "supports_buffer_checkpoint",
-            property(lambda _self: False),
+    def test_factory_rejects_dynamic_capability_before_construction(self):
+        PropertyCapabilitySampler.constructed = False
+        with pytest.raises(TypeError, match="boolean class attribute"):
+            create_sampler(
+                FakeBuffer(),
+                CustomSamplerConfig(
+                    target=f"{__name__}:PropertyCapabilitySampler",
+                ),
+            )
+        assert not PropertyCapabilitySampler.constructed
+
+    def test_custom_checkpoint_capability_is_discoverable_without_construction(self):
+        CheckpointingEchoSampler.constructed = False
+        assert sampler_supports_buffer_checkpoint(
+            CustomSamplerConfig(
+                target=f"{__name__}:CheckpointingEchoSampler",
+            )
         )
-        with pytest.raises(RuntimeError, match="disagrees with"):
-            create_sampler(FakeBuffer(), WindowedSamplerConfig())
+        assert not CheckpointingEchoSampler.constructed
 
 
 class TestCustomFqnSampler:
+    def test_custom_target_must_be_a_class(self):
+        with pytest.raises(TypeError, match="not a class"):
+            create_sampler(
+                FakeBuffer(),
+                CustomSamplerConfig(
+                    target=f"{__name__}:NOT_A_SAMPLER_CLASS",
+                ),
+            )
+
     def test_custom_target_loads_out_of_repo_sampler(self):
         # A user sampler defined anywhere importable; here, this test module.
         s = create_sampler(
@@ -352,7 +371,7 @@ class TestDispatchCursorRestore:
         assert _run(s.admit(trainer_version_fn=lambda: 0)) == 0
 
     def test_negative_resume_step_rejected(self):
-        with pytest.raises(ValueError, match="resume_from_step"):
+        with pytest.raises(ValueError, match="resume_from_trainer_version"):
             WindowedSampler(FakeBuffer(), max_staleness_versions=1).set_dispatch_index(
                 -1
             )
@@ -404,3 +423,30 @@ class TestInflightAbortPolicy:
 
 class EchoSampler(InOrderSampler):
     """Stand-in for a user-defined sampler loaded by FQN."""
+
+
+class CheckpointingEchoSampler(EchoSampler):
+    """Custom sampler with a static replay-checkpoint capability."""
+
+    supports_buffer_checkpoint = True
+    constructed = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        type(self).constructed = True
+        super().__init__(*args, **kwargs)
+
+
+class PropertyCapabilitySampler:
+    """Invalid custom sampler whose capability requires construction."""
+
+    constructed = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        type(self).constructed = True
+
+    @property
+    def supports_buffer_checkpoint(self) -> bool:
+        return True
+
+
+NOT_A_SAMPLER_CLASS = object()

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -54,7 +54,6 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     REPLAY_BUFFER_METADATA_STORAGE,
     DataPlaneCheckpointBarrier,
 )
-from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSamplerConfig,
     WindowedSamplerConfig,
@@ -75,7 +74,7 @@ from nemo_rl.algorithms.single_controller_utils import (
 )
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.data.utils import load_dataloader_state
-from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION, KVBatchMeta
 from nemo_rl.utils.checkpoint import CheckpointManager
 
 # Reuse the factory patches from the setup tests (same cross-module fixture

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -48,13 +48,13 @@ import yaml
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.async_utils.replay_buffer import (
-    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
     LEGACY_REPLAY_BUFFER_FILENAME,
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
     REPLAY_BUFFER_METADATA_STORAGE,
     DataPlaneCheckpointBarrier,
 )
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSamplerConfig,
     WindowedSamplerConfig,

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -213,11 +213,48 @@ class _ExhaustingSampler(_FakeSampler):
 
 
 class _FakeDPClient:
-    def __init__(self) -> None:
+    def __init__(self, *, save_error: Optional[Exception] = None) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
+        self.save_calls: list[dict[str, Any]] = []
+        self.save_error = save_error
 
     def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
         self.clear_calls.append((list(sample_ids), partition_id))
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str,
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.save_calls.append(
+            {
+                "checkpoint_dir": checkpoint_dir,
+                "metadata": dict(metadata or {}),
+            }
+        )
+        if self.save_error is not None:
+            raise self.save_error
+        os.makedirs(checkpoint_dir, exist_ok=True)
+        with open(os.path.join(checkpoint_dir, "metadata.json"), "w") as f:
+            json.dump({"user_metadata": metadata or {}}, f)
+
+
+class _BlockingDPClient(_FakeDPClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_started = threading.Event()
+        self.release_save = threading.Event()
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: str,
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.save_started.set()
+        assert self.release_save.wait(timeout=30.0), "test never released TQ save"
+        super().save_checkpoint(checkpoint_dir, metadata=metadata)
 
 
 class _FakeWeightSynchronizer:
@@ -251,6 +288,10 @@ class _FakeTQBuffer:
         self.load_return = load_return
         self.state_dict_calls: list[int] = []
         self.load_calls: list[dict[str, Any]] = []
+        self.checkpoint_lock: Optional[asyncio.Lock] = None
+
+    def set_data_plane_checkpoint_lock(self, lock: asyncio.Lock) -> None:
+        self.checkpoint_lock = lock
 
     async def state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
         self.state_dict_calls.append(saved_capacity)
@@ -313,6 +354,7 @@ def _actor_master_config(
     ft_save_period: Optional[int] = None,
     num_prompts_per_step: int = 2,
     max_num_epochs: int = 1,
+    data_plane_checkpoint: bool = False,
 ) -> MasterConfig:
     """MasterConfig for in-process SingleControllerActor tests.
 
@@ -355,7 +397,12 @@ def _actor_master_config(
             "checkpoint_must_save_by": checkpoint_must_save_by,
             "ft_save_period": ft_save_period,
         },
-        data_plane={"enabled": True, "impl": "transfer_queue"},
+        data_plane={
+            "enabled": True,
+            "impl": "transfer_queue",
+            "backend": "simple",
+            "checkpointing_enabled": data_plane_checkpoint,
+        },
         async_rl=AsyncRLConfig(
             sampler=sampler_cfg,
             min_groups_for_streaming_train=1,
@@ -371,6 +418,7 @@ def _make_actor_args(
     save_state: Optional[GRPOSaveState] = None,
     dataloader: Optional[_FakeDataloader] = None,
     tq_buffer: Optional[_FakeTQBuffer] = None,
+    dp_client: Optional[_FakeDPClient] = None,
     last_checkpoint_path: Optional[str] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
@@ -379,7 +427,7 @@ def _make_actor_args(
         env_handles={},
         train_cluster=None,  # type: ignore[arg-type]
         inference_cluster=None,  # type: ignore[arg-type]
-        dp_client=_FakeDPClient(),
+        dp_client=dp_client if dp_client is not None else _FakeDPClient(),
         dataloader=dataloader if dataloader is not None else _FakeDataloader(),
         weight_synchronizer=_FakeWeightSynchronizer(),  # type: ignore[arg-type]
         advantage_estimator=None,
@@ -697,6 +745,88 @@ class TestSaveTrigger:
 
         # step_2 from ft_save_period, step_3 from last-step.
         assert _step_dir_names(tmp_path / "checkpoints") == {"step_2", "step_3"}
+
+
+class TestDataPlaneShadowCheckpoint:
+    def test_saves_tq_state_and_keeps_legacy_replay_payload(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            data_plane_checkpoint=True,
+        )
+        dp_client = _FakeDPClient()
+        buffer = _FakeTQBuffer(state={"legacy_payload": "kept"})
+
+        _run_train_pump(
+            mc,
+            _make_actor_args(dp_client=dp_client, tq_buffer=buffer),
+        )
+
+        assert len(dp_client.save_calls) == 1
+        save_call = dp_client.save_calls[0]
+        assert save_call["checkpoint_dir"] == str(
+            tmp_path / "checkpoints" / "tmp_step_1" / "data_plane"
+        )
+        assert save_call["metadata"] == {
+            "data_plane_checkpoint_schema_version": 1,
+            "single_controller_train_steps": 1,
+            "single_controller_trainer_version": 1,
+            "single_controller_epoch": 0,
+            "partition_id": _PARTITION_ID,
+            "mode": "shadow",
+        }
+        step_dir = tmp_path / "checkpoints" / "step_1"
+        assert (step_dir / "data_plane" / "metadata.json").is_file()
+        assert torch.load(step_dir / "replay_buffer.pt", weights_only=False) == {
+            "legacy_payload": "kept"
+        }
+        assert buffer.state_dict_calls == [4]
+
+    def test_tq_save_failure_aborts_checkpoint(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            data_plane_checkpoint=True,
+        )
+        dp_client = _FakeDPClient(save_error=RuntimeError("injected TQ failure"))
+
+        with pytest.raises(RuntimeError, match="injected TQ failure"):
+            _run_train_pump(mc, _make_actor_args(dp_client=dp_client))
+
+        assert not (tmp_path / "checkpoints" / "step_1").exists()
+
+    def test_consumed_clear_waits_for_tq_save(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            data_plane_checkpoint=True,
+        )
+        dp_client = _BlockingDPClient()
+
+        async def _main() -> None:
+            actor = _ACTOR_CLS(mc, _make_actor_args(dp_client=dp_client))
+            actor._train_steps = 1
+            actor._trainer_version = 1
+            save_task = asyncio.create_task(actor._save_checkpoint({"loss": 1.0}))
+            started = await asyncio.to_thread(dp_client.save_started.wait, 30.0)
+            assert started
+
+            clear_task = asyncio.create_task(
+                actor._clear_data_plane_samples(["sample-0"])
+            )
+            await asyncio.sleep(0)
+            assert dp_client.clear_calls == []
+
+            dp_client.release_save.set()
+            await save_task
+            await clear_task
+            actor._checkpointer.shutdown()
+
+        asyncio.run(_main())
+        assert dp_client.clear_calls == [(["sample-0"], _PARTITION_ID)]
 
 
 # ── async-save finalization ──────────────────────────────────────────────────

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -49,11 +49,11 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.async_utils.replay_buffer import (
     DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
-    DataPlaneCheckpointBarrier,
     LEGACY_REPLAY_BUFFER_FILENAME,
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
     REPLAY_BUFFER_METADATA_STORAGE,
+    DataPlaneCheckpointBarrier,
 )
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSamplerConfig,
@@ -209,7 +209,7 @@ class _FakeSampler:
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         return None
 
-    def set_dispatch_index(self, resume_from_step: int) -> None:
+    def set_dispatch_index(self, resume_from_trainer_version: int) -> None:
         pass
 
 
@@ -1686,9 +1686,7 @@ class TestReplayBufferPersistence:
                 _make_actor_args(last_checkpoint_path=str(ckpt_dir)),
             )
 
-    def test_run_missing_native_replay_metadata_starts_empty(
-        self, tmp_path, monkeypatch
-    ):
+    def test_run_missing_native_replay_metadata_starts_empty(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
         mc = _actor_master_config(
@@ -1698,11 +1696,6 @@ class TestReplayBufferPersistence:
             data_plane_checkpoint=True,
         )
         buffer = _FakeTQBuffer()
-        printed: list[str] = []
-        monkeypatch.setattr(
-            "builtins.print",
-            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
-        )
 
         actor, _ = _run_actor_run(
             mc,
@@ -1711,7 +1704,6 @@ class TestReplayBufferPersistence:
 
         assert buffer.load_calls == []
         assert actor._buffer_capacity._value == 4  # zero permits consumed
-        assert any("No native replay metadata found" in line for line in printed)
 
     def test_run_rejects_native_replay_state_with_gated_sampler(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -27,8 +27,7 @@ Covers:
   - dataloader state: train_dataloader.pt written at save, position
     round-trip through a real StatefulDataLoader, dataset-swap guard,
     setup restore wiring + missing-file corruption check;
-  - replay buffer persistence (restore skipped on a sampler_name mismatch,
-    restored permits released by a live train pump);
+  - native replay persistence requires both sampler support and TQ checkpointing;
   - setup_single_controller resume-path wiring (get_resume_paths forwarded
     to the trainer factory, save_state loaded from training_info.json).
 """
@@ -48,7 +47,18 @@ import torch
 import yaml
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from nemo_rl.algorithms.async_utils.staleness_sampler import WindowedSamplerConfig
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    DataPlaneCheckpointBarrier,
+    LEGACY_REPLAY_BUFFER_FILENAME,
+    REPLAY_BUFFER_METADATA_FILENAME,
+    REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    REPLAY_BUFFER_METADATA_STORAGE,
+)
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    InOrderSamplerConfig,
+    WindowedSamplerConfig,
+)
 from nemo_rl.algorithms.grpo import (
     GRPOConfig,
     GRPOSaveState,
@@ -159,7 +169,8 @@ class _FailingFinalizeTrainer(_FakeTrainer):
 class _FakeSampler:
     """PromptGroupSampler stand-in: always returns a full, fresh batch."""
 
-    def __init__(self) -> None:
+    def __init__(self, supports_buffer_checkpoint: bool = True) -> None:
+        self._supports_buffer_checkpoint = supports_buffer_checkpoint
         self._step = 0
 
     async def admit(self, *, trainer_version_fn) -> Optional[int]:
@@ -191,6 +202,10 @@ class _FakeSampler:
     def is_on_policy(self) -> bool:
         return False
 
+    @property
+    def supports_buffer_checkpoint(self) -> bool:
+        return self._supports_buffer_checkpoint
+
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         return None
 
@@ -212,16 +227,63 @@ class _ExhaustingSampler(_FakeSampler):
         return await super().select(**kwargs)
 
 
+class _RestoredGroupsSampler(_FakeSampler):
+    """Drain the exact groups represented by a restored metadata sidecar."""
+
+    def __init__(self, groups: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self._groups = list(groups)
+
+    async def select(
+        self,
+        *,
+        current_train_weight: int,
+        min_prompt_groups: int,
+        max_prompt_groups: int,
+    ) -> tuple[Optional[KVBatchMeta], int]:
+        del current_train_weight
+        selected = self._groups[:max_prompt_groups]
+        if len(selected) < min_prompt_groups:
+            return None, 0
+        del self._groups[: len(selected)]
+
+        metas = [group["meta"] for group in selected]
+        return (
+            KVBatchMeta(
+                partition_id=_PARTITION_ID,
+                task_name=None,
+                sample_ids=[sid for meta in metas for sid in meta.sample_ids],
+                sequence_lengths=[
+                    length for meta in metas for length in (meta.sequence_lengths or [])
+                ],
+                tags=[tag for meta in metas for tag in (meta.tags or [])],
+            ),
+            len(selected),
+        )
+
+
 class _FakeDPClient:
-    def __init__(self, *, save_error: Optional[Exception] = None) -> None:
+    def __init__(
+        self,
+        *,
+        save_error: Optional[Exception] = None,
+        sample_ids: Optional[list[str]] = None,
+    ) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
         self.clear_thread_ids: list[int] = []
         self.save_calls: list[dict[str, Any]] = []
         self.save_error = save_error
+        self.sample_ids = list(sample_ids or [])
+
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        assert partition_id == _PARTITION_ID
+        return sorted(self.sample_ids)
 
     def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
         self.clear_thread_ids.append(threading.get_ident())
         self.clear_calls.append((list(sample_ids), partition_id))
+        cleared = set(sample_ids)
+        self.sample_ids = [sid for sid in self.sample_ids if sid not in cleared]
 
     def save_checkpoint(
         self,
@@ -281,23 +343,32 @@ class _FakeTQBuffer:
 
     def __init__(
         self,
-        state: Optional[dict[str, Any]] = None,
+        metadata_state: Optional[dict[str, Any]] = None,
         load_return: int = 0,
     ) -> None:
         # Empty like a drained buffer; the pump's exhaustion checks len() it.
         self._num_groups = 0
-        self._state = state if state is not None else {"fake_buffer_envelope": 1}
+        self._metadata_state = metadata_state or {
+            "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "storage": REPLAY_BUFFER_METADATA_STORAGE,
+            "partition_id": _PARTITION_ID,
+            "saved_capacity": 4,
+            "manifest_digest": "fake-manifest-digest",
+            "groups": [],
+        }
         self.load_return = load_return
-        self.state_dict_calls: list[int] = []
+        self.metadata_state_dict_calls: list[int] = []
         self.load_calls: list[dict[str, Any]] = []
-        self.checkpoint_lock: Optional[asyncio.Lock] = None
+        self.checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
 
-    def set_data_plane_checkpoint_lock(self, lock: asyncio.Lock) -> None:
-        self.checkpoint_lock = lock
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        self.checkpoint_barrier = barrier
 
-    async def state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
-        self.state_dict_calls.append(saved_capacity)
-        return dict(self._state)
+    def metadata_state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
+        self.metadata_state_dict_calls.append(saved_capacity)
+        return dict(self._metadata_state)
 
     async def load_state_dict(
         self,
@@ -306,6 +377,7 @@ class _FakeTQBuffer:
         max_groups: int,
         expected_partition_id: str,
         expected_group_size: int,
+        expected_manifest_digest: str,
     ) -> int:
         self.load_calls.append(
             {
@@ -313,6 +385,7 @@ class _FakeTQBuffer:
                 "max_groups": max_groups,
                 "expected_partition_id": expected_partition_id,
                 "expected_group_size": expected_group_size,
+                "expected_manifest_digest": expected_manifest_digest,
             }
         )
         return self.load_return
@@ -356,6 +429,7 @@ def _actor_master_config(
     ft_save_period: Optional[int] = None,
     num_prompts_per_step: int = 2,
     max_num_epochs: int = 1,
+    buffer_checkpoint: bool = False,
     data_plane_checkpoint: bool = False,
 ) -> MasterConfig:
     """MasterConfig for in-process SingleControllerActor tests.
@@ -363,7 +437,11 @@ def _actor_master_config(
     All fields are populated (init_tmp_checkpoint dumps the whole config to
     config.yaml); values satisfy validate_single_controller_config.
     """
-    sampler_cfg = WindowedSamplerConfig(max_staleness_versions=1)
+    sampler_cfg = (
+        WindowedSamplerConfig(max_staleness_versions=1)
+        if buffer_checkpoint
+        else InOrderSamplerConfig(max_lookahead_versions=1)
+    )
     return MasterConfig.model_construct(
         policy={
             # One optimizer.step per RL step: prompts * generations == gbs.
@@ -422,6 +500,7 @@ def _make_actor_args(
     tq_buffer: Optional[_FakeTQBuffer] = None,
     dp_client: Optional[_FakeDPClient] = None,
     last_checkpoint_path: Optional[str] = None,
+    data_plane_checkpoint_metadata: Optional[dict[str, Any]] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
         gen_handle=object(),
@@ -441,6 +520,7 @@ def _make_actor_args(
             save_state if save_state is not None else _initial_grpo_save_state()
         ),
         last_checkpoint_path=last_checkpoint_path,
+        data_plane_checkpoint_metadata=data_plane_checkpoint_metadata,
     )
 
 
@@ -458,7 +538,9 @@ def _run_train_pump(
 
     async def _main():
         actor = _ACTOR_CLS(mc, actor_args, SetupTimingMetrics())
-        actor._sampler = _FakeSampler()
+        actor._sampler = _FakeSampler(
+            supports_buffer_checkpoint=(mc.async_rl.sampler.name == "windowed")
+        )
         # In-process runs have no Ray runtime; the pump only reads the GPU
         # count for a throughput metric.
         with patch("ray.cluster_resources", return_value={"GPU": 0}):
@@ -488,7 +570,10 @@ def _run_actor_run(mc: MasterConfig, actor_args: SingleControllerActorArgs):
 
 
 def _run_restore_then_train_pump(
-    mc: MasterConfig, actor_args: SingleControllerActorArgs
+    mc: MasterConfig,
+    actor_args: SingleControllerActorArgs,
+    *,
+    restored_groups: list[dict[str, Any]],
 ):
     """Restore the replay buffer, then drive a live _train_pump.
 
@@ -500,7 +585,7 @@ def _run_restore_then_train_pump(
     async def _main():
         actor = _ACTOR_CLS(mc, actor_args, SetupTimingMetrics())
         await actor._maybe_restore_replay_buffer()
-        actor._sampler = _FakeSampler()
+        actor._sampler = _RestoredGroupsSampler(restored_groups)
         with patch("ray.cluster_resources", return_value={"GPU": 0}):
             await asyncio.wait_for(actor._train_pump(), timeout=60.0)
         actor._checkpointer.shutdown()
@@ -547,6 +632,21 @@ class TestCounterRestore:
         assert actor._consumed_samples == 42
         assert actor._current_epoch == 2
         assert actor._total_valid_tokens == 1234
+
+    def test_restores_trainer_version_independently_from_train_step(self, tmp_path):
+        save_state = _initial_grpo_save_state()
+        save_state.current_step = 7
+        save_state.trainer_version = 11
+
+        actor = _ACTOR_CLS(
+            _actor_master_config(tmp_path),
+            _make_actor_args(save_state=save_state),
+            SetupTimingMetrics(),
+        )
+
+        assert actor._train_steps == 7
+        assert actor._trainer_version == 11
+        assert actor._sampler._dispatch_index == 10
 
     def test_fresh_start_defaults(self, tmp_path):
         actor = _ACTOR_CLS(
@@ -620,6 +720,7 @@ class TestSaveTrigger:
 
         info_2 = _training_info(ckpt_dir, 2)
         assert info_2["current_step"] == 2
+        assert info_2["trainer_version"] == 2
         assert info_2["total_steps"] == 2
         assert info_2["consumed_samples"] == 4  # 2 prompts/step * 2 steps
         # No validation ran, so the default val_reward is dropped.
@@ -749,16 +850,46 @@ class TestSaveTrigger:
         assert _step_dir_names(tmp_path / "checkpoints") == {"step_2", "step_3"}
 
 
-class TestDataPlaneShadowCheckpoint:
-    def test_saves_tq_state_and_keeps_legacy_replay_payload(self, tmp_path):
+class TestDataPlaneCheckpoint:
+    def test_saves_authoritative_tq_state_and_metadata_only_replay_index(
+        self, tmp_path
+    ):
         mc = _actor_master_config(
             tmp_path,
             max_num_steps=1,
             save_period=1,
+            buffer_checkpoint=True,
             data_plane_checkpoint=True,
         )
-        dp_client = _FakeDPClient()
-        buffer = _FakeTQBuffer(state={"legacy_payload": "kept"})
+        sample_ids = ["g0-0", "g0-1"]
+        dp_client = _FakeDPClient(sample_ids=sample_ids)
+        replay_metadata = {
+            "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "storage": REPLAY_BUFFER_METADATA_STORAGE,
+            "partition_id": _PARTITION_ID,
+            "saved_capacity": 4,
+            "manifest_digest": "digest-1",
+            "groups": [
+                {
+                    "meta": KVBatchMeta(
+                        partition_id=_PARTITION_ID,
+                        task_name="train",
+                        sample_ids=sample_ids,
+                        fields=["input_ids"],
+                        sequence_lengths=[16, 16],
+                        tags=[
+                            {"weight_version": 0},
+                            {"weight_version": 0},
+                        ],
+                    ),
+                    "start_weight": 0,
+                    "end_weight": 0,
+                    "target_step": None,
+                    "group_id": "g0",
+                }
+            ],
+        }
+        buffer = _FakeTQBuffer(metadata_state=replay_metadata)
 
         _run_train_pump(
             mc,
@@ -771,19 +902,108 @@ class TestDataPlaneShadowCheckpoint:
             tmp_path / "checkpoints" / "tmp_step_1" / "data_plane"
         )
         assert save_call["metadata"] == {
-            "data_plane_checkpoint_schema_version": 1,
+            "data_plane_checkpoint_schema_version": (
+                DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+            ),
             "single_controller_train_steps": 1,
             "single_controller_trainer_version": 1,
             "single_controller_epoch": 0,
             "partition_id": _PARTITION_ID,
-            "mode": "shadow",
+            "sampler_name": "windowed",
+            "mode": "authoritative",
+            "replay_metadata_schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "replay_manifest_digest": "digest-1",
+            "replay_group_count": 1,
         }
         step_dir = tmp_path / "checkpoints" / "step_1"
         assert (step_dir / "data_plane" / "metadata.json").is_file()
-        assert torch.load(step_dir / "replay_buffer.pt", weights_only=False) == {
-            "legacy_payload": "kept"
+        assert (
+            torch.load(step_dir / REPLAY_BUFFER_METADATA_FILENAME, weights_only=False)
+            == replay_metadata
+        )
+        assert not (step_dir / "replay_buffer.pt").exists()
+        assert buffer.metadata_state_dict_calls == [4]
+
+    @pytest.mark.parametrize(
+        ("actual_sample_ids", "error_fragment"),
+        [
+            (["g0-0"], r"missing=\['g0-1'\]"),
+            (
+                ["g0-0", "g0-1", "orphan-0"],
+                r"unexpected=\['orphan-0'\]",
+            ),
+        ],
+    )
+    def test_tq_save_rejects_inventory_mismatch(
+        self, tmp_path, actual_sample_ids, error_fragment
+    ):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+        sample_ids = ["g0-0", "g0-1"]
+        replay_metadata = {
+            "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "storage": REPLAY_BUFFER_METADATA_STORAGE,
+            "partition_id": _PARTITION_ID,
+            "saved_capacity": 4,
+            "manifest_digest": "digest-1",
+            "groups": [
+                {
+                    "meta": KVBatchMeta(
+                        partition_id=_PARTITION_ID,
+                        task_name="train",
+                        sample_ids=sample_ids,
+                        fields=["input_ids"],
+                        sequence_lengths=[16, 16],
+                        tags=[
+                            {"weight_version": 0},
+                            {"weight_version": 0},
+                        ],
+                    ),
+                    "start_weight": 0,
+                    "end_weight": 0,
+                    "target_step": None,
+                    "group_id": "g0",
+                }
+            ],
         }
-        assert buffer.state_dict_calls == [4]
+
+        with pytest.raises(RuntimeError, match=error_fragment):
+            _run_train_pump(
+                mc,
+                _make_actor_args(
+                    dp_client=_FakeDPClient(sample_ids=actual_sample_ids),
+                    tq_buffer=_FakeTQBuffer(metadata_state=replay_metadata),
+                ),
+            )
+
+        assert not (tmp_path / "checkpoints" / "step_1").exists()
+
+    def test_gated_sampler_keeps_tq_checkpoint_in_shadow_mode(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            buffer_checkpoint=False,
+            data_plane_checkpoint=True,
+        )
+        dp_client = _FakeDPClient()
+        buffer = _FakeTQBuffer()
+
+        _run_train_pump(
+            mc,
+            _make_actor_args(dp_client=dp_client, tq_buffer=buffer),
+        )
+
+        assert dp_client.save_calls[0]["metadata"]["mode"] == "shadow"
+        step_dir = tmp_path / "checkpoints" / "step_1"
+        assert not (step_dir / REPLAY_BUFFER_METADATA_FILENAME).exists()
+        assert not (step_dir / "replay_buffer.pt").exists()
+        assert buffer.metadata_state_dict_calls == []
 
     def test_tq_save_failure_aborts_checkpoint(self, tmp_path):
         mc = _actor_master_config(
@@ -809,7 +1029,9 @@ class TestDataPlaneShadowCheckpoint:
         dp_client = _BlockingDPClient()
 
         async def _main() -> None:
-            actor = _ACTOR_CLS(mc, _make_actor_args(dp_client=dp_client))
+            actor = _ACTOR_CLS(
+                mc, _make_actor_args(dp_client=dp_client), SetupTimingMetrics()
+            )
             actor._train_steps = 1
             actor._trainer_version = 1
             save_task = asyncio.create_task(actor._save_checkpoint({"loss": 1.0}))
@@ -835,7 +1057,9 @@ class TestDataPlaneShadowCheckpoint:
         dp_client = _FakeDPClient()
 
         async def _main() -> int:
-            actor = _ACTOR_CLS(mc, _make_actor_args(dp_client=dp_client))
+            actor = _ACTOR_CLS(
+                mc, _make_actor_args(dp_client=dp_client), SetupTimingMetrics()
+            )
             event_loop_thread_id = threading.get_ident()
             await actor._clear_data_plane_samples(["sample-0"])
             actor._checkpointer.shutdown()
@@ -1227,44 +1451,97 @@ class TestDataloaderState:
 # ── replay buffer persistence ────────────────────────────────────────────────
 
 
-def _matching_save_state() -> dict[str, Any]:
-    """save_state whose sampler_name matches _actor_master_config's sampler."""
-    save_state = _initial_grpo_save_state()
-    save_state.sampler_name = "windowed"
-    return save_state
-
-
 class TestReplayBufferPersistence:
-    def test_save_writes_replay_buffer(self, tmp_path):
-        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
-        envelope = {"groups": [], "sentinel": "abc"}
-        buffer = _FakeTQBuffer(state=envelope)
+    def test_checkpoint_capable_sampler_without_native_tq_is_rejected(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=2,
+            save_period=2,
+            buffer_checkpoint=True,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="replay-checkpoint-capable sampler requires",
+        ):
+            _ACTOR_CLS(mc, _make_actor_args(), SetupTimingMetrics())
+
+    def test_no_replay_buffer_with_gated_sampler(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, buffer_checkpoint=False
+        )
+        buffer = _FakeTQBuffer()
 
         _run_train_pump(mc, _make_actor_args(tq_buffer=buffer))
 
         ckpt_dir = tmp_path / "checkpoints"
-        buffer_path = ckpt_dir / "step_2" / "replay_buffer.pt"
-        assert buffer_path.exists()
-        assert torch.load(buffer_path, weights_only=False) == envelope
-        # state_dict is stamped with the capacity at save time; the sampler
-        # identity lands in training_info.json for the restore-side check.
-        assert buffer.state_dict_calls == [4]
-        assert _training_info(ckpt_dir, 2)["sampler_name"] == "windowed"
+        assert (ckpt_dir / "step_2" / "training_info.json").exists()
+        assert not (ckpt_dir / "step_2" / "replay_buffer.pt").exists()
+        assert not (ckpt_dir / "step_2" / REPLAY_BUFFER_METADATA_FILENAME).exists()
 
-    def test_run_restores_replay_buffer_and_permits(self, tmp_path):
+    def test_run_rejects_legacy_replay_file(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        envelope = {"groups": ["g0", "g1", "g2"]}
-        torch.save(envelope, ckpt_dir / "replay_buffer.pt")
-        mc = _actor_master_config(tmp_path, max_num_steps=0)
-        buffer = _FakeTQBuffer(load_return=3)
+        torch.save({"groups": ["legacy"]}, ckpt_dir / LEGACY_REPLAY_BUFFER_FILENAME)
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+        buffer = _FakeTQBuffer()
+
+        with pytest.raises(RuntimeError, match="legacy replay_buffer.pt"):
+            _run_actor_run(
+                mc,
+                _make_actor_args(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
+            )
+
+        assert buffer.load_calls == []
+
+    def test_run_restores_native_tq_replay_metadata_without_payload_reput(
+        self, tmp_path
+    ):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        sample_ids = ["g0-0", "g0-1", "g1-0", "g1-1"]
+        groups = [
+            {
+                "meta": KVBatchMeta(
+                    partition_id=_PARTITION_ID,
+                    task_name=None,
+                    sample_ids=[f"g{i}-0", f"g{i}-1"],
+                    sequence_lengths=[16, 16],
+                    tags=[{"weight_version": 0}, {"weight_version": 0}],
+                ),
+                "start_weight": 0,
+                "end_weight": 0,
+                "target_step": i,
+                "group_id": f"g{i}",
+            }
+            for i in range(2)
+        ]
+        envelope = {"groups": groups}
+        torch.save(envelope, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        tq_metadata = {
+            "replay_manifest_digest": "digest-1",
+            "replay_group_count": 2,
+        }
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+        buffer = _FakeTQBuffer(load_return=2)
 
         actor, result = _run_actor_run(
             mc,
             _make_actor_args(
                 tq_buffer=buffer,
+                dp_client=_FakeDPClient(sample_ids=sample_ids),
                 last_checkpoint_path=str(ckpt_dir),
-                save_state=_matching_save_state(),
+                data_plane_checkpoint_metadata=tq_metadata,
             ),
         )
 
@@ -1274,10 +1551,10 @@ class TestReplayBufferPersistence:
                 "max_groups": 4,
                 "expected_partition_id": _PARTITION_ID,
                 "expected_group_size": 2,
+                "expected_manifest_digest": "digest-1",
             }
         ]
-        # Each restored group holds one _buffer_capacity permit.
-        assert actor._buffer_capacity._value == 4 - 3
+        assert actor._buffer_capacity._value == 2
         assert result["train_steps"] == 0
 
     def test_restored_permits_are_released_by_a_live_pump(self, tmp_path):
@@ -1289,17 +1566,46 @@ class TestReplayBufferPersistence:
         # acquisition shape.
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        torch.save({"groups": []}, ckpt_dir / "replay_buffer.pt")
-        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
+        sample_ids = [f"g{i}-{j}" for i in range(4) for j in range(2)]
+        groups = [
+            {
+                "meta": KVBatchMeta(
+                    partition_id=_PARTITION_ID,
+                    task_name=None,
+                    sample_ids=[f"g{i}-0", f"g{i}-1"],
+                    sequence_lengths=[16, 16],
+                    tags=[{"weight_version": 0}, {"weight_version": 0}],
+                ),
+                "start_weight": 0,
+                "end_weight": 0,
+                "target_step": None,
+                "group_id": f"g{i}",
+            }
+            for i in range(4)
+        ]
+        torch.save({"groups": groups}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        tq_metadata = {
+            "replay_manifest_digest": "digest-1",
+            "replay_group_count": 4,
+        }
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=2,
+            save_period=2,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
         buffer = _FakeTQBuffer(load_return=4)
 
         actor = _run_restore_then_train_pump(
             mc,
             _make_actor_args(
                 tq_buffer=buffer,
+                dp_client=_FakeDPClient(sample_ids=sample_ids),
                 last_checkpoint_path=str(ckpt_dir),
-                save_state=_matching_save_state(),
+                data_plane_checkpoint_metadata=tq_metadata,
             ),
+            restored_groups=groups,
         )
 
         assert len(buffer.load_calls) == 1
@@ -1308,12 +1614,89 @@ class TestReplayBufferPersistence:
         # selected group (2 steps x 2 prompt groups), so all 4 came back.
         assert actor._buffer_capacity._value == 4
 
-    def test_run_missing_replay_buffer_file_starts_empty(self, tmp_path, monkeypatch):
-        # Resuming from a checkpoint that predates replay-buffer persistence:
-        # no replay_buffer.pt.
+    @pytest.mark.parametrize(
+        ("actual_sample_ids", "error_fragment"),
+        [
+            (["g0-0"], r"missing=\['g0-1'\]"),
+            (
+                ["g0-0", "g0-1", "orphan-0"],
+                r"unexpected=\['orphan-0'\]",
+            ),
+        ],
+    )
+    def test_native_restore_rejects_tq_inventory_mismatch(
+        self, tmp_path, actual_sample_ids, error_fragment
+    ):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        mc = _actor_master_config(tmp_path, max_num_steps=0)
+        envelope = {
+            "groups": [
+                {
+                    "meta": KVBatchMeta(
+                        partition_id=_PARTITION_ID,
+                        task_name=None,
+                        sample_ids=["g0-0", "g0-1"],
+                        sequence_lengths=[16, 16],
+                        tags=[{"weight_version": 0}, {"weight_version": 0}],
+                    ),
+                    "start_weight": 0,
+                    "end_weight": 0,
+                    "target_step": 0,
+                    "group_id": "g0",
+                }
+            ]
+        }
+        torch.save(envelope, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        tq_metadata = {
+            "replay_manifest_digest": "digest-1",
+            "replay_group_count": 1,
+        }
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+
+        with pytest.raises(RuntimeError, match=error_fragment):
+            _run_actor_run(
+                mc,
+                _make_actor_args(
+                    tq_buffer=_FakeTQBuffer(load_return=1),
+                    dp_client=_FakeDPClient(sample_ids=actual_sample_ids),
+                    last_checkpoint_path=str(ckpt_dir),
+                    data_plane_checkpoint_metadata=tq_metadata,
+                ),
+            )
+
+    def test_native_replay_metadata_requires_setup_side_tq_restore(self, tmp_path):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save({"groups": []}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+
+        with pytest.raises(RuntimeError, match="native TQ checkpoint was not restored"):
+            _run_actor_run(
+                mc,
+                _make_actor_args(last_checkpoint_path=str(ckpt_dir)),
+            )
+
+    def test_run_missing_native_replay_metadata_starts_empty(
+        self, tmp_path, monkeypatch
+    ):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
         buffer = _FakeTQBuffer()
         printed: list[str] = []
         monkeypatch.setattr(
@@ -1328,34 +1711,16 @@ class TestReplayBufferPersistence:
 
         assert buffer.load_calls == []
         assert actor._buffer_capacity._value == 4  # zero permits consumed
-        assert any("No replay buffer checkpoint found" in line for line in printed)
+        assert any("No native replay metadata found" in line for line in printed)
 
-    def test_run_no_restore_on_sampler_mismatch(self, tmp_path, monkeypatch):
-        # File present but the checkpoint's training_info records a different
-        # sampler: warn and skip — the saved stamps may never be selectable
-        # under the current policy.
+    def test_run_rejects_native_replay_state_with_gated_sampler(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        torch.save({"groups": []}, ckpt_dir / "replay_buffer.pt")
-        mc = _actor_master_config(tmp_path, max_num_steps=0)
-        save_state = _initial_grpo_save_state()
-        save_state.sampler_name = "in_order"  # current run uses windowed
-        buffer = _FakeTQBuffer(load_return=2)
-        printed: list[str] = []
-        monkeypatch.setattr(
-            "builtins.print",
-            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
-        )
+        torch.save({"groups": []}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        mc = _actor_master_config(tmp_path, max_num_steps=0, buffer_checkpoint=False)
 
-        actor, _ = _run_actor_run(
-            mc,
-            _make_actor_args(
-                tq_buffer=buffer,
-                last_checkpoint_path=str(ckpt_dir),
-                save_state=save_state,
-            ),
-        )
-
-        assert buffer.load_calls == []
-        assert actor._buffer_capacity._value == 4
-        assert any("skipping the buffer restore" in line for line in printed)
+        with pytest.raises(RuntimeError, match="does not support replay-buffer"):
+            _run_actor_run(
+                mc,
+                _make_actor_args(last_checkpoint_path=str(ckpt_dir)),
+            )

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -215,10 +215,12 @@ class _ExhaustingSampler(_FakeSampler):
 class _FakeDPClient:
     def __init__(self, *, save_error: Optional[Exception] = None) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
+        self.clear_thread_ids: list[int] = []
         self.save_calls: list[dict[str, Any]] = []
         self.save_error = save_error
 
     def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
+        self.clear_thread_ids.append(threading.get_ident())
         self.clear_calls.append((list(sample_ids), partition_id))
 
     def save_checkpoint(
@@ -827,6 +829,21 @@ class TestDataPlaneShadowCheckpoint:
 
         asyncio.run(_main())
         assert dp_client.clear_calls == [(["sample-0"], _PARTITION_ID)]
+
+    def test_consumed_clear_does_not_block_actor_event_loop(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=1, save_period=1)
+        dp_client = _FakeDPClient()
+
+        async def _main() -> int:
+            actor = _ACTOR_CLS(mc, _make_actor_args(dp_client=dp_client))
+            event_loop_thread_id = threading.get_ident()
+            await actor._clear_data_plane_samples(["sample-0"])
+            actor._checkpointer.shutdown()
+            return event_loop_thread_id
+
+        event_loop_thread_id = asyncio.run(_main())
+        assert dp_client.clear_thread_ids
+        assert dp_client.clear_thread_ids[0] != event_loop_thread_id
 
 
 # ── async-save finalization ──────────────────────────────────────────────────

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -132,6 +132,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
         inference_cluster=None,
         save_state=_initial_grpo_save_state(),
         last_checkpoint_path=None,
+        data_plane_checkpoint_metadata=None,
     )
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
 

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 import nemo_rl.algorithms.single_controller as single_controller
+from nemo_rl.algorithms.async_utils.replay_buffer import DataPlaneCheckpointBarrier
 from nemo_rl.algorithms.grpo import GRPOConfig, _initial_grpo_save_state
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
@@ -185,6 +186,7 @@ def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
         inference_cluster=None,
         save_state=_initial_grpo_save_state(),
         last_checkpoint_path=None,
+        data_plane_checkpoint_metadata=None,
     )
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
 
@@ -366,6 +368,7 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._timer = Timer()
     ctrl._trainer_version = 0
     ctrl._train_steps = 0
+    ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
     ctrl._step_log_dict = {
         "rewards": [],
         "masked_advantages": [],

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -30,7 +30,11 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
 )
-from nemo_rl.algorithms.async_utils.staleness_sampler import WindowedSamplerConfig
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    CustomSamplerConfig,
+    WindowedSampler,
+    WindowedSamplerConfig,
+)
 from nemo_rl.algorithms.grpo import (
     GRPOConfig,
     GRPOSaveState,
@@ -43,6 +47,13 @@ from nemo_rl.algorithms.single_controller_utils import (
     SingleControllerActorArgs,
     setup_single_controller,
 )
+
+
+class _CheckpointingCustomSampler(WindowedSampler):
+    """Custom sampler whose static capability must be validated during setup."""
+
+    def __init__(self, buffer: Any) -> None:
+        super().__init__(buffer, max_staleness_versions=1)
 
 
 def _make_master_config(
@@ -282,6 +293,28 @@ class TestSetup:
         mc = _make_master_config()
         mc.checkpointing["enabled"] = True
         mc.async_rl.sampler = WindowedSamplerConfig(max_staleness_versions=1)
+        mc.data_plane.update(
+            {
+                "backend": "simple",
+                "checkpointing_enabled": False,
+            }
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "replay-checkpoint-capable sampler requires "
+                "data_plane.checkpointing_enabled=true"
+            ),
+        ):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+    def test_rejects_checkpointing_custom_sampler_without_native_tq(self):
+        mc = _make_master_config()
+        mc.checkpointing["enabled"] = True
+        mc.async_rl.sampler = CustomSamplerConfig(
+            target=f"{__name__}:_CheckpointingCustomSampler"
+        )
         mc.data_plane.update(
             {
                 "backend": "simple",

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -29,7 +29,6 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
 )
-from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     CustomSamplerConfig,
     WindowedSampler,
@@ -47,6 +46,7 @@ from nemo_rl.algorithms.single_controller_utils import (
     SingleControllerActorArgs,
     setup_single_controller,
 )
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
 
 
 class _CheckpointingCustomSampler(WindowedSampler):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -224,6 +224,17 @@ class TestSetup:
         with pytest.raises(ValueError, match="data_plane.enabled=True"):
             setup_single_controller(mc, MagicMock())
 
+    def test_rejects_mooncake_data_plane_checkpointing(self):
+        mc = _make_master_config()
+        mc.data_plane.update(
+            {
+                "backend": "mooncake_cpu",
+                "checkpointing_enabled": True,
+            }
+        )
+        with pytest.raises(NotImplementedError, match="backend='simple'"):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
     def test_multiple_dataloader_not_supported(self):
         mc = _make_master_config(use_multiple_dataloader=True)
         with pytest.raises(NotImplementedError, match="use_multiple_dataloader"):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -25,11 +25,11 @@ import torch
 import nemo_rl.algorithms.single_controller_utils.setup as sc_setup_mod
 from nemo_rl.algorithms.async_utils.replay_buffer import (
     DATA_PLANE_CHECKPOINT_DIR,
-    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
     LEGACY_REPLAY_BUFFER_FILENAME,
     REPLAY_BUFFER_METADATA_FILENAME,
     REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
 )
+from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     CustomSamplerConfig,
     WindowedSampler,

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -16,12 +16,26 @@
 
 from __future__ import annotations
 
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 import nemo_rl.algorithms.single_controller_utils.setup as sc_setup_mod
-from nemo_rl.algorithms.grpo import GRPOConfig
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DATA_PLANE_CHECKPOINT_DIR,
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    LEGACY_REPLAY_BUFFER_FILENAME,
+    REPLAY_BUFFER_METADATA_FILENAME,
+    REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+)
+from nemo_rl.algorithms.async_utils.staleness_sampler import WindowedSamplerConfig
+from nemo_rl.algorithms.grpo import (
+    GRPOConfig,
+    GRPOSaveState,
+    _initial_grpo_save_state,
+)
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.single_controller_utils import (
     AsyncRLConfig,
@@ -97,6 +111,35 @@ def _make_master_config(
             max_buffered_rollouts=num_prompts_per_step * 2,
         ),
     )
+
+
+def _native_tq_metadata(
+    *, step: int = 3, trainer_version: Optional[int] = None, epoch: int = 1
+) -> dict[str, Any]:
+    return {
+        "data_plane_checkpoint_schema_version": (DATA_PLANE_CHECKPOINT_SCHEMA_VERSION),
+        "single_controller_train_steps": step,
+        "single_controller_trainer_version": (
+            step if trainer_version is None else trainer_version
+        ),
+        "single_controller_epoch": epoch,
+        "partition_id": "rollout_data",
+        "sampler_name": "in_order",
+        "mode": "authoritative",
+        "replay_metadata_schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+        "replay_manifest_digest": "digest-1",
+        "replay_group_count": 2,
+    }
+
+
+def _save_state(
+    *, step: int = 3, trainer_version: Optional[int] = None, epoch: int = 1
+) -> GRPOSaveState:
+    state = _initial_grpo_save_state()
+    state.current_step = step
+    state.current_epoch = epoch
+    state.trainer_version = trainer_version
+    return state
 
 
 @pytest.fixture
@@ -233,6 +276,26 @@ class TestSetup:
             }
         )
         with pytest.raises(NotImplementedError, match="backend='simple'"):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+    def test_rejects_windowed_checkpointing_without_native_tq(self):
+        mc = _make_master_config()
+        mc.checkpointing["enabled"] = True
+        mc.async_rl.sampler = WindowedSamplerConfig(max_staleness_versions=1)
+        mc.data_plane.update(
+            {
+                "backend": "simple",
+                "checkpointing_enabled": False,
+            }
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "replay-checkpoint-capable sampler requires "
+                "data_plane.checkpointing_enabled=true"
+            ),
+        ):
             setup_single_controller(mc, MagicMock(pad_token_id=0))
 
     def test_multiple_dataloader_not_supported(self):
@@ -641,3 +704,139 @@ class TestSetup:
         ):
             setup_single_controller(mc, MagicMock(pad_token_id=0))
         mock_spinup.assert_not_called()
+
+
+class TestNativeTQRecoverySetup:
+    def test_setup_loads_tq_before_creating_single_controller_client(
+        self, tmp_path, patched_factories
+    ):
+        checkpoint_path = tmp_path / "step_3"
+        (checkpoint_path / DATA_PLANE_CHECKPOINT_DIR).mkdir(parents=True)
+        (checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME).touch()
+        torch.save({}, checkpoint_path / "train_dataloader.pt")
+        save_state = _save_state()
+        policy = patched_factories["fake_policy"]
+        events: list[str] = []
+        policy.load_data_plane_checkpoint.side_effect = (
+            lambda checkpoint_dir: events.append("load") or _native_tq_metadata()
+        )
+        patched_factories["build_data_plane_client"].side_effect = (
+            lambda *args, **kwargs: events.append("build")
+            or MagicMock(name="dp_client")
+        )
+        checkpointer = MagicMock()
+        checkpointer.get_latest_checkpoint_path.return_value = str(checkpoint_path)
+        checkpointer.load_training_info.return_value = vars(save_state)
+        checkpointer.get_resume_paths.return_value = (None, None)
+        mc = _make_master_config()
+
+        with patch.object(sc_setup_mod, "CheckpointManager", return_value=checkpointer):
+            actor_args, _ = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert events == ["load", "build"]
+        assert actor_args.data_plane_checkpoint_metadata == _native_tq_metadata()
+
+    def test_loads_authoritative_tq_checkpoint_when_metadata_sidecar_exists(
+        self, tmp_path
+    ):
+        checkpoint_path = tmp_path / "step_3"
+        (checkpoint_path / DATA_PLANE_CHECKPOINT_DIR).mkdir(parents=True)
+        (checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME).touch()
+        policy = MagicMock()
+        metadata = _native_tq_metadata()
+        policy.load_data_plane_checkpoint.return_value = metadata
+        save_state = _save_state()
+
+        restored = sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+            policy,
+            last_checkpoint_path=str(checkpoint_path),
+            save_state=save_state,
+            partition_id="rollout_data",
+            sampler_name="in_order",
+        )
+
+        assert restored == metadata
+        policy.load_data_plane_checkpoint.assert_called_once_with(
+            checkpoint_path / DATA_PLANE_CHECKPOINT_DIR
+        )
+
+    def test_validates_trainer_version_independently_from_train_step(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        (checkpoint_path / DATA_PLANE_CHECKPOINT_DIR).mkdir(parents=True)
+        (checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME).touch()
+        policy = MagicMock()
+        metadata = _native_tq_metadata(step=3, trainer_version=7)
+        policy.load_data_plane_checkpoint.return_value = metadata
+
+        restored = sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+            policy,
+            last_checkpoint_path=str(checkpoint_path),
+            save_state=_save_state(trainer_version=7),
+            partition_id="rollout_data",
+            sampler_name="in_order",
+        )
+
+        assert restored == metadata
+
+    def test_legacy_replay_checkpoint_is_rejected(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        (checkpoint_path / LEGACY_REPLAY_BUFFER_FILENAME).touch()
+        policy = MagicMock()
+
+        with pytest.raises(RuntimeError, match="legacy replay_buffer.pt"):
+            sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+                policy,
+                last_checkpoint_path=str(checkpoint_path),
+                save_state=_save_state(),
+                partition_id="rollout_data",
+                sampler_name="in_order",
+            )
+
+        policy.load_data_plane_checkpoint.assert_not_called()
+
+    def test_checkpoint_without_replay_artifacts_does_not_load_tq(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        policy = MagicMock()
+
+        restored = sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+            policy,
+            last_checkpoint_path=str(checkpoint_path),
+            save_state=_save_state(),
+            partition_id="rollout_data",
+            sampler_name="in_order",
+        )
+
+        assert restored is None
+        policy.load_data_plane_checkpoint.assert_not_called()
+
+    def test_metadata_sidecar_requires_matching_tq_directory(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        (checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME).touch()
+
+        with pytest.raises(FileNotFoundError, match="matching native TQ checkpoint"):
+            sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+                MagicMock(),
+                last_checkpoint_path=str(checkpoint_path),
+                save_state=_save_state(),
+                partition_id="rollout_data",
+                sampler_name="in_order",
+            )
+
+    def test_rejects_tq_checkpoint_from_different_training_step(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        (checkpoint_path / DATA_PLANE_CHECKPOINT_DIR).mkdir(parents=True)
+        (checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME).touch()
+        policy = MagicMock()
+        policy.load_data_plane_checkpoint.return_value = _native_tq_metadata(step=2)
+
+        with pytest.raises(ValueError, match="does not match the trainer checkpoint"):
+            sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+                policy,
+                last_checkpoint_path=str(checkpoint_path),
+                save_state=_save_state(),
+                partition_id="rollout_data",
+                sampler_name="in_order",
+            )

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -17,16 +17,20 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import threading
 from typing import Any
 
 import pytest
 import torch
-from tensordict import TensorDict
 
 import nemo_rl.algorithms.async_utils.replay_buffer as _replay_buffer_module
-from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+    REPLAY_BUFFER_METADATA_STORAGE,
+    DataPlaneCheckpointBarrier,
+    TQReplayBuffer,
+    replay_manifest_digest,
+)
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.experience.interfaces import PromptGroupRecord
@@ -104,6 +108,10 @@ class FakeDataPlaneClient:
         for sid in ids:
             self._rows.pop(sid, None)
 
+    def list_sample_ids(self, partition_id: str) -> list[str]:
+        assert partition_id == self._partition_id
+        return sorted(self._rows)
+
     def get_samples(
         self,
         sample_ids: list[str],
@@ -119,7 +127,7 @@ class FakeDataPlaneClient:
                 ),
             }
         )
-        # Opaque per-group payload; load_state_dict must re-put it verbatim.
+        # Opaque payload used by tests that inspect direct DataPlane reads.
         return {"payload_for": list(sample_ids)}
 
     def depth(self) -> int:
@@ -160,7 +168,7 @@ def _make_buffer(
     dp: FakeDataPlaneClient,
     *,
     require_routed_experts: bool = False,
-    checkpoint_lock: asyncio.Lock | None = None,
+    checkpoint_barrier: DataPlaneCheckpointBarrier | None = None,
 ) -> TQReplayBuffer:
     buffer = TQReplayBuffer(
         dp,
@@ -168,7 +176,9 @@ def _make_buffer(
         pad_value_dict={"token_ids": 0},
         require_routed_experts=require_routed_experts,
     )
-    buffer.set_data_plane_checkpoint_lock(checkpoint_lock or asyncio.Lock())
+    buffer.set_data_plane_checkpoint_barrier(
+        checkpoint_barrier or DataPlaneCheckpointBarrier()
+    )
     return buffer
 
 
@@ -191,7 +201,87 @@ def _add_group(
     )
 
 
+class TestDataPlaneCheckpointBarrier:
+    def test_mutations_run_concurrently_without_checkpoint(self):
+        async def exercise() -> None:
+            barrier = DataPlaneCheckpointBarrier()
+            both_entered = asyncio.Event()
+            release = asyncio.Event()
+            active = 0
+
+            async def mutate() -> None:
+                nonlocal active
+                async with barrier.mutation():
+                    active += 1
+                    if active == 2:
+                        both_entered.set()
+                    await release.wait()
+                    active -= 1
+
+            tasks = [asyncio.create_task(mutate()) for _ in range(2)]
+            await asyncio.wait_for(both_entered.wait(), timeout=5.0)
+            assert active == 2
+            release.set()
+            await asyncio.gather(*tasks)
+
+        asyncio.run(exercise())
+
+    def test_checkpoint_waits_for_active_mutation(self):
+        async def exercise() -> None:
+            barrier = DataPlaneCheckpointBarrier()
+            mutation_entered = asyncio.Event()
+            release_mutation = asyncio.Event()
+            checkpoint_entered = asyncio.Event()
+
+            async def mutate() -> None:
+                async with barrier.mutation():
+                    mutation_entered.set()
+                    await release_mutation.wait()
+
+            async def checkpoint() -> None:
+                async with barrier.checkpoint():
+                    checkpoint_entered.set()
+
+            mutation_task = asyncio.create_task(mutate())
+            await mutation_entered.wait()
+            checkpoint_task = asyncio.create_task(checkpoint())
+            await asyncio.sleep(0)
+            assert not checkpoint_entered.is_set()
+
+            release_mutation.set()
+            await asyncio.gather(mutation_task, checkpoint_task)
+            assert checkpoint_entered.is_set()
+
+        asyncio.run(exercise())
+
+
 class TestTQReplayBufferReserveCommit:
+    def test_commit_waits_for_active_checkpoint(self):
+        async def exercise() -> None:
+            dp = FakeDataPlaneClient()
+            checkpoint_barrier = DataPlaneCheckpointBarrier()
+            buf = _make_buffer(dp, checkpoint_barrier=checkpoint_barrier)
+            group_id = buf.reserve(weight_version=3)
+
+            async with checkpoint_barrier.checkpoint():
+                commit_task = asyncio.create_task(
+                    buf.commit(
+                        group_id,
+                        _make_record(),
+                        start_weight_version=3,
+                        end_weight_version=3,
+                    )
+                )
+                await asyncio.sleep(0)
+                assert dp.put_calls == []
+                assert buf.ready_list == [False]
+
+            await commit_task
+            assert len(dp.put_calls) == 1
+            assert buf.ready_list == [True]
+
+        asyncio.run(exercise())
+
     def test_commit_clears_rows_when_put_raises_after_writing(self):
         dp = FailAfterPutDataPlaneClient()
         buf = _make_buffer(dp)
@@ -353,7 +443,7 @@ class TestTQReplayBufferReserveCommit:
 
 
 class TestTQReplayBufferRemove:
-    def test_dp_clear_fails_without_bound_checkpoint_lock(self):
+    def test_dp_clear_fails_without_bound_checkpoint_barrier(self):
         dp = FakeDataPlaneClient()
         buf = TQReplayBuffer(
             dp,
@@ -366,11 +456,11 @@ class TestTQReplayBufferRemove:
 
         assert dp.clear_calls == []
 
-    def test_dp_clear_waits_for_bound_checkpoint_lock(self):
+    def test_dp_clear_waits_for_active_checkpoint(self):
         async def exercise() -> None:
             dp = FakeDataPlaneClient()
-            checkpoint_lock = asyncio.Lock()
-            buf = _make_buffer(dp, checkpoint_lock=checkpoint_lock)
+            checkpoint_barrier = DataPlaneCheckpointBarrier()
+            buf = _make_buffer(dp, checkpoint_barrier=checkpoint_barrier)
             group_id = buf.reserve(weight_version=0)
             await buf.commit(
                 group_id,
@@ -379,12 +469,11 @@ class TestTQReplayBufferRemove:
                 end_weight_version=0,
             )
 
-            await checkpoint_lock.acquire()
-            remove_task = asyncio.create_task(buf.remove([0], remove_in_dp=True))
-            await asyncio.sleep(0)
-            assert dp.clear_calls == []
+            async with checkpoint_barrier.checkpoint():
+                remove_task = asyncio.create_task(buf.remove([0], remove_in_dp=True))
+                await asyncio.sleep(0)
+                assert dp.clear_calls == []
 
-            checkpoint_lock.release()
             await remove_task
             assert dp.clear_calls == [dp.put_calls[0]["sample_ids"]]
 
@@ -535,20 +624,23 @@ def _make_group_entry(
         "end_weight": weight,
         "target_step": target_step,
         "group_id": group_id,
-        "fields_data": {"payload_for": sids},
     }
 
 
-def _make_envelope(
+def _make_metadata_envelope(
     groups: list[dict[str, Any]],
     *,
     partition_id: str = "rollout_data",
     saved_capacity: int = 8,
 ) -> dict[str, Any]:
+    metadata_groups = [dict(group) for group in groups]
     return {
+        "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+        "storage": REPLAY_BUFFER_METADATA_STORAGE,
         "partition_id": partition_id,
         "saved_capacity": saved_capacity,
-        "groups": list(groups),
+        "manifest_digest": replay_manifest_digest(metadata_groups),
+        "groups": metadata_groups,
     }
 
 
@@ -559,74 +651,61 @@ def _load(
     max_groups: int = 8,
     expected_partition_id: str = "rollout_data",
     expected_group_size: int = _N_GENS,
+    expected_manifest_digest: str | None = None,
 ) -> int:
+    if expected_manifest_digest is None:
+        expected_manifest_digest = str(state.get("manifest_digest", ""))
     return _run(
         buf.load_state_dict(
             state,
             max_groups=max_groups,
             expected_partition_id=expected_partition_id,
             expected_group_size=expected_group_size,
+            expected_manifest_digest=expected_manifest_digest,
         )
     )
 
 
 class TestTQReplayBufferStateDict:
-    def test_state_dict_serializes_ready_and_skips_unready(self):
+    def test_metadata_state_dict_omits_tensors_and_data_plane_reads(self):
         dp = FakeDataPlaneClient()
         buf = _make_buffer(dp)
         metas = [_add_group(buf, weight=w) for w in (1, 2)]
-        buf.reserve(weight_version=3)  # in-flight: must be excluded
+        buf.reserve(weight_version=3)
 
-        state = _run(buf.state_dict(saved_capacity=8))
+        state = buf.metadata_state_dict(saved_capacity=8)
 
-        assert state["partition_id"] == "rollout_data"
-        assert state["saved_capacity"] == 8
+        assert state["schema_version"] == REPLAY_BUFFER_METADATA_SCHEMA_VERSION
+        assert state["storage"] == REPLAY_BUFFER_METADATA_STORAGE
         assert len(state["groups"]) == 2
-        assert [g["start_weight"] for g in state["groups"]] == [1, 2]
-        assert [g["end_weight"] for g in state["groups"]] == [1, 2]
-        assert [g["target_step"] for g in state["groups"]] == [None, None]
-        assert [g["group_id"] for g in state["groups"]] == [
-            _group_id_of(metas[0]),
-            _group_id_of(metas[1]),
+        assert all("fields_data" not in group for group in state["groups"])
+        assert [group["meta"].sample_ids for group in state["groups"]] == [
+            list(meta.sample_ids) for meta in metas
         ]
-        # Payloads are fetched from the DataPlane rows of each group.
-        assert [c["sample_ids"] for c in dp.get_calls] == [
-            list(metas[0].sample_ids),
-            list(metas[1].sample_ids),
-        ]
-        assert dp.get_calls[0]["select_fields"] == list(metas[0].fields)
-        assert state["groups"][0]["fields_data"] == {
-            "payload_for": list(metas[0].sample_ids)
-        }
+        assert state["manifest_digest"] == replay_manifest_digest(state["groups"])
+        assert dp.get_calls == []
 
-    def test_round_trip_restores_lists_and_rows(self):
+    def test_native_tq_round_trip_restores_index_without_reputting_rows(self):
         dp = FakeDataPlaneClient()
         buf = _make_buffer(dp)
         metas = [_add_group(buf, weight=w) for w in (1, 2)]
-        state = _run(buf.state_dict(saved_capacity=8))
+        state = buf.metadata_state_dict(saved_capacity=8)
 
-        dp2 = FakeDataPlaneClient()
-        buf2 = _make_buffer(dp2)
-        restored = _load(buf2, state)
+        restored_dp = FakeDataPlaneClient()
+        restored_buf = _make_buffer(restored_dp)
+        restored = _load(
+            restored_buf,
+            state,
+            expected_manifest_digest=state["manifest_digest"],
+        )
 
         assert restored == 2
-        assert buf2.size() == 2
-        # Parallel lists rebuilt in order, all ready.
-        assert buf2.start_weight_list == [1, 2]
-        assert buf2.end_weight_list == [1, 2]
-        assert buf2.target_step_list == [None, None]
-        assert buf2.ready_list == [True, True]
-        assert buf2._group_ids == [_group_id_of(m) for m in metas]
-        assert [m.sample_ids for m in buf2.meta_list] == [
-            list(metas[0].sample_ids),
-            list(metas[1].sample_ids),
+        assert restored_buf.start_weight_list == [1, 2]
+        assert restored_buf.ready_list == [True, True]
+        assert [meta.sample_ids for meta in restored_buf.meta_list] == [
+            list(meta.sample_ids) for meta in metas
         ]
-        # Rows re-put with identical sample_ids / fields payload / tags.
-        assert len(dp2.put_calls) == 2
-        for put, meta in zip(dp2.put_calls, metas):
-            assert put["sample_ids"] == list(meta.sample_ids)
-            assert put["fields"] == {"payload_for": list(meta.sample_ids)}
-            assert put["tags"] == [dict(t) for t in meta.tags]
+        assert restored_dp.put_calls == []
 
     def test_round_trip_preserves_end_weight_and_target_step(self):
         # start != end and a non-None target_step must survive the round-trip:
@@ -636,7 +715,7 @@ class TestTQReplayBufferStateDict:
         buf = _make_buffer(dp)
         _add_group(buf, weight=1, end_weight=2)
         _add_group(buf, weight=5, target_step=7)
-        state = _run(buf.state_dict(saved_capacity=8))
+        state = buf.metadata_state_dict(saved_capacity=8)
 
         buf2 = _make_buffer(FakeDataPlaneClient())
         assert _load(buf2, state) == 2
@@ -648,7 +727,7 @@ class TestTQReplayBufferStateDict:
     def test_round_trip_empty_buffer(self):
         # Common resume shape: no group committed before the checkpoint.
         buf = _make_buffer(FakeDataPlaneClient())
-        state = _run(buf.state_dict(saved_capacity=8))
+        state = buf.metadata_state_dict(saved_capacity=8)
         assert state["groups"] == []
 
         dp2 = FakeDataPlaneClient()
@@ -666,7 +745,7 @@ class TestTQReplayBufferStateDict:
         buf.reserve(weight_version=2)  # in-flight, sandwiched
         third = _add_group(buf, weight=3)
 
-        state = _run(buf.state_dict(saved_capacity=8))
+        state = buf.metadata_state_dict(saved_capacity=8)
 
         assert [g["start_weight"] for g in state["groups"]] == [1, 3]
         assert [g["group_id"] for g in state["groups"]] == [
@@ -677,37 +756,6 @@ class TestTQReplayBufferStateDict:
             list(first.sample_ids),
             list(third.sample_ids),
         ]
-
-    def test_round_trip_tensordict_payload_through_torch_save(self):
-        # The production checkpoint file is torch.save(envelope) with
-        # TensorDict-valued fields_data; exercise that serialization for real
-        # (mixed dtypes + a non-contiguous view) instead of the opaque fake.
-        fields = TensorDict(
-            {
-                "input_ids": torch.arange(12, dtype=torch.long).reshape(2, 6),
-                "prev_logprobs": torch.randn(2, 12, dtype=torch.float32)[:, ::2],
-                "sample_mask": torch.ones(2, dtype=torch.long),
-            },
-            batch_size=(2,),
-        )
-        group = _make_group_entry("g0", weight=1)
-        group["fields_data"] = fields
-        state = _make_envelope([group])
-
-        buffer_bytes = io.BytesIO()
-        torch.save(state, buffer_bytes)
-        buffer_bytes.seek(0)
-        loaded_state = torch.load(buffer_bytes, weights_only=False)
-
-        dp = FakeDataPlaneClient()
-        buf = _make_buffer(dp)
-        assert (
-            _load(buf, loaded_state, expected_group_size=len(group["meta"].sample_ids))
-            == 1
-        )
-        put_fields = dp.put_calls[0]["fields"]
-        for key in fields.keys():
-            assert torch.equal(put_fields[key], fields[key])
 
 
 class TestTQReplayBufferLoadPreflight:
@@ -725,20 +773,26 @@ class TestTQReplayBufferLoadPreflight:
         self._assert_rejected({"groups": []}, match="missing required keys")
 
     def test_partition_id_mismatch(self):
-        state = _make_envelope([], partition_id="other_partition")
+        state = _make_metadata_envelope([], partition_id="other_partition")
         self._assert_rejected(state, match="partition_id mismatch")
 
     def test_group_missing_keys(self):
+        state = _make_metadata_envelope([_make_group_entry("g0", weight=1)])
+        del state["groups"][0]["group_id"]
+        self._assert_rejected(state, match="group missing keys")
+
+    def test_group_with_tensor_payload_is_rejected(self):
         group = _make_group_entry("g0", weight=1)
-        del group["fields_data"]
-        self._assert_rejected(_make_envelope([group]), match="group missing keys")
+        group["fields_data"] = {"input_ids": torch.ones(2, 3)}
+        state = _make_metadata_envelope([group])
+        self._assert_rejected(state, match="must not contain fields_data")
 
     def test_group_misaligned_sequence_lengths(self):
         group = _make_group_entry("g0", weight=1, sequence_lengths=[3])
-        self._assert_rejected(_make_envelope([group]), match="misaligned")
+        self._assert_rejected(_make_metadata_envelope([group]), match="misaligned")
 
     def test_group_size_mismatch(self):
-        state = _make_envelope([_make_group_entry("g0", weight=1, n=2)])
+        state = _make_metadata_envelope([_make_group_entry("g0", weight=1, n=2)])
         self._assert_rejected(state, match="misaligned", expected_group_size=3)
 
     def test_duplicate_sample_ids_across_groups(self):
@@ -746,75 +800,25 @@ class TestTQReplayBufferLoadPreflight:
         g1 = _make_group_entry(
             "g1", weight=2, sample_ids=["g0_g0", "g1_g1"]
         )  # g0_g0 collides
-        self._assert_rejected(_make_envelope([g0, g1]), match="duplicate sample_id")
-
-
-class TestTQReplayBufferLoadTruncation:
-    def test_capacity_change_truncates_to_freshest(self, monkeypatch):
-        state = _make_envelope(
-            [_make_group_entry(f"g{w}", weight=w) for w in (1, 2, 3)],
-            saved_capacity=8,
-        )
-        dp = FakeDataPlaneClient()
-        buf = _make_buffer(dp)
-        printed: list[str] = []
-        monkeypatch.setattr(
-            "builtins.print",
-            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
+        self._assert_rejected(
+            _make_metadata_envelope([g0, g1]), match="duplicate sample_id"
         )
 
-        restored = _load(buf, state, max_groups=2)
-
-        assert restored == 2
-        # The freshest max_groups groups survive, original order preserved.
-        assert buf.start_weight_list == [2, 3]
-        put_sample_ids = [sid for c in dp.put_calls for sid in c["sample_ids"]]
-        assert "g1_g0" not in put_sample_ids and "g1_g1" not in put_sample_ids
-        assert any("capacity changed" in line for line in printed)
-
-    def test_over_capacity_target_stamped_groups_raise(self):
-        # start_weight and target_step are both monotonic for the InOrder
-        # family, so freshest-first would keep the far-future targets and drop
-        # the near-term ones. InOrderSampler.evict only drops
-        # target < current_train_weight, so those permits are never released:
-        # rollout blocks on capacity while the train pump waits for a target
-        # that can no longer be filled. Fail loudly instead of truncating.
-        state = _make_envelope(
-            [_make_group_entry(f"g{w}", weight=w, target_step=w) for w in (1, 2, 3)],
-            saved_capacity=8,
+    def test_metadata_only_restore_rejects_tq_digest_mismatch(self):
+        state = _make_metadata_envelope([_make_group_entry("g0", weight=1)])
+        self._assert_rejected(
+            state,
+            match="does not match the loaded TQ checkpoint",
+            expected_manifest_digest="wrong-digest",
         )
-        dp = FakeDataPlaneClient()
-        buf = _make_buffer(dp)
 
-        with pytest.raises(ValueError, match="max_buffered_rollouts >= 3"):
-            _load(buf, state, max_groups=2)
-
-        # Preflight semantics: nothing reached the DataPlane or the buffer.
-        assert dp.put_calls == []
-        assert buf.size() == 0
-
-    def test_over_capacity_mixed_stamps_raise(self):
-        # One target-stamped group is enough to make truncation unsafe.
-        state = _make_envelope(
-            [
-                _make_group_entry("g1", weight=1),
-                _make_group_entry("g2", weight=2),
-                _make_group_entry("g3", weight=3, target_step=3),
-            ],
-            saved_capacity=8,
+    def test_metadata_only_restore_rejects_capacity_truncation(self):
+        state = _make_metadata_envelope(
+            [_make_group_entry(f"g{w}", weight=w) for w in (1, 2, 3)]
         )
-        buf = _make_buffer(FakeDataPlaneClient())
-
-        with pytest.raises(ValueError, match="target_step stamps"):
-            _load(buf, state, max_groups=2)
-
-    def test_target_stamped_groups_within_capacity_load_fine(self):
-        # The guard is scoped to the over-capacity case only.
-        state = _make_envelope(
-            [_make_group_entry(f"g{w}", weight=w, target_step=w) for w in (1, 2)],
-            saved_capacity=8,
+        self._assert_rejected(
+            state,
+            match="more replay groups than the current buffer capacity",
+            max_groups=2,
+            expected_manifest_digest=state["manifest_digest"],
         )
-        buf = _make_buffer(FakeDataPlaneClient())
-
-        assert _load(buf, state, max_groups=2) == 2
-        assert buf.target_step_list == [1, 2]

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -254,6 +254,35 @@ class TestDataPlaneCheckpointBarrier:
 
         asyncio.run(exercise())
 
+    def test_two_checkpoints_serialize_without_deadlock(self):
+        async def exercise() -> None:
+            barrier = DataPlaneCheckpointBarrier()
+            release = asyncio.Event()
+            entered: list[str] = []
+
+            async def checkpoint(tag: str) -> None:
+                async with barrier.checkpoint():
+                    entered.append(f"{tag}-enter")
+                    await release.wait()
+                    entered.append(f"{tag}-exit")
+
+            first = asyncio.create_task(checkpoint("first"))
+            await asyncio.sleep(0)
+            second = asyncio.create_task(checkpoint("second"))
+            await asyncio.sleep(0)
+            assert entered == ["first-enter"]
+
+            release.set()
+            await asyncio.wait_for(asyncio.gather(first, second), timeout=5.0)
+            assert entered == [
+                "first-enter",
+                "first-exit",
+                "second-enter",
+                "second-exit",
+            ]
+
+        asyncio.run(exercise())
+
 
 class TestTQReplayBufferReserveCommit:
     def test_commit_waits_for_active_checkpoint(self):
@@ -664,6 +693,27 @@ def _load(
             expected_manifest_digest=expected_manifest_digest,
         )
     )
+
+
+class TestReplayManifestDigest:
+    def test_rejects_non_json_metadata_with_field_path(self):
+        group = _make_group_entry("group-1", weight=1)
+        assert group["meta"].tags is not None
+        group["meta"].tags[0]["unsupported"] = torch.tensor(1)
+
+        with pytest.raises(
+            TypeError,
+            match=r"groups\[0\]\.meta\.tags\[0\]\.unsupported",
+        ):
+            replay_manifest_digest([group])
+
+    def test_mapping_order_does_not_change_digest(self):
+        first = _make_group_entry("group-1", weight=1)
+        second = _make_group_entry("group-1", weight=1)
+        first["meta"].extra_info = {"a": 1, "b": [2, 3]}
+        second["meta"].extra_info = {"b": [2, 3], "a": 1}
+
+        assert replay_manifest_digest([first]) == replay_manifest_digest([second])
 
 
 class TestTQReplayBufferStateDict:

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -157,13 +157,16 @@ def _make_buffer(
     dp: FakeDataPlaneClient,
     *,
     require_routed_experts: bool = False,
+    checkpoint_lock: asyncio.Lock | None = None,
 ) -> TQReplayBuffer:
-    return TQReplayBuffer(
+    buffer = TQReplayBuffer(
         dp,
         partition_id="rollout_data",
         pad_value_dict={"token_ids": 0},
         require_routed_experts=require_routed_experts,
     )
+    buffer.set_data_plane_checkpoint_lock(checkpoint_lock or asyncio.Lock())
+    return buffer
 
 
 def _add_group(
@@ -347,6 +350,43 @@ class TestTQReplayBufferReserveCommit:
 
 
 class TestTQReplayBufferRemove:
+    def test_dp_clear_fails_without_bound_checkpoint_lock(self):
+        dp = FakeDataPlaneClient()
+        buf = TQReplayBuffer(
+            dp,
+            partition_id="rollout_data",
+            pad_value_dict={"token_ids": 0},
+        )
+
+        with pytest.raises(RuntimeError, match="must be bound"):
+            _run(buf._clear_samples(sample_ids=["sample-1"]))
+
+        assert dp.clear_calls == []
+
+    def test_dp_clear_waits_for_bound_checkpoint_lock(self):
+        async def exercise() -> None:
+            dp = FakeDataPlaneClient()
+            checkpoint_lock = asyncio.Lock()
+            buf = _make_buffer(dp, checkpoint_lock=checkpoint_lock)
+            group_id = buf.reserve(weight_version=0)
+            await buf.commit(
+                group_id,
+                _make_record(),
+                start_weight_version=0,
+                end_weight_version=0,
+            )
+
+            await checkpoint_lock.acquire()
+            remove_task = asyncio.create_task(buf.remove([0], remove_in_dp=True))
+            await asyncio.sleep(0)
+            assert dp.clear_calls == []
+
+            checkpoint_lock.release()
+            await remove_task
+            assert dp.clear_calls == [dp.put_calls[0]["sample_ids"]]
+
+        asyncio.run(exercise())
+
     def test_remove_drops_indices_and_clears_dp_when_requested(self):
         dp = FakeDataPlaneClient()
         buf = _make_buffer(dp)

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import threading
 from typing import Any
 
 import pytest
@@ -65,6 +66,7 @@ class FakeDataPlaneClient:
         self._rows: dict[str, dict[str, Any]] = {}
         self.put_calls: list[dict[str, Any]] = []
         self.clear_calls: list[list[str]] = []
+        self.clear_thread_ids: list[int] = []
         self.get_calls: list[dict[str, Any]] = []
 
     def put_samples(
@@ -96,6 +98,7 @@ class FakeDataPlaneClient:
 
     def clear_samples(self, sample_ids: list[str] | None, partition_id: str) -> None:
         assert partition_id == self._partition_id
+        self.clear_thread_ids.append(threading.get_ident())
         ids = list(sample_ids) if sample_ids is not None else list(self._rows)
         self.clear_calls.append(list(ids))
         for sid in ids:
@@ -386,6 +389,18 @@ class TestTQReplayBufferRemove:
             assert dp.clear_calls == [dp.put_calls[0]["sample_ids"]]
 
         asyncio.run(exercise())
+
+    def test_dp_clear_does_not_block_actor_event_loop(self):
+        async def exercise() -> tuple[FakeDataPlaneClient, int]:
+            dp = FakeDataPlaneClient()
+            buf = _make_buffer(dp)
+            event_loop_thread_id = threading.get_ident()
+            await buf._clear_samples(sample_ids=["sample-1"])
+            return dp, event_loop_thread_id
+
+        dp, event_loop_thread_id = asyncio.run(exercise())
+        assert dp.clear_thread_ids
+        assert dp.clear_thread_ids[0] != event_loop_thread_id
 
     def test_remove_drops_indices_and_clears_dp_when_requested(self):
         dp = FakeDataPlaneClient()

--- a/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
+++ b/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
@@ -26,7 +26,8 @@ def test_save_finalizes_by_renaming_parent_bundle(monkeypatch, tmp_path) -> None
 
     def fake_save(checkpoint_dir, num_storage_units) -> None:
         save_calls.append((checkpoint_dir, num_storage_units))
-        checkpoint_dir.mkdir(parents=True)
+        assert checkpoint_dir.parent.is_dir()
+        checkpoint_dir.mkdir()
         (checkpoint_dir / "marker").write_text("saved")
 
     monkeypatch.setattr(verifier, "_save", fake_save)
@@ -48,3 +49,22 @@ def test_save_refuses_to_replace_final_bundle(monkeypatch, tmp_path) -> None:
         verifier._save_and_finalize_bundle(final_bundle, num_storage_units=1)
 
     save.assert_not_called()
+
+
+def test_save_failure_removes_created_staging_bundle(monkeypatch, tmp_path) -> None:
+    final_bundle = tmp_path / "step_7"
+    staging_bundle = tmp_path / "tmp_step_7"
+
+    def failing_save(checkpoint_dir, num_storage_units) -> None:
+        del num_storage_units
+        assert checkpoint_dir.parent == staging_bundle
+        assert staging_bundle.is_dir()
+        raise RuntimeError("injected TQ save failure")
+
+    monkeypatch.setattr(verifier, "_save", failing_save)
+
+    with pytest.raises(RuntimeError, match="injected TQ save failure"):
+        verifier._save_and_finalize_bundle(final_bundle, num_storage_units=1)
+
+    assert not staging_bundle.exists()
+    assert not final_bundle.exists()

--- a/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
+++ b/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import verify_tq_data_plane_checkpoint as verifier
+
+
+def test_save_finalizes_by_renaming_parent_bundle(monkeypatch, tmp_path) -> None:
+    final_bundle = tmp_path / "step_7"
+    expected_staging_bundle = tmp_path / "tmp_step_7"
+    save_calls = []
+
+    def fake_save(checkpoint_dir, num_storage_units) -> None:
+        save_calls.append((checkpoint_dir, num_storage_units))
+        checkpoint_dir.mkdir(parents=True)
+        (checkpoint_dir / "marker").write_text("saved")
+
+    monkeypatch.setattr(verifier, "_save", fake_save)
+
+    verifier._save_and_finalize_bundle(final_bundle, num_storage_units=3)
+
+    assert save_calls == [(expected_staging_bundle / "data_plane", 3)]
+    assert not expected_staging_bundle.exists()
+    assert (final_bundle / "data_plane" / "marker").read_text() == "saved"
+
+
+def test_save_refuses_to_replace_final_bundle(monkeypatch, tmp_path) -> None:
+    final_bundle = tmp_path / "step_7"
+    final_bundle.mkdir()
+    save = MagicMock()
+    monkeypatch.setattr(verifier, "_save", save)
+
+    with pytest.raises(FileExistsError, match=str(final_bundle)):
+        verifier._save_and_finalize_bundle(final_bundle, num_storage_units=1)
+
+    save.assert_not_called()

--- a/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
+++ b/tests/unit/tools/test_verify_tq_data_plane_checkpoint.py
@@ -12,11 +12,175 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from tensordict import TensorDict
 
 from tools import verify_tq_data_plane_checkpoint as verifier
+
+
+class _FakeDataPlaneClient:
+    def __init__(
+        self,
+        checkpoint_state: dict[str, Any],
+        *,
+        missing_samples: bool = False,
+        premature_consumption: bool = False,
+    ) -> None:
+        self._checkpoint_state = checkpoint_state
+        self._missing_samples = missing_samples
+        self._premature_consumption = premature_consumption
+        self._fields: TensorDict | None = None
+        self._consumed: set[str] = set()
+
+    def register_partition(self, **kwargs: Any) -> None:
+        pass
+
+    def put_samples(self, *, fields: TensorDict, **kwargs: Any) -> None:
+        self._fields = fields.clone()
+
+    def claim_meta(self, *, batch_size: int, **kwargs: Any) -> MagicMock:
+        available = [
+            sample_id
+            for sample_id in verifier.SAMPLE_IDS
+            if sample_id not in self._consumed
+        ]
+        sample_ids = available[:batch_size]
+        self._consumed.update(sample_ids)
+        return MagicMock(size=len(sample_ids), sample_ids=sample_ids)
+
+    def save_checkpoint(
+        self,
+        checkpoint_dir: Path,
+        *,
+        metadata: dict[str, Any],
+    ) -> None:
+        del checkpoint_dir
+        self._checkpoint_state.update(
+            {
+                "fields": self._fields,
+                "consumed": set(self._consumed),
+                "metadata": dict(metadata),
+            }
+        )
+
+    def load_checkpoint(self, checkpoint_dir: Path) -> dict[str, Any]:
+        del checkpoint_dir
+        self._fields = self._checkpoint_state["fields"].clone()
+        self._consumed = set(self._checkpoint_state["consumed"])
+        return dict(self._checkpoint_state["metadata"])
+
+    def get_samples(self, **kwargs: Any) -> TensorDict:
+        if self._missing_samples:
+            raise KeyError("injected missing sample")
+        assert self._fields is not None
+        return self._fields
+
+    def check_consumption_status(self, *args: Any) -> bool:
+        if self._premature_consumption:
+            return True
+        return len(self._consumed) == len(verifier.SAMPLE_IDS)
+
+    def close(self) -> None:
+        pass
+
+
+def _checkpoint_state(*, schema_version: int | None = None) -> dict[str, Any]:
+    return {
+        "fields": verifier._expected_fields(),
+        "consumed": {verifier.SAMPLE_IDS[0]},
+        "metadata": {
+            "data_plane_checkpoint_schema_version": (
+                verifier.DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+                if schema_version is None
+                else schema_version
+            ),
+            "expected_consumed_ids": [verifier.SAMPLE_IDS[0]],
+        },
+    }
+
+
+def test_save_load_round_trip_exercises_payload_and_cursor_restore(
+    monkeypatch, tmp_path
+) -> None:
+    checkpoint_state: dict[str, Any] = {}
+    clients = iter(
+        [
+            _FakeDataPlaneClient(checkpoint_state),
+            _FakeDataPlaneClient(checkpoint_state),
+        ]
+    )
+    monkeypatch.setattr(
+        verifier,
+        "build_data_plane_client",
+        lambda *args, **kwargs: next(clients),
+    )
+
+    verifier._save(tmp_path / "data_plane", num_storage_units=2)
+    verifier._load(tmp_path / "data_plane", num_storage_units=2)
+
+
+@pytest.mark.parametrize(
+    ("client_kwargs", "error_type", "match"),
+    [
+        ({"missing_samples": True}, KeyError, "injected missing sample"),
+        (
+            {"premature_consumption": True},
+            AssertionError,
+            "marked every row consumed",
+        ),
+    ],
+)
+def test_load_rejects_invalid_restored_state(
+    monkeypatch,
+    tmp_path,
+    client_kwargs,
+    error_type,
+    match,
+) -> None:
+    client = _FakeDataPlaneClient(_checkpoint_state(), **client_kwargs)
+    monkeypatch.setattr(
+        verifier,
+        "build_data_plane_client",
+        lambda *args, **kwargs: client,
+    )
+
+    with pytest.raises(error_type, match=match):
+        verifier._load(tmp_path / "data_plane", num_storage_units=2)
+
+
+def test_load_rejects_schema_mismatch(monkeypatch, tmp_path) -> None:
+    client = _FakeDataPlaneClient(_checkpoint_state(schema_version=-1))
+    monkeypatch.setattr(
+        verifier,
+        "build_data_plane_client",
+        lambda *args, **kwargs: client,
+    )
+
+    with pytest.raises(AssertionError, match="Unexpected data-plane checkpoint schema"):
+        verifier._load(tmp_path / "data_plane", num_storage_units=2)
+
+
+def test_run_child_uses_fresh_process(monkeypatch, tmp_path) -> None:
+    run = MagicMock()
+    monkeypatch.setattr(verifier.subprocess, "run", run)
+
+    verifier._run_child("load", tmp_path / "step_1", num_storage_units=3)
+
+    command = run.call_args.args[0]
+    assert command[0] == verifier.sys.executable
+    assert command[2:] == [
+        "--phase",
+        "load",
+        "--checkpoint-dir",
+        str(tmp_path / "step_1"),
+        "--num-storage-units",
+        "3",
+    ]
+    assert run.call_args.kwargs == {"check": True}
 
 
 def test_save_finalizes_by_renaming_parent_bundle(monkeypatch, tmp_path) -> None:

--- a/tools/verify_tq_data_plane_checkpoint.py
+++ b/tools/verify_tq_data_plane_checkpoint.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Verify TQ data-plane save/load across a fresh process restart.
+"""Verify TQ data-plane save/load across a fresh process and parent rename.
 
 The save phase writes sample tensors, tags, and partial consumer progress to
-TQ before checkpointing it. The load phase starts a fresh TQ instance, restores
-the checkpoint before any partition operations, and verifies both the tensors
-and the consumer cursor.
+TQ under ``tmp_<bundle>/data_plane``, then renames the parent bundle to its
+final path just like ``CheckpointManager``. The load phase starts a fresh TQ
+instance, restores from ``<bundle>/data_plane`` before any partition operations,
+and verifies both the tensors and the consumer cursor.
 
 Example:
     uv run --no-sync python tools/verify_tq_data_plane_checkpoint.py \
@@ -27,6 +28,7 @@ Example:
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -42,6 +44,7 @@ TASK_NAME = "train"
 SAMPLE_IDS = [f"prompt-0:generation-{index}" for index in range(4)]
 SEQ_LEN = 16
 FIELDS = ["token_ids", "token_mask", "generation_logprobs"]
+DATA_PLANE_DIR = "data_plane"
 
 
 def _data_plane_config(num_storage_units: int) -> DataPlaneConfig:
@@ -161,6 +164,28 @@ def _load(checkpoint_dir: Path, num_storage_units: int) -> None:
         dp_client.close()
 
 
+def _save_and_finalize_bundle(
+    bundle_dir: Path,
+    num_storage_units: int,
+) -> None:
+    """Save below a temporary parent, then rename it to ``bundle_dir``."""
+    staging_dir = bundle_dir.with_name(f"tmp_{bundle_dir.name}")
+    if bundle_dir.exists():
+        raise FileExistsError(f"Final checkpoint bundle already exists: {bundle_dir}")
+    if staging_dir.exists():
+        raise FileExistsError(
+            f"Staging checkpoint bundle already exists: {staging_dir}"
+        )
+
+    try:
+        _save(staging_dir / DATA_PLANE_DIR, num_storage_units)
+        staging_dir.rename(bundle_dir)
+    except Exception:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        raise
+
+
 def _run_child(
     phase: str,
     checkpoint_dir: Path,
@@ -189,21 +214,29 @@ def main() -> None:
         default="round-trip",
         help=argparse.SUPPRESS,
     )
-    parser.add_argument("--checkpoint-dir", type=Path, required=True)
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        required=True,
+        help="Final SC-like checkpoint bundle directory.",
+    )
     parser.add_argument("--num-storage-units", type=int, default=4)
     args = parser.parse_args()
 
     checkpoint_dir = args.checkpoint_dir.expanduser().resolve()
     if args.phase == "save":
-        _save(checkpoint_dir, args.num_storage_units)
+        _save_and_finalize_bundle(checkpoint_dir, args.num_storage_units)
         return
     if args.phase == "load":
-        _load(checkpoint_dir, args.num_storage_units)
+        _load(checkpoint_dir / DATA_PLANE_DIR, args.num_storage_units)
         return
 
     _run_child("save", checkpoint_dir, args.num_storage_units)
     _run_child("load", checkpoint_dir, args.num_storage_units)
-    print("PASS: TQ data-plane checkpoint survived a fresh process", flush=True)
+    print(
+        "PASS: TQ checkpoint survived a parent rename and fresh process",
+        flush=True,
+    )
 
 
 if __name__ == "__main__":

--- a/tools/verify_tq_data_plane_checkpoint.py
+++ b/tools/verify_tq_data_plane_checkpoint.py
@@ -177,6 +177,9 @@ def _save_and_finalize_bundle(
             f"Staging checkpoint bundle already exists: {staging_dir}"
         )
 
+    # CheckpointManager creates tmp_step_N before component writers run.
+    # Mirror that precondition instead of relying on TQ to create the parent.
+    staging_dir.mkdir(parents=True)
     try:
         _save(staging_dir / DATA_PLANE_DIR, num_storage_units)
         staging_dir.rename(bundle_dir)

--- a/tools/verify_tq_data_plane_checkpoint.py
+++ b/tools/verify_tq_data_plane_checkpoint.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify TQ data-plane save/load across a fresh process restart.
+
+The save phase writes sample tensors, tags, and partial consumer progress to
+TQ before checkpointing it. The load phase starts a fresh TQ instance, restores
+the checkpoint before any partition operations, and verifies both the tensors
+and the consumer cursor.
+
+Example:
+    uv run --no-sync python tools/verify_tq_data_plane_checkpoint.py \
+        --checkpoint-dir /lustre/.../tq-data-plane-checkpoint-smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import cast
+
+import torch
+from tensordict import TensorDict
+
+from nemo_rl.data_plane import DataPlaneConfig, build_data_plane_client
+
+PARTITION_ID = "tq_checkpoint_smoke"
+TASK_NAME = "train"
+SAMPLE_IDS = [f"prompt-0:generation-{index}" for index in range(4)]
+SEQ_LEN = 16
+FIELDS = ["token_ids", "token_mask", "generation_logprobs"]
+
+
+def _data_plane_config(num_storage_units: int) -> DataPlaneConfig:
+    return cast(
+        DataPlaneConfig,
+        {
+            "enabled": True,
+            "impl": "transfer_queue",
+            "backend": "simple",
+            "checkpointing_enabled": True,
+            "storage_capacity": 1024,
+            "num_storage_units": num_storage_units,
+            "claim_meta_poll_interval_s": 0.05,
+            "global_segment_size": 8 * 1024**3,
+            "local_buffer_size": 1024**3,
+        },
+    )
+
+
+def _expected_fields() -> TensorDict:
+    token_ids = torch.arange(len(SAMPLE_IDS) * SEQ_LEN, dtype=torch.int64).reshape(
+        len(SAMPLE_IDS),
+        SEQ_LEN,
+    )
+    return TensorDict(
+        {
+            "token_ids": token_ids,
+            "token_mask": torch.ones_like(token_ids),
+            "generation_logprobs": -token_ids.to(torch.float32) / 100.0,
+        },
+        batch_size=[len(SAMPLE_IDS)],
+    )
+
+
+def _save(checkpoint_dir: Path, num_storage_units: int) -> None:
+    dp_client = build_data_plane_client(
+        _data_plane_config(num_storage_units),
+        bootstrap=True,
+    )
+    try:
+        dp_client.register_partition(
+            partition_id=PARTITION_ID,
+            fields=FIELDS,
+            num_samples=len(SAMPLE_IDS),
+            consumer_tasks=[TASK_NAME],
+        )
+        dp_client.put_samples(
+            sample_ids=SAMPLE_IDS,
+            partition_id=PARTITION_ID,
+            fields=_expected_fields(),
+            tags=[{"policy_version": 3, "prompt_id": "prompt-0"} for _ in SAMPLE_IDS],
+        )
+
+        consumed = dp_client.claim_meta(
+            partition_id=PARTITION_ID,
+            task_name=TASK_NAME,
+            required_fields=FIELDS,
+            batch_size=1,
+            timeout_s=30.0,
+        )
+        if consumed.size != 1:
+            raise AssertionError(f"Expected one consumed row, got {consumed.size}")
+
+        dp_client.save_checkpoint(
+            checkpoint_dir,
+            metadata={
+                "data_plane_checkpoint_schema_version": 1,
+                "expected_consumed_ids": consumed.sample_ids,
+            },
+        )
+    finally:
+        dp_client.close()
+
+
+def _load(checkpoint_dir: Path, num_storage_units: int) -> None:
+    dp_client = build_data_plane_client(
+        _data_plane_config(num_storage_units),
+        bootstrap=True,
+    )
+    try:
+        metadata = dp_client.load_checkpoint(checkpoint_dir)
+
+        restored = dp_client.get_samples(
+            sample_ids=SAMPLE_IDS,
+            partition_id=PARTITION_ID,
+            select_fields=FIELDS,
+        )
+        expected = _expected_fields()
+        for field in FIELDS:
+            if not torch.equal(restored[field], expected[field]):
+                raise AssertionError(f"Restored field differs: {field}")
+
+        if metadata["data_plane_checkpoint_schema_version"] != 1:
+            raise AssertionError("Unexpected data-plane checkpoint schema")
+        consumed_ids = set(metadata["expected_consumed_ids"])
+        expected_remaining_ids = set(SAMPLE_IDS) - consumed_ids
+
+        if dp_client.check_consumption_status(PARTITION_ID, [TASK_NAME]):
+            raise AssertionError(
+                "Restored consumer cursor marked every row consumed before "
+                "the expected remaining rows were claimed"
+            )
+        remaining = dp_client.claim_meta(
+            partition_id=PARTITION_ID,
+            task_name=TASK_NAME,
+            required_fields=FIELDS,
+            batch_size=len(expected_remaining_ids),
+            timeout_s=30.0,
+        )
+        if consumed_ids.intersection(remaining.sample_ids):
+            raise AssertionError("A previously consumed row was claimed after restore")
+        if set(remaining.sample_ids) != expected_remaining_ids:
+            raise AssertionError("Restored consumption state lost or added rows")
+        if not dp_client.check_consumption_status(PARTITION_ID, [TASK_NAME]):
+            raise AssertionError("Restored consumer cursor did not reach completion")
+    finally:
+        dp_client.close()
+
+
+def _run_child(
+    phase: str,
+    checkpoint_dir: Path,
+    num_storage_units: int,
+) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--phase",
+            phase,
+            "--checkpoint-dir",
+            str(checkpoint_dir),
+            "--num-storage-units",
+            str(num_storage_units),
+        ],
+        check=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phase",
+        choices=("round-trip", "save", "load"),
+        default="round-trip",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument("--checkpoint-dir", type=Path, required=True)
+    parser.add_argument("--num-storage-units", type=int, default=4)
+    args = parser.parse_args()
+
+    checkpoint_dir = args.checkpoint_dir.expanduser().resolve()
+    if args.phase == "save":
+        _save(checkpoint_dir, args.num_storage_units)
+        return
+    if args.phase == "load":
+        _load(checkpoint_dir, args.num_storage_units)
+        return
+
+    _run_child("save", checkpoint_dir, args.num_storage_units)
+    _run_child("load", checkpoint_dir, args.num_storage_units)
+    print("PASS: TQ data-plane checkpoint survived a fresh process", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_tq_data_plane_checkpoint.py
+++ b/tools/verify_tq_data_plane_checkpoint.py
@@ -37,7 +37,11 @@ from typing import cast
 import torch
 from tensordict import TensorDict
 
-from nemo_rl.data_plane import DataPlaneConfig, build_data_plane_client
+from nemo_rl.data_plane import (
+    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION,
+    DataPlaneConfig,
+    build_data_plane_client,
+)
 
 PARTITION_ID = "tq_checkpoint_smoke"
 TASK_NAME = "train"
@@ -111,7 +115,9 @@ def _save(checkpoint_dir: Path, num_storage_units: int) -> None:
         dp_client.save_checkpoint(
             checkpoint_dir,
             metadata={
-                "data_plane_checkpoint_schema_version": 1,
+                "data_plane_checkpoint_schema_version": (
+                    DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+                ),
                 "expected_consumed_ids": consumed.sample_ids,
             },
         )
@@ -134,10 +140,17 @@ def _load(checkpoint_dir: Path, num_storage_units: int) -> None:
         )
         expected = _expected_fields()
         for field in FIELDS:
-            if not torch.equal(restored[field], expected[field]):
+            restored_value = restored[field]
+            expected_value = expected[field]
+            assert isinstance(restored_value, torch.Tensor)
+            assert isinstance(expected_value, torch.Tensor)
+            if not torch.equal(restored_value, expected_value):
                 raise AssertionError(f"Restored field differs: {field}")
 
-        if metadata["data_plane_checkpoint_schema_version"] != 1:
+        if (
+            metadata["data_plane_checkpoint_schema_version"]
+            != DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+        ):
             raise AssertionError("Unexpected data-plane checkpoint schema")
         consumed_ids = set(metadata["expected_consumed_ids"])
         expected_remaining_ids = set(SAMPLE_IDS) - consumed_ids


### PR DESCRIPTION
# What does this PR do ?

CPU-only unit tests for one property of #3480:

> **Pausing a run to checkpoint and resuming it should train on exactly the same prompt groups as never pausing at all.**

Draft, targeted at `amahishi/sc-tq-native-recovery` rather than `main`, so the tests land with the feature. Tests only — no source changes.

## Result

```
10 failed, 19 passed, 4 xfailed in 11.69s      (CPU only, no GPU)
```

Visual walkthrough of all six cases and all eighteen outcomes:
**https://terrykong.github.io/gh-pages-poc/terryk/pr-3827-test-matrix.html**

**The 10 failures are deliberate and are the point of this PR.** They are not "tests I could not get working" — they are groups that came back before this change and do not now.

## Three files, split by which bar a case misses

There are two bars, and conflating them hides the signal:

| bar | meaning |
|---|---|
| **no data loss** | every group the run still needs comes back |
| **no regression** | nothing that came back *before this change* was lost |

| file | holds | count |
|---|---|---|
| `test_checkpoint_no_data_loss.py` | both bars | 11 passed |
| `test_checkpoint_regressions.py` | **misses no-regression** — real failures, **not** xfail | 10 failed, 3 passed |
| `test_checkpoint_no_data_loss_xfail.py` | clears no-regression, misses no-data-loss | 4 xfailed, 5 passed |

A step backwards should be loud, so the regression file has no xfail marks. A gap that was always there is a missing feature, so those are `xfail(strict=True)` — a fix turns them into XPASS failures and the row gets moved into `PASSING`.

## What the previous behaviour actually was

Checked against the merge base rather than assumed:

* the buffer was saved on **every** checkpoint, no capability gate — [`single_controller.py:802`](https://github.com/NVIDIA-NeMo/RL/blob/7cba25ac3d876f727efbf06bfa9719fd3aa8def5/nemo_rl/algorithms/single_controller.py#L802)
* the restore ran for **any** sampler, gated only on the saved sampler name matching — [`:270`](https://github.com/NVIDIA-NeMo/RL/blob/7cba25ac3d876f727efbf06bfa9719fd3aa8def5/nemo_rl/algorithms/single_controller.py#L270) — and both sides read `self._async_cfg.sampler.name`, so it always matches on a same-sampler resume
* `state_dict` saved the committed slots and dropped in-flight ones, in as many words: *"Unready reservations are in-flight rollouts and are dropped, matching legacy semantics."*

So **every fully generated group used to survive a restart under every sampler**, and in-flight loss is pre-existing. That is exactly the line between the two files.

### The regressions

`in_order` and `weight_fifo` declare `supports_buffer_checkpoint = False`, so no sidecar is written ([`:981`](https://github.com/NVIDIA-NeMo/RL/blob/608e9bde376d23604b7c6472e1e1e19a43bf8345/nemo_rl/algorithms/single_controller.py#L981)) and the restore returns early ([`:322`](https://github.com/NVIDIA-NeMo/RL/blob/608e9bde376d23604b7c6472e1e1e19a43bf8345/nemo_rl/algorithms/single_controller.py#L322)):

```
AssertionError: in_order/lag1-next-step-complete: ['g12', 'g13', 'g14'] came back
before this change and do not now. These groups finished generating and committed,
so the old save wrote them and the old restore returned them on a same-sampler
resume. recovered=[]
```

Two gated rows **pass**, which is the assertion working rather than blanket-failing: in `trained-what-was-ready-leaving-a-hole` the only untrained groups are in-flight, so the old code recovered nothing either and there is nothing to regress.

`test_the_rows_are_still_in_transfer_queue_after_a_gated_restore` passes too — TransferQueue still holds every committed row. **The regression is the index, not the tensors**, so a fix can be index-only.

### The pre-existing gap

A group that has not committed is never saved: `reserve()` marks the slot not-ready ([`replay_buffer.py:910`](https://github.com/NVIDIA-NeMo/RL/blob/608e9bde376d23604b7c6472e1e1e19a43bf8345/nemo_rl/algorithms/async_utils/replay_buffer.py#L910)) and `metadata_state_dict` skips it ([`:1093`](https://github.com/NVIDIA-NeMo/RL/blob/608e9bde376d23604b7c6472e1e1e19a43bf8345/nemo_rl/algorithms/async_utils/replay_buffer.py#L1093)). A group is reserved or committed with nothing in between, so "one rollout still running" and "not started" are the same thing to a checkpoint — group 13 in `S_PARTIAL` finished **both** rollouts and is dropped anyway.

**These assert on presence, not on readiness, so they survive whatever partial-group recovery ends up looking like.** `recovered` counts a group if the restored buffer knows about it *at all* — already committed with its missing rollouts regenerated, or a reserved slot for the run to finish. Either design flips these to XPASS, and `strict=True` makes that a failure that has to be dealt with.

## How to read the matrix

Two plain tables, so the setups can be scanned without the machinery:

```python
# test_checkpoint_regressions.py
REGRESSED = [Case(s, sampler) for sampler in GATED_SAMPLERS for s in ALL_SCENARIOS]

# test_checkpoint_no_data_loss_xfail.py
EXPECTED_TO_FAIL = [
    Case(S_PARTIAL,              "windowed", IN_FLIGHT),
    Case(S_LAG2,                 "windowed", IN_FLIGHT),
    Case(S_EVICTED,              "windowed", IN_FLIGHT),
    Case(S_TRAINED_OUT_OF_ORDER, "windowed", IN_FLIGHT),
]
```

A scenario reads the way you would say it out loud:

```python
S_PARTIAL = Scenario(
    name="lag1-next-step-partly-generated",
    groups=(
        Group(9, 2, weight=0), Group(10, 2, weight=0), Group(11, 2, weight=0),
        Group(12, 1, weight=1, target=5),   # one rollout still running
        Group(13, 2, weight=1, target=5),
        Group(14, 0, weight=1, target=5),   # not started
    ),
    cursor=15,
    trained=frozenset({9, 10, 11}),
    lag=1,
)
```

## Fidelity

Real `TQReplayBuffer`, real `reserve`/`commit`, real `metadata_state_dict`/`load_state_dict`, real manifest digest, real samplers via `create_sampler`, real `NoOpDataPlaneClient.save_checkpoint`/`load_checkpoint`. The save/restore gate mirrors the two call sites above by reading the sampler's own `supports_buffer_checkpoint`. Only the tensor converter is stubbed, so a scenario can use empty prompt records.

## Testing

```bash
cd tests && uv run pytest unit/single_controller/test_checkpoint_no_data_loss.py \
                          unit/single_controller/test_checkpoint_regressions.py \
                          unit/single_controller/test_checkpoint_no_data_loss_xfail.py -v
```

No GPU, no Ray cluster, no TransferQueue process. Collected by the existing `L0_Unit_Tests_Other` lane. Note the repo's `addopts` includes `-x`, so a CI run stops at the first regression rather than reporting all 10.

## Open questions

1. **Is losing the gated-sampler restore a deliberate trade?** If one durable store instead of two is worth it, the right resolution is not to xfail these but to decide the old behaviour is not coming back and say so where someone configuring `in_order` will read it. If it is not deliberate, the tensors are still in TransferQueue and the fix is index-only.
2. **Does #3456 lead to partial-group recovery?** It stages token lineage for running generations, which looks like the prerequisite, but nothing states that a restore would then finish a half-done group. If that is out of scope, the 4 xfail rows may belong to a later change.
3. **Does `S_EVICTED` model eviction the way you would?** An evicted group is treated as an intentional discard and excluded from what a restore must return.

Happy to drop, re-scope, or re-target any of this — the tables are meant to be argued with.
