### PR TITLE
feat(sc): add the teacher top-k forward for distillation on SingleController

### DIFF
--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -561,6 +561,50 @@ class TQWorkerMixin:
         )
         del result
 
+    @wrap_with_nvtx_name("policy_worker/get_topk_logits_presharded")
+    def get_topk_logits_presharded(
+        self,
+        meta: "KVBatchMeta",
+        k: int,
+        micro_batch_size: Optional[int] = None,
+    ) -> None:
+        """Per-rank teacher top-k forward entrypoint.
+
+        Same contract as ``get_logprobs_presharded``, with one difference worth
+        naming: ``get_topk_logits`` returns two tensors rather than one, so this
+        writes back twice. Both are ``[B, S, k]`` -- the write-back only checks
+        the batch dimension, so the extra axis passes through unchanged.
+
+        Only a distillation teacher mixes this in. The teacher never trains, so
+        there is no split begin/microbatch/finish counterpart: one call is one
+        forward.
+
+        Args:
+            meta: Per-rank ``KVBatchMeta`` for this slice.
+            k: Number of top logits to keep per position.
+            micro_batch_size: Inference micro batch size; None uses the config default.
+        """
+        data = self._fetch(meta)
+        data = self._attach_or_repack_pack_metadata(data, meta)
+        result: BatchedDataDict[Any] = self.get_topk_logits(  # type: ignore[attr-defined]
+            data=data,
+            k=k,
+            micro_batch_size=micro_batch_size,
+        )
+        self._write_back_result_field(
+            meta,
+            result,
+            result_key="topk_logits",
+            tq_field="teacher_topk_logits",
+        )
+        self._write_back_result_field(
+            meta,
+            result,
+            result_key="topk_indices",
+            tq_field="teacher_topk_indices",
+        )
+        del result
+
     @wrap_with_nvtx_name("value_worker/get_values_presharded")
     def get_values_presharded(
         self,

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -286,6 +286,38 @@ class TQPolicy(TQDriverMixin, Policy):
             common_kwargs={"micro_batch_size": micro_batch_size},
         )
 
