### PR TITLE
feat: Overlap external vLLM and NeMo RL startup

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -52,6 +52,7 @@ from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import (
     NemoGym,
     NemoGymConfig,
+    extract_external_service_readiness,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
     should_use_nemo_gym,
@@ -531,6 +532,9 @@ def setup(
                     "invalid_tool_call_patterns", None
                 )
                 thinking_tags = nemo_gym_dict.pop("thinking_tags", None)
+                external_service_readiness = extract_external_service_readiness(
+                    nemo_gym_dict
+                )
                 # Pass prebuilt cache + venv dirs through the global config so the
                 # gym reuses image-baked venvs instead of rebuilding them.
                 uv_cache_dir = get_nemo_gym_uv_cache_dir()
@@ -545,6 +549,7 @@ def setup(
                     invalid_tool_call_patterns=invalid_tool_call_patterns,
                     thinking_tags=thinking_tags,
                     use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
+                    external_service_readiness=external_service_readiness,
                     initial_global_config_dict=nemo_gym_dict,
                 )
                 nemo_gym_opts = {

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -11,19 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import math
 import os
 import subprocess
 import sys
+import time
+import urllib.parse
+import urllib.request
 from collections import Counter
 from collections.abc import AsyncGenerator, Mapping
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, Optional, Protocol, TypedDict
+from typing import Any, Dict, List, NotRequired, Optional, Protocol, Self, TypedDict
 
 import ray
 import torch
 from PIL import Image
+from pydantic import BaseModel, Field, field_validator, model_validator
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from transformers import PreTrainedTokenizerBase
 
@@ -78,6 +83,40 @@ class NemoGymCompatibleConfig(Protocol):
 
     @property
     def policy(self) -> PolicyConfig: ...
+
+
+class ExternalServiceReadinessTargetConfig(BaseModel, extra="allow"):
+    """Health endpoint and required backend count for one external service."""
+
+    name: str = Field(min_length=1)
+    url: str
+    expected_backends: int = Field(gt=0)
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, url: str) -> str:
+        """Require an absolute HTTP(S) health endpoint."""
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("url must be an absolute HTTP(S) URL")
+        return url
+
+
+class ExternalServiceReadinessConfig(BaseModel, extra="allow"):
+    """Startup gate for external services used by NeMo Gym rollouts."""
+
+    services: list[ExternalServiceReadinessTargetConfig] = Field(min_length=1)
+    timeout_seconds: float = Field(gt=0)
+    poll_interval_seconds: float = Field(gt=0)
+    request_timeout_seconds: float = Field(gt=0)
+
+    @model_validator(mode="after")
+    def validate_unique_service_names(self) -> Self:
+        """Reject ambiguous duplicate service labels in diagnostics."""
+        names = [service.name for service in self.services]
+        if len(names) != len(set(names)):
+            raise ValueError("external readiness service names must be unique")
+        return self
 
 
 def should_use_nemo_gym(master_config: NemoGymCompatibleConfig) -> bool:
@@ -208,6 +247,12 @@ class NemoGymConfig(TypedDict):
     # Forwarded from policy.tokenizer.use_fastokens so rollout actors patch their
     # tokenizer consistently with the driver. Defaults to off when absent.
     use_fastokens: NotRequired[bool]
+    # Optional startup gate for externally served Gym dependencies. The actor
+    # starts local Gym services first, then waits for every target before it
+    # exposes its rollout collection helper to the training driver.
+    external_service_readiness: NotRequired[
+        ExternalServiceReadinessConfig | None
+    ]
     # Multimodal fields (populated by `setup_nemo_gym_config` when VLM is enabled).
     tokenizer_config: NotRequired[
         Optional[TokenizerConfig]
@@ -215,6 +260,120 @@ class NemoGymConfig(TypedDict):
     pad_dynamic_image_shapes: NotRequired[
         bool
     ]  # Normalize heterogeneous image tensors while retaining exact imgs_sizes
+
+
+def extract_external_service_readiness(
+    nemo_gym_dict: dict[str, Any],
+) -> ExternalServiceReadinessConfig | None:
+    """Remove and validate NeMo-RL's external readiness block from Gym config."""
+    readiness_dict = nemo_gym_dict.pop("external_service_readiness", None)
+    if readiness_dict is None:
+        return None
+    return ExternalServiceReadinessConfig.model_validate(readiness_dict)
+
+
+def _probe_external_service(
+    service: ExternalServiceReadinessTargetConfig,
+    *,
+    request_timeout_seconds: float,
+) -> str | None:
+    """Return a readiness problem for one service, or None when it is ready."""
+    try:
+        with urllib.request.urlopen(
+            service.url, timeout=request_timeout_seconds
+        ) as response:
+            status_code = response.status
+            response_body = response.read()
+    except OSError as error:
+        return f"request failed: {error}"
+
+    if status_code != 200:
+        return f"HTTP {status_code}"
+
+    try:
+        payload = json.loads(response_body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        return f"invalid JSON response: {error}"
+    if not isinstance(payload, dict):
+        return f"expected a JSON object, got {type(payload).__name__}"
+
+    status = payload.get("status")
+    healthy_backends = payload.get("healthy_backends")
+    total_backends = payload.get("total_backends")
+    if (
+        not isinstance(healthy_backends, int)
+        or isinstance(healthy_backends, bool)
+        or not isinstance(total_backends, int)
+        or isinstance(total_backends, bool)
+    ):
+        return (
+            "health response must contain integer healthy_backends and "
+            "total_backends"
+        )
+    if (
+        status != "ok"
+        or healthy_backends < service.expected_backends
+        or total_backends < service.expected_backends
+    ):
+        return (
+            f"status={status!r}, healthy_backends={healthy_backends}, "
+            f"total_backends={total_backends}, "
+            f"expected_backends={service.expected_backends}"
+        )
+    return None
+
+
+def _wait_for_external_services(
+    config: ExternalServiceReadinessConfig | None,
+) -> None:
+    """Wait for all external Gym dependencies under one shared deadline."""
+    if config is None:
+        return
+
+    deadline = time.monotonic() + config.timeout_seconds
+    previous_problems: dict[str, str] = {}
+    while True:
+        problems: dict[str, str] = {}
+        for service in config.services:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                problems[service.name] = "startup deadline expired before probe"
+                continue
+            problem = _probe_external_service(
+                service,
+                request_timeout_seconds=min(
+                    config.request_timeout_seconds, remaining_seconds
+                ),
+            )
+            if problem is not None:
+                problems[service.name] = problem
+
+        if not problems:
+            print(
+                "All external NeMo-Gym services are ready: "
+                + ", ".join(service.name for service in config.services)
+            )
+            return
+
+        if problems != previous_problems:
+            print(
+                "Waiting for external NeMo-Gym services: "
+                + "; ".join(
+                    f"{name}: {problem}" for name, problem in problems.items()
+                )
+            )
+            previous_problems = problems
+
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            details = "; ".join(
+                f"{name}: {problem}" for name, problem in problems.items()
+            )
+            raise TimeoutError(
+                "Timed out waiting for external NeMo-Gym services after "
+                f"{config.timeout_seconds:g}s. Last observations: {details}"
+            )
+        time.sleep(min(config.poll_interval_seconds, remaining_seconds))
 
 
 def _detect_invalid_tool_call_and_malformed_thinking(
@@ -620,6 +779,17 @@ Depending on your data shape, you may want to change these values."""
                 skip_load_from_cli=True,
             )
         )
+
+        try:
+            _wait_for_external_services(
+                self.cfg.get("external_service_readiness")
+            )
+        except TimeoutError:
+            # RunHelper.start() has already spawned local Gym services. Do not
+            # leave them behind when an external dependency misses its deadline.
+            self.rh.shutdown()
+            self.rh = None
+            raise
 
         # Setup for rollout collection
         self.head_server_config = BaseServerConfig(
@@ -1169,6 +1339,7 @@ def spinup_nemo_gym_actor(
     invalid_tool_call_patterns = nemo_gym_dict.pop("invalid_tool_call_patterns", None)
     thinking_tags = nemo_gym_dict.pop("thinking_tags", None)
     tokenizer_config = nemo_gym_dict.pop("tokenizer_config", None)
+    external_service_readiness = extract_external_service_readiness(nemo_gym_dict)
     # Same treatment for the multimodal knobs: NemoGymConfig declares them as
     # top-level fields, so populate them here instead of leaving the actor to
     # read them back out of Gym's global config dict.
@@ -1196,6 +1367,7 @@ def spinup_nemo_gym_actor(
         require_routed_experts=enable_router_replay,
         routed_experts_dtype=routed_experts_dtype,
         use_fastokens=use_fastokens,
+        external_service_readiness=external_service_readiness,
         initial_global_config_dict=nemo_gym_dict,
         **multimodal_flags,
     )

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -17,6 +17,7 @@ import time
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -38,9 +39,12 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
     get_actor_python_env,
 )
 from nemo_rl.environments.nemo_gym import (
+    ExternalServiceReadinessConfig,
     NemoGym,
     NemoGymConfig,
+    _wait_for_external_services,
     build_reward_component_columns,
+    extract_external_service_readiness,
     extract_reward_components,
     setup_nemo_gym_config,
     validate_reward_components_match_scalar,
@@ -84,6 +88,109 @@ def test_multimodal_content_types_cover_responses_media_aliases():
         "audio",
         "audio_url",
     } <= MULTIMODAL_CONTENT_TYPES
+
+
+def _external_health_response(
+    *, status: str, healthy_backends: int, total_backends: int
+) -> MagicMock:
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(
+        {
+            "status": status,
+            "healthy_backends": healthy_backends,
+            "total_backends": total_backends,
+        }
+    ).encode()
+    response.__enter__.return_value = response
+    return response
+
+
+def test_external_service_readiness_waits_for_every_expected_backend():
+    config = ExternalServiceReadinessConfig(
+        services=[
+            {
+                "name": "GENRM",
+                "url": "http://10.0.0.1:9213/health",
+                "expected_backends": 2,
+            }
+        ],
+        timeout_seconds=10,
+        poll_interval_seconds=1,
+        request_timeout_seconds=2,
+    )
+
+    with (
+        patch(
+            "nemo_rl.environments.nemo_gym.urllib.request.urlopen",
+            side_effect=[
+                _external_health_response(
+                    status="ok", healthy_backends=1, total_backends=2
+                ),
+                _external_health_response(
+                    status="ok", healthy_backends=2, total_backends=2
+                ),
+            ],
+        ) as urlopen,
+        patch("nemo_rl.environments.nemo_gym.time.sleep") as sleep,
+    ):
+        _wait_for_external_services(config)
+
+    assert urlopen.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+def test_external_service_readiness_times_out_with_last_observation():
+    config = ExternalServiceReadinessConfig(
+        services=[
+            {
+                "name": "GENRM",
+                "url": "http://10.0.0.1:9213/health",
+                "expected_backends": 2,
+            }
+        ],
+        timeout_seconds=1,
+        poll_interval_seconds=1,
+        request_timeout_seconds=1,
+    )
+
+    with (
+        patch(
+            "nemo_rl.environments.nemo_gym.urllib.request.urlopen",
+            side_effect=OSError("connection refused"),
+        ),
+        patch(
+            "nemo_rl.environments.nemo_gym.time.monotonic",
+            side_effect=[0, 0, 2],
+        ),
+    ):
+        with pytest.raises(TimeoutError, match="GENRM: request failed"):
+            _wait_for_external_services(config)
+
+
+def test_external_service_readiness_is_not_forwarded_to_gym():
+    nemo_gym_dict = {
+        "external_service_readiness": {
+            "services": [
+                {
+                    "name": "GENRM",
+                    "url": "http://10.0.0.1:9213/health",
+                    "expected_backends": 2,
+                }
+            ],
+            "timeout_seconds": 10,
+            "poll_interval_seconds": 1,
+            "request_timeout_seconds": 2,
+        },
+        "skip_venv_if_present": True,
+    }
+
+    readiness = extract_external_service_readiness(nemo_gym_dict)
+
+    assert readiness is not None
+    assert readiness.services[0].name == "GENRM"
+    assert "external_service_readiness" not in nemo_gym_dict
+    assert nemo_gym_dict == {"skip_venv_if_present": True}
 
 
 def test_extract_static_video_message_resolves_local_file(tmp_path):

--- a/tests/unit/tools/test_external_gym_vllm.py
+++ b/tests/unit/tools/test_external_gym_vllm.py
@@ -591,6 +591,13 @@ def test_launcher_routes_generic_pools_to_explicit_hetgroups():
     assert (
         'COMMAND="${COMMAND//${placeholders[${pool}]}/${pool_urls[${pool}]}}"' in source
     )
+    assert "++env.nemo_gym.external_service_readiness" in source
+    assert "expected_backends:${replicas[${pool}]}" in source
+    assert "external_service_readiness_json" not in source
+    assert source.index('bash "${RAY_SUB}" &') < source.index(
+        "deadline=$((SECONDS + max_startup_timeout))"
+    )
+    assert source.count("check_startup_steps") == 3
     assert "genrm" not in source.lower()
     assert "nl2bash" not in source.lower()
     assert "safety" not in source.lower()

--- a/tools/external_gym_vllm/README.md
+++ b/tools/external_gym_vllm/README.md
@@ -16,10 +16,19 @@ vLLM arguments. The wrapper then:
 1. validates every pool and splits hetgroup 1 into disjoint node slices;
 2. starts every replica in its own private Ray cluster;
 3. starts one OpenAI-compatible load balancer per pool;
-4. waits for every backend and load balancer to become healthy;
-5. replaces each pool's URL placeholder in `COMMAND`;
-6. starts `ray.sub` on hetgroup 0 only; and
+4. replaces each pool's URL placeholder and injects an explicit backend-count
+   readiness contract into the NeMo Gym config;
+5. starts `ray.sub` on hetgroup 0 while the external models are still loading;
+6. lets the NeMo Gym actor start its local servers, then waits for every
+   external load balancer to report the required healthy backend count; and
 7. stops training if any required external service exits.
+
+This overlaps Ray, policy/trainer, and local Gym initialization with external
+model loading without letting rollout setup complete early. The load
+balancer's `/health` response must report `status: ok` and both
+`healthy_backends` and `total_backends` at or above the registered replica
+count. The Gym actor applies one shared, bounded deadline across all pools and
+shuts down its local servers if that deadline expires.
 
 Recipe launchers keep their concrete model and serving settings outside these
 helpers. A launcher can add another service without adding another server body
@@ -122,6 +131,8 @@ Optional globals:
 | `EXTERNAL_VLLM_LB_PYTHON` | `/opt/nemo_rl_venv/bin/python` | Python with `aiohttp` in `CONTAINER`. |
 | `RAY_SUB` | `$SLURM_SUBMIT_DIR/ray.sub` | Normal NeMo RL Slurm entrypoint. |
 | `EXTERNAL_VLLM_SHARED_ROOT` | `/lustre` | Shared host path mounted at the same path in every external-service container. |
+| `EXTERNAL_VLLM_READINESS_POLL_INTERVAL_SECONDS` | `5` | How often the NeMo Gym actor rechecks external load-balancer health. |
+| `EXTERNAL_VLLM_READINESS_REQUEST_TIMEOUT_SECONDS` | `10` | Per-request timeout for the NeMo Gym external-health probes. |
 | `DEDICATED_RAY_HEAD` | unset | Passed through to `ray.sub`. With `1`, include one extra node in hetgroup 0 while keeping `cluster.num_nodes` equal to the GPU worker-node count; the head node's GPUs remain allocated but idle. |
 
 The number of nodes in hetgroup 1 must equal:
@@ -197,7 +208,7 @@ sbatch \
 ```
 
 Slurm gang-schedules the two components. Replica `srun` steps explicitly use
-hetgroup 1 and load-balancer steps explicitly use hetgroup 0. Before starting
+hetgroup 1 and load-balancer steps explicitly use hetgroup 0. When starting
 `ray.sub`, the wrapper scopes its unsuffixed Slurm nodelist and node-count
 variables to component 0; Slurm then uses component 0 by default for its steps.
 External nodes therefore cannot accidentally join the training Ray cluster.

--- a/tools/external_gym_vllm/run_in_allocation.sh
+++ b/tools/external_gym_vllm/run_in_allocation.sh
@@ -42,6 +42,8 @@ RAY_SUB="${RAY_SUB:-${SLURM_SUBMIT_DIR}/ray.sub}"
 export GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
 EXTERNAL_VLLM_LB_PYTHON="${EXTERNAL_VLLM_LB_PYTHON:-/opt/nemo_rl_venv/bin/python}"
 EXTERNAL_VLLM_SHARED_ROOT="${EXTERNAL_VLLM_SHARED_ROOT:-/lustre}"
+EXTERNAL_VLLM_READINESS_POLL_INTERVAL_SECONDS="${EXTERNAL_VLLM_READINESS_POLL_INTERVAL_SECONDS:-5}"
+EXTERNAL_VLLM_READINESS_REQUEST_TIMEOUT_SECONDS="${EXTERNAL_VLLM_READINESS_REQUEST_TIMEOUT_SECONDS:-10}"
 
 if [[ ! -f "${RAY_SUB}" ]]; then
   echo "[FATAL] ray.sub does not exist: ${RAY_SUB}" >&2
@@ -61,6 +63,15 @@ if [[ "${EXTERNAL_VLLM_SHARED_ROOT}" != /* ]]; then
   echo "[FATAL] EXTERNAL_VLLM_SHARED_ROOT must be absolute" >&2
   exit 1
 fi
+for readiness_variable in \
+  EXTERNAL_VLLM_READINESS_POLL_INTERVAL_SECONDS \
+  EXTERNAL_VLLM_READINESS_REQUEST_TIMEOUT_SECONDS; do
+  readiness_value="${!readiness_variable}"
+  if [[ ! "${readiness_value}" =~ ^[0-9]+$ ]] || (( readiness_value <= 0 )); then
+    echo "[FATAL] ${readiness_variable} must be a positive integer" >&2
+    exit 1
+  fi
+done
 
 read -r -a pool_names <<< "${EXTERNAL_VLLM_POOLS}"
 if (( ${#pool_names[@]} == 0 )); then
@@ -320,6 +331,25 @@ check_service_steps() {
   done
 }
 
+check_ray_sub_step() {
+  local status
+  if [[ -n "${ray_sub_pid}" ]] && ! kill -0 "${ray_sub_pid}" 2>/dev/null; then
+    if wait "${ray_sub_pid}"; then
+      status=0
+    else
+      status=$?
+    fi
+    ray_sub_pid=""
+    echo "[FATAL] NeMo RL exited during external vLLM startup with status ${status}" >&2
+    return 1
+  fi
+}
+
+check_startup_steps() {
+  check_service_steps
+  check_ray_sub_step
+}
+
 resolve_node_ip() {
   local node="$1" ip
   ip=$(getent ahostsv4 "${node}" 2>/dev/null | awk 'NR == 1 { print $1 }' || true)
@@ -548,6 +578,8 @@ for pool in "${pool_names[@]}"; do
 done
 
 ray_head_ip=$(resolve_node_ip "${ray_head_node}")
+external_service_readiness_override='{services:['
+readiness_separator=""
 for pool in "${pool_names[@]}"; do
   pool_urls["${pool}"]="http://${ray_head_ip}:${lb_ports[${pool}]}/v1"
   echo "[INFO] Starting ${display_names[${pool}]} load balancer at ${pool_urls[${pool}]}"
@@ -570,7 +602,30 @@ for pool in "${pool_names[@]}"; do
     bash -lc "PYTHON='${EXTERNAL_VLLM_LB_PYTHON}' /opt/external-vllm-tools/lb_watchdog.sh '${lb_ports[${pool}]}' '${lb_state_dirs[${pool}]}' '${group_ids[${pool}]}'" &
   lb_step_pids+=("$!")
   lb_step_labels+=("${display_names[${pool}]} load balancer")
+
+  COMMAND="${COMMAND//${placeholders[${pool}]}/${pool_urls[${pool}]}}"
+  external_service_readiness_override+="${readiness_separator}{name:${pool},url:\"http://${ray_head_ip}:${lb_ports[${pool}]}/health\",expected_backends:${replicas[${pool}]}}"
+  readiness_separator=","
 done
+external_service_readiness_override+='],timeout_seconds:'
+external_service_readiness_override+="${max_startup_timeout}"
+external_service_readiness_override+=',poll_interval_seconds:'
+external_service_readiness_override+="${EXTERNAL_VLLM_READINESS_POLL_INTERVAL_SECONDS}"
+external_service_readiness_override+=',request_timeout_seconds:'
+external_service_readiness_override+="${EXTERNAL_VLLM_READINESS_REQUEST_TIMEOUT_SECONDS}"
+external_service_readiness_override+='}'
+COMMAND+=" ++env.nemo_gym.external_service_readiness='${external_service_readiness_override}'"
+export COMMAND
+
+echo "[INFO] Starting NeMo RL while external vLLM pools load"
+# ray.sub predates hetjobs and consumes the unsuffixed allocation variables.
+# Restrict those variables to component 0; srun also defaults to hetgroup 0.
+# `env` execs bash directly, so ray_sub_pid is the process that owns its traps.
+env \
+  SLURM_JOB_NODELIST="${SLURM_JOB_NODELIST_HET_GROUP_0}" \
+  SLURM_JOB_NUM_NODES="${#ray_nodes[@]}" \
+  bash "${RAY_SUB}" &
+ray_sub_pid=$!
 
 deadline=$((SECONDS + max_startup_timeout))
 while true; do
@@ -591,7 +646,7 @@ while true; do
     fi
   done
   (( all_ready == 1 )) && break
-  check_service_steps
+  check_startup_steps
   if (( SECONDS >= deadline )); then
     echo "[FATAL] Timed out waiting for all external vLLM pools" >&2
     exit 1
@@ -601,7 +656,7 @@ done
 
 for pool in "${pool_names[@]}"; do
   until curl -sfm 10 "${pool_urls[${pool}]}/models" >/dev/null 2>&1; do
-    check_service_steps
+    check_startup_steps
     if (( SECONDS >= deadline )); then
       echo "[FATAL] ${display_names[${pool}]} load balancer failed its end-to-end /models probe" >&2
       exit 1
@@ -609,19 +664,8 @@ for pool in "${pool_names[@]}"; do
     sleep 5
   done
   echo "${pool_urls[${pool}]}" > "${LOG_DIR}/${pool,,}_url"
-  COMMAND="${COMMAND//${placeholders[${pool}]}/${pool_urls[${pool}]}}"
 done
-export COMMAND
-
-echo "[INFO] External vLLM pools are healthy; starting NeMo RL"
-# ray.sub predates hetjobs and consumes the unsuffixed allocation variables.
-# Restrict those variables to component 0; srun also defaults to hetgroup 0.
-# `env` execs bash directly, so ray_sub_pid is the process that owns its traps.
-env \
-  SLURM_JOB_NODELIST="${SLURM_JOB_NODELIST_HET_GROUP_0}" \
-  SLURM_JOB_NUM_NODES="${#ray_nodes[@]}" \
-  bash "${RAY_SUB}" &
-ray_sub_pid=$!
+echo "[INFO] External vLLM pools are healthy; NeMo RL startup can proceed"
 
 while kill -0 "${ray_sub_pid}" 2>/dev/null; do
   if ! check_service_steps; then


### PR DESCRIPTION
## Summary

- start NeMo RL as soon as external load-balancer URLs are available, overlapping Ray, trainer, policy, and local Gym initialization with external model loading
- add a typed NeMo Gym readiness gate that waits for each external pool to report its expected healthy backend count before rollout setup completes
- bound readiness polling and clean up local Gym services if readiness times out

The external vLLM wrapper continues monitoring the serving pools after startup, and this change does not modify `ray.sub`.

## Testing

- `pytest -q tests/unit/environments/test_nemo_gym.py -k external_service_readiness`
- `pytest -q tests/unit/tools/test_external_gym_vllm.py`
- `ruff check nemo_rl/algorithms/distillation.py nemo_rl/environments/nemo_gym.py tests/unit/environments/test_nemo_gym.py tests/unit/tools/test_external_gym_vllm.py`
- `bash -n tools/external_gym_vllm/run_in_allocation.sh`