### PR TITLE
fix(ppo): reject refit_transport on every backend, not only on vLLM

### DIFF
--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -372,6 +372,18 @@ def setup(
                 "default collective path. Set policy.generation.refit_transport=null. "
                 "Tracked in https://github.com/NVIDIA-NeMo/RL/issues/3275."
             )
+    elif generation_config.get("refit_transport") is not None:
+        # The block above only runs for vLLM, but PPO also supports SGLang, so
+        # a transport set there used to be dropped without a word. GRPO rejects
+        # the same pairing at grpo.py's setup; this mirrors it.
+        raise ValueError(
+            f"policy.generation.refit_transport="
+            f"{generation_config['refit_transport']!r} is not yet supported by "
+            f"PPO on the {generation_config['backend']!r} generation backend; "
+            "PPO refits over the default collective path. Set "
+            "policy.generation.refit_transport=null. Tracked in "
+            "https://github.com/NVIDIA-NeMo/RL/issues/3275."
+        )
 
     if "megatron_cfg" in policy_config and policy_config["megatron_cfg"]["enabled"]:
         policy_megatron_config = cast(MegatronConfig, policy_config["megatron_cfg"])

--- a/tests/unit/algorithms/test_ppo_refit_transport_guard.py
+++ b/tests/unit/algorithms/test_ppo_refit_transport_guard.py
@@ -32,7 +32,13 @@ import pytest
 from nemo_rl.algorithms.ppo import setup
 
 # Anything that is not the default collective path.
-_TRANSPORTS = ["nixl", "nccl_reshard"]
+# The three transports that main drops in silence: each returns None from
+# ``checkpoint_engine_refit_config``, so ``create_weight_synchronizer`` falls
+# through to the SGLang branch with the setting discarded. ``nixl`` and custom
+# ``module:ClassName`` engines are deliberately NOT here -- they build a
+# checkpoint-engine config that weight_sync/factory.py already rejects loudly,
+# so the guard is redundant for them and listing them would overstate it.
+_TRANSPORTS = ["nccl_reshard", "vllm_s3_sparse", "vllm_zmq_sparse"]
 
 
 def _master_config(backend: str, transport):
@@ -69,8 +75,13 @@ def test_sglang_with_a_transport_is_rejected(transport):
 
 @pytest.mark.parametrize("transport", _TRANSPORTS)
 def test_vllm_with_a_transport_is_still_rejected(transport):
-    """The pre-existing rejection must survive the restructuring."""
-    with pytest.raises(ValueError, match="refit_transport"):
+    """The pre-existing rejection must survive the restructuring.
+
+    The two sparse transports get their own, older message on vLLM -- they are
+    a GRPO-only feature rather than an unwired one -- so match on the shared
+    tracking issue instead of on either wording.
+    """
+    with pytest.raises(ValueError, match="3275"):
         _run("vllm", transport)
 
 
@@ -78,7 +89,7 @@ def test_the_error_names_the_backend_that_was_configured():
     """A message that only says 'not supported by PPO' sends the reader to the
     vLLM branch, which is not where their config went wrong."""
     with pytest.raises(ValueError, match="sglang"):
-        _run("sglang", "nixl")
+        _run("sglang", "nccl_reshard")
 
 
 @pytest.mark.parametrize("backend", ["vllm", "sglang"])

--- a/tests/unit/algorithms/test_ppo_refit_transport_guard.py
+++ b/tests/unit/algorithms/test_ppo_refit_transport_guard.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PPO must reject ``refit_transport`` on every backend, not only on vLLM.
+
+The rejection lived inside ``if generation_config["backend"] == "vllm":``, but
+PPO also supports SGLang (``ppo.py`` asserts ``backend in ("vllm", "sglang")``),
+so the same YAML that raises under GRPO ran to completion under PPO with the
+transport silently dropped.
+
+CPU-only: the guard is at the top of ``setup``, above any cluster or model
+construction.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_rl.algorithms.ppo import setup
+
+# Anything that is not the default collective path.
+_TRANSPORTS = ["nixl", "nccl_reshard"]
+
+
+def _master_config(backend: str, transport):
+    generation = {"backend": backend}
+    if transport is not None:
+        generation["refit_transport"] = transport
+    return SimpleNamespace(
+        policy={"generation": generation},
+        value={},
+        env={},
+        loss_fn=SimpleNamespace(),
+        ppo=SimpleNamespace(),
+        data={},
+        logger={},
+        cluster={},
+    )
+
+
+def _run(backend: str, transport):
+    setup(
+        master_config=_master_config(backend, transport),
+        tokenizer=MagicMock(),
+        dataset=MagicMock(),
+        val_dataset=None,
+    )
+
+
+@pytest.mark.parametrize("transport", _TRANSPORTS)
+def test_sglang_with_a_transport_is_rejected(transport):
+    """This is the case that used to run silently."""
+    with pytest.raises(ValueError, match="refit_transport"):
+        _run("sglang", transport)
+
+
+@pytest.mark.parametrize("transport", _TRANSPORTS)
+def test_vllm_with_a_transport_is_still_rejected(transport):
+    """The pre-existing rejection must survive the restructuring."""
+    with pytest.raises(ValueError, match="refit_transport"):
+        _run("vllm", transport)
+
+
+def test_the_error_names_the_backend_that_was_configured():
+    """A message that only says 'not supported by PPO' sends the reader to the
+    vLLM branch, which is not where their config went wrong."""
+    with pytest.raises(ValueError, match="sglang"):
+        _run("sglang", "nixl")
+
+
+@pytest.mark.parametrize("backend", ["vllm", "sglang"])
+def test_no_transport_gets_past_the_guard(backend):
+    """The supported pairing. Setup fails later on the mocks, which is what
+    keeps this from passing vacuously if the guard were made unconditional."""
+    with pytest.raises(Exception) as excinfo:
+        _run(backend, None)
+    assert "refit_transport" not in str(excinfo.value)

--- a/tests/unit/algorithms/test_ppo_refit_transport_guard.py
+++ b/tests/unit/algorithms/test_ppo_refit_transport_guard.py
@@ -94,8 +94,6 @@ def test_the_error_names_the_backend_that_was_configured():
 
 @pytest.mark.parametrize("backend", ["vllm", "sglang"])
 def test_no_transport_gets_past_the_guard(backend):
-    """The supported pairing. Setup fails later on the mocks, which is what
-    keeps this from passing vacuously if the guard were made unconditional."""
-    with pytest.raises(Exception) as excinfo:
+    """The supported pairing reaches the next validation on the mock config."""
+    with pytest.raises(KeyError, match="megatron_cfg"):
         _run(backend, None)
-    assert "refit_transport" not in str(excinfo.value)


### PR DESCRIPTION
## What does this PR do?

Rejects `policy.generation.refit_transport` during PPO setup whenever the selected backend cannot honor it.

PPO already rejected explicit transports on vLLM. On SGLang, several values instead fell through to the default collective path and were silently ignored. The new guard fails during setup and names the selected backend.

`nixl` and custom checkpoint-engine classes remain handled by the existing weight-sync factory, which also rejects unsupported combinations during setup.

## Validation

Current head `962f04b80ec698a7901a69b83e7a574fd103fb34`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- `tests/unit/algorithms/test_ppo_refit_transport_guard.py`: **9 passed**
- exact error assertions cover dropped SGLang transports, preserve vLLM rejection, and allow the no-transport cases past this guard
- Ruff check, Ruff format check, and `git diff --check`: passed

This guard runs before cluster/model construction, so no GPU workload is required.