+    def get_topk_logits_from_meta(
+        self,
+        meta: KVBatchMeta,
+        k: int,
+        micro_batch_size: Optional[int] = None,
+        timer: Optional[Timer] = None,
+    ) -> None:
+        """1-hop counterpart to get_topk_logits, for a distillation teacher.
+
+        Returns nothing: the two tensors land in TQ under
+        ``teacher_topk_logits`` / ``teacher_topk_indices`` via the worker-side
+        write-back, so the loss reads them from there rather than through Ray.
+
+        Reuses ``LP_SEED_FIELDS`` because a teacher forward needs exactly what a
+        logprob forward needs -- the student's tokens and their masks. The
+        teacher contributes only its own scoring of them.
+
+        Args:
+            meta: Full-step batch metadata consumed by all DP ranks.
+            k: Number of top logits to keep per position.
+            micro_batch_size: Inference micro batch size; None uses the config default.
+            timer: Optional timer for nested measurements.
+        """
+        self._logprob_dispatch(
+            meta,
+            task_name="teacher_topk",
+            worker_method="get_topk_logits_presharded",
+            timer_prefix="get_topk_logits",
+            timer=timer,
+            common_kwargs={"k": k, "micro_batch_size": micro_batch_size},
+        )
+
     def train_from_meta(
         self,
         meta: KVBatchMeta,

--- a/tests/unit/models/policy/test_tq_teacher_topk.py
+++ b/tests/unit/models/policy/test_tq_teacher_topk.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the TQ-mediated distillation teacher forward.
+
+Same shape as tests/unit/models/value/test_tq_value.py. The teacher differs
+from every other ``*_presharded`` entrypoint in one way worth covering: it
+writes back **two** tensors rather than one, and both carry a third axis
+(``[B, S, k]``) that the single-tensor entrypoints never produce.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
+
+
+class _TeacherStubWorker(TQWorkerMixin):
+    """Mixin host recording backend calls; fetch/attach are stubbed."""
+
+    def __init__(
+        self,
+        is_leader: bool = True,
+        logits: torch.Tensor | None = None,
+        indices: torch.Tensor | None = None,
+    ):
+        self.calls: list[tuple] = []
+        self._leader = is_leader
+        self._dp_client = MagicMock()
+        self._logits = logits if logits is not None else torch.ones(2, 3, 4)
+        self._indices = (
+            indices if indices is not None else torch.zeros(2, 3, 4, dtype=torch.long)
+        )
+
+    def _fetch(self, meta):
+        self.calls.append(("fetch", meta))
+        return {"data_from": meta}
+
+    def _attach_or_repack_pack_metadata(self, data, meta):
+        self.calls.append(("attach", meta))
+        return data
+
+    def _is_replica_leader(self) -> bool:
+        return self._leader
+
+    def get_topk_logits(self, data, k, micro_batch_size=None):
+        self.calls.append(("get_topk_logits", data, k, micro_batch_size))
+        return {"topk_logits": self._logits, "topk_indices": self._indices}
+
+
+def _meta(sample_ids: list[str] | None = None) -> KVBatchMeta:
+    return KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=sample_ids if sample_ids is not None else ["s0", "s1"],
+    )
+
+
+class TestGetTopkLogitsPresharded:
+    def test_writes_both_tensors_back_and_returns_nothing(self):
+        w = _TeacherStubWorker()
+        meta = _meta()
+
+        with patch("nemo_rl.data_plane.column_io.write_columns") as write_columns:
+            out = w.get_topk_logits_presharded(meta=meta, k=4, micro_batch_size=8)
+
+        assert out is None
+        assert [c[0] for c in w.calls] == ["fetch", "attach", "get_topk_logits"]
+        assert w.calls[2][2] == 4
+        assert w.calls[2][3] == 8
+
+        # Two write-backs, not one: logits and indices are separate columns.
+        assert write_columns.call_count == 2
+        written = {}
+        for call in write_columns.call_args_list:
+            written.update(call.args[2])
+        assert set(written) == {"teacher_topk_logits", "teacher_topk_indices"}
+        assert torch.equal(written["teacher_topk_logits"], torch.ones(2, 3, 4))
+        assert written["teacher_topk_indices"].dtype == torch.long
+
+    def test_the_k_axis_survives_the_write_back(self):
+        """The single-tensor entrypoints all write [B, S]; this one must not
+        flatten or truncate the extra axis on the way through."""
+        w = _TeacherStubWorker(logits=torch.randn(2, 5, 7))
+
+        with patch("nemo_rl.data_plane.column_io.write_columns") as write_columns:
+            w.get_topk_logits_presharded(meta=_meta(), k=7)
+
+        written = {}
+        for call in write_columns.call_args_list:
+            written.update(call.args[2])
+        assert written["teacher_topk_logits"].shape == (2, 5, 7)
+
+    def test_non_leader_twin_does_not_write(self):
+        """TP/CP/PP twins hold identical copies; a second writer is the
+        duplicate-write bug the leader gate exists to prevent. Doubly relevant
+        here, where one call writes two columns."""
+        w = _TeacherStubWorker(is_leader=False)
+
+        with patch("nemo_rl.data_plane.column_io.write_columns") as write_columns:
+            w.get_topk_logits_presharded(meta=_meta(), k=4)
+
+        write_columns.assert_not_called()
+
+    def test_rejects_batch_dim_mismatch(self):
+        w = _TeacherStubWorker(logits=torch.ones(3, 3, 4))
+
+        with pytest.raises(ValueError, match="shape mismatch"):
+            w.get_topk_logits_presharded(meta=_meta(["s0", "s1"]), k=4)


### PR DESCRIPTION
## What does this PR do?

Adds the teacher top-k forward primitive needed by distillation on SingleController:

- `TQWorkerMixin.get_topk_logits_presharded` runs the rank-local forward and writes both top-k tensors back to TransferQueue.
- `TQPolicy.get_topk_logits_from_meta` dispatches that work from the driver.
- The tests pin both output columns, the `[B, S, k]` shape, leader-only write-back, and batch-size validation.

This is the first PR in the #3843 → #3846 → #3849 stack. Nothing calls the new entry point until #3846.

## Ownership

#2580 already contains the same `get_topk_logits_presharded` entry point and the same `teacher_topk_logits` / `teacher_topk_indices` columns as part of a larger TQ distillation implementation. That PR is still open, so ownership is unresolved. I am holding this stack here and will not add more downstream work until the maintainers choose which direction to keep.

## Validation

- Current live head: `744463629719d1e33d49d85ff5f959ac1c4865de`.
- Focused policy tests cover the worker and driver entry points.
- The full stack at #3849 head `907606048aa8c950027dbc199bff1495035e862c` passed 765 unit/config cases (6 GPU-only skips) and a real 2-GPU teacher/student checkpoint-restore run.

This base branch is intentionally not being presented as current-main-ready while #2580 ownership remains unresolved; the two downstream branches are kept tested, but no further stack is being built on it.
