### PR TITLE
fix(vllm): apply fp8 patch for ray executor v2

### DIFF
--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -16,6 +16,7 @@ import os
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import Any
 from unittest.mock import patch
 
 import ray
@@ -96,33 +97,78 @@ def my_run_engine_core(*args, **kwargs):
     return original_run_engine_core(*args, **kwargs)
 
 
-def monkey_patch_vllm_ray_executor(fp8_config):
-    if fp8_config.model_parallel_size > 1:
-        # we patch vllm's collective_rpc so that before vllm initalizes the model on each rank, we execute
-        # a ray remote that patches each worker with the required fp8 vllm patches
-        from vllm.v1.executor.ray_executor import RayDistributedExecutor
+def monkey_patch_vllm_ray_executor(fp8_config: FP8Config) -> None:
+    global fp8_patches_applied
 
-        original_run_workers = RayDistributedExecutor.collective_rpc
-
-        def patched_run_workers(self, *args, **kwargs):
-            global fp8_patches_applied
-            if not fp8_patches_applied:
-                futures = [
-                    worker.execute_method.remote(apply_fp8_patches, fp8_config)
-                    for worker in self.workers
-                ]
-                [ray.get(future) for future in futures]
-                fp8_patches_applied = True
-
-            return original_run_workers(self, *args, **kwargs)
-
-        RayDistributedExecutor.collective_rpc = patched_run_workers
-    else:
+    if fp8_config.model_parallel_size <= 1:
         # for single gpu there is no ray, so just call the patches
         apply_fp8_patches(None, fp8_config)
 
-        global fp8_patches_applied
         fp8_patches_applied = True
+        return
+
+    use_ray_v2_executor = (
+        os.environ.get("VLLM_USE_RAY_V2_EXECUTOR_BACKEND", "1").strip() != "0"
+    )
+    if use_ray_v2_executor:
+        from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
+
+        RayWorkerProc._nrl_fp8_config = fp8_config
+        if getattr(RayWorkerProc, "_nrl_fp8_patched", False):
+            return
+
+        # RayExecutorV2 loads the model inside RayWorkerProc.initialize_worker(),
+        # before executor-level collective_rpc is available, so patch the worker
+        # at that earlier entry point.
+        RayWorkerProc._nrl_fp8_original_initialize_worker = (
+            RayWorkerProc.initialize_worker
+        )
+        RayWorkerProc.initialize_worker = _patched_ray_executor_v2_initialize_worker
+        RayWorkerProc._nrl_fp8_patched = True
+        return
+
+    try:
+        # vLLM 0.25+
+        from vllm.v1.executor.ray_executor import RayDistributedExecutor
+    except ImportError:
+        # Older vLLM releases used this import path.
+        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
+
+    RayDistributedExecutor._nrl_fp8_config = fp8_config
+    if getattr(RayDistributedExecutor, "_nrl_fp8_patched", False):
+        return
+
+    # Patch vLLM's collective_rpc so that before vLLM initializes the model on
+    # each rank, we execute a ray remote that patches each worker with the
+    # required FP8 vLLM patches.
+    RayDistributedExecutor._nrl_fp8_original_collective_rpc = (
+        RayDistributedExecutor.collective_rpc
+    )
+    RayDistributedExecutor.collective_rpc = (
+        _patched_ray_distributed_executor_collective_rpc
+    )
+    RayDistributedExecutor._nrl_fp8_patched = True
+
+
+def _patched_ray_distributed_executor_collective_rpc(
+    self, *args: Any, **kwargs: Any
+) -> Any:
+    global fp8_patches_applied
+    if not fp8_patches_applied:
+        futures = [
+            worker.execute_method.remote(apply_fp8_patches, self._nrl_fp8_config)
+            for worker in self.workers
+        ]
+        ray.get(futures)
+        fp8_patches_applied = True
+
+    return self._nrl_fp8_original_collective_rpc(*args, **kwargs)
+
+
+def _patched_ray_executor_v2_initialize_worker(self, *args: Any, **kwargs: Any) -> Any:
+    if not fp8_patches_applied:
+        apply_fp8_patches(self, self._nrl_fp8_config)
+    return self._nrl_fp8_original_initialize_worker(*args, **kwargs)
 
 
 def apply_fp8_patches(self, fp8_config):

