### PR TITLE
fix(vllm): return 400 for plain context overflow

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -442,7 +442,8 @@ class VllmAsyncGenerationWorkerImpl(
                 if remaining <= 0:
                     raise ValueError(
                         f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
-                        f"max_model_len ({self.model_config.max_model_len}). "
+                        "this model's maximum context length "
+                        f"(max_model_len={self.model_config.max_model_len}). "
                         f"No room for output tokens."
                     )
                 max_tokens = min(request_max_tokens, remaining)
@@ -778,14 +779,34 @@ class VllmAsyncGenerationWorkerImpl(
                     request, raw_request
                 )
             except VLLMValidationError as e:
-                # vLLM raises VLLMValidationError for prompts exceeding
-                # max_model_len during tokenization, instead of returning an
-                # ErrorResponse. Convert to HTTP 400 so the Gym proxy can
-                # detect context-length overflow and handle it gracefully.
+                # Preserve the existing behavior for all typed vLLM request
+                # validation failures. VLLMValidationError inherits ValueError,
+                # so this handler must precede the narrower plain-ValueError case.
                 return JSONResponse(
                     content={
                         "error": {
                             "message": str(e),
+                            "type": "invalid_request_error",
+                            "code": 400,
+                        }
+                    },
+                    status_code=400,
+                )
+            except ValueError as e:
+                # vLLM 0.25 can raise a plain ValueError for context overflow
+                # while preprocessing a chat request. Convert only that known
+                # request error to HTTP 400; unrelated ValueErrors are server
+                # bugs and must remain visible.
+                message = str(e)
+                if (
+                    "max_model_len" not in message
+                    and "maximum context length" not in message
+                ):
+                    raise
+                return JSONResponse(
+                    content={
+                        "error": {
+                            "message": message,
                             "type": "invalid_request_error",
                             "code": 400,
                         }

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -288,8 +288,10 @@ def _install_fake_vllm_openai_modules(monkeypatch):
             self.kwargs = kwargs
             self.instances.append(self)
 
-    class VLLMValidationError(Exception):
-        pass
+    class VLLMValidationError(ValueError):
+        def __init__(self, message="", parameter=None):
+            super().__init__(message)
+            self.parameter = parameter
 
     class ToolParserManager:
         import_tool_parser = MagicMock()
@@ -348,7 +350,12 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         ToolParserManager=ToolParserManager,
     )
     make_module("vllm.v1.engine.async_llm", logger=MagicMock())
-    return ToolParserManager, ReasoningParserManager, OpenAIServingChat
+    return (
+        ToolParserManager,
+        ReasoningParserManager,
+        OpenAIServingChat,
+        VLLMValidationError,
+    )
 
 
 class _FakeFastAPIApp:
@@ -368,6 +375,7 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
         tool_parser_manager,
         reasoning_parser_manager,
         openai_serving_chat,
+        _,
     ) = _install_fake_vllm_openai_modules(monkeypatch)
 
     worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
@@ -399,6 +407,102 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
+
+
+def _setup_fake_vllm_chat_handler(monkeypatch):
+    (
+        _,
+        _,
+        openai_serving_chat,
+        vllm_validation_error,
+    ) = _install_fake_vllm_openai_modules(monkeypatch)
+
+    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
+    worker.cfg = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "val_temperature": 0.0,
+        "val_top_p": 1.0,
+        "vllm_cfg": {},
+    }
+    worker.llm = MagicMock(model_config="model-config", renderer="renderer")
+    worker.llm_async_engine_args = MagicMock()
+    worker.llm_async_engine_args.create_model_config.return_value = MagicMock(
+        served_model_name="served-model", model="model-path"
+    )
+
+    app = _FakeFastAPIApp()
+    worker._setup_vllm_openai_api_server(app)
+    serving_chat = openai_serving_chat.instances[0]
+    chat_handler = next(
+        handler for path, handler in app.routes if path == "/v1/chat/completions"
+    )
+    return serving_chat, chat_handler, vllm_validation_error
+
+
+def _fake_chat_request():
+    return types.SimpleNamespace(
+        top_k=-1,
+        top_p=1.0,
+        temperature=1.0,
+        max_tokens=1,
+        max_completion_tokens=None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Input length (196609) exceeds model's maximum context length (196608)",
+        "Prompt fills or exceeds max_model_len (196608)",
+    ],
+)
+async def test_vllm_http_server_maps_plain_context_overflow_to_400(
+    monkeypatch, message
+):
+    serving_chat, chat_handler, _ = _setup_fake_vllm_chat_handler(monkeypatch)
+
+    async def raise_context_overflow(_request, _raw_request):
+        raise ValueError(message)
+
+    serving_chat.create_chat_completion = raise_context_overflow
+    response = await chat_handler(_fake_chat_request(), MagicMock())
+
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == {
+        "message": message,
+        "type": "invalid_request_error",
+        "code": 400,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vllm_http_server_preserves_typed_validation_errors(monkeypatch):
+    serving_chat, chat_handler, vllm_validation_error = _setup_fake_vllm_chat_handler(
+        monkeypatch
+    )
+
+    async def raise_validation_error(_request, _raw_request):
+        raise vllm_validation_error("invalid sampling parameter")
+
+    serving_chat.create_chat_completion = raise_validation_error
+    response = await chat_handler(_fake_chat_request(), MagicMock())
+
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"]["message"] == "invalid sampling parameter"
+
+
+@pytest.mark.asyncio
+async def test_vllm_http_server_reraises_unrelated_value_error(monkeypatch):
+    serving_chat, chat_handler, _ = _setup_fake_vllm_chat_handler(monkeypatch)
+
+    async def raise_internal_error(_request, _raw_request):
+        raise ValueError("unexpected internal failure")
+
+    serving_chat.create_chat_completion = raise_internal_error
+    with pytest.raises(ValueError, match="unexpected internal failure"):
+        await chat_handler(_fake_chat_request(), MagicMock())
 
 
 def test_nano_v3_reasoning_parser_swaps_reasoning_when_thinking_disabled(


### PR DESCRIPTION
## Summary

- translate plain vLLM 0.25 context-length `ValueError`s into HTTP 400 responses
- preserve existing handling for all typed `VLLMValidationError`s and re-raise unrelated plain `ValueError`s
- make locally detected overflow messages recognizable by NeMo Gym so deterministic oversized requests are not retried

## Motivation

vLLM 0.25 may raise a plain `ValueError` while preprocessing an oversized chat prompt. The embedded NeMo RL server previously surfaced it as HTTP 500, causing NeMo Gym to retry the same request even though it cannot succeed.

## Validation

- focused vLLM HTTP server unit tests: 5 passed
- Ruff lint and format checks for the modified files
