### PR TITLE
fix(grpo): group advantages by rollout identity

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -57,6 +57,7 @@ from nemo_rl.algorithms.reward_functions import (
     apply_reward_shaping,
 )
 from nemo_rl.algorithms.utils import (
+    build_rollout_group_ids,
     calculate_baseline_and_std_per_prompt,
     get_gdpo_reward_component_keys,
     log_generation_metrics,
@@ -2937,6 +2938,7 @@ def grpo_train(
         batch_cache: BatchedDataDict[DatumSpec] = None
         # This is the number of batches we processed so far at each step to generate responses whose std is non-zero. Maximum threshold is set by dynamic_sampling_max_gen_batches. Used in the case of dynamic sampling.
         dynamic_sampling_num_gen_batches = 0
+        next_rollout_group_id = 0
 
         # Run grpo/dapo training loop (single-turn)
         for batch in wrapped_dataloader:
@@ -3181,12 +3183,25 @@ def grpo_train(
                         and "unshaped_total_reward" in repeated_batch
                         else None
                     )
+                    reward_group_ids = build_rollout_group_ids(
+                        repeated_batch.size,
+                        master_config.grpo.num_generations_per_prompt,
+                        start_group_id=next_rollout_group_id,
+                    )
+                    next_rollout_group_id += (
+                        repeated_batch.size
+                        // master_config.grpo.num_generations_per_prompt
+                    )
+                    # Dynamic sampling may cache and concatenate survivors from
+                    # multiple generation batches. Carry the explicit identity
+                    # through those transformations instead of rebuilding it.
+                    repeated_batch["rollout_group_ids"] = reward_group_ids
                     if master_config.grpo.calculate_advantages_on_gpu:
                         print("Computing advantages on GPU!")
                         # Just fix the device id for now
                         device_id = 0
                         baseline, std = calculate_baseline_and_std_per_prompt(
-                            input_ids.cuda(device_id),
+                            reward_group_ids.cuda(device_id),
                             rewards.cuda(device_id),
                             torch.ones_like(rewards).cuda(device_id),
                             leave_one_out_baseline=master_config.grpo.use_leave_one_out_baseline,
@@ -3200,7 +3215,7 @@ def grpo_train(
                         std = std.cpu()
                     else:
                         baseline, std = calculate_baseline_and_std_per_prompt(
-                            input_ids,
+                            reward_group_ids,
                             rewards,
                             torch.ones_like(rewards),
                             leave_one_out_baseline=master_config.grpo.use_leave_one_out_baseline,
@@ -3243,23 +3258,12 @@ def grpo_train(
                     # Save baseline for logging (before deletion)
                     baseline_for_log = baseline.clone()
 
-                    # Must precede prompt extraction: it reuses the same message
-                    # dicts, so this also protects the prompt flatten below.
+                    # Backfill before flattening the full rollout for training.
                     backfill_missing_routed_experts(repeated_batch["message_log"])
 
-                    # Extract original prompt messages using the length field
-                    # This correctly handles multi-turn prompts that contain assistant messages
-                    initial_prompt_message_logs = extract_initial_prompt_messages(
-                        repeated_batch["message_log"],
-                        repeated_batch["length"],
-                    )
-                    prompt_batched_flat, _ = batched_message_log_to_flat_message(
-                        initial_prompt_message_logs,
-                        pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                    )
-                    prompt_ids_for_adv = prompt_batched_flat["token_ids"]
-                    del initial_prompt_message_logs
-                    del prompt_batched_flat
+                    # Use the sampling group itself as the GRPO identity. Distinct
+                    # media-conditioned prompts can have identical text tokens.
+                    prompt_ids_for_adv = repeated_batch.pop("rollout_group_ids")
                     del input_ids
                     del baseline
                     del std
@@ -3892,6 +3896,7 @@ def grpo_train(
             # Reset the batch and set dynamic_sampling_num_gen_batches to 0
             batch_cache = None
             dynamic_sampling_num_gen_batches = 0
+            next_rollout_group_id = 0
 
             # Clear mem
             memory_tracker.snapshot_start_of_stage("After CPU memory clear", dir())
@@ -4877,24 +4882,14 @@ def async_grpo_train(
 
                 print("▶ Processing rewards...")
                 with timer.time("reward_calculation"):
-                    # Must precede prompt extraction: it reuses the same message
-                    # dicts, so this also protects the prompt flatten below.
+                    # Backfill before flattening the full rollout for training.
                     backfill_missing_routed_experts(repeated_batch["message_log"])
-
-                    # Extract original prompt messages using the length field
-                    # This correctly handles multi-turn prompts that contain assistant messages
-                    initial_prompt_message_logs = extract_initial_prompt_messages(
-                        repeated_batch["message_log"],
-                        repeated_batch["length"],
+                    # Each replay entry is one complete prompt group and the
+                    # concatenation above preserves group-contiguous ordering.
+                    prompt_ids_for_adv = build_rollout_group_ids(
+                        repeated_batch.size,
+                        master_config.grpo.num_generations_per_prompt,
                     )
-
-                    prompt_batched_flat, _ = batched_message_log_to_flat_message(
-                        initial_prompt_message_logs,
-                        pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                    )
-                    prompt_ids_for_adv = prompt_batched_flat["token_ids"]
-                    del initial_prompt_message_logs
-                    del prompt_batched_flat
 
                     rewards = repeated_batch["total_reward"]
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2992,12 +2992,6 @@ def grpo_train(
                             enabled=master_config.grpo.debug_payload_metrics,
                         )
                     )
-                    # Convert LLMMessageLogType to FlatMessagesType for generation
-                    batched_flat, input_lengths = batched_message_log_to_flat_message(
-                        repeated_batch["message_log"],
-                        pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                    )
-                    input_ids = batched_flat["token_ids"]
 
                 # Generate responses - this updates the LLMMessageLogType in repeated_batch
                 memory_tracker.snapshot_start_of_stage("Generation", dir())
@@ -3103,7 +3097,6 @@ def grpo_train(
                                 master_config.grpo.debug_payload_metrics
                             ),
                         )
-                        input_ids = nemo_gym_rollout_result.input_ids
                         repeated_batch = nemo_gym_rollout_result.final_batch
                         rollout_metrics = nemo_gym_rollout_result.rollout_metrics
                         del nemo_gym_rollout_result
@@ -3264,7 +3257,6 @@ def grpo_train(
                     # Use the sampling group itself as the GRPO identity. Distinct
                     # media-conditioned prompts can have identical text tokens.
                     prompt_ids_for_adv = repeated_batch.pop("rollout_group_ids")
-                    del input_ids
                     del baseline
                     del std
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -234,8 +234,8 @@ def _apply_dynamic_sampling(
     # Rebuild them after cache concatenation so groups from different generation
     # batches cannot collide. Dynamic sampling may retain only part of a group,
     # so validate the sample-ID format without requiring a complete group here.
-    pending_carry["prompt_ids_for_adv"] = (
-        build_rollout_group_ids_from_sample_ids(pending_meta.sample_ids)
+    pending_carry["prompt_ids_for_adv"] = build_rollout_group_ids_from_sample_ids(
+        pending_meta.sample_ids
     )
 
     unfiltered_for_log = torch.cat(pending_unfiltered_rewards)[:train_prompts_size]

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -66,6 +66,7 @@ from nemo_rl.algorithms.loss import (
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.reward_functions import apply_reward_shaping
 from nemo_rl.algorithms.utils import (
+    build_rollout_group_ids_from_sample_ids,
     calculate_baseline_and_std_per_prompt,
     get_gdpo_reward_component_keys,
     log_generation_metrics,
@@ -228,6 +229,14 @@ def _apply_dynamic_sampling(
         ds_metrics["dynamic_sampling_num_discarded_valid_samples"] = (
             n - train_prompts_size
         )
+
+    # Each generation batch initially assigns dense group IDs starting at zero.
+    # Rebuild them after cache concatenation so groups from different generation
+    # batches cannot collide. Dynamic sampling may retain only part of a group,
+    # so validate the sample-ID format without requiring a complete group here.
+    pending_carry["prompt_ids_for_adv"] = (
+        build_rollout_group_ids_from_sample_ids(pending_meta.sample_ids)
+    )
 
     unfiltered_for_log = torch.cat(pending_unfiltered_rewards)[:train_prompts_size]
     return pending_meta, pending_carry, [], True, ds_metrics, unfiltered_for_log
@@ -688,6 +697,14 @@ def grpo_train_sync(
                 # now back on the driver where they belong (no bulk
                 # touched by any of these ops).
                 with timer.time("reward_calculation"):
+                    # TQ sample IDs encode the rollout-group UUID. Use that
+                    # explicit identity instead of media-blind prompt tokens.
+                    driver_carry["prompt_ids_for_adv"] = (
+                        build_rollout_group_ids_from_sample_ids(
+                            meta.sample_ids,
+                            expected_group_size=master_config.grpo.num_generations_per_prompt,
+                        )
+                    )
                     driver_carry = scale_rewards(
                         driver_carry,
                         master_config.grpo.reward_scaling,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -76,6 +76,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
     squeeze_trailing_unit_dim,
     tensor_field,
 )
+from nemo_rl.algorithms.utils import build_rollout_group_ids_from_sample_ids
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
@@ -1971,7 +1972,12 @@ class SingleControllerActor:
             select_fields=self._advantage_input_fields(),
         )
 
-        prompt_ids = tensor_field(data, adv_cfg.prompt_ids_field)
+        # The selected metadata retains each prompt group's UUID in its sample
+        # IDs. Text-token equality is insufficient for multimodal prompts.
+        prompt_ids = build_rollout_group_ids_from_sample_ids(
+            meta.sample_ids,
+            expected_group_size=self._algo_cfg.num_generations_per_prompt,
+        )
         rewards = squeeze_trailing_unit_dim(
             tensor_field(data, adv_cfg.reward_field)
         ).float()
@@ -2110,7 +2116,6 @@ class SingleControllerActor:
     def _advantage_input_fields(self) -> list[str]:
         adv_cfg = self._advantage_cfg
         fields = [
-            adv_cfg.prompt_ids_field,
             adv_cfg.reward_field,
             adv_cfg.token_mask_field,
             adv_cfg.sample_mask_field,

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -123,9 +123,7 @@ def build_rollout_group_ids(
             f"group_size={group_size}"
         )
     if start_group_id < 0:
-        raise ValueError(
-            f"start_group_id must be non-negative, got {start_group_id}"
-        )
+        raise ValueError(f"start_group_id must be non-negative, got {start_group_id}")
     num_groups = batch_size // group_size
     return torch.arange(
         start_group_id,

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -101,6 +101,86 @@ def calculate_kl(
     return kl
 
 
+def build_rollout_group_ids(
+    batch_size: int,
+    group_size: int,
+    *,
+    start_group_id: int = 0,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Return an explicit identifier for every rollout's sampling group.
+
+    GRPO baselines are defined over the completions sampled together for one
+    prompt instance. Prompt token IDs are not a valid group identifier for
+    multimodal prompts because different media can have identical text and
+    therefore identical token rows.
+    """
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}")
+    if batch_size < 0 or batch_size % group_size != 0:
+        raise ValueError(
+            f"batch_size={batch_size} must be non-negative and divisible by "
+            f"group_size={group_size}"
+        )
+    if start_group_id < 0:
+        raise ValueError(
+            f"start_group_id must be non-negative, got {start_group_id}"
+        )
+    num_groups = batch_size // group_size
+    return torch.arange(
+        start_group_id,
+        start_group_id + num_groups,
+        device=device,
+        dtype=torch.long,
+    ).repeat_interleave(group_size)[:, None]
+
+
+def build_rollout_group_ids_from_sample_ids(
+    sample_ids: list[str],
+    *,
+    expected_group_size: int | None = None,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Derive explicit prompt-group IDs from ``{group_id}_g{index}`` sample IDs."""
+    if expected_group_size is not None and expected_group_size <= 0:
+        raise ValueError(
+            f"expected_group_size must be positive, got {expected_group_size}"
+        )
+    group_to_index: dict[str, int] = {}
+    group_to_generation_indices: dict[str, set[int]] = {}
+    group_indices: list[int] = []
+    for sample_id in sample_ids:
+        try:
+            group_id, generation_index = sample_id.rsplit("_g", 1)
+            generation_index = int(generation_index)
+        except (ValueError, TypeError) as error:
+            raise ValueError(
+                "Expected sample ID in '{group_id}_g{generation_index}' format, "
+                f"got {sample_id!r}"
+            ) from error
+        if not group_id:
+            raise ValueError(f"Sample ID has an empty group ID: {sample_id!r}")
+        if generation_index < 0:
+            raise ValueError(
+                f"Sample ID has a negative generation index: {sample_id!r}"
+            )
+        generation_indices = group_to_generation_indices.setdefault(group_id, set())
+        if generation_index in generation_indices:
+            raise ValueError(f"Duplicate generation index in sample ID: {sample_id!r}")
+        generation_indices.add(generation_index)
+        group_indices.append(group_to_index.setdefault(group_id, len(group_to_index)))
+    if expected_group_size is not None:
+        expected_indices = set(range(expected_group_size))
+        for group_id, generation_indices in group_to_generation_indices.items():
+            if generation_indices != expected_indices:
+                raise ValueError(
+                    f"Rollout group {group_id!r} has generation indices "
+                    f"{sorted(generation_indices)}, expected "
+                    f"{list(range(expected_group_size))}"
+                )
+    return torch.tensor(group_indices, device=device, dtype=torch.long)[:, None]
+
+
 def calculate_baseline_and_std_per_prompt(
     prompts: torch.Tensor,
     rewards: torch.Tensor,

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2231,9 +2231,7 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
 
     repeated_batch = create_mock_batch(batch_size, task_names, message_logs)
     repeated_batch["total_reward"] = torch.tensor([1.0, 0.0, 0.5])  # Non-zero std
-    repeated_batch["rollout_group_ids"] = torch.zeros(
-        (batch_size, 1), dtype=torch.long
-    )
+    repeated_batch["rollout_group_ids"] = torch.zeros((batch_size, 1), dtype=torch.long)
 
     prompts = torch.tensor(
         [
@@ -2276,9 +2274,7 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
     # Run dynamic sampling again with a separately namespaced rollout group.
     next_batch = create_mock_batch(batch_size, task_names, message_logs)
     next_batch["total_reward"] = torch.tensor([1.0, 0.0, 0.5])
-    next_batch["rollout_group_ids"] = torch.ones(
-        (batch_size, 1), dtype=torch.long
-    )
+    next_batch["rollout_group_ids"] = torch.ones((batch_size, 1), dtype=torch.long)
     result_batch, is_batch_complete, batch_cache, _ = dynamic_sampling(
         next_batch,
         std,

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2231,6 +2231,9 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
 
     repeated_batch = create_mock_batch(batch_size, task_names, message_logs)
     repeated_batch["total_reward"] = torch.tensor([1.0, 0.0, 0.5])  # Non-zero std
+    repeated_batch["rollout_group_ids"] = torch.zeros(
+        (batch_size, 1), dtype=torch.long
+    )
 
     prompts = torch.tensor(
         [
@@ -2270,12 +2273,17 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
     assert batch_cache is not None
     assert batch_cache == result_batch
 
-    # Run dynamic sampling again with the cached batch
+    # Run dynamic sampling again with a separately namespaced rollout group.
+    next_batch = create_mock_batch(batch_size, task_names, message_logs)
+    next_batch["total_reward"] = torch.tensor([1.0, 0.0, 0.5])
+    next_batch["rollout_group_ids"] = torch.ones(
+        (batch_size, 1), dtype=torch.long
+    )
     result_batch, is_batch_complete, batch_cache, _ = dynamic_sampling(
-        repeated_batch,
+        next_batch,
         std,
         baseline,
-        dynamic_sampling_num_gen_batches,
+        dynamic_sampling_num_gen_batches + 1,
         master_config,
         timer,
         batch_cache,
@@ -2287,6 +2295,10 @@ def test_dapo_dynamic_sampling_batch_caching(mock_grpo_components):
     )  # All samples from the single prompt with non-zero std
     assert is_batch_complete == True
     assert batch_cache is not None
+    assert torch.equal(
+        result_batch["rollout_group_ids"],
+        torch.tensor([[0], [0], [0], [1], [1], [1]]),
+    )
 
 
 def test_dapo_cache_aligns_deduplicated_media_with_text_only_batch(

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -43,9 +43,7 @@ def test_rollout_group_ids_keep_identical_multimodal_prompts_separate():
     rewards = torch.cat((torch.ones(16), torch.zeros(16)))
     valid_mask = torch.ones_like(rewards)
 
-    baseline, _ = calculate_baseline_and_std_per_prompt(
-        group_ids, rewards, valid_mask
-    )
+    baseline, _ = calculate_baseline_and_std_per_prompt(group_ids, rewards, valid_mask)
 
     assert torch.equal(baseline, rewards)
 
@@ -76,9 +74,7 @@ def test_rollout_group_ids_from_tq_sample_ids():
 )
 def test_rollout_group_ids_reject_malformed_or_partial_groups(sample_ids):
     with pytest.raises(ValueError):
-        build_rollout_group_ids_from_sample_ids(
-            sample_ids, expected_group_size=2
-        )
+        build_rollout_group_ids_from_sample_ids(sample_ids, expected_group_size=2)
 
 
 @pytest.mark.parametrize(
@@ -89,9 +85,7 @@ def test_rollout_group_ids_reject_invalid_shapes(
     batch_size, group_size, start_group_id
 ):
     with pytest.raises(ValueError):
-        build_rollout_group_ids(
-            batch_size, group_size, start_group_id=start_group_id
-        )
+        build_rollout_group_ids(batch_size, group_size, start_group_id=start_group_id)
 
 
 @pytest.fixture

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -25,6 +25,8 @@ from nemo_rl.algorithms.ppo import PPOConfig
 from nemo_rl.algorithms.utils import (
     EFFICIENCY_CATEGORIES,
     WALL_CLOCK_EFFICIENCY_CATEGORIES,
+    build_rollout_group_ids,
+    build_rollout_group_ids_from_sample_ids,
     calculate_baseline_and_std_per_prompt,
     get_tokenizer,
     maybe_pad_last_batch,
@@ -33,6 +35,63 @@ from nemo_rl.algorithms.utils import (
 )
 from nemo_rl.data.chat_templates import COMMON_CHAT_TEMPLATES
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def test_rollout_group_ids_keep_identical_multimodal_prompts_separate():
+    """Different media states must not share a GRPO reward baseline."""
+    group_ids = build_rollout_group_ids(batch_size=32, group_size=16)
+    rewards = torch.cat((torch.ones(16), torch.zeros(16)))
+    valid_mask = torch.ones_like(rewards)
+
+    baseline, _ = calculate_baseline_and_std_per_prompt(
+        group_ids, rewards, valid_mask
+    )
+
+    assert torch.equal(baseline, rewards)
+
+
+def test_rollout_group_ids_support_namespacing_across_cached_batches():
+    assert torch.equal(
+        build_rollout_group_ids(batch_size=4, group_size=2, start_group_id=3),
+        torch.tensor([[3], [3], [4], [4]]),
+    )
+
+
+def test_rollout_group_ids_from_tq_sample_ids():
+    sample_ids = ["prompt-a_g0", "prompt-a_g1", "prompt-b_g0", "prompt-b_g1"]
+
+    assert torch.equal(
+        build_rollout_group_ids_from_sample_ids(sample_ids, expected_group_size=2),
+        torch.tensor([[0], [0], [1], [1]]),
+    )
+
+
+@pytest.mark.parametrize(
+    "sample_ids",
+    [
+        ["prompt-a_g0", "prompt-a_g0"],
+        ["prompt-a_g1", "prompt-a_g2"],
+        ["prompt-a_g-1", "prompt-a_g0"],
+    ],
+)
+def test_rollout_group_ids_reject_malformed_or_partial_groups(sample_ids):
+    with pytest.raises(ValueError):
+        build_rollout_group_ids_from_sample_ids(
+            sample_ids, expected_group_size=2
+        )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "group_size", "start_group_id"),
+    [(31, 16, 0), (32, 0, 0), (-1, 1, 0), (32, 16, -1)],
+)
+def test_rollout_group_ids_reject_invalid_shapes(
+    batch_size, group_size, start_group_id
+):
+    with pytest.raises(ValueError):
+        build_rollout_group_ids(
+            batch_size, group_size, start_group_id=start_group_id
+        )
 
 
 @pytest.fixture

--- a/tests/unit/data_plane/test_sync_one_hop.py
+++ b/tests/unit/data_plane/test_sync_one_hop.py
@@ -323,6 +323,71 @@ def test_apply_dynamic_sampling_completes_when_train_size_reached():
     assert torch.equal(unfiltered, torch.tensor([1.0, 2.0, 3.0, 4.0]))
 
 
+def test_apply_dynamic_sampling_rebuilds_group_ids_across_generation_batches():
+    """Cached batches must not reuse the same dense rollout-group IDs."""
+    from nemo_rl.algorithms.grpo_sync import _apply_dynamic_sampling
+    from nemo_rl.algorithms.utils import calculate_baseline_and_std_per_prompt
+
+    client = NoOpDataPlaneClient()
+    register_train_partition(client, num_samples=4)
+    full_meta = kv_first_write(
+        _final_batch(4),
+        sample_ids=keys_from_uids(["prompt-a", "prompt-b"], n_gen=2),
+        dp_client=client,
+        partition_id="train",
+    )
+    meta_a = _stamp_filter_tags(full_meta.slice(0, 2), [0.5, 0.5])
+    meta_b = _stamp_filter_tags(full_meta.slice(2, 4), [0.5, 0.5])
+
+    # Each generation batch independently starts its temporary dense IDs at 0.
+    carry_a = _make_driver_carry([1.0, 0.0], [0.5, 0.5])
+    carry_b = _make_driver_carry([10.0, 20.0], [0.5, 0.5])
+    carry_a["prompt_ids_for_adv"] = torch.zeros((2, 1), dtype=torch.long)
+    carry_b["prompt_ids_for_adv"] = torch.zeros((2, 1), dtype=torch.long)
+
+    pending_meta, pending_carry, pending_rewards, complete, _, _ = (
+        _apply_dynamic_sampling(
+            meta=meta_a,
+            driver_carry=carry_a,
+            pending_meta=None,
+            pending_carry=None,
+            pending_unfiltered_rewards=[],
+            train_prompts_size=4,
+            num_gen_batches=1,
+            max_gen_batches=2,
+            policy=_fake_policy(client),
+        )
+    )
+    assert complete is False
+
+    final_meta, final_carry, _, complete, _, _ = _apply_dynamic_sampling(
+        meta=meta_b,
+        driver_carry=carry_b,
+        pending_meta=pending_meta,
+        pending_carry=pending_carry,
+        pending_unfiltered_rewards=pending_rewards,
+        train_prompts_size=4,
+        num_gen_batches=2,
+        max_gen_batches=2,
+        policy=_fake_policy(client),
+    )
+
+    assert complete is True
+    assert final_meta is not None and final_carry is not None
+    assert torch.equal(
+        final_carry["prompt_ids_for_adv"],
+        torch.tensor([[0], [0], [1], [1]]),
+    )
+
+    rewards = final_carry["filtered_reward"]
+    baseline, _ = calculate_baseline_and_std_per_prompt(
+        final_carry["prompt_ids_for_adv"],
+        rewards,
+        torch.ones_like(rewards),
+    )
+    assert torch.equal(baseline, torch.tensor([0.0, 1.0, 20.0, 10.0]))
+
+
 def test_apply_dynamic_sampling_overflow_slices_and_clears():
     """When the cache exceeds train_prompts_size, slice + clear_samples discards."""
     from nemo_rl.algorithms.grpo_sync import _apply_dynamic_sampling

--- a/tests/unit/single_controller/test_single_controller_actor.py
+++ b/tests/unit/single_controller/test_single_controller_actor.py
@@ -546,6 +546,82 @@ class _MaskRecordingAdvantageEstimator:
         return rewards.unsqueeze(-1).expand_as(mask).clone()
 
 
+class _PromptRecordingAdvantageEstimator(_MaskRecordingAdvantageEstimator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.prompt_ids: torch.Tensor | None = None
+
+    def compute_advantage(self, *, prompt_ids, **kwargs) -> torch.Tensor:
+        self.prompt_ids = prompt_ids.clone()
+        return super().compute_advantage(**kwargs)
+
+
+def _two_rollouts_per_group_sample_ids(batch_size: int) -> list[str]:
+    assert batch_size % 2 == 0
+    return [
+        f"prompt-{group_index}_g{generation_index}"
+        for group_index in range(batch_size // 2)
+        for generation_index in range(2)
+    ]
+
+
+def test_advantage_stage_uses_rollout_group_identity_not_prompt_tokens() -> None:
+    batch_size, sequence_length = 4, 5
+    data = TensorDict(
+        {
+            # Simulate two media-conditioned prompts with identical text tokens.
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([1.0, 1.0, 0.0, 0.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.ones(batch_size),
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = _PromptRecordingAdvantageEstimator()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._policy_logprobs_required = False
+    ctrl._reference_logprobs_required = False
+    ctrl._teacher_logprobs_required = False
+    ctrl._is_ppo = False
+    ctrl._master_config = SimpleNamespace(
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=None,
+            num_generations_per_prompt=2,
+        )
+    )
+    ctrl._algo_cfg = ctrl._master_config.grpo
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "masked_advantages": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
+        fields=list(data.keys()),
+    )
+
+    asyncio.run(ctrl._advantage_stage(meta))
+
+    assert estimator.prompt_ids is not None
+    assert torch.equal(
+        estimator.prompt_ids,
+        torch.tensor([[0], [0], [1], [1]]),
+    )
+    assert data_plane.selected_fields is not None
+    assert "prompt_ids_for_adv" not in data_plane.selected_fields
+
+
 def test_advantage_stage_applies_seq_logprob_error_mask_before_streaming_train(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -580,7 +656,10 @@ def test_advantage_stage_applies_seq_logprob_error_mask_before_streaming_train(
     ctrl._teacher_logprobs_required = False
     ctrl._is_ppo = False
     ctrl._master_config = SimpleNamespace(
-        grpo=SimpleNamespace(seq_logprob_error_threshold=2.0)
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=2.0,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.grpo
     ctrl._step_log_dict = {
@@ -592,7 +671,7 @@ def test_advantage_stage_applies_seq_logprob_error_mask_before_streaming_train(
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
         fields=list(data.keys()),
     )
 
@@ -649,7 +728,10 @@ def test_advantage_stage_reports_seq_logprob_metrics_without_masking() -> None:
     ctrl._teacher_logprobs_required = False
     ctrl._is_ppo = False
     ctrl._master_config = SimpleNamespace(
-        grpo=SimpleNamespace(seq_logprob_error_threshold=None)
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=None,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.grpo
     ctrl._step_log_dict = {
@@ -661,7 +743,7 @@ def test_advantage_stage_reports_seq_logprob_metrics_without_masking() -> None:
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
         fields=list(data.keys()),
     )
 
@@ -712,7 +794,10 @@ def test_advantage_stage_skips_estimator_when_seq_mask_removes_whole_chunk(
     ctrl._teacher_logprobs_required = False
     ctrl._is_ppo = False
     ctrl._master_config = SimpleNamespace(
-        grpo=SimpleNamespace(seq_logprob_error_threshold=2.0)
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=2.0,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.grpo
     ctrl._step_log_dict = {
@@ -724,7 +809,7 @@ def test_advantage_stage_skips_estimator_when_seq_mask_removes_whole_chunk(
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
         fields=list(data.keys()),
     )
 
@@ -768,7 +853,10 @@ def test_advantage_stage_skips_preexisting_empty_mask_without_seq_threshold() ->
     ctrl._teacher_logprobs_required = False
     ctrl._is_ppo = False
     ctrl._master_config = SimpleNamespace(
-        grpo=SimpleNamespace(seq_logprob_error_threshold=None)
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=None,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.grpo
     ctrl._step_log_dict = {
@@ -780,7 +868,7 @@ def test_advantage_stage_skips_preexisting_empty_mask_without_seq_threshold() ->
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
         fields=list(data.keys()),
     )
 
@@ -844,7 +932,10 @@ def test_opd_advantage_stage_reads_teacher_and_student_logprobs() -> None:
     ctrl._is_ppo = False
     ctrl._dp_client = FakeDataPlane()
     ctrl._master_config = SimpleNamespace(
-        grpo=SimpleNamespace(seq_logprob_error_threshold=None)
+        grpo=SimpleNamespace(
+            seq_logprob_error_threshold=None,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.grpo
     ctrl._step_log_dict = {
@@ -859,7 +950,7 @@ def test_opd_advantage_stage_reads_teacher_and_student_logprobs() -> None:
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=["a", "b"],
+        sample_ids=_two_rollouts_per_group_sample_ids(2),
         fields=[],
         sequence_lengths=[3, 3],
     )
@@ -1752,7 +1843,10 @@ def test_advantage_stage_writes_gae_returns_alongside_advantages() -> None:
     ctrl._teacher_logprobs_required = False
     ctrl._is_ppo = True
     ctrl._master_config = SimpleNamespace(
-        ppo=SimpleNamespace(seq_logprob_error_threshold=None)
+        ppo=SimpleNamespace(
+            seq_logprob_error_threshold=None,
+            num_generations_per_prompt=2,
+        )
     )
     ctrl._algo_cfg = ctrl._master_config.ppo
     ctrl._step_log_dict = {
@@ -1764,7 +1858,7 @@ def test_advantage_stage_writes_gae_returns_alongside_advantages() -> None:
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        sample_ids=_two_rollouts_per_group_sample_ids(batch_size),
         fields=list(data.keys()),
     )
 


### PR DESCRIPTION
# What does this PR do ?

Fix GRPO credit assignment by grouping completions by their rollout sampling identity instead of tokenized prompt equality.

## Problem

GRPO baselines are defined over the completions sampled together for one prompt instance. NeMo RL previously used the tokenized initial prompt as that instance's group identifier. Independent rollout groups were therefore merged whenever their initial token rows were identical.

This is especially likely for multimodal and stateful environments. Different images can share the same text and image-placeholder token sequence, while text-only environment instances can share initial instructions but differ in reward-relevant state such as their seed, tool state, or later observations.

For example, consider two independent 16-generation groups with identical initial token rows:

```text
Group A: image/state A, rewards [0, 0, ..., 0]
Group B: image/state B, rewards [1, 1, ..., 1]
```

The correct within-group RLOO advantages are zero for both groups. Token-based grouping instead forms one 32-sample group. A zero-reward sample receives a baseline of `16/31`, and a one-reward sample receives a baseline of `15/31`, creating false negative and positive advantages.

The issue is often not visible in normal training because most text datasets have unique prompt tokens. Even when collisions occur, pooling has no numerical effect if the colliding groups have the same reward distribution. A limited amount of corrupted credit assignment can also look like ordinary optimization noise rather than an obvious failure.

## Fix

- Assign explicit sampling-group IDs in legacy synchronous and asynchronous GRPO.
- Recover the existing group UUID from `{group_id}_g{generation_index}` sample IDs in TransferQueue and Single Controller paths.
- Preserve group identity through filtering, caching, concatenation, and slicing.
- Rebuild TransferQueue group IDs after dynamic-sampling caches from multiple generation batches are combined.
- Validate malformed, duplicate, and incomplete unfiltered groups while permitting legitimate partial groups after dynamic sampling.

This does not change the sample-ID or checkpoint schema; it consumes group identity already present in rollout metadata.

# Issues

None.

# Usage

No user-facing configuration or API changes are required.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Read and followed the contributor guidelines.
- [x] Added regression tests for the affected execution paths.
- [x] Ran 17 targeted unit tests in the project container.
- [x] No documentation update is required because this is an internal correctness fix with no user-facing behavior or configuration change.

# Additional Information

The regression coverage includes:

- identical token prompts belonging to different reward groups;
- rollout-group ID construction and validation;
- Single Controller advantage computation;
- legacy dynamic-sampling cache concatenation;
- TransferQueue caching across two generation batches whose temporary dense IDs both begin at zero;
- expected RLOO baselines after cached groups are separated correctly.

This fixes incorrect GRPO credit assignment. It does not claim to resolve entropy collapse or other policy-degeneration behavior generally.

Full repository CI remains the merge gate.