--- a/tests/unit/models/generation/test_vllm_fp8_quantization.py
+++ b/tests/unit/models/generation/test_vllm_fp8_quantization.py
@@ -918,6 +918,180 @@ def test_apply_fp8_patches_registers_modelopt_patches_only_for_mxfp8(
     assert all(patcher.started for patcher in fp8.fp8_state.vllm_patches)
 
 
+def test_monkey_patch_vllm_ray_executor_patches_legacy_workers_before_rpc(
+    fp8_module, monkeypatch
+):
+    try:
+        from vllm.v1.executor import ray_executor_v2
+    except ImportError:
+        ray_executor_v2 = None
+    from vllm.v1.executor.ray_executor import RayDistributedExecutor
+
+    fp8 = fp8_module
+    worker_calls = []
+    original_calls = []
+    ray_get_calls = []
+
+    class FakeExecuteMethod:
+        def remote(self, func, config):
+            worker_calls.append((func, config))
+            return f"future-{len(worker_calls)}"
+
+    class FakeWorker:
+        def __init__(self):
+            self.execute_method = FakeExecuteMethod()
+
+    def original_collective_rpc(self, *args, **kwargs):
+        original_calls.append((self, args, kwargs))
+        return "rpc-result"
+
+    def fake_ray_get(futures):
+        ray_get_calls.append(futures)
+        return ["patched"]
+
+    def original_initialize_worker(self, *args, **kwargs):
+        return "initialized"
+
+    monkeypatch.setattr(
+        RayDistributedExecutor, "collective_rpc", original_collective_rpc
+    )
+    monkeypatch.setattr(
+        RayDistributedExecutor, "_nrl_fp8_patched", False, raising=False
+    )
+    monkeypatch.setattr(RayDistributedExecutor, "_nrl_fp8_config", None, raising=False)
+    monkeypatch.setattr(
+        RayDistributedExecutor,
+        "_nrl_fp8_original_collective_rpc",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(fp8.ray, "get", fake_ray_get)
+    monkeypatch.setenv("VLLM_USE_RAY_V2_EXECUTOR_BACKEND", "0")
+    if ray_executor_v2 is not None:
+        monkeypatch.setattr(
+            ray_executor_v2.RayWorkerProc,
+            "initialize_worker",
+            original_initialize_worker,
+        )
+        monkeypatch.setattr(
+            ray_executor_v2.RayWorkerProc, "_nrl_fp8_patched", False, raising=False
+        )
+        monkeypatch.setattr(
+            ray_executor_v2.RayWorkerProc, "_nrl_fp8_config", None, raising=False
+        )
+        monkeypatch.setattr(
+            ray_executor_v2.RayWorkerProc,
+            "_nrl_fp8_original_initialize_worker",
+            None,
+            raising=False,
+        )
+
+    config = fp8.FP8Config(use_fp8_weights=True, model_parallel_size=2)
+    executor = RayDistributedExecutor.__new__(RayDistributedExecutor)
+    executor.workers = [FakeWorker(), FakeWorker()]
+
+    fp8.monkey_patch_vllm_ray_executor(config)
+    if ray_executor_v2 is not None:
+        assert (
+            ray_executor_v2.RayWorkerProc.initialize_worker
+            is original_initialize_worker
+        )
+    result = RayDistributedExecutor.collective_rpc(
+        executor, "load_model", timeout=1, kwargs={"foo": "bar"}
+    )
+
+    assert result == "rpc-result"
+    assert worker_calls == [
+        (fp8.apply_fp8_patches, config),
+        (fp8.apply_fp8_patches, config),
+    ]
+    assert ray_get_calls == [["future-1", "future-2"]]
+    assert original_calls == [
+        (executor, ("load_model",), {"timeout": 1, "kwargs": {"foo": "bar"}})
+    ]
+    assert fp8.fp8_patches_applied is True
+
+
+def test_monkey_patch_vllm_ray_executor_v2_patches_worker_before_initialize(
+    fp8_module, monkeypatch
+):
+    ray_executor_v2 = pytest.importorskip("vllm.v1.executor.ray_executor_v2")
+    from vllm.v1.executor.ray_executor import RayDistributedExecutor
+
+    fp8 = fp8_module
+    events = []
+
+    def original_collective_rpc(self, *args, **kwargs):
+        raise AssertionError("RayExecutorV2 worker patch must not use legacy RPC")
+
+    def original_initialize_worker(self, *args, **kwargs):
+        events.append(("initialize", self, args, kwargs))
+        return "initialized"
+
+    def fake_apply_fp8_patches(self, config):
+        events.append(("apply", self, config))
+        fp8.fp8_patches_applied = True
+
+    monkeypatch.setattr(
+        RayDistributedExecutor, "collective_rpc", original_collective_rpc
+    )
+    monkeypatch.setattr(
+        RayDistributedExecutor, "_nrl_fp8_patched", False, raising=False
+    )
+    monkeypatch.setattr(RayDistributedExecutor, "_nrl_fp8_config", None, raising=False)
+    monkeypatch.setattr(
+        RayDistributedExecutor,
+        "_nrl_fp8_original_collective_rpc",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ray_executor_v2.RayWorkerProc,
+        "initialize_worker",
+        original_initialize_worker,
+    )
+    monkeypatch.setattr(
+        ray_executor_v2.RayWorkerProc, "_nrl_fp8_patched", False, raising=False
+    )
+    monkeypatch.setattr(
+        ray_executor_v2.RayWorkerProc, "_nrl_fp8_config", None, raising=False
+    )
+    monkeypatch.setattr(
+        ray_executor_v2.RayWorkerProc,
+        "_nrl_fp8_original_initialize_worker",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(fp8, "apply_fp8_patches", fake_apply_fp8_patches)
+    monkeypatch.delenv("VLLM_USE_RAY_V2_EXECUTOR_BACKEND", raising=False)
+
+    config = fp8.FP8Config(use_fp8_weights=True, model_parallel_size=2)
+    worker = ray_executor_v2.RayWorkerProc.__new__(ray_executor_v2.RayWorkerProc)
+
+    fp8.monkey_patch_vllm_ray_executor(config)
+    assert RayDistributedExecutor.collective_rpc is original_collective_rpc
+
+    result = ray_executor_v2.RayWorkerProc.initialize_worker(
+        worker,
+        0,
+        {"LOCAL_RANK": "0"},
+        driver_env_vars={"RANK": "0"},
+        assigned_physical_gpu_ids=[0],
+    )
+
+    assert result == "initialized"
+    assert events == [
+        ("apply", worker, config),
+        (
+            "initialize",
+            worker,
+            (0, {"LOCAL_RANK": "0"}),
+            {"driver_env_vars": {"RANK": "0"}, "assigned_physical_gpu_ids": [0]},
+        ),
+    ]
+    assert fp8.fp8_patches_applied is True
+
+
 def test_process_weights_after_loading_copies_in_place_on_refit(monkeypatch):
     """Refit runs this every step; rebinding .data each time fragments memory.
 


### PR DESCRIPTION
# What does this PR do ?

In vllm 0.25.1, the default ray executor has changed because VLLM_USE_RAY_V2_EXECUTOR_BACKEND has been default to 1 ([link](https://docs.vllm.ai/en/latest/configuration/env_vars/#environment-variables)),  so we need to patch RayExecutorV2 instead of the RayDistributedExecutor; but when VLLM_USE_RAY_V2_EXECUTOR_BACKEND is explicitly passed as 0 then we still need to patch in previous way.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
