### PR TITLE
feat: forward rollout session IDs to Dynamo

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -50,6 +50,7 @@ from nemo_rl.experience.failures import (
     RolloutDataFailure,
     http_status_is_infra,
 )
+from nemo_rl.models.generation.dynamo.token_wrapper import DYNAMO_SESSION_ID_HEADER
 from nemo_rl.models.generation.interfaces import (
     resolve_routed_experts_dtype_name_for_model,
     should_use_async_rollouts,
@@ -1254,6 +1255,15 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
     # Stop strings or token ids are not supported
     generation_config["stop_strings"] = None
     generation_config["stop_token_ids"] = None
+
+    if generation_config["backend"] == "dynamo":
+        model_config = (
+            config.env.setdefault("nemo_gym", {})
+            .setdefault("policy_model", {})
+            .setdefault("responses_api_models", {})
+            .setdefault("vllm_model", {})
+        )
+        model_config["session_id_header"] = DYNAMO_SESSION_ID_HEADER
 
     # For VLM runs, plumb the tokenizer config into the gym env config so the
     # NemoGym actor can reconstruct the processor inside itself (needed for

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -59,8 +59,10 @@ from nemo_rl.experience.rollout_recovery import (
 )
 from nemo_rl.experience.rollouts import (
     EffortLevelsConfig,
+    _add_dynamo_session_id,
     _apply_effort_shaping,
     _attach_routed_experts_to_message_log_prefix,
+    _create_dynamo_session_id,
     _dummy_routed_experts_for_tokens,
     _effort_shaping_metrics,
     _find_routed_experts_template,
@@ -466,6 +468,7 @@ class AsyncRolloutImpl:
         current_extra_env_info = copy.deepcopy(input_sample["extra_env_info"])
         current_stop_strings = input_sample.get("stop_strings", None)
         task_name = input_sample["task_name"]
+        session_id = _create_dynamo_session_id(self._policy_generation)
 
         total_reward = 0.0
         turn_count = 0
@@ -503,6 +506,7 @@ class AsyncRolloutImpl:
                 ) = await self._generate_response(
                     current_message_log,
                     current_stop_strings,
+                    session_id=session_id,
                 )
             except Exception as e:
                 raise _classify_generation_failure(
@@ -629,6 +633,8 @@ class AsyncRolloutImpl:
         self,
         message_log: list[dict],
         stop_strings: list[str] | None,
+        *,
+        session_id: str | None = None,
     ) -> tuple[dict, torch.Tensor, dict[str, Any]]:
         """Generate a single-turn response for one sample.
 
@@ -652,6 +658,11 @@ class AsyncRolloutImpl:
         )
         generation_input_data.update(
             flat_messages.get_multimodal_dict(as_tensors=False)
+        )
+        _add_dynamo_session_id(
+            generation_input_data,
+            self._policy_generation,
+            session_id,
         )
 
         # Generate response

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1239,6 +1239,8 @@ async def async_generate_response_for_sample_turn(
         tokenizer: Tokenizer to use
         max_seq_len: Maximum sequence length
         greedy: Whether to use greedy decoding
+        session_id: Stable Dynamo session ID reused across every turn of one
+            trajectory attempt. Ignored unless the generation backend is Dynamo.
         sample_multimodal_data: Native vLLM media fields for this sample.
         deduplicate_multimodal_data: Avoid sending both native and policy-ready
             media through the async generation boundary.

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Optional
+from uuid import uuid4
 
 import ray
 import torch
@@ -99,6 +100,25 @@ _REWARD_PENALTY_METRICS = {
         "malformed_think_tag_rate",
     ),
 }
+
+
+def _create_dynamo_session_id(
+    policy_generation: GenerationInterface,
+) -> str | None:
+    generation_config = getattr(policy_generation, "cfg", {})
+    if generation_config.get("backend") == "dynamo":
+        return str(uuid4())
+    return None
+
+
+def _add_dynamo_session_id(
+    generation_input_data: BatchedDataDict[GenerationDatumSpec],
+    policy_generation: GenerationInterface,
+    session_id: str | None,
+) -> None:
+    generation_config = getattr(policy_generation, "cfg", {})
+    if session_id is not None and generation_config.get("backend") == "dynamo":
+        generation_input_data["session_ids"] = [session_id]
 
 
 def attach_initial_nemo_gym_image_payloads(
@@ -1206,6 +1226,7 @@ async def async_generate_response_for_sample_turn(
     max_seq_len: int,
     greedy: bool = False,
     *,
+    session_id: str | None = None,
     sample_multimodal_data: dict[str, Any] | None = None,
     deduplicate_multimodal_data: bool = False,
 ) -> tuple[list[dict], torch.Tensor, torch.Tensor, dict[str, float]]:
@@ -1243,6 +1264,11 @@ async def async_generate_response_for_sample_turn(
             "input_lengths": input_lengths,
             "stop_strings": [sample_stop_strings],
         }
+    )
+    _add_dynamo_session_id(
+        generation_input_data,
+        policy_generation,
+        session_id,
     )
 
     # Create a dummy batch for generate_responses_async
@@ -1316,6 +1342,7 @@ async def run_sample_multi_turn_rollout(
     current_extra_env_info = copy.deepcopy(initial_sample_state["extra_env_info"])
     current_stop_strings = initial_sample_state.get("stop_strings", None)
     task_name = initial_sample_state["task_name"]
+    session_id = _create_dynamo_session_id(policy_generation)
     sample_multimodal_data = {
         key: initial_sample_state[key]
         for key in NATIVE_MULTIMODAL_KEYS
@@ -1366,6 +1393,7 @@ async def run_sample_multi_turn_rollout(
                 tokenizer,
                 max_seq_len,
                 greedy=greedy,
+                session_id=session_id,
                 sample_multimodal_data=turn_multimodal_data,
                 deduplicate_multimodal_data=deduplicate_multimodal_data,
             )

--- a/nemo_rl/models/generation/dynamo/dynamo_generation.py
+++ b/nemo_rl/models/generation/dynamo/dynamo_generation.py
@@ -459,11 +459,11 @@ class DynamoGeneration(GenerationInterface):
         )
         response: dict[str, Any] = {}
         for attempt in range(1, _HTTP_MAX_ATTEMPTS + 1):
-            request_kwargs: dict[str, Any] = {}
-            if request_headers is not None:
-                request_kwargs["headers"] = request_headers
             response = await async_http_post_json(
-                request_url, payload, self._request_timeout_s(), **request_kwargs
+                request_url,
+                payload,
+                self._request_timeout_s(),
+                headers=request_headers,
             )
             if not _is_retryable_http_response(response):
                 break

--- a/nemo_rl/models/generation/dynamo/dynamo_generation.py
+++ b/nemo_rl/models/generation/dynamo/dynamo_generation.py
@@ -30,7 +30,10 @@ from nemo_rl.models.generation.dynamo.http_client import (
 from nemo_rl.models.generation.dynamo.managed_runtime import ManagedDynamoRuntime
 from nemo_rl.models.generation.dynamo.metrics import DynamoMetricsSampler
 from nemo_rl.models.generation.dynamo.refit import DynamoRefitChannel
-from nemo_rl.models.generation.dynamo.token_wrapper import DynamoTokenWrapperServer
+from nemo_rl.models.generation.dynamo.token_wrapper import (
+    DYNAMO_SESSION_ID_HEADER,
+    DynamoTokenWrapperServer,
+)
 from nemo_rl.models.generation.interfaces import (
     CollectiveSenderSpec,
     GenerationDatumSpec,
@@ -442,6 +445,7 @@ class DynamoGeneration(GenerationInterface):
         greedy: bool,
         stop_strings: Optional[list[str]],
         max_new_tokens: int,
+        session_id: Optional[str] = None,
     ) -> tuple[list[int], list[float], bool]:
         request_url = self._completion_url()
         payload = self._build_completion_request(
@@ -450,12 +454,16 @@ class DynamoGeneration(GenerationInterface):
             stop_strings=stop_strings,
             max_new_tokens=max_new_tokens,
         )
+        request_headers = (
+            {DYNAMO_SESSION_ID_HEADER: session_id} if session_id is not None else None
+        )
         response: dict[str, Any] = {}
         for attempt in range(1, _HTTP_MAX_ATTEMPTS + 1):
+            request_kwargs: dict[str, Any] = {}
+            if request_headers is not None:
+                request_kwargs["headers"] = request_headers
             response = await async_http_post_json(
-                request_url,
-                payload,
-                self._request_timeout_s(),
+                request_url, payload, self._request_timeout_s(), **request_kwargs
             )
             if not _is_retryable_http_response(response):
                 break
@@ -570,6 +578,16 @@ class DynamoGeneration(GenerationInterface):
             "outside this method."
         )
         sample_idx = 0
+        session_ids = data.get("session_ids")
+        session_id = None
+        if session_ids is not None:
+            if len(session_ids) != batch_size:
+                raise ValueError(
+                    "Dynamo session_ids must contain one value for each input sample."
+                )
+            session_id = session_ids[sample_idx]
+            if not isinstance(session_id, str) or not session_id.strip():
+                raise ValueError("Dynamo session IDs must be non-empty strings.")
         input_length = int(input_lengths_batch[sample_idx].item())
         batch_stop_strings = data.get("stop_strings", [[] for _ in range(batch_size)])
         per_sample_stop_strings = None
@@ -590,6 +608,7 @@ class DynamoGeneration(GenerationInterface):
             greedy=greedy,
             stop_strings=final_stop_strings,
             max_new_tokens=allowed_new_tokens,
+            session_id=session_id,
         )
 
         yield (

--- a/nemo_rl/models/generation/dynamo/http_client.py
+++ b/nemo_rl/models/generation/dynamo/http_client.py
@@ -17,6 +17,7 @@
 import json
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from typing import Any
 
 import aiohttp
@@ -63,13 +64,20 @@ def http_post_json(
 
 
 async def async_http_post_json(
-    url: str, payload: dict[str, Any], timeout_s: float
+    url: str,
+    payload: dict[str, Any],
+    timeout_s: float,
+    *,
+    headers: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """POST JSON without blocking the rollout actor event loop."""
     timeout = aiohttp.ClientTimeout(total=timeout_s)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(url, json=payload) as response:
+            request_kwargs: dict[str, Any] = {"json": payload}
+            if headers is not None:
+                request_kwargs["headers"] = headers
+            async with session.post(url, **request_kwargs) as response:
                 body = await response.read()
                 if response.status >= 400:
                     return {

--- a/nemo_rl/models/generation/dynamo/http_client.py
+++ b/nemo_rl/models/generation/dynamo/http_client.py
@@ -74,10 +74,7 @@ async def async_http_post_json(
     timeout = aiohttp.ClientTimeout(total=timeout_s)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            request_kwargs: dict[str, Any] = {"json": payload}
-            if headers is not None:
-                request_kwargs["headers"] = headers
-            async with session.post(url, **request_kwargs) as response:
+            async with session.post(url, json=payload, headers=headers) as response:
                 body = await response.read()
                 if response.status >= 400:
                     return {

--- a/nemo_rl/models/generation/dynamo/token_wrapper.py
+++ b/nemo_rl/models/generation/dynamo/token_wrapper.py
@@ -35,6 +35,7 @@ _GYM_TOKEN_METADATA_FIELDS = (
     "generation_log_probs",
 )
 _TOOL_ARGUMENT_MAPPING_ERROR = "Can only get item pairs from a mapping."
+DYNAMO_SESSION_ID_HEADER = "X-Dynamo-Session-ID"
 
 
 def _coerce_token_id_list(value: Any, field_name: str) -> list[int]:
@@ -474,6 +475,7 @@ class DynamoTokenWrapperServer:
             status_code, response_body = await self._forward_chat_completion(
                 prepared_body,
                 authorization=request.headers.get("authorization"),
+                session_id=request.headers.get("x-dynamo-session-id"),
             )
             if 200 <= status_code < 300:
                 try:
@@ -512,6 +514,7 @@ class DynamoTokenWrapperServer:
         request_body: dict[str, Any],
         *,
         authorization: Optional[str],
+        session_id: Optional[str] = None,
     ) -> tuple[int, dict[str, Any]]:
         import aiohttp
 
@@ -519,6 +522,8 @@ class DynamoTokenWrapperServer:
         headers = {"Content-Type": "application/json"}
         if authorization:
             headers["Authorization"] = authorization
+        if session_id:
+            headers[DYNAMO_SESSION_ID_HEADER] = session_id
 
         session = self._client_session
         if session is None:

--- a/nemo_rl/models/generation/dynamo/token_wrapper.py
+++ b/nemo_rl/models/generation/dynamo/token_wrapper.py
@@ -475,7 +475,7 @@ class DynamoTokenWrapperServer:
             status_code, response_body = await self._forward_chat_completion(
                 prepared_body,
                 authorization=request.headers.get("authorization"),
-                session_id=request.headers.get("x-dynamo-session-id"),
+                session_id=request.headers.get(DYNAMO_SESSION_ID_HEADER),
             )
             if 200 <= status_code < 300:
                 try:

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -309,7 +309,7 @@ class GenerationDatumSpec(TypedDict):
     - input_ids: Tensor of token IDs representing the input sequences (right padded)
     - input_lengths: Tensor containing the actual length of each sequence (without padding)
     - stop_strings: Optional list of strings to stop generation (per sample)
-    - session_ids: Optional stable request session ID for each sample
+    - session_ids: Optional per-sample stable session IDs; honored only by the Dynamo backend
     - __extra__: Additional model-specific data fields
 
     Example of a batch with 4 entries with different sequence lengths:

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -309,6 +309,7 @@ class GenerationDatumSpec(TypedDict):
     - input_ids: Tensor of token IDs representing the input sequences (right padded)
     - input_lengths: Tensor containing the actual length of each sequence (without padding)
     - stop_strings: Optional list of strings to stop generation (per sample)
+    - session_ids: Optional stable request session ID for each sample
     - __extra__: Additional model-specific data fields
 
     Example of a batch with 4 entries with different sequence lengths:
@@ -334,6 +335,7 @@ class GenerationDatumSpec(TypedDict):
     input_ids: torch.Tensor
     input_lengths: torch.Tensor
     stop_strings: NotRequired[list[str]]
+    session_ids: NotRequired[list[str]]
     __extra__: Any
 
 

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -1029,25 +1029,43 @@ def test_validate_reward_components_match_scalar():
         )
 
 
-@pytest.mark.parametrize("backend", ["dynamo", "vllm"])
-def test_setup_nemo_gym_config_sets_session_header_only_for_dynamo(backend) -> None:
+def test_setup_nemo_gym_config_merges_session_header_for_dynamo() -> None:
     config = SimpleNamespace(
-        policy={"generation": {"backend": backend, "vllm_cfg": {}}},
+        policy={"generation": {"backend": "dynamo", "vllm_cfg": {}}},
+        env={
+            "nemo_gym": {
+                "num_gpu_nodes": 2,
+                "policy_model": {
+                    "responses_api_models": {
+                        "vllm_model": {"model_name": "keep-me"},
+                        "other_model": {"model_name": "untouched"},
+                    }
+                },
+            }
+        },
+    )
+
+    setup_nemo_gym_config(config, tokenizer=object())
+
+    nemo_gym = config.env["nemo_gym"]
+    responses_api_models = nemo_gym["policy_model"]["responses_api_models"]
+    assert responses_api_models["vllm_model"] == {
+        "model_name": "keep-me",
+        "session_id_header": DYNAMO_SESSION_ID_HEADER,
+    }
+    assert responses_api_models["other_model"] == {"model_name": "untouched"}
+    assert nemo_gym["num_gpu_nodes"] == 2
+
+
+def test_setup_nemo_gym_config_does_not_set_session_header_for_vllm() -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "vllm", "vllm_cfg": {}}},
         env={},
     )
 
     setup_nemo_gym_config(config, tokenizer=object())
-    setup_nemo_gym_config(config, tokenizer=object())
 
-    if backend == "dynamo":
-        assert (
-            config.env["nemo_gym"]["policy_model"]["responses_api_models"][
-                "vllm_model"
-            ]["session_id_header"]
-            == DYNAMO_SESSION_ID_HEADER
-        )
-    else:
-        assert config.env == {}
+    assert config.env == {}
 
 
 @pytest.mark.nemo_gym

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -65,6 +65,7 @@ from nemo_rl.experience.rollouts import (
     _reattach_original_multimodal_payloads,
     attach_static_multimodal_payload,
 )
+from nemo_rl.models.generation.dynamo.token_wrapper import DYNAMO_SESSION_ID_HEADER
 from nemo_rl.models.generation.vllm import VllmGeneration
 
 # cluster and tokenizer are fixture imports
@@ -1026,6 +1027,27 @@ def test_validate_reward_components_match_scalar():
                 },
             ]
         )
+
+
+@pytest.mark.parametrize("backend", ["dynamo", "vllm"])
+def test_setup_nemo_gym_config_sets_session_header_only_for_dynamo(backend) -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": backend, "vllm_cfg": {}}},
+        env={},
+    )
+
+    setup_nemo_gym_config(config, tokenizer=object())
+    setup_nemo_gym_config(config, tokenizer=object())
+
+    if backend == "dynamo":
+        assert (
+            config.env["nemo_gym"]["policy_model"]["responses_api_models"][
+                "vllm_model"
+            ]["session_id_header"]
+            == DYNAMO_SESSION_ID_HEADER
+        )
+    else:
+        assert config.env == {}
 
 
 @pytest.mark.nemo_gym

--- a/tests/unit/experience/test_rollout_manager_router_replay.py
+++ b/tests/unit/experience/test_rollout_manager_router_replay.py
@@ -224,7 +224,7 @@ def test_second_turn_overwrites_prefix_fallback_routes() -> None:
     assert torch.equal(final_env["routed_experts"], _fallback_routes(2))
 
 
-def test_dynamo_session_id_is_stable_per_trajectory_attempt() -> None:
+def test_dynamo_session_id_is_stable_across_turns_and_distinct_for_siblings() -> None:
     second_turn_output = _generation_output(
         (10, 11, 12, 20, 21, 31, 32, 40, 41),
         route_start=100,
@@ -233,7 +233,6 @@ def test_dynamo_session_id_is_stable_per_trajectory_attempt() -> None:
         [
             _generation_output(),
             second_turn_output,
-            _generation_output(),
             _generation_output(),
         ],
         max_rollout_turns=2,
@@ -269,22 +268,19 @@ def test_dynamo_session_id_is_stable_per_trajectory_attempt() -> None:
                 env_output(terminated=False),
                 env_output(terminated=True),
                 env_output(terminated=True),
-                env_output(terminated=True),
             ],
         ),
         patch(
             "nemo_rl.experience.rollouts.uuid4",
-            side_effect=["attempt-a", "sibling-b", "retry-c"],
+            side_effect=["attempt-a", "sibling-b"],
         ),
     ):
         asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
         asyncio.run(impl._run_single_rollout(input_sample, traj_idx=1))
-        asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
 
     generation = impl._policy_generation
     assert [call["session_ids"][0] for call in generation.calls] == [
         "attempt-a",
         "attempt-a",
         "sibling-b",
-        "retry-c",
     ]

--- a/tests/unit/experience/test_rollout_manager_router_replay.py
+++ b/tests/unit/experience/test_rollout_manager_router_replay.py
@@ -50,12 +50,20 @@ class _FakeTokenizer:
 
 
 class _FakeGeneration:
-    def __init__(self, outputs: BatchedDataDict | list[BatchedDataDict]) -> None:
+    def __init__(
+        self,
+        outputs: BatchedDataDict | list[BatchedDataDict],
+        *,
+        backend: str | None = None,
+    ) -> None:
         self._outputs = outputs if isinstance(outputs, list) else [outputs]
         self._next_output = 0
+        self.calls = []
+        if backend is not None:
+            self.cfg = {"backend": backend}
 
     async def generate_async(self, data: BatchedDataDict):
-        del data
+        self.calls.append(data)
         output = self._outputs[self._next_output]
         self._next_output += 1
         yield 0, output
@@ -65,6 +73,7 @@ def _rollout_impl(
     output: BatchedDataDict | list[BatchedDataDict],
     *,
     max_rollout_turns: int = 1,
+    backend: str | None = None,
 ) -> AsyncRolloutImpl:
     return AsyncRolloutImpl(
         tokenizer=_FakeTokenizer(),  # type: ignore[arg-type]
@@ -72,7 +81,7 @@ def _rollout_impl(
         num_generations_per_prompt=1,
         max_seq_len=32,
         max_rollout_turns=max_rollout_turns,
-        policy_generation=_FakeGeneration(output),  # type: ignore[arg-type]
+        policy_generation=_FakeGeneration(output, backend=backend),  # type: ignore[arg-type]
     )
 
 
@@ -213,3 +222,69 @@ def test_second_turn_overwrites_prefix_fallback_routes() -> None:
         torch.cat((_routes(1, start=107), _fallback_routes(1))),
     )
     assert torch.equal(final_env["routed_experts"], _fallback_routes(2))
+
+
+def test_dynamo_session_id_is_stable_per_trajectory_attempt() -> None:
+    second_turn_output = _generation_output(
+        (10, 11, 12, 20, 21, 31, 32, 40, 41),
+        route_start=100,
+    )
+    impl = _rollout_impl(
+        [
+            _generation_output(),
+            second_turn_output,
+            _generation_output(),
+            _generation_output(),
+        ],
+        max_rollout_turns=2,
+        backend="dynamo",
+    )
+    input_sample = {
+        "idx": 0,
+        "message_log": [
+            {
+                "role": "user",
+                "content": "prompt",
+                "token_ids": torch.tensor([10, 11, 12]),
+            }
+        ],
+        "extra_env_info": None,
+        "task_name": "test",
+    }
+
+    def env_output(*, terminated: bool) -> EnvironmentReturn:
+        return EnvironmentReturn(
+            observations=[{"role": "user", "content": "environment"}],
+            metadata=[None],
+            next_stop_strings=[None],
+            rewards=torch.tensor([0.0]),
+            terminateds=torch.tensor([terminated]),
+            answers=[None],
+        )
+
+    with (
+        patch(
+            "nemo_rl.experience.rollout_manager.calculate_rewards",
+            side_effect=[
+                env_output(terminated=False),
+                env_output(terminated=True),
+                env_output(terminated=True),
+                env_output(terminated=True),
+            ],
+        ),
+        patch(
+            "nemo_rl.experience.rollouts.uuid4",
+            side_effect=["attempt-a", "sibling-b", "retry-c"],
+        ),
+    ):
+        asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
+        asyncio.run(impl._run_single_rollout(input_sample, traj_idx=1))
+        asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
+
+    generation = impl._policy_generation
+    assert [call["session_ids"][0] for call in generation.calls] == [
+        "attempt-a",
+        "attempt-a",
+        "sibling-b",
+        "retry-c",
+    ]

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -19,6 +19,7 @@ import tempfile
 from copy import deepcopy
 from dataclasses import asdict
 from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 import ray
@@ -58,6 +59,7 @@ from nemo_rl.experience.rollout_manager import (
 )
 from nemo_rl.experience.rollouts import (
     _add_multimodal_generation_payload,
+    _create_dynamo_session_id,
     _reattach_original_multimodal_payloads,
     async_generate_response_for_sample_turn,
     generate_responses_async,
@@ -871,6 +873,16 @@ class _DummyDynamoGeneration(_DummySGLangGeneration):
         self.generation_input = data
         async for item in super().generate_async(data, greedy=greedy):
             yield item
+
+
+def test_create_dynamo_session_id_mints_a_real_uuid_string() -> None:
+    session_id = _create_dynamo_session_id(_DummyDynamoGeneration())
+
+    assert isinstance(session_id, str)
+    assert UUID(session_id).version == 4
+    assert session_id != _create_dynamo_session_id(_DummyDynamoGeneration())
+    assert _create_dynamo_session_id(_CapturingAsyncVllmGeneration()) is None
+    assert _create_dynamo_session_id(object()) is None
 
 
 def test_direct_session_id_is_added_only_for_dynamo() -> None:

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -779,6 +779,7 @@ def test_async_vlm_multiturn_drops_stale_native_content(
         max_seq_len,
         greedy=False,
         *,
+        session_id=None,
         sample_multimodal_data=None,
         deduplicate_multimodal_data=False,
     ):
@@ -864,6 +865,39 @@ def test_async_vlm_multiturn_drops_stale_native_content(
 class _DummyDynamoGeneration(_DummySGLangGeneration):
     def __init__(self):
         self.cfg = {"backend": "dynamo"}
+        self.generation_input = None
+
+    async def generate_async(self, data, greedy=False):
+        self.generation_input = data
+        async for item in super().generate_async(data, greedy=greedy):
+            yield item
+
+
+def test_direct_session_id_is_added_only_for_dynamo() -> None:
+    message_log = [
+        {
+            "role": "user",
+            "content": "prompt",
+            "token_ids": torch.tensor([1]),
+        }
+    ]
+    dynamo_generation = _DummyDynamoGeneration()
+    vllm_generation = _CapturingAsyncVllmGeneration()
+
+    for generation in (dynamo_generation, vllm_generation):
+        asyncio.run(
+            async_generate_response_for_sample_turn(
+                generation,
+                message_log,
+                None,
+                _DummyTokenizer(),
+                max_seq_len=32,
+                session_id="trajectory-session",
+            )
+        )
+
+    assert dynamo_generation.generation_input["session_ids"] == ["trajectory-session"]
+    assert "session_ids" not in vllm_generation.generation_input
 
 
 def test_generate_responses_async_requires_sglang_opt_in():

--- a/tests/unit/models/generation/test_dynamo_generation.py
+++ b/tests/unit/models/generation/test_dynamo_generation.py
@@ -211,8 +211,19 @@ def test_blocking_generate_is_rejected_and_async_generation_uses_http(
     assert requests[0][3]["headers"] == {"X-Dynamo-Session-ID": "trajectory-session"}
 
 
-@pytest.mark.parametrize("session_ids", [[], [""]])
-def test_async_generation_rejects_invalid_session_ids(monkeypatch, session_ids) -> None:
+@pytest.mark.parametrize(
+    ("session_ids", "expected_message"),
+    [
+        ([], "one value for each input sample"),
+        (["a", "b"], "one value for each input sample"),
+        ([""], "must be non-empty strings"),
+        (["   "], "must be non-empty strings"),
+        ([None], "must be non-empty strings"),
+    ],
+)
+def test_async_generation_rejects_invalid_session_ids(
+    monkeypatch, session_ids, expected_message
+) -> None:
     _patch_runtime(monkeypatch)
     generation = DynamoGeneration(cluster=object(), config=_config())
     data = _data()
@@ -221,7 +232,7 @@ def test_async_generation_rejects_invalid_session_ids(monkeypatch, session_ids) 
     async def collect():
         return [item async for item in generation.generate_async(data)]
 
-    with pytest.raises(ValueError, match="Dynamo session"):
+    with pytest.raises(ValueError, match=expected_message):
         asyncio.run(collect())
 
 
@@ -506,7 +517,7 @@ def test_completion_retry_stops_on_nonretryable_or_exhaustion(
     _patch_runtime(monkeypatch)
     calls = []
 
-    async def fake_post(*args):
+    async def fake_post(*args, **kwargs):
         calls.append(args)
         return {"status": "error", "http_status": status}
 
@@ -539,7 +550,7 @@ def test_direct_completions_are_not_limited_by_default_thread_pool(
     all_entered = asyncio.Event()
     release = asyncio.Event()
 
-    async def fake_post(*args):
+    async def fake_post(*args, **kwargs):
         nonlocal entered_count
         entered_count += 1
         if entered_count == request_count:

--- a/tests/unit/models/generation/test_dynamo_generation.py
+++ b/tests/unit/models/generation/test_dynamo_generation.py
@@ -128,14 +128,17 @@ def _patch_runtime(
     monkeypatch.setattr(generation_module, "ManagedDynamoRuntime", FakeRuntime)
 
 
-def _data() -> BatchedDataDict:
-    return BatchedDataDict(
+def _data(*, session_id: str | None = None) -> BatchedDataDict:
+    data = BatchedDataDict(
         {
             "input_ids": torch.tensor([[1, 2, 3, 0]], dtype=torch.long),
             "input_lengths": torch.tensor([3], dtype=torch.long),
             "stop_strings": [["stop"]],
         }
     )
+    if session_id is not None:
+        data["session_ids"] = [session_id]
+    return data
 
 
 def _completion_response(token_ids: list[int]) -> dict[str, Any]:
@@ -181,8 +184,8 @@ def test_blocking_generate_is_rejected_and_async_generation_uses_http(
     _patch_runtime(monkeypatch)
     requests = []
 
-    async def fake_post(url, payload, timeout_s):
-        requests.append((url, payload, timeout_s))
+    async def fake_post(url, payload, timeout_s, **kwargs):
+        requests.append((url, payload, timeout_s, kwargs))
         return _completion_response([8, 9])
 
     monkeypatch.setattr(generation_module, "async_http_post_json", fake_post)
@@ -191,7 +194,12 @@ def test_blocking_generate_is_rejected_and_async_generation_uses_http(
         generation.generate(_data())
 
     async def collect():
-        return [item async for item in generation.generate_async(_data())]
+        return [
+            item
+            async for item in generation.generate_async(
+                _data(session_id="trajectory-session")
+            )
+        ]
 
     outputs = asyncio.run(collect())
     assert outputs[0][0] == 0
@@ -200,6 +208,21 @@ def test_blocking_generate_is_rejected_and_async_generation_uses_http(
     assert requests[0][1]["max_tokens"] == 2
     assert requests[0][1]["stop"] == ["stop"]
     assert "return_tokens_as_token_ids" not in requests[0][1]
+    assert requests[0][3]["headers"] == {"X-Dynamo-Session-ID": "trajectory-session"}
+
+
+@pytest.mark.parametrize("session_ids", [[], [""]])
+def test_async_generation_rejects_invalid_session_ids(monkeypatch, session_ids) -> None:
+    _patch_runtime(monkeypatch)
+    generation = DynamoGeneration(cluster=object(), config=_config())
+    data = _data()
+    data["session_ids"] = session_ids
+
+    async def collect():
+        return [item async for item in generation.generate_async(data)]
+
+    with pytest.raises(ValueError, match="Dynamo session"):
+        asyncio.run(collect())
 
 
 def test_prompt_at_context_limit_is_rejected(monkeypatch) -> None:
@@ -447,8 +470,8 @@ def test_completion_retry_eventually_succeeds(monkeypatch) -> None:
     )
     calls = []
 
-    async def fake_post(*args):
-        calls.append(args)
+    async def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
         return next(responses)
 
     async def no_sleep(_):
@@ -464,11 +487,16 @@ def test_completion_retry_eventually_succeeds(monkeypatch) -> None:
             greedy=False,
             stop_strings=None,
             max_new_tokens=1,
+            session_id="trajectory-session",
         )
     )
 
     assert token_ids == [8]
     assert len(calls) == 2
+    assert [call[1]["headers"] for call in calls] == [
+        {"X-Dynamo-Session-ID": "trajectory-session"},
+        {"X-Dynamo-Session-ID": "trajectory-session"},
+    ]
 
 
 @pytest.mark.parametrize("status", [400, 503])

--- a/tests/unit/models/generation/test_dynamo_http_client.py
+++ b/tests/unit/models/generation/test_dynamo_http_client.py
@@ -65,8 +65,8 @@ class _AsyncSession:
     async def __aexit__(self, *args):
         return None
 
-    def post(self, url, *, json):
-        self.requests.append((url, json))
+    def post(self, url, *, json, headers=None):
+        self.requests.append((url, json, headers))
         if self._error is not None:
             raise self._error
         return self._response
@@ -191,7 +191,34 @@ def test_async_http_post_json_uses_same_error_contract(
 
     assert response == expected
     assert generation_module._is_retryable_http_response(response) is retryable
-    assert session.requests == [("http://worker/route", {"value": 1})]
+    assert session.requests == [("http://worker/route", {"value": 1}, None)]
+
+
+def test_async_http_post_json_forwards_headers(monkeypatch) -> None:
+    session = _AsyncSession(_AsyncResponse(b'{"status":"ok"}'))
+    monkeypatch.setattr(
+        http_client.aiohttp,
+        "ClientSession",
+        lambda **kwargs: session,
+    )
+
+    response = asyncio.run(
+        http_client.async_http_post_json(
+            "http://worker/route",
+            {"value": 1},
+            timeout_s=3,
+            headers={"X-Dynamo-Session-ID": "trajectory-session"},
+        )
+    )
+
+    assert response == {"status": "ok"}
+    assert session.requests == [
+        (
+            "http://worker/route",
+            {"value": 1},
+            {"X-Dynamo-Session-ID": "trajectory-session"},
+        )
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/generation/test_dynamo_token_wrapper.py
+++ b/tests/unit/models/generation/test_dynamo_token_wrapper.py
@@ -638,9 +638,15 @@ def test_forward_chat_completion_reuses_loop_bound_session() -> None:
 
     async def forward_twice():
         await server._forward_chat_completion({}, authorization=None)
-        await server._forward_chat_completion({}, authorization="Bearer token")
+        await server._forward_chat_completion(
+            {},
+            authorization="Bearer token",
+            session_id="trajectory-session",
+        )
 
     asyncio.run(forward_twice())
 
     assert len(session.calls) == 2
+    assert "X-Dynamo-Session-ID" not in session.calls[0][2]
     assert session.calls[1][2]["Authorization"] == "Bearer token"
+    assert session.calls[1][2]["X-Dynamo-Session-ID"] == "trajectory-session"


### PR DESCRIPTION
# What does this PR do ?

Forward stable rollout session IDs to Dynamo for NeMo-Gym and direct NeMo-RL rollouts.

- NeMo-Gym reuses its stable session UUID and sends it through the Dynamo token wrapper.
- Direct rollouts create one UUID per trajectory attempt and reuse it across turns and HTTP retries.
- Sibling trajectories and complete-trajectory retries receive different IDs.
- Only Dynamo receives `X-Dynamo-Session-ID`; other backends and Dynamo routing policy are unchanged.
- Pin Gym to `NVIDIA-NeMo/Gym@cc8ec02281a590ff9e5111acae8d70fe1dd354ab` for optional session-header support.

This PR is transport-only. Session affinity remains opt-in through the existing `frontend_args.extra_cli_args` escape hatch. It does not add an affinity default, tracing controls, or a new routing policy.

# Issues

None.

# Usage

No user configuration is required for header forwarding. Dynamo-backed Gym and direct rollouts add the session header automatically. Users who want session affinity can configure the existing Dynamo frontend CLI escape hatch.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Read and followed the contributor guidelines.
- [x] Added focused tests for Gym configuration, wrapper forwarding, direct rollout identity, and Dynamo HTTP forwarding.
- [ ] Functional and GPU tests were not run. The focused CPU unit tests pass.
- [x] No documentation update is required because this does not add a user-facing option.

# Additional Information

Validation:

- Gym VLLM model test file: 126 passed.
- NeMo-RL affected unit-test files: 138 passed.
- Scoped Gym and NeMo-RL pre-commit checks passed, including pyrefly.
- `uv sync --locked` passed.
- The new Gym pin is a fast-forward from the current upstream NeMo-RL Gym pin.
- A fresh fetch of the exact Gym SHA from the official Gym URL passed.
- No GPU test was run.