### PR TITLE
fix(grpo): apply effort shaping to async Gym rollouts

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -30,6 +30,7 @@ from transformers import PreTrainedTokenizerBase
 from nemo_rl.algorithms.grpo import (
     AsyncGRPOConfig,
     GRPOConfig,
+    _get_effort_config,
 )
 from nemo_rl.algorithms.grpo import (
     MasterConfig as GRPOMasterConfig,
@@ -1290,6 +1291,11 @@ class AsyncTrajectoryCollector:
                 ),
                 max_rollout_turns=None,
                 greedy=False,
+                effort_config=(
+                    _get_effort_config(self.master_config)
+                    if isinstance(self.master_config, GRPOMasterConfig)
+                    else None
+                ),
                 reward_penalty_config=self.master_config.reward_penalties,
                 length_penalty_config=self.master_config.grpo.model_dump(),
                 thinking_tags=get_nemo_gym_thinking_tags(self.master_config.env),

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -62,6 +62,7 @@ from nemo_rl.experience.interfaces import (
     PENDING_PROMPTS_KEY,
     RETAINED_TASK_INDICES_KEY,
 )
+from nemo_rl.experience.rollouts import EffortLevelsConfig
 
 
 @ray.remote(num_cpus=0)
@@ -2898,8 +2899,10 @@ class TestAsyncTrajectoryCollector:
         assert exc.value.__cause__ is not None
         assert "unexpected add status" in str(exc.value.__cause__)
 
-    def test_nemo_gym_batch_retry_does_not_duplicate_buffered_groups(self, monkeypatch):
-        """A partial stream retry only enqueues prompt groups not already buffered."""
+    def test_nemo_gym_batch_retry_forwards_effort_config_without_duplicates(
+        self, monkeypatch
+    ):
+        """Retries preserve effort shaping and do not re-enqueue buffered groups."""
 
         class _ReadyResult:
             def __init__(self, value):
@@ -2930,6 +2933,14 @@ class TestAsyncTrajectoryCollector:
             "stop_token_ids": [1],
             "stop_strings": ["stop"],
         }
+        collector.master_config.env["nemo_gym"] = {
+            "effort_levels": {
+                "low_weight": 0.1,
+                "low_penalty": 1.0,
+                "low_ub": 15_000,
+                "low_string": "{reasoning effort: efficient}",
+            }
+        }
         target_weight = 15
         collector._generating_targets.add(target_weight)
         repeated_batch = BatchedDataDict(
@@ -2957,6 +2968,12 @@ class TestAsyncTrajectoryCollector:
             assert kwargs["generation_config"]["stop_token_ids"] is None
             assert kwargs["generation_config"]["stop_strings"] is None
             assert kwargs["log_full_result_tables"] is False
+            assert kwargs["effort_config"] == EffortLevelsConfig(
+                low_weight=0.1,
+                low_penalty=1.0,
+                low_ub=15_000,
+                low_string="{reasoning effort: efficient}",
+            )
             rollout_calls += 1
             yield _rollout_result(7)
             if rollout_calls == 1:


### PR DESCRIPTION
## Problem

Legacy async GRPO calls `run_async_nemo_gym_rollout` without `effort_config`. Runs configured with `env.nemo_gym.effort_levels` therefore shape synchronous and validation rewards but silently skip the same shaping during async training.

## Change

- resolve the existing validated effort config in `AsyncTrajectoryCollector`
- pass it to every NeMo Gym stream attempt for GRPO
- keep the shared PPO collector behavior unchanged
- preserve the Super branch flexible length-penalty wiring at the same rollout boundary
- cover the collector-to-rollout wiring, including a partial-stream retry

This is the `super-v3.5-posttraining` counterpart to the main fix and addresses the gap identified in https://github.com/NVIDIA-NeMo/RL/pull/3770#discussion_r3852293228.

## Validation

- `pytest -q tests/unit/algorithms/test_async_utils.py -k nemo_gym_batch_retry_forwards_effort_config_without_duplicates`
- `ruff check nemo_rl/algorithms/async_utils/trajectory_collector.py tests/unit/algorithms/test_async_utils.py`
- `ruff format --check nemo_rl/algorithms/async_utils/trajectory_collector.py tests/unit/algorithms/test_async_utils.py`