### PR TITLE
perf(vllm): optimize native HTTP request processing

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1277,7 +1277,11 @@ def setup(
     def init_vllm():
         """Initialize vLLM generation workers."""
         t0 = time.perf_counter()
-        pg = VllmGeneration(cluster=inference_cluster, config=generation_config)
+        pg = VllmGeneration(
+            cluster=inference_cluster,
+            config=generation_config,
+            use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
+        )
         pg.finish_generation()
         return pg, time.perf_counter() - t0
 
@@ -1550,6 +1554,7 @@ def setup(
                 cluster=inference_cluster,
                 config=generation_config,
                 defer_model_load=True,
+                use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
             )
             vllm_reserve_time = time.perf_counter() - vllm_reserve_t0
             print(

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -136,6 +136,7 @@ class VllmGeneration(GenerationInterface):
         name_prefix: str = "vllm_policy",
         workers_per_node: Optional[Union[int, list[int]]] = None,
         defer_model_load: bool = False,
+        use_fastokens: bool = False,
     ):
         """Initialize a vLLM policy with distributed workers.
 
@@ -150,6 +151,8 @@ class VllmGeneration(GenerationInterface):
             name_prefix: Prefix for Ray actor names
             workers_per_node: Workers per node override
             defer_model_load: If True, defer model loading for overlapped init
+            use_fastokens: Apply the configured Fastokens patch in async vLLM
+                actors before they create their tokenizer and HTTP renderer.
         """
         # Store config
         self.cfg = config
@@ -249,7 +252,10 @@ class VllmGeneration(GenerationInterface):
         worker_cls = resolve_generation_worker_cls(worker_cls, self.cfg)
         if self.cfg["vllm_cfg"]["async_engine"]:
             worker_builder = RayWorkerBuilder(
-                worker_cls, config, defer_model_load=defer_model_load
+                worker_cls,
+                config,
+                defer_model_load=defer_model_load,
+                use_fastokens=use_fastokens,
             )
         else:
             worker_builder = RayWorkerBuilder(worker_cls, config)

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -23,10 +23,12 @@ import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, AsyncGenerator, Optional, cast
 
+import orjson
 import ray
 import torch
 import uvicorn
 from fastapi import FastAPI
+from fastapi.responses import Response
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import (
@@ -56,6 +58,7 @@ from nemo_rl.models.generation.openai_server_utils import (
     replace_prefix_tokens,
 )
 from nemo_rl.telemetry.setup import shutdown_telemetry
+from nemo_rl.utils.fastokens import maybe_patch_fastokens
 
 LOGGER = logging.getLogger(__name__)
 
@@ -146,6 +149,29 @@ class _AsyncLLMHTTPClient:
         return await self._engine_client.is_tracing_enabled()
 
 
+def _copy_vllm_chat_messages(messages):
+    """Copy only the request containers that vLLM normalizes in place."""
+    copied_messages = []
+    for message in messages:
+        copied_message = dict(message)
+        if message.get("tool_calls"):
+            copied_message["tool_calls"] = list(message["tool_calls"])
+        copied_messages.append(copied_message)
+    return copied_messages
+
+
+def _parse_orjson_request(request_body: bytes, request_type):
+    return request_type.model_validate(orjson.loads(request_body))
+
+
+def _orjson_response(content, status_code: int = 200) -> Response:
+    return Response(
+        content=orjson.dumps(content),
+        status_code=status_code,
+        media_type="application/json",
+    )
+
+
 class VllmAsyncGenerationWorkerImpl(
     VllmAsyncCheckpointEngineRpcMixin, BaseVllmGenerationWorker
 ):
@@ -157,6 +183,7 @@ class VllmAsyncGenerationWorkerImpl(
         seed=None,
         extra_env_vars: Optional[list[str]] = None,
         defer_model_load: bool = False,
+        use_fastokens: bool = False,
     ):
         """Initialize an async vLLM worker.
 
@@ -173,7 +200,10 @@ class VllmAsyncGenerationWorkerImpl(
             extra_env_vars: Additional environment variable names to forward into
                           the vLLM worker subprocess.
             defer_model_load: If True, skip model loading and only reserve port
+            use_fastokens: Apply Fastokens before vLLM creates its tokenizer.
         """
+        maybe_patch_fastokens(use_fastokens)
+
         # Deferred-loading state. Always initialized so every instance has a
         # consistent set of attributes regardless of init path.
         self._reserved_socket = None
@@ -672,13 +702,14 @@ class VllmAsyncGenerationWorkerImpl(
     # ruff: noqa
     def _setup_vllm_openai_api_server(self, app: FastAPI) -> FastAPI:
         worker_self = self
-        from copy import deepcopy
         from logging import Filter as LoggingFilter
         from logging import LogRecord
         from typing import List, Optional, Union
 
         from fastapi import Request
+        from fastapi.encoders import jsonable_encoder
         from fastapi.responses import JSONResponse, StreamingResponse
+        from pydantic import ValidationError
         from vllm.entrypoints.chat_utils import load_chat_template
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionRequest,
@@ -740,6 +771,10 @@ class VllmAsyncGenerationWorkerImpl(
                 if self.required_prefix_token_ids is None:
                     for message in reversed(self.messages):
                         if "prompt_token_ids" in message:
+                            LOGGER.warning(
+                                "Native vLLM used the compatibility prefix fallback; "
+                                "the Gym request did not provide required_prefix_token_ids."
+                            )
                             self.required_prefix_token_ids = (
                                 message["prompt_token_ids"]
                                 + message["generation_token_ids"]
@@ -798,11 +833,7 @@ class VllmAsyncGenerationWorkerImpl(
                 *,
                 skip_mm_cache: bool = False,
             ):
-                for message in messages:
-                    if message.get("tool_calls"):
-                        message["tool_calls"] = list(message["tool_calls"])
-
-                messages_for_replace_prefix_tokens = deepcopy(messages)
+                messages_for_render = _copy_vllm_chat_messages(messages)
 
                 # Temporarily set to 1 so vLLM's pre-tokenization length check passes;
                 # the actual value will be set through _clamp_max_tokens later.
@@ -821,7 +852,7 @@ class VllmAsyncGenerationWorkerImpl(
                 try:
                     res = await super().preprocess_chat(
                         request=request,
-                        messages=messages,
+                        messages=messages_for_render,
                         default_template=default_template,
                         default_template_content_format=default_template_content_format,
                         default_template_kwargs=default_template_kwargs,
@@ -877,21 +908,17 @@ class VllmAsyncGenerationWorkerImpl(
 
                 # Token-in splice path — shared by staging_chain and direct prefix.
                 last_assistant_message_idx = None
-                for i in reversed(range(len(messages_for_replace_prefix_tokens))):
-                    if messages_for_replace_prefix_tokens[i]["role"] == "assistant":
+                for i in reversed(range(len(messages_for_render))):
+                    if messages_for_render[i]["role"] == "assistant":
                         last_assistant_message_idx = i
                         break
 
                 if last_assistant_message_idx is None:
-                    messages_to_last_assistant_message = (
-                        messages_for_replace_prefix_tokens
-                    )
+                    messages_to_last_assistant_message = messages_for_render
                 else:
-                    messages_to_last_assistant_message = (
-                        messages_for_replace_prefix_tokens[
-                            : last_assistant_message_idx + 1
-                        ]
-                    )
+                    messages_to_last_assistant_message = messages_for_render[
+                        : last_assistant_message_idx + 1
+                    ]
 
                 modified_request = request.model_copy(
                     update={"add_generation_prompt": False}
@@ -1101,9 +1128,28 @@ class VllmAsyncGenerationWorkerImpl(
 
         # The create_chat_completion and tokenize methods are taken from vllm/entrypoints/openai/api_server.py
         @app.post("/v1/chat/completions")
-        async def create_chat_completion(
-            request: NeMoRLChatCompletionRequest, raw_request: Request
-        ):
+        async def create_chat_completion(raw_request: Request):
+            try:
+                request = _parse_orjson_request(
+                    await raw_request.body(), NeMoRLChatCompletionRequest
+                )
+            except orjson.JSONDecodeError as e:
+                return _orjson_response(
+                    {
+                        "error": {
+                            "message": f"Invalid JSON: {e}",
+                            "type": "invalid_request_error",
+                            "code": 400,
+                        }
+                    },
+                    status_code=400,
+                )
+
+            except ValidationError as e:
+                return _orjson_response(
+                    {"detail": jsonable_encoder(e.errors())}, status_code=422
+                )
+
             # This needs to match the behavior in nemo_rl/models/generation/vllm/vllm_worker.py::BaseVllmGenerationWorker::_build_sampling_params
             # Right now we explicitly assert set this to -1.
             assert request.top_k in (None, -1), (
@@ -1155,8 +1201,8 @@ class VllmAsyncGenerationWorkerImpl(
                 # ErrorResponse. Convert to HTTP 400 so the Gym proxy can
                 # detect context-length overflow and handle it gracefully.
                 worker_self._abort_request_capture(request, reason="context_length")
-                return JSONResponse(
-                    content={
+                return _orjson_response(
+                    {
                         "error": {
                             "message": str(e),
                             "type": "invalid_request_error",
@@ -1172,8 +1218,8 @@ class VllmAsyncGenerationWorkerImpl(
 
             if isinstance(generator, ErrorResponse):
                 worker_self._abort_request_capture(request, reason="error_response")
-                return JSONResponse(
-                    content=generator.model_dump(), status_code=generator.error.code
+                return _orjson_response(
+                    generator.model_dump(), status_code=generator.error.code
                 )
 
             elif isinstance(generator, ChatCompletionResponse):
@@ -1187,7 +1233,7 @@ class VllmAsyncGenerationWorkerImpl(
                 content = await asyncio.to_thread(
                     worker_self._finish_request_capture, request, content
                 )
-                return JSONResponse(content=content)
+                return _orjson_response(content)
 
             worker_self._abort_request_capture(request, reason="streaming_response")
             return StreamingResponse(content=generator, media_type="text/event-stream")

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -23,10 +23,12 @@ from copy import deepcopy
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import orjson
 import pytest
 import ray
 import requests
 import torch
+from pydantic import BaseModel, ValidationError
 
 from nemo_rl.algorithms.grpo import refit_policy_generation
 from nemo_rl.algorithms.loss import NLLLossFn
@@ -40,6 +42,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.models.generation.openai_server_utils import replace_prefix_tokens
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.vllm_worker import (
+    BaseVllmGenerationWorker,
     VllmGenerationWorkerImpl,
     _context_capped_max_new_tokens,
     _resolve_enable_prefix_caching,
@@ -47,6 +50,9 @@ from nemo_rl.models.generation.vllm.vllm_worker import (
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
     _AsyncLLMHTTPClient,
+    _copy_vllm_chat_messages,
+    _orjson_response,
+    _parse_orjson_request,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
 from nemo_rl.models.policy.lm_policy import Policy
@@ -634,6 +640,96 @@ class _FakeFastAPIApp:
             return func
 
         return decorator
+
+
+def test_vllm_async_worker_applies_fastokens_before_base_init(monkeypatch):
+    events = []
+
+    def fake_base_init(worker, *args, **kwargs):
+        events.append("base-init")
+        worker.is_model_owner = False
+
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_worker_async.maybe_patch_fastokens",
+        lambda enabled: events.append(("fastokens", enabled)),
+    )
+    monkeypatch.setattr(BaseVllmGenerationWorker, "__init__", fake_base_init)
+
+    VllmAsyncGenerationWorkerImpl(config={}, use_fastokens=True)
+
+    assert events == [("fastokens", True), "base-init"]
+
+
+def test_vllm_chat_message_copy_is_shallow_and_does_not_mutate_input():
+    nested_tool_call = {
+        "id": "call-1",
+        "function": {"name": "tool", "arguments": '{"value":1}'},
+    }
+    messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": (nested_tool_call,),
+        },
+    ]
+
+    copied = _copy_vllm_chat_messages(messages)
+
+    assert copied == [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [nested_tool_call],
+        },
+    ]
+    assert copied is not messages
+    assert copied[0] is not messages[0]
+    assert copied[1] is not messages[1]
+    assert copied[1]["tool_calls"] is not messages[1]["tool_calls"]
+    assert copied[1]["tool_calls"][0] is nested_tool_call
+    assert isinstance(messages[1]["tool_calls"], tuple)
+
+
+class _OrjsonRequest(BaseModel):
+    messages: list[dict]
+
+
+def test_vllm_orjson_request_and_response_preserve_fields():
+    body = orjson.dumps(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {
+                                "name": "tool",
+                                "arguments": '{"value":1}',
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
+    parsed = _parse_orjson_request(body, _OrjsonRequest)
+    response = _orjson_response(parsed.model_dump(), status_code=201)
+
+    assert response.status_code == 201
+    assert response.media_type == "application/json"
+    assert orjson.loads(response.body) == orjson.loads(body)
+
+
+def test_vllm_orjson_request_rejects_invalid_json_and_schema():
+    with pytest.raises(orjson.JSONDecodeError):
+        _parse_orjson_request(b"{", _OrjsonRequest)
+
+    with pytest.raises(ValidationError):
+        _parse_orjson_request(b'{"messages":"not-a-list"}', _OrjsonRequest)
 
 
 def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):


### PR DESCRIPTION
## Summary

- pass the existing `policy.tokenizer.use_fastokens` setting to native async vLLM actors and apply Fastokens before vLLM creates its tokenizer and HTTP renderer
- replace the full message-history deep copy with shallow copies of the message list, message mappings, and `tool_calls` lists
- parse native HTTP request bytes with `orjson` and serialize non-streaming success and error responses with `orjson`; keep Pydantic validation and streaming behavior unchanged
- consume the Gym-derived exact prefix from NVIDIA-NeMo/Gym#2836 while retaining the existing metadata scan as a compatibility fallback

This targets `main` directly and does not depend on NeMo-RL #3761.

## End-to-end result

Matched 48-GPU Nano V3.5 native vLLM 0.26 runs used the same model, data, six TP4 serving workers, six policy nodes, 144 trajectories per step, four optimizer steps, concurrency 192, and eight Gym workers.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Model calls | 59,753 | 62,389 | +4.41% |
| Generated tokens | 14,501,490 | 15,397,347 | +6.18% |
| Summed client model-call time | 261,684.84 s | 199,291.67 s | -23.84% |
| Seconds per model call | 4.3794 | 3.1943 | -27.06% |
| Generated tokens per model-call second | 55.42 | 77.26 | +39.42% |
| Summed rollout wall time | 8,851.27 s | 8,042.62 s | -9.14% |
| Token-normalized rollout wall time | 1.000 | 0.856 | -14.42% |

Generated work differed by 6.18%, so the raw rollout-wall result is directional. The token-normalized result and per-call metrics account for that work difference. `model-call time` is client-observed request time, not vLLM engine-only execution time.

The optimized native result also closely matched the retained optimized Dynamo aggregate result: `3.1943` versus `3.1986` seconds per call and `77.26` versus `77.16` generated tokens per model-call second.

## Validation

- `7 passed` focused NeMo-RL tests covering early Fastokens activation, Fastokens token-ID parity, shallow-copy behavior, orjson parsing and response preservation, invalid input, exact prefix splicing, and existing HTTP parser setup
- `3 passed` focused Gym tests in NVIDIA-NeMo/Gym#2836
- Ruff and changed-file pre-commit hooks passed, including pyrefly
- real Nano V3.5 TP4 smoke passed first-turn and multi-turn HTTP requests with exact token metadata, Fastokens, Gym prefix ownership, and orjson responses
- full native vLLM 0.26 trainer exited successfully with four steps, exactly 144 trajectories per step, weight version 4, no `/tokenize` recovery, no prefix fallback, and no token-ID or log-probability mismatch

## Scope

- no new configuration option or dependency
- no threads, processes, retries, or streaming-response changes
- no Dynamo changes
