### PR TITLE
  fix(megatron): refit before awaiting NeMo Gym startup

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1273,6 +1273,31 @@ def setup(
         )
         return mg, time.perf_counter() - t0
 
+    def init_megatron_weight_synchronizer(
+        policy: ColocatablePolicyInterface,
+        policy_generation: MegatronGeneration,
+    ) -> None:
+        """Initialize Megatron refit and load non-colocated generation weights."""
+        t0 = time.perf_counter()
+        weight_synchronizer = create_weight_synchronizer(
+            policy=policy,
+            generation=policy_generation,
+            generation_backend="megatron",
+            colocated=colocated_inference,
+            train_cluster=train_cluster,
+            inference_cluster=None if colocated_inference else inference_cluster,
+        )
+        policy_generation.weight_synchronizer = weight_synchronizer
+        weight_synchronizer.init_communicator()
+        setup_timing_metrics.collective_init_time_s = time.perf_counter() - t0
+        if not colocated_inference:
+            # The skip-load inference engine gets its final weight buffers here.
+            # Its first prepare_for_generation also starts the HTTP server only
+            # after the refit, so CUDA graphs capture those persistent buffers.
+            t0 = time.perf_counter()
+            weight_synchronizer.sync_weights()
+            setup_timing_metrics.weight_sync_time_s = time.perf_counter() - t0
+
     def initialize_generation_with_policy(
         init_generation_fn,
         colocated_inference: bool,
@@ -1382,16 +1407,21 @@ def setup(
                     nemo_gym_future = executor.submit(init_nemo_gym)
                     policy, policy_time = policy_future.result()
                     policy_generation, megatron_gen_time = generation_future.result()
+                    if not colocated_inference:
+                        setup_timing_metrics.parallel_wall_time_s = (
+                            time.perf_counter() - init_tasks_t0
+                        )
+                        setup_timing_metrics.parallel_init_enabled = 1.0
+                        # NeMo Gym probes the pre-published endpoint before its
+                        # future completes. A skip-load Megatron endpoint starts
+                        # only during this initial refit, so it must happen while
+                        # Gym is waiting rather than after its future resolves.
+                        init_megatron_weight_synchronizer(policy, policy_generation)
                     nemo_gym_actor, nemo_gym_time = nemo_gym_future.result()
             finally:
                 ray.kill(port_holder)
 
-            if not colocated_inference:
-                setup_timing_metrics.parallel_wall_time_s = (
-                    time.perf_counter() - init_tasks_t0
-                )
-                setup_timing_metrics.parallel_init_enabled = 1.0
-            else:
+            if colocated_inference:
                 setup_timing_metrics.parallel_init_enabled = 0.0
             setup_timing_metrics.policy_init_time_s = policy_time
             setup_timing_metrics.generation_init_time_s = (
@@ -1659,22 +1689,8 @@ def setup(
         )
 
     if backend == "megatron":
-        t0 = time.perf_counter()
-        policy_generation.weight_synchronizer = create_weight_synchronizer(
-            policy=policy,
-            generation=policy_generation,
-            generation_backend=backend,
-            colocated=colocated_inference,
-            train_cluster=train_cluster,
-            inference_cluster=None if colocated_inference else inference_cluster,
-        )
-        policy_generation.weight_synchronizer.init_communicator()
-        setup_timing_metrics.collective_init_time_s = time.perf_counter() - t0
-        if not colocated_inference:
-            # Load the model weights now.
-            t0 = time.perf_counter()
-            policy_generation.weight_synchronizer.sync_weights()
-            setup_timing_metrics.weight_sync_time_s = time.perf_counter() - t0
+        if policy_generation.weight_synchronizer is None:
+            init_megatron_weight_synchronizer(policy, policy_generation)
         if enable_nemo_gym:
             served_urls = policy_generation.dp_openai_server_base_urls
             if served_urls != [reserved_url]:

--- a/tests/functional/grpo_megatron_mxfp8_refit_gb200.sh
+++ b/tests/functional/grpo_megatron_mxfp8_refit_gb200.sh
@@ -110,7 +110,7 @@ uv run tests/check_metrics.py "$JSON_METRICS" \
     'len(data["train/gen_kl_error"]) == 2' \
     'max(data["train/gen_kl_error"]) < 0.15' \
     'len(data["train/token_mult_prob_error"]) == 2' \
-    'max(data["train/token_mult_prob_error"]) < 2.0'
+    'max(data["train/token_mult_prob_error"]) < 1.5'
 
 assert_grep 'cuda graph warmup' "$RUN_LOG"
 

--- a/tests/functional/grpo_megatron_mxfp8_refit_gb200.sh
+++ b/tests/functional/grpo_megatron_mxfp8_refit_gb200.sh
@@ -97,17 +97,19 @@ uv run coverage run -a --data-file="$PROJECT_ROOT/tests/.coverage" --source="$PR
 
 uv run tests/json_dump_tb_logs.py "$LOG_DIR" --output_path "$JSON_METRICS"
 
-# The setup timing proves that the initial load ran, while the per-step transfer
-# timing proves that the post-update refit ran. Raw rollout log-probs are compared
-# against BF16 policy recomputation; the bounds allow the established MXFP8
-# quantization delta while rejecting a bad refit.
+# The setup weight-sync timing proves that the initial refit ran, while the
+# per-step transfer timing proves that the post-update refit ran. Raw rollout
+# log-probs are compared against BF16 policy recomputation; the bounds allow the
+# established MXFP8 quantization delta while rejecting a bad refit.
 uv run tests/check_metrics.py "$JSON_METRICS" \
     'len(data["train/loss"]) == 2' \
-    'len(data["timing/setup/generation_init_load_time_s"]) == 1' \
-    'min(data["timing/setup/generation_init_load_time_s"]) > 0' \
+    'len(data["timing/setup/weight_sync_time_s"]) == 1' \
+    'min(data["timing/setup/weight_sync_time_s"]) > 0' \
     'len(data["timing/train/prepare_for_generation/transfer_and_update_weights"]) == 1' \
     'min(data["timing/train/prepare_for_generation/transfer_and_update_weights"]) > 0' \
+    'len(data["train/gen_kl_error"]) == 2' \
     'max(data["train/gen_kl_error"]) < 0.15' \
+    'len(data["train/token_mult_prob_error"]) == 2' \
     'max(data["train/token_mult_prob_error"]) < 2.0'
 
 assert_grep 'cuda graph warmup' "$RUN_LOG"

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -15,6 +15,8 @@
 import os
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
+from threading import Event
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -3142,6 +3144,129 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
         routed_experts_dtype="int16",
         use_fastokens=False,
     )
+
+
+def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
+    monkeypatch, mock_grpo_components
+):
+    """The initial refit must start a skip-load endpoint before Gym can finish."""
+    from nemo_rl.algorithms import grpo as grpo_mod
+
+    events = []
+    gym_started = Event()
+    engine_ready = Event()
+    checkpointer = MagicMock()
+    checkpointer.get_latest_checkpoint_path.return_value = None
+    checkpointer.load_training_info.return_value = None
+    checkpointer.get_resume_paths.return_value = (None, None)
+
+    reserved_url = "http://megatron.example/v1"
+    port_holder = object()
+    generation = SimpleNamespace(
+        weight_synchronizer=None,
+        dp_openai_server_base_urls=[],
+    )
+    generation_cls = MagicMock(return_value=generation)
+    generation_cls.reserve_http_server_address.return_value = (
+        reserved_url,
+        1234,
+        port_holder,
+    )
+
+    synchronizer = MagicMock()
+    synchronizer.init_communicator.side_effect = lambda: events.append("init")
+
+    def sync_weights():
+        assert gym_started.wait(timeout=5), "NeMo Gym did not start concurrently"
+        events.append("sync")
+        generation.dp_openai_server_base_urls = [reserved_url]
+        engine_ready.set()
+
+    synchronizer.sync_weights.side_effect = sync_weights
+    nemo_gym_actor = object()
+
+    def spinup_nemo_gym_actor(**kwargs):
+        assert kwargs["base_urls"] == [reserved_url]
+        events.append("gym_started")
+        gym_started.set()
+        assert engine_ready.wait(timeout=5), (
+            "NeMo Gym waited for an endpoint that the initial refit never started"
+        )
+        events.append("gym_ready")
+        return nemo_gym_actor
+
+    logger = MagicMock()
+    policy_cls = MagicMock(return_value=MagicMock())
+    ray_kill = MagicMock()
+    monkeypatch.setattr(grpo_mod, "Logger", lambda *_args, **_kwargs: logger)
+    monkeypatch.setattr(
+        grpo_mod, "CheckpointManager", lambda *_args, **_kwargs: checkpointer
+    )
+    monkeypatch.setattr(
+        grpo_mod, "ClippedPGLossFn", lambda *_args, **_kwargs: MagicMock()
+    )
+    monkeypatch.setattr(
+        grpo_mod, "StatefulDataLoader", lambda *_args, **_kwargs: [None]
+    )
+    monkeypatch.setattr(grpo_mod, "RayVirtualCluster", MagicMock)
+    monkeypatch.setattr(grpo_mod, "Policy", policy_cls)
+    monkeypatch.setattr(grpo_mod, "MegatronGeneration", generation_cls)
+    monkeypatch.setattr(
+        grpo_mod, "create_weight_synchronizer", lambda **_kwargs: synchronizer
+    )
+    monkeypatch.setattr(grpo_mod, "spinup_nemo_gym_actor", spinup_nemo_gym_actor)
+    monkeypatch.setattr(grpo_mod.ray, "kill", ray_kill)
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.policy["model_name"] = "test-model"
+    master_config.policy["tokenizer"] = {"use_fastokens": False}
+    master_config.policy["dtensor_cfg"] = {"enabled": False}
+    master_config.policy["megatron_cfg"] = {
+        "enabled": False,
+        "pipeline_model_parallel_size": 1,
+    }
+    master_config.policy["generation"] = {
+        "backend": "megatron",
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "top_k": None,
+        "val_temperature": 1.0,
+        "val_top_p": 1.0,
+        "val_top_k": None,
+        "colocated": {
+            "enabled": False,
+            "resources": {"gpus_per_node": 1, "num_nodes": 1},
+        },
+        "mcore_generation_config": {"expose_http_server": True},
+    }
+    master_config.env = {"should_use_nemo_gym": True}
+    master_config.loss_fn = ClippedPGLossConfig(reference_policy_kl_penalty=0.0)
+    master_config.grpo.val_period = 0
+    master_config.grpo.batch_multiplier = 1
+    master_config.cluster["gpus_per_node"] = 2
+    master_config.data["shuffle"] = False
+    master_config.data["num_workers"] = 0
+
+    dataset = MagicMock()
+    dataset.__len__ = MagicMock(return_value=1)
+    result = grpo_mod.setup(master_config, MagicMock(), dataset, None)
+
+    assert generation_cls.call_args.kwargs["skip_weight_load"] is True
+    assert generation_cls.call_args.kwargs["reserved_http_server_port"] == 1234
+    assert "reserved_http_server_port" not in policy_cls.call_args.kwargs
+    assert events.index("init") < events.index("sync")
+    assert events.index("gym_started") < events.index("sync")
+    assert events.index("sync") < events.index("gym_ready")
+    synchronizer.init_communicator.assert_called_once_with()
+    synchronizer.sync_weights.assert_called_once_with()
+    ray_kill.assert_called_once_with(port_holder)
+    setup_metrics = next(
+        call.args[0]
+        for call in logger.log_metrics.call_args_list
+        if call.kwargs.get("prefix") == "timing/setup"
+    )
+    assert setup_metrics["weight_sync_time_s"] > 0
+    assert result[2] is nemo_gym_actor
 
 
 def test_grpo_train_collects_generation_logger_and_seq_metrics(


### PR DESCRIPTION

  Description

  ## Summary

  Restore the correct initialization order for non-colocated Megatron generation with NeMo Gym, including MXFP8 rollouts.

  ## Problem

  The combination of #3569 and #3731 introduced a circular dependency:

  - NeMo Gym starts concurrently and waits for the reserved generation endpoint to become ready.
  - Megatron generation using `skip_weight_load` intentionally delays engine startup until after the initial refit. This ensures MXFP8 persistent buffers are installed before
  CUDA-graph capture.
  - The initialization path waited for NeMo Gym before initializing weight synchronization and performing that refit.

  As a result, Gym waited for the generation endpoint while generation waited for the refit that could only happen after Gym returned.

  Starting the generation engine before refit is not safe for MXFP8 because CUDA graphs may capture the wrong parameter buffers.

  ## Fix

  - Initialize the weight synchronizer and perform the initial policy-to-generation refit after the policy and generation workers are ready, but while NeMo Gym is still
  waiting for endpoint readiness.
  - Await NeMo Gym only after the initial refit has allowed the generation engine and HTTP endpoint to start.
  - Reuse the existing initialization helper for other configurations and avoid duplicate synchronization.
  - Add a regression test that verifies the required ordering:
    `Gym started → initial refit → generation endpoint ready`.
  - Repair the GB200 MXFP8 functional assertions:
    - Check `weight_sync_time_s`, which is where the initial refit is recorded.

  No dependency pins or submodule revisions are included.
