### PR TITLE
fix(grpo_sync): drop env-flagged samples from the loss

### DIFF
--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -50,6 +50,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from nemo_rl.algorithms.grpo import (
     GRPOSaveState,
     MasterConfig,
+    _apply_mask_sample_filter,
     _clip_grpo_advantages,
     _create_advantage_estimator,
     _initial_policy_generation_stale,
@@ -802,6 +803,13 @@ def grpo_train_sync(
                     lm[driver_carry["truncated"]] = 0
                     driver_carry["loss_multiplier"] = lm
 
+                # Same order grpo.py uses (:3304-3314): overlong filtering,
+                # then the env flag. The two trainers are selected by
+                # ``data_plane.enabled`` alone, so an infrastructure switch
+                # must not change which samples reach the loss. Shares
+                # grpo.py's implementation rather than restating the rule.
+                num_mask_sample_filtered = _apply_mask_sample_filter(driver_carry)
+
                 # ── Unpack slice (small per-sample tensors) ────────────
                 rewards = (
                     driver_carry["filtered_reward"]
@@ -1096,6 +1104,7 @@ def grpo_train_sync(
                     "advantages/min": torch.min(response_advantages).detach().item()
                     if response_advantages.numel() > 0
                     else 0.0,
+                    "num_mask_sample_filtered": num_mask_sample_filtered,
                     **ds_metrics,
                 }
                 if "moe_metrics" in train_results:

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -803,7 +803,7 @@ def grpo_train_sync(
                     lm[driver_carry["truncated"]] = 0
                     driver_carry["loss_multiplier"] = lm
 
-                # Same order grpo.py uses (:3304-3314): overlong filtering,
+                # Same order grpo.py uses: overlong filtering,
                 # then the env flag. The two trainers are selected by
                 # ``data_plane.enabled`` alone, so an infrastructure switch
                 # must not change which samples reach the loss. Shares

--- a/nemo_rl/data_plane/README.md
+++ b/nemo_rl/data_plane/README.md
@@ -225,7 +225,9 @@ meta, driver_carry, rollout_metrics, gen_metrics = ray.get(
 # driver_carry          : BatchedDataDict of per-row tensors
 #                         (total_reward, loss_multiplier, truncated,
 #                          length, input_lengths, prompt_ids_for_adv,
-#                          response_token_lengths, GDPO components)
+#                          response_token_lengths, GDPO components,
+#                          mask_sample on the NeMo Gym path unless
+#                          env.should_mask_flagged_samples is false)
 ```
 
 **2. Reward + dynamic sampling** (driver, on `driver_carry` only):

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -58,6 +58,7 @@ from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_multi_turn_rollout,
     run_nemo_gym_rollout_sync,
+    should_mask_flagged_samples,
 )
 from nemo_rl.models.generation.interfaces import GenerationInterface
 from nemo_rl.utils.logger import should_log_nemo_gym_full_result_tables
@@ -269,6 +270,7 @@ class SyncRolloutActor:
                 thinking_tags=get_nemo_gym_thinking_tags(cfg.env),
                 deduplicate_multimodal_data=cfg.grpo.deduplicate_multimodal_data,
                 debug_payload_metrics=cfg.grpo.debug_payload_metrics,
+                mask_env_flagged_samples=should_mask_flagged_samples(cfg.env),
             )
             final_batch, rollout_metrics = r.final_batch, r.rollout_metrics
         else:
@@ -381,6 +383,16 @@ class SyncRolloutActor:
             # apply_reward_shaping on the driver without a TQ fetch.
             "response_token_lengths": decomposed["response_token_lengths"],
         }
+        # Env-flagged samples, for the driver's mask_sample filter. It is a
+        # bool tensor, so the pass-through loop above skips it, and the driver
+        # cannot recover it from a TQ slice fetch. Absent when the env opted
+        # out via ``env.should_mask_flagged_samples=false`` or when the
+        # rollout path is not NeMo Gym.
+        if "mask_sample" in fb:
+            mask_sample = fb["mask_sample"]
+            if not isinstance(mask_sample, torch.Tensor):
+                mask_sample = torch.tensor(mask_sample, dtype=torch.bool)
+            driver_carry["mask_sample"] = mask_sample
         # GDPO multi-reward components: scale_rewards iterates these
         # keys driver-side and the GDPO advantage estimator reads them
         # from ``adv_inputs``. Plumb them through ``driver_carry``

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -19,7 +19,7 @@ reward shaping / baseline-std for a sync GRPO step. The driver dispatches
 a per-step prompt batch + uids; the actor runs ``run_multi_turn_rollout``
 (or async / nemo_gym variants), then writes the bulk schema to TQ via
 :func:`nemo_rl.data_plane.column_io.kv_first_write`. Only a ``KVBatchMeta``
-and a small per-sample ``driver_carry`` dict (rewards, masks, lengths,
+and a small per-sample ``driver_carry`` batch (rewards, masks, lengths,
 baseline/std, prompt_ids_for_adv) cross back to the driver via Ray.
 
 **Goal — rollout 1-hop put**: bulk tensors (input_ids, output_ids,
@@ -152,7 +152,7 @@ class SyncRolloutActor:
         carry_keys: Optional[list[str]] = None,
     ) -> tuple[
         KVBatchMeta,
-        dict[str, Any],
+        BatchedDataDict[Any],
         dict[str, Any],
         Optional[dict[str, Any]],
     ]:
@@ -211,7 +211,7 @@ class SyncRolloutActor:
 
         Returns:
             ``(meta, driver_carry, rollout_metrics, generation_logger_metrics)``
-            where ``driver_carry`` is a per-row dict of tensors the driver
+            where ``driver_carry`` is a per-row ``BatchedDataDict`` the driver
             uses for compute (rewards, masks, lengths, prompt_ids_for_adv,
             …) — stays on the driver, never crosses an actor boundary.
         """

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -280,6 +280,25 @@ class TestMaskSampleFilter:
             repeated_batch["loss_multiplier"], torch.tensor([1.0, 0.0, 0.0])
         )
 
+    def test_operates_on_the_plain_dict_the_sync_driver_carries(self):
+        """grpo_sync reuses this on ``driver_carry``, which is a plain dict.
+
+        The annotation says ``BatchedDataDict``; sharing one implementation
+        across both drivers is the point, so pin that a dict works rather than
+        letting someone restate the rule a third time.
+        """
+        driver_carry = {
+            "loss_multiplier": torch.tensor([1.0, 1.0, 1.0]),
+            "mask_sample": torch.tensor([False, True, False]),
+        }
+
+        num_masked = _apply_mask_sample_filter(driver_carry)
+
+        assert num_masked == 1
+        assert torch.equal(
+            driver_carry["loss_multiplier"], torch.tensor([1.0, 0.0, 1.0])
+        )
+
     def test_masks_list_valued_mask_sample(self):
         repeated_batch = BatchedDataDict(
             {
@@ -1391,7 +1410,7 @@ def mock_async_grpo_infrastructure(
     return stack
 
 
-def mock_sync_grpo_infrastructure(policy):
+def mock_sync_grpo_infrastructure(policy, driver_carry_extra=None):
     """Context manager that mocks the TQ/data-plane infrastructure of grpo_train_sync.
 
     Mirrors ``mock_async_grpo_infrastructure``: the Ray rollout actor and the
@@ -1412,6 +1431,7 @@ def mock_sync_grpo_infrastructure(policy):
             "loss_multiplier": torch.tensor([1.0]),
             "truncated": torch.tensor([False]),
             "length": torch.tensor([3]),
+            **(driver_carry_extra or {}),
         }
     )
     meta = MagicMock()
@@ -4368,6 +4388,86 @@ def _enter_stop_test_mocks(
         )
     )
     return "nemo_rl.algorithms.grpo.validate"
+
+
+def test_grpo_sync_drops_env_flagged_samples_from_the_loss(mock_grpo_components):
+    """``data_plane.enabled`` picks the trainer; it must not pick the objective.
+
+    ``run_grpo.py`` presents grpo.py and grpo_sync.py as two implementations of
+    one synchronous algorithm. grpo.py drops env-flagged rollouts from the loss
+    (``_apply_mask_sample_filter``, called at grpo.py:3313 and :4955); before
+    this fix grpo_sync.py never called it, so a rollout the environment marked
+    unusable still contributed its full policy-gradient term there.
+    """
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_end = False
+    logger = mock_grpo_components["logger"]
+
+    with ExitStack() as stack:
+        master_config.data_plane = {"enabled": True}
+        stack.enter_context(
+            mock_sync_grpo_infrastructure(
+                mock_grpo_components["policy"],
+                driver_carry_extra={"mask_sample": torch.tensor([True])},
+            )
+        )
+        stack.enter_context(
+            patch("nemo_rl.algorithms.grpo_sync.validate_sync", return_value=({}, {}))
+        )
+        grpo_train_sync(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            logger,
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    metrics = _logged_train_metrics_with_key(logger, "num_mask_sample_filtered")
+    assert metrics["num_mask_sample_filtered"] == 1
+
+
+def test_grpo_sync_reports_zero_when_nothing_is_flagged(mock_grpo_components):
+    """The metric has to exist on every step, or a dashboard reads a gap as zero."""
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_end = False
+    logger = mock_grpo_components["logger"]
+
+    with ExitStack() as stack:
+        master_config.data_plane = {"enabled": True}
+        stack.enter_context(
+            mock_sync_grpo_infrastructure(mock_grpo_components["policy"])
+        )
+        stack.enter_context(
+            patch("nemo_rl.algorithms.grpo_sync.validate_sync", return_value=({}, {}))
+        )
+        grpo_train_sync(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            logger,
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    metrics = _logged_train_metrics_with_key(logger, "num_mask_sample_filtered")
+    assert metrics["num_mask_sample_filtered"] == 0
 
 
 @pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train, grpo_train_sync])

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -4389,6 +4389,7 @@ def _rollout_actor_driver_carry(
             "generation": {},
             "make_sequence_length_divisible_by": 1,
             "max_total_sequence_length": 8,
+            "precision": "bfloat16",
         },
         logger={"wandb_enabled": False, "wandb": {}},
         env={},

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -88,6 +88,7 @@ from nemo_rl.experience.interfaces import (
     RETAINED_TASK_INDICES_KEY,
     TRAINED_TASK_INDICES_KEY,
 )
+from nemo_rl.experience.sync_rollout_actor import SyncRolloutActor
 from nemo_rl.experience.rollouts import calculate_rewards
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.models.generation.dynamo import DynamoConfig
@@ -4371,6 +4372,101 @@ def _enter_stop_test_mocks(
     return "nemo_rl.algorithms.grpo.validate"
 
 
+def _rollout_actor_driver_carry(
+    mask_sample: bool | None, *, mask_env_flagged_samples: bool = True
+) -> BatchedDataDict[Any]:
+    """Run the real actor caller and return the payload consumed by the driver."""
+    from nemo_rl.data.llm_message_utils import MESSAGE_LOG_BULK_FIELDS
+
+    actor_cls = SyncRolloutActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor.policy_generation = None
+    actor.tokenizer = SimpleNamespace(pad_token_id=0)
+    actor.task_to_env = {}
+    actor._dp_client = MagicMock()
+    actor.master_config = SimpleNamespace(
+        policy={
+            "generation": {},
+            "make_sequence_length_divisible_by": 1,
+            "max_total_sequence_length": 8,
+        },
+        logger={"wandb_enabled": False, "wandb": {}},
+        env={},
+        grpo=SimpleNamespace(
+            deduplicate_multimodal_data=False,
+            debug_payload_metrics=False,
+            max_rollout_turns=1,
+        ),
+        reward_penalties=SimpleNamespace(),
+    )
+
+    final_batch_data = {
+        "message_log": [[{"role": "user", "content": "prompt"}]],
+        "length": torch.tensor([1]),
+        "loss_multiplier": torch.tensor([1.0]),
+        "total_reward": torch.tensor([1.0]),
+        "truncated": torch.tensor([False]),
+    }
+    if mask_sample is not None:
+        final_batch_data["mask_sample"] = torch.tensor([mask_sample])
+    final_batch = BatchedDataDict(final_batch_data)
+    flat = BatchedDataDict(
+        {
+            "token_ids": torch.tensor([[1, 2]]),
+            "generation_logprobs": torch.tensor([[0.0, 0.0]]),
+            "token_loss_mask": torch.tensor([[0, 1]]),
+        }
+    )
+    prompt_flat = BatchedDataDict({"token_ids": torch.tensor([[1]])})
+    decomposed = {
+        **{key: [None] for key in MESSAGE_LOG_BULK_FIELDS},
+        "response_token_lengths": torch.tensor([1]),
+    }
+
+    with (
+        patch(
+            "nemo_rl.environments.nemo_gym.should_use_nemo_gym",
+            return_value=True,
+        ),
+        patch(
+            "nemo_rl.experience.sync_rollout_actor.run_nemo_gym_rollout_sync",
+            return_value=SimpleNamespace(final_batch=final_batch, rollout_metrics={}),
+        ) as rollout,
+        patch(
+            "nemo_rl.experience.sync_rollout_actor.should_mask_flagged_samples",
+            return_value=mask_env_flagged_samples,
+        ),
+        patch(
+            "nemo_rl.experience.sync_rollout_actor._flatten_rollout_message_log_for_tq",
+            return_value=(flat, torch.tensor([2]), prompt_flat),
+        ),
+        patch(
+            "nemo_rl.data.llm_message_utils.decompose_message_log",
+            return_value=decomposed,
+        ),
+        patch(
+            "nemo_rl.experience.sync_rollout_actor.kv_first_write",
+            return_value=MagicMock(),
+        ),
+    ):
+        _, driver_carry, _, _ = actor.rollout_to_tq(
+            BatchedDataDict({"prompt": ["p"]}), partition_id="train"
+        )
+
+    assert (
+        rollout.call_args.kwargs["mask_env_flagged_samples"] is mask_env_flagged_samples
+    )
+    return driver_carry
+
+
+def test_sync_rollout_actor_honors_env_mask_opt_out():
+    driver_carry = _rollout_actor_driver_carry(
+        mask_sample=None, mask_env_flagged_samples=False
+    )
+
+    assert "mask_sample" not in driver_carry
+
+
 def test_grpo_sync_drops_env_flagged_samples_from_the_loss(mock_grpo_components):
     """``data_plane.enabled`` picks the trainer; it must not pick the objective.
 
@@ -4391,7 +4487,7 @@ def test_grpo_sync_drops_env_flagged_samples_from_the_loss(mock_grpo_components)
         stack.enter_context(
             mock_sync_grpo_infrastructure(
                 mock_grpo_components["policy"],
-                driver_carry_extra={"mask_sample": torch.tensor([True])},
+                driver_carry_extra=_rollout_actor_driver_carry(mask_sample=True),
             )
         )
         stack.enter_context(

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -280,25 +280,6 @@ class TestMaskSampleFilter:
             repeated_batch["loss_multiplier"], torch.tensor([1.0, 0.0, 0.0])
         )
 
-    def test_operates_on_the_plain_dict_the_sync_driver_carries(self):
-        """grpo_sync reuses this on ``driver_carry``, which is a plain dict.
-
-        The annotation says ``BatchedDataDict``; sharing one implementation
-        across both drivers is the point, so pin that a dict works rather than
-        letting someone restate the rule a third time.
-        """
-        driver_carry = {
-            "loss_multiplier": torch.tensor([1.0, 1.0, 1.0]),
-            "mask_sample": torch.tensor([False, True, False]),
-        }
-
-        num_masked = _apply_mask_sample_filter(driver_carry)
-
-        assert num_masked == 1
-        assert torch.equal(
-            driver_carry["loss_multiplier"], torch.tensor([1.0, 0.0, 1.0])
-        )
-
     def test_masks_list_valued_mask_sample(self):
         repeated_batch = BatchedDataDict(
             {


### PR DESCRIPTION
## What does this PR do?

Makes data-plane synchronous GRPO honor the same environment `mask_sample` behavior as the legacy driver.

- `SyncRolloutActor` forwards `should_mask_flagged_samples` to the Gym rollout call.
- When enabled, the actor carries the boolean `mask_sample` tensor to the driver.
- `grpo_train_sync` applies the shared filter after overlong filtering and reports `num_mask_sample_filtered` every step.
- The opt-out remains real: when disabled, no mask carry is produced and flagged samples are not dropped.
- `rollout_to_tq` annotations/docstrings now name its actual `BatchedDataDict` return type.

Flagged samples still participate in advantage computation and are removed only from the loss, matching the legacy path.

## Validation

Current head `8d71808dd6f4031b86a5b84bb873f9272386cb0a`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- full `tests/unit/algorithms/test_grpo.py`: **169 passed**
- three focused actor → driver → `grpo_train_sync` regressions passed
- refreshed the caller fixture for current main's required `policy.precision`
- Ruff check, Ruff format check, and `git diff --check`: passed

These regressions exercise the actor/driver plumbing with the existing CPU harness; no GPU workload is required.
