### PR TITLE
feat: Fix vLLM patch loading in dedicated serving containers

### DIFF
--- a/tests/unit/tools/test_external_gym_vllm.py
+++ b/tests/unit/tools/test_external_gym_vllm.py
@@ -16,6 +16,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
@@ -35,6 +36,31 @@ from tools.external_gym_vllm.vllm_pool_lb import (
 )
 
 REPO_ROOT = Path(__file__).parents[3]
+
+
+def test_serve_wrapper_loads_patches_without_importing_nemo_rl_package():
+    script = REPO_ROOT / "tools/external_gym_vllm/serve_vllm_on_ray.py"
+    program = textwrap.dedent(
+        f"""
+        import runpy
+        import sys
+        import types
+
+        sys.modules["ray"] = types.ModuleType("ray")
+        namespace = runpy.run_path({str(script)!r})
+        namespace["_load_apply_vllm_patches"]()
+        assert "nemo_rl.models.generation" not in sys.modules
+        assert "nemo_rl.models.policy" not in sys.modules
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_shutdown_timeout_bounds_watchdog_restart_outage():

--- a/tools/external_gym_vllm/README.md
+++ b/tools/external_gym_vllm/README.md
@@ -79,7 +79,7 @@ The generated fields are:
 |---|---:|---|---|
 | `POOL_MODEL` | yes | — | Checkpoint path under `EXTERNAL_VLLM_SHARED_ROOT` or Hugging Face model ID. |
 | `POOL_CONTAINER` | yes | — | Container used by this pool's replicas. |
-| `POOL_VLLM_PYTHON` | yes | — | Python executable containing vLLM, Ray, and NeMo RL's compatibility patch. |
+| `POOL_VLLM_PYTHON` | yes | — | Python executable containing vLLM and Ray. |
 | `POOL_REPLICAS` | yes | — | Number of independent DP=1 servers. |
 | `POOL_TENSOR_PARALLEL_SIZE` | yes | — | Tensor parallel size per server. |
 | `POOL_LB_PORT` | yes | — | Unique load-balancer port on the Ray head node. |
@@ -176,11 +176,17 @@ also accepted.
 Each pool container must provide:
 
 - its configured `POOL_VLLM_PYTHON`;
-- importable `nemo_rl`, `ray`, and `vllm` packages in that environment; and
+- importable `ray` and `vllm` packages in that environment;
+- access to the matching NeMo RL source checkout, or an importable `nemo_rl`
+  package as a fallback; and
 - the `ray` command on `PATH`.
 
-`serve_vllm_on_ray.py` applies NeMo RL's vLLM compatibility patches before it
-imports the vLLM API server. `CONTAINER` must provide
+`serve_vllm_on_ray.py` loads NeMo RL's vLLM compatibility patch module directly
+from the matching source checkout and applies it before importing the vLLM API
+server. This avoids importing NeMo RL's policy modules and training dependency
+stack into a purpose-built serving container. If the source checkout is not
+available, the wrapper falls back to the installed `nemo_rl` package.
+`CONTAINER` must provide
 `EXTERNAL_VLLM_LB_PYTHON` with `aiohttp` installed.
 
 ## Slurm submission

--- a/tools/external_gym_vllm/serve_vllm_on_ray.py
+++ b/tools/external_gym_vllm/serve_vllm_on_ray.py
@@ -17,17 +17,36 @@
 
 from __future__ import annotations
 
+import runpy
 import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
 
 import ray
 
-from nemo_rl.models.generation.vllm.patches import _apply_vllm_patches
+
+def _load_apply_vllm_patches() -> Callable[[str], None]:
+    """Load vLLM patches without importing NeMo RL's dependency stack."""
+    repo_root = Path(__file__).resolve().parents[2]
+    patches_path = repo_root / "nemo_rl/models/generation/vllm/patches.py"
+    if patches_path.is_file():
+        namespace = runpy.run_path(str(patches_path))
+        apply_vllm_patches = namespace.get("_apply_vllm_patches")
+        if not callable(apply_vllm_patches):
+            raise RuntimeError(f"_apply_vllm_patches is missing from {patches_path}")
+        return cast(Callable[[str], None], apply_vllm_patches)
+
+    # Support installations that copy this tool without the source checkout.
+    from nemo_rl.models.generation.vllm.patches import _apply_vllm_patches
+
+    return _apply_vllm_patches
 
 
 def main() -> None:
     """Connect to the private cluster and start the requested vLLM command."""
     worker_python = sys.executable
-    _apply_vllm_patches(worker_python)
+    _load_apply_vllm_patches()(worker_python)
     ray.init(address="auto", runtime_env={"py_executable": worker_python})
 
     # vLLM is available only in the generation worker environment and must be


### PR DESCRIPTION
## Summary

- load the standalone NeMo RL vLLM compatibility patch module directly from the matching source checkout before importing vLLM
- avoid importing NeMo RL policy modules and their training dependency stack when Gym serves GenRM or other model pools from a dedicated vLLM container
- retain the installed-package fallback and continue propagating the serving-container Python interpreter to Ray workers
- document the dedicated-container requirements and cover the isolated import path with a regression test

The compatibility patches remain required for node-spanning RayExecutorV2 engines, including TCPStore port separation and MessageQueue bind retries.

## Testing

- `pytest -q tests/unit/tools/test_external_gym_vllm.py` (37 passed)
- `ruff check tools/external_gym_vllm/serve_vllm_on_ray.py tests/unit/tools/test_external_gym_vllm.py`
- `git diff --check`