### PR TITLE
fix(async): preserve rollout lookahead on resume

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -415,18 +415,21 @@ class AsyncTrajectoryCollector:
         return self.data_exhausted
 
     def get_status(self) -> dict:
-        """Return a snapshot of the collector's internal state for driver-side diagnostics."""
+        """Return collector progress used for driver coordination and diagnostics."""
         with self._threads_lock:
             inflight_workers = len(self._inflight_threads)
         with self._failure_lock:
             collection_failed = self.collection_failed
             collection_error = self.collection_error
+        with self._generation_check_lock:
+            generating_targets = sorted(self._generating_targets)
         return {
             "running": self.running,
             "data_exhausted": self.data_exhausted,
             "errored": collection_failed,
             "error": collection_error,
             "inflight_workers": inflight_workers,
+            "generating_targets": generating_targets,
         }
 
     def _mark_collection_failed(self, error: Exception) -> None:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4117,6 +4117,41 @@ def aggregate_rollout_metrics(
     return aggregated
 
 
+def _startup_pipeline_ready(
+    replay_buffer: Any,
+    collector_status: dict[str, Any],
+    *,
+    current_step_ready: bool,
+    step: int,
+    num_prompts_per_step: int,
+    max_trajectory_age_steps: int,
+    max_num_steps: int,
+) -> bool:
+    """Return whether async training can overlap safely with lookahead generation.
+
+    A complete current step is sufficient only after the collector has either
+    completed or claimed the next target. The claim preserves the same
+    training/generation overlap used by steady-state async training without
+    allowing an unrelated reservation to open the startup barrier.
+    """
+    if not current_step_ready:
+        return False
+
+    next_step = step + 1
+    need_lookahead = max_trajectory_age_steps > 0 and next_step < max_num_steps
+    if not need_lookahead:
+        return True
+
+    next_step_ready = ray.get(
+        replay_buffer.has_complete_batch.remote(
+            next_step, num_prompts_per_step, max_trajectory_age_steps
+        )
+    )
+    return next_step_ready or next_step in collector_status.get(
+        "generating_targets", ()
+    )
+
+
 def async_grpo_train(
     policy: ColocatablePolicyInterface,
     policy_generation: Optional[GenerationInterface],
@@ -4548,31 +4583,24 @@ def async_grpo_train(
             f"step {step} ready={current_step_ready}"
         )
 
-        if current_step_ready:
-            # Keep the async pipeline one step ahead before entering training.
+        collector_status = ray.get(trajectory_collector.get_status.remote())
+        pipeline_ready = _startup_pipeline_ready(
+            replay_buffer,
+            collector_status,
+            current_step_ready=current_step_ready,
+            step=step,
+            num_prompts_per_step=num_prompts_per_step,
+            max_trajectory_age_steps=max_trajectory_age_steps,
+            max_num_steps=master_config.grpo.max_num_steps,
+        )
+        if current_step_ready and not pipeline_ready:
+            print(
+                f"  Pipeline barrier: step {step} ready but "
+                f"step {step + 1} is not yet claimed — waiting for lookahead "
+                f"to prevent resume deadlock"
+            )
 
-            # A restored buffer may already contain `step`, allowing startup to
-            # consume it before the collector generates `step + 1`. After refit,
-            # the collector advances to targets starting at `step + 2`, leaving
-            # `step + 1` permanently missing. Wait for the initial collector,
-            # whose range includes both steps, to complete the lookahead first.
-            max_num_steps = master_config.grpo.max_num_steps
-            need_lookahead = max_trajectory_age_steps > 0 and step + 1 < max_num_steps
-            if need_lookahead:
-                next_step_ready = ray.get(
-                    replay_buffer.has_complete_batch.remote(
-                        step + 1, num_prompts_per_step, max_trajectory_age_steps
-                    )
-                )
-                if not next_step_ready:  # pragma: no cover
-                    print(
-                        f"  Pipeline barrier: step {step} ready but "
-                        f"step {step + 1} not yet — waiting for lookahead fill "
-                        f"to prevent resume deadlock"
-                    )
-                    wait_iterations += 1
-                    time.sleep(1.0)
-                    continue
+        if pipeline_ready:
             break
 
         trajectories_needed = ray.get(
@@ -4586,7 +4614,6 @@ def async_grpo_train(
                 f"trajectories for step {step}"
             )
 
-        collector_status = ray.get(trajectory_collector.get_status.remote())
         if (
             (
                 collector_status["data_exhausted"]
@@ -4595,11 +4622,24 @@ def async_grpo_train(
             and not collector_status["running"]
             and collector_status["inflight_workers"] == 0
         ):
+            awaited_target = step + 1 if current_step_ready else step
+            awaited_work = "lookahead claim" if current_step_ready else "buffer fill"
+            stop_reason = (
+                "dataloader exhausted"
+                if collector_status["data_exhausted"]
+                else "collector errored"
+            )
+            recovery_advice = (
+                "Increase data.train.max_num_epochs or use a larger dataset."
+                if collector_status["data_exhausted"]
+                else "Inspect the preceding trajectory collector error."
+            )
             raise RuntimeError(
-                f"Trajectory collector stopped: dataloader exhausted while waiting for initial buffer fill at step={step}. "
-                f"The dataset ran out of data before training could start. "
+                f"Trajectory collector stopped ({stop_reason}) while waiting for "
+                f"{awaited_work} at target={awaited_target}. "
+                f"Training cannot start without the required target. "
                 f"Collector status: {collector_status}. "
-                f"Increase data.train.max_num_epochs or use a larger dataset."
+                f"{recovery_advice}"
             )
 
         wait_iterations += 1
@@ -4702,6 +4742,11 @@ def async_grpo_train(
 
                         collector_status = ray.get(
                             trajectory_collector.get_status.remote()
+                        )
+                        awaited_target = step
+                        print(
+                            f"   Awaiting target {awaited_target}; claimed by collector: "
+                            f"{awaited_target in collector_status.get('generating_targets', ())}"
                         )
                         if (
                             (

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -250,9 +250,7 @@ class NemoGymConfig(TypedDict):
     # Optional startup gate for externally served Gym dependencies. The actor
     # starts local Gym services first, then waits for every target before it
     # exposes its rollout collection helper to the training driver.
-    external_service_readiness: NotRequired[
-        ExternalServiceReadinessConfig | None
-    ]
+    external_service_readiness: NotRequired[ExternalServiceReadinessConfig | None]
     # Multimodal fields (populated by `setup_nemo_gym_config` when VLM is enabled).
     tokenizer_config: NotRequired[
         Optional[TokenizerConfig]
@@ -307,8 +305,7 @@ def _probe_external_service(
         or isinstance(total_backends, bool)
     ):
         return (
-            "health response must contain integer healthy_backends and "
-            "total_backends"
+            "health response must contain integer healthy_backends and total_backends"
         )
     if (
         status != "ok"
@@ -358,9 +355,7 @@ def _wait_for_external_services(
         if problems != previous_problems:
             print(
                 "Waiting for external NeMo-Gym services: "
-                + "; ".join(
-                    f"{name}: {problem}" for name, problem in problems.items()
-                )
+                + "; ".join(f"{name}: {problem}" for name, problem in problems.items())
             )
             previous_problems = problems
 
@@ -781,9 +776,7 @@ Depending on your data shape, you may want to change these values."""
         )
 
         try:
-            _wait_for_external_services(
-                self.cfg.get("external_service_readiness")
-            )
+            _wait_for_external_services(self.cfg.get("external_service_readiness"))
         except TimeoutError:
             # RunHelper.start() has already spawned local Gym services. Do not
             # leave them behind when an external dependency misses its deadline.

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -45,6 +45,7 @@ from nemo_rl.algorithms.grpo import (
     AsyncGRPOConfig,
     GRPOConfig,
     MasterConfig,
+    _startup_pipeline_ready,
     add_grpo_token_loss_masks_and_generation_logprobs,
     extract_initial_prompt_messages,
 )
@@ -1222,23 +1223,21 @@ class TestReplayBuffer:
 
         ray.kill(buffer2)
 
-    def test_resume_deadlock_precondition_detectable(self):
-        """Regression: restored buffer can expose an async resume deadlock.
+    def test_restore_preserves_complete_current_target_without_lookahead(self):
+        """A restored buffer preserves target N while target N+1 remains absent.
 
-        After PR #2651 introduced replay-buffer checkpointing, resuming from a
-        checkpoint where target N is complete but target N+1 is absent can
-        deadlock Async GRPO or Async PPO:
+        This is the precondition for the async resume deadlock that PR #2651's
+        replay-buffer checkpointing exposed in Async GRPO or Async PPO:
 
           1. Startup wait sees has_complete_batch(N) == True and breaks immediately.
           2. Training consumes all target-N trajectories and triggers a refit.
           3. Collector's post-refit target window becomes [N+2, ...] (skipping N+1).
           4. Training waits for target N+1, which nobody generates — stall forever.
 
-        The fix is a startup pipeline barrier: before breaking, also require
-        has_complete_batch(N+1) to be True (or N+1 >= max_steps).  This test
-        constructs the exact precondition state — current step complete, lookahead
-        absent — to ensure it remains detectable and to document the expected
-        buffer readiness values that the barrier logic branches on.
+        The startup pipeline barrier requires target N+1 to be complete *or*
+        actively claimed by the collector before training may begin.  This test
+        constructs the precondition state — current step complete, lookahead
+        absent — and documents the buffer readiness values the barrier branches on.
         """
         num_prompts = 8
         resume_step = 30
@@ -1278,12 +1277,11 @@ class TestReplayBuffer:
             buffer2.has_complete_batch.remote(resume_step, num_prompts, max_age)
         ), "target step must be complete after restore"
 
-        # Step 31 is absent — this is the deadlock precondition.
-        # The startup pipeline barrier must detect this and continue waiting
-        # instead of breaking, giving the collector time to generate step 31.
+        # Step 31 is absent — startup may proceed only after collector status
+        # reports that this target has been claimed.
         assert not ray.get(
             buffer2.has_complete_batch.remote(resume_step + 1, num_prompts, max_age)
-        ), "lookahead step must be absent; barrier should block here"
+        ), "lookahead step must be absent from the restored buffer"
 
         ray.kill(buffer2)
 
@@ -2473,6 +2471,70 @@ class TestAsyncTrajectoryCollector:
         collector._release_target(target_weight)
 
         assert target_weight not in collector._generating_targets
+
+    def test_startup_barrier_clears_when_collector_reserves_lookahead(self):
+        """A real lookahead reservation opens the resume startup barrier."""
+        num_prompts = 2
+        resume_step = 30
+        max_age = 2
+
+        buffer1 = ReplayBuffer.remote(
+            max_size=20, drop_incomplete_targets_on_restore=False
+        )
+        buffer2 = None
+        try:
+            for _ in range(num_prompts):
+                ray.get(
+                    buffer1.add.remote(
+                        {"batch": {"data": "x"}, "rollout_metrics": {}},
+                        weight_version=resume_step - 1,
+                        target_weight_version=resume_step,
+                    )
+                )
+            state = ray.get(buffer1.state_dict.remote())
+            ray.kill(buffer1)
+            buffer1 = None
+
+            buffer2 = ReplayBuffer.remote(
+                max_size=20, drop_incomplete_targets_on_restore=False
+            )
+            ray.get(
+                buffer2.load_state_dict.remote(
+                    state,
+                    num_prompts_per_step=num_prompts,
+                    current_training_step=resume_step,
+                    max_age_steps=max_age,
+                )
+            )
+
+            collector = self.create_local_collector(replay_buffer=buffer2)
+            collector.initial_weight_version = resume_step
+            collector.current_weight_version = resume_step
+
+            def barrier_open() -> bool:
+                return _startup_pipeline_ready(
+                    buffer2,
+                    collector.get_status(),
+                    current_step_ready=True,
+                    step=resume_step,
+                    num_prompts_per_step=num_prompts,
+                    max_trajectory_age_steps=max_age,
+                    max_num_steps=resume_step + 100,
+                )
+
+            assert not barrier_open()
+            reserved = collector._get_next_target_for_generation(resume_step)
+            assert reserved == resume_step + 1
+            assert collector.get_status()["generating_targets"] == [resume_step + 1]
+            assert barrier_open()
+
+            collector._release_target(reserved)
+            assert not barrier_open()
+        finally:
+            if buffer1 is not None:
+                ray.kill(buffer1)
+            if buffer2 is not None:
+                ray.kill(buffer2)
 
     def test_process_batch_releases_target_when_worker_start_fails(self, monkeypatch):
         """Test start failures do not leave a target reserved forever."""

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -48,6 +48,7 @@ from nemo_rl.algorithms.grpo import (
     _resolve_logprob_skip_flags,
     _resolve_message_level_advantage_penalties,
     _save_async_replay_buffer_checkpoint,
+    _startup_pipeline_ready,
     _validate_multimodal_dedup_capability,
     _validate_use_kl_in_reward_compat,
     aggregate_rollout_metrics,
@@ -1116,6 +1117,21 @@ class StubAsyncTrajectoryCollector:
         return self._remote_method("resume_after_refit")
 
     @property
+    def get_status(self):
+        """Return a healthy collector status with no reserved targets."""
+        mock = MagicMock()
+        mock.remote = MagicMock(
+            return_value={
+                "running": True,
+                "data_exhausted": False,
+                "errored": False,
+                "inflight_workers": 0,
+                "generating_targets": [],
+            }
+        )
+        return mock
+
+    @property
     def stop(self):
         """Stop collection - returns a remote-callable mock"""
         mock = MagicMock()
@@ -1820,6 +1836,54 @@ def test_should_use_nemo_gym_requires_dynamo_token_wrapper() -> None:
 
     master_config.policy["generation"]["vllm_cfg"]["expose_http_server"] = True
     assert should_use_nemo_gym(master_config) is True
+
+
+@pytest.mark.parametrize(
+    (
+        "lookahead_complete",
+        "generating_targets",
+        "current_step_ready",
+        "step",
+        "max_num_steps",
+        "expected",
+        "expected_queries",
+    ),
+    [
+        pytest.param(True, [], True, 3, 10, True, 1, id="complete"),
+        pytest.param(False, [4], True, 3, 10, True, 1, id="reserved-only"),
+        pytest.param(False, [], True, 3, 10, False, 1, id="neither"),
+        pytest.param(False, [5, 6], True, 3, 10, False, 1, id="other-target-reserved"),
+        pytest.param(False, [], True, 9, 10, True, 0, id="last-step"),
+        pytest.param(False, [], False, 3, 10, False, 0, id="current-not-ready"),
+    ],
+)
+def test_startup_pipeline_ready(
+    lookahead_complete,
+    generating_targets,
+    current_step_ready,
+    step,
+    max_num_steps,
+    expected,
+    expected_queries,
+):
+    """Startup needs a complete or claimed lookahead except at the last step."""
+    replay_buffer = MagicMock()
+    replay_buffer.has_complete_batch.remote.return_value = lookahead_complete
+    collector_status = {"generating_targets": generating_targets}
+
+    with patch("nemo_rl.algorithms.grpo.ray.get", side_effect=lambda value: value):
+        result = _startup_pipeline_ready(
+            replay_buffer,
+            collector_status,
+            current_step_ready=current_step_ready,
+            step=step,
+            num_prompts_per_step=8,
+            max_trajectory_age_steps=1,
+            max_num_steps=max_num_steps,
+        )
+
+    assert result is expected
+    assert replay_buffer.has_complete_batch.remote.call_count == expected_queries
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- Backport the changes from #3435 to `super-v3.5-posttraining`.
- Report actively reserved rollout targets through collector status.
- Let the resume startup barrier clear once the lookahead target is complete or actively claimed, preserving rollout/training overlap without reintroducing the checkpoint-resume stall.

Source commit: `3fc2964d9727726760c2ab3c9707904fdde728bc`

## Validation

- `pytest -q tests/unit/algorithms/test_async_utils.py tests/unit/algorithms/test_grpo.py` — 261 passed
- PR-specific regression tests on the final target base — 8 passed
- Targeted pre-commit hooks for all four changed files — passed
- Source and backport stable patch IDs match