### PR TITLE
fix(vllm): return HTTP 400 for chat completion context overflow

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -768,11 +768,16 @@ class VllmAsyncGenerationWorkerImpl(
                 remaining = self.model_config.max_model_len - len(prompt_token_ids)
                 if remaining <= 0:
                     # preserve the literal "context length" in this message to match Gym's overflow handling
-                    raise VLLMValidationError(
+                    message = (
                         f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
                         f"this model's maximum context length ({self.model_config.max_model_len}). "
-                        f"No room for output tokens.",
-                        parameter="max_model_len",
+                        f"No room for output tokens."
+                    )
+                    LOGGER.warning("Prompt exceeds max_model_len: %s", message)
+                    raise VLLMValidationError(
+                        message,
+                        parameter="input_tokens",
+                        value=len(prompt_token_ids),
                     )
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
@@ -1155,6 +1160,7 @@ class VllmAsyncGenerationWorkerImpl(
                         "error": {
                             "message": str(e),
                             "type": "invalid_request_error",
+                            "param": e.parameter,
                             "code": 400,
                         }
                     },

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -767,10 +767,12 @@ class VllmAsyncGenerationWorkerImpl(
                 """Clamp the request's max output tokens so that input + output <= max_model_len."""
                 remaining = self.model_config.max_model_len - len(prompt_token_ids)
                 if remaining <= 0:
-                    raise ValueError(
+                    # preserve the literal "context length" in this message to match Gym's overflow handling
+                    raise VLLMValidationError(
                         f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
-                        f"max_model_len ({self.model_config.max_model_len}). "
-                        f"No room for output tokens."
+                        f"this model's maximum context length ({self.model_config.max_model_len}). "
+                        f"No room for output tokens.",
+                        parameter="max_model_len",
                     )
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -546,10 +546,23 @@ def _install_fake_vllm_openai_modules(monkeypatch):
             self.kwargs = kwargs
             self.instances.append(self)
 
-    class VLLMValidationError(Exception):
-        def __init__(self, message="", parameter=None):
+    class VLLMValidationError(ValueError):
+        def __init__(self, message, *, parameter=None, value=None):
             super().__init__(message)
             self.parameter = parameter
+            self.value = value
+
+        def __str__(self):
+            base = super().__str__()
+            extras = [
+                f"{name}={value}"
+                for name, value in (
+                    ("parameter", self.parameter),
+                    ("value", self.value),
+                )
+                if value is not None
+            ]
+            return f"{base} ({', '.join(extras)})" if extras else base
 
     class ToolParserManager:
         import_tool_parser = MagicMock()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -547,7 +547,9 @@ def _install_fake_vllm_openai_modules(monkeypatch):
             self.instances.append(self)
 
     class VLLMValidationError(Exception):
-        pass
+        def __init__(self, message="", parameter=None):
+            super().__init__(message)
+            self.parameter = parameter
 
     class ToolParserManager:
         import_tool_parser = MagicMock()
@@ -658,6 +660,75 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
+
+
+def _nemo_gym_recognizes_context_overflow(
+    *, status: int, response_content: str
+) -> bool:
+    """Mirror responses_api_models/vllm_model/app.py overflow detection."""
+    return status == 400 and (
+        "context length" in response_content or "max_tokens" in response_content
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_returns_http_400_for_nemo_gym(monkeypatch):
+    """Overflow from _clamp_max_tokens must be HTTP 400 that NeMo Gym recognizes."""
+    _, _, openai_serving_chat = _install_fake_vllm_openai_modules(monkeypatch)
+
+    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
+    worker.cfg = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "val_temperature": 0.0,
+        "val_top_p": 1.0,
+        "vllm_cfg": {},
+    }
+    worker.llm = MagicMock(model_config="model-config", renderer="renderer")
+    worker._http_engine_client = worker.llm
+    worker._capture_calls = {}
+    worker.token_capture = None
+    worker.llm_async_engine_args = MagicMock()
+    worker.llm_async_engine_args.create_model_config.return_value = MagicMock(
+        served_model_name="served-model", model="model-path"
+    )
+
+    app = _FakeFastAPIApp()
+    worker._setup_vllm_openai_api_server(app)
+
+    max_model_len = 128
+    renderer = openai_serving_chat.instances[0].kwargs["online_renderer"]
+    renderer.model_config = types.SimpleNamespace(max_model_len=max_model_len)
+    serving_chat = openai_serving_chat.instances[0]
+    chat_handler = next(
+        handler for path, handler in app.routes if path == "/v1/chat/completions"
+    )
+    overflow_prompt = [0] * max_model_len
+
+    async def create_chat_completion(request, _raw_request):
+        renderer._clamp_max_tokens(request, request.max_tokens, overflow_prompt)
+
+    serving_chat.create_chat_completion = create_chat_completion
+    response = await chat_handler(
+        types.SimpleNamespace(
+            top_k=-1,
+            top_p=1.0,
+            temperature=1.0,
+            max_tokens=1,
+            max_completion_tokens=None,
+        ),
+        MagicMock(),
+    )
+
+    response_content = response.body.decode()
+    assert response.status_code == 400
+    assert _nemo_gym_recognizes_context_overflow(
+        status=response.status_code,
+        response_content=response_content,
+    )
+    error = json.loads(response_content)["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == 400
 
 
 def test_nano_v3_reasoning_parser_swaps_reasoning_when_thinking_disabled(

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -735,12 +735,15 @@ async def test_context_overflow_returns_http_400_for_nemo_gym(monkeypatch):
 
     response_content = response.body.decode()
     assert response.status_code == 400
+    assert "maximum context length" in response_content
+    assert "(parameter=input_tokens, value=128)" in response_content
     assert _nemo_gym_recognizes_context_overflow(
         status=response.status_code,
         response_content=response_content,
     )
     error = json.loads(response_content)["error"]
     assert error["type"] == "invalid_request_error"
+    assert error["param"] == "input_tokens"
     assert error["code"] == 400
 
 


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a contract mismatch between NeMo-RL and NeMo-Gym: when `_clamp_max_tokens` detects an overflow the ValueError exception results in an HTTP 500 error that Gym retries. Turn it into an VLLMValidationError that Gym sees as HTTP 400 and can immediately treat as a context overflow.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
