### PR TITLE
fix(loss): report sampling_importance_ratio before TIS truncation

### DIFF
--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -673,7 +673,9 @@ This is simply $\frac{1}{|T|}\sum_{t \in \text{tokens}}\text{exp}(\text{log}(\pi
 
 Similar to [Multiplicative Token Probability Error](#multiplicative-token-probability-error), this is a measure of how far off your inference backend is from your training framework. However, this metric is meant to find the bias in that error, rather than the variance, as it does not take the absolute value of the error. With some noise, this should hover around 1.
 
-This metric is always calculated and the per-token version (without the mean) is used in the loss function when [Importance Sampling Correction](#importance-sampling-correction) is enabled.
+This metric is always calculated, and reports the raw ratio above even when `truncated_importance_sampling_type` is set — truncation is a change to the loss, not to what the mismatch actually was, and clamping the metric would make it saturate (`tis`) or read below 1 (`icepop`, which zeroes out-of-band tokens rather than clamping them) exactly when the backend has drifted furthest. How often truncation fires is reported separately as `is_oob_ratio`.
+
+The per-token version (without the mean) is what the loss function uses when [Importance Sampling Correction](#importance-sampling-correction) is enabled; with truncation on, the loss uses the truncated weights while this metric keeps reporting the untruncated ones.
 
 ### Entropy
 This feature is controlled by the parameter `approx_entropy`. It estimates the entropy of the policy distribution, which can be used to encourage exploration and prevent premature convergence during training. We roughly approximate the entropy of the LLM's distribution throughout training by calculating:

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -660,6 +660,24 @@ class ClippedPGLossFn(LossFunction):
             actor_importance_weights_expanded = torch.nan_to_num(
                 actor_importance_weights_expanded, nan=0.0, posinf=0.0, neginf=0.0
             )
+        # Snapshot before truncation: ``sampling_importance_ratio`` is defined
+        # in docs/guides/grpo.md#sampling-importance-ratio as the raw
+        # exp(log pi_training - log pi_inference), and its stated job is to
+        # surface *the bias* in training/inference mismatch. Reporting the
+        # truncated weights instead makes it saturate under ``tis`` and invert
+        # under ``icepop``, where out-of-band tokens are zeroed rather than
+        # clamped: a batch whose true mean ratio is 4.5 reads as 0.48, i.e.
+        # below 1, exactly when the backend has drifted furthest above it. How
+        # often truncation fires is already reported separately as
+        # ``is_oob_ratio``.
+        #
+        # An alias, not a copy: all three truncation branches below rebind
+        # ``actor_importance_weights_expanded`` to a fresh tensor rather than
+        # mutating it, so this keeps pointing at the raw weights. Switching one
+        # to an in-place form (``clamp_``) would break that silently -- the two
+        # tests named after this metric are what would catch it.
+        untruncated_importance_weights = actor_importance_weights_expanded
+
         # ---- Truncated Importance Sampling ----
         # "tis"          – clamp IS weights to [min, max], where min defaults to 0
         # "icepop"       – zero out tokens whose IS weight ∉ [min, max]   (ref bounds: 0.5–5)
@@ -774,13 +792,13 @@ class ClippedPGLossFn(LossFunction):
         # See: docs/guides/grpo.md#sampling-importance-ratio
         if self.sequence_level_importance_ratios:
             sample_importance_ratio = masked_mean(
-                actor_importance_weights.squeeze(-1),
+                untruncated_importance_weights.squeeze(-1),
                 sample_mask,
                 global_normalization_factor=global_valid_seqs,
             )
         else:
             sample_importance_ratio = masked_mean(
-                actor_importance_weights,
+                untruncated_importance_weights,
                 mask,
                 global_normalization_factor=global_valid_toks,
             )

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -3188,8 +3188,17 @@ def test_sampling_importance_ratio_is_reported_untruncated():
     raw = _sampling_importance_ratio(None)
 
     assert raw == pytest.approx(4.5359, abs=1e-3)
-    for tis_type in ("tis", "icepop", "seq-mask-tis"):
-        assert _sampling_importance_ratio(tis_type) == pytest.approx(raw, abs=1e-3), (
+    # Bounds are per-mode so each branch actually truncates on this fixture:
+    # tis/icepop compare per-token weights (max 12.18), seq-mask-tis compares
+    # the sequence geometric mean (1.82), so a shared [0.5, 5.0] would leave
+    # the seq-mask-tis multiply a no-op and that leg would prove nothing.
+    for tis_type, ratio, ratio_min in (
+        ("tis", 5.0, 0.5),
+        ("icepop", 5.0, 0.5),
+        ("seq-mask-tis", 1.5, 0.5),
+    ):
+        got = _sampling_importance_ratio(tis_type, ratio=ratio, ratio_min=ratio_min)
+        assert got == pytest.approx(raw, abs=1e-3), (
             f"{tis_type} moved sampling_importance_ratio away from its definition"
         )
 
@@ -3206,5 +3215,4 @@ def test_icepop_does_not_invert_the_sampling_importance_ratio():
     reported = _sampling_importance_ratio("icepop")
 
     assert reported > 1.0
-    # The value the truncated weights would have given, for the record.
-    assert reported != pytest.approx(0.4751, abs=1e-3)
+    assert reported == pytest.approx(4.5359, abs=1e-3)

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -3142,3 +3142,69 @@ def test_vocab_parallel_gather_columns_tp_sharded(monkeypatch):
     ref[..., idx].float().backward(grad_out)
     torch.testing.assert_close(shards[0].grad, ref.grad[..., :v_local])
     torch.testing.assert_close(shards[1].grad, ref.grad[..., v_local:])
+
+
+def _sampling_importance_ratio(tis_type, *, ratio=5.0, ratio_min=0.5):
+    """Run the loss on fixed logprobs and return the reported metric.
+
+    One prompt, three response tokens whose true IS weights are roughly
+    [0.61, 12.18, 0.82] — mean 4.54, i.e. a backend that has drifted well
+    above 1. Under ``icepop`` the middle token is zeroed rather than clamped,
+    which is what drags the reported mean below 1.
+    """
+    torch.manual_seed(0)
+    data, *_ = _setup_clipped_pg_test_data(batch_size=1, seq_len=4, device="cpu")
+    data["advantages"] = torch.zeros(1, 4)
+    data["prev_logprobs"] = torch.tensor([[0.0, -1.0, -1.0, -1.0]])
+    data["generation_logprobs"] = torch.tensor([[0.0, -0.5, -3.5, -0.8]])
+    data["reference_policy_logprobs"] = torch.zeros(1, 4)
+
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_type=tis_type,
+        truncated_importance_sampling_ratio=None if tis_type is None else ratio,
+        truncated_importance_sampling_ratio_min=None if tis_type is None else ratio_min,
+    )
+    loss_fn = ClippedPGLossFn(cfg)
+
+    logprobs = torch.tensor([[-1.0, -1.0, -1.0]])
+    valid_seqs = data["sample_mask"].sum().float()
+    valid_toks = (data["token_mask"][:, 1:] * data["sample_mask"].unsqueeze(-1)).sum()
+    _, metrics = loss_fn(logprobs, data, valid_seqs, valid_toks.float())
+    return metrics["sampling_importance_ratio"]
+
+
+def test_sampling_importance_ratio_is_reported_untruncated():
+    """The metric is defined without truncation, and truncation must not move it.
+
+    docs/guides/grpo.md#sampling-importance-ratio defines it as the raw
+    ``exp(log pi_training - log pi_inference)`` and says it exists to surface
+    the *bias* in training/inference mismatch. Reporting the post-truncation
+    weights makes it saturate at ``truncated_importance_sampling_ratio``, so a
+    backend that drifted to 4.5 reads as the cap. How often truncation fires
+    is reported separately as ``is_oob_ratio``.
+    """
+    raw = _sampling_importance_ratio(None)
+
+    assert raw == pytest.approx(4.5359, abs=1e-3)
+    for tis_type in ("tis", "icepop", "seq-mask-tis"):
+        assert _sampling_importance_ratio(tis_type) == pytest.approx(raw, abs=1e-3), (
+            f"{tis_type} moved sampling_importance_ratio away from its definition"
+        )
+
+
+def test_icepop_does_not_invert_the_sampling_importance_ratio():
+    """Under icepop the old reading pointed the opposite way from the drift.
+
+    icepop zeroes out-of-band tokens instead of clamping them, so the mean is
+    pulled *down*: the same batch whose true mean ratio is 4.54 reported 0.48.
+    A user reads "below 1" — the training policy assigning less probability
+    than inference — at the moment the truth is the reverse, and the guide
+    tells them this should hover around 1.
+    """
+    reported = _sampling_importance_ratio("icepop")
+
+    assert reported > 1.0
+    # The value the truncated weights would have given, for the record.
+    assert reported != pytest.approx(0.4751, abs=1e-3)


### PR DESCRIPTION
## What does this PR do?

Reports `sampling_importance_ratio` from the raw training/inference probability ratio, before truncated importance sampling rewrites the weights.

The loss path is unchanged: `tis`, `icepop`, and `seq-mask-tis` still apply their configured truncation to the weights entering the gradient. The diagnostic keeps the definition documented in the GRPO guide, while `is_oob_ratio` continues to report how often truncation activates.

For raw token weights `[0.606531, 12.182494, 0.818731]`:

| Mode | Reported diagnostic | Loss-effective reference |
| --- | ---: | ---: |
| none | 4.535918 | 4.535918 |
| `tis` | 4.535918 | 2.141754 |
| `icepop` | 4.535918 | 0.475087 |
| `seq-mask-tis` | 4.535918 | sequence mask still applied |

## Validation

Current head `48a94363bfb958da68a5b570c85266a6f9aba074`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- `tests/unit/algorithms/test_loss_functions.py`: **43 passed, 44 GPU-gated skipped** on the local CPU harness
- both diagnostic behavior tests passed
- Ruff check, Ruff format check, and `git diff --check`: passed

The pre-refresh head also ran the full file on an H100 with **83 passed**, including all four CUDA cases from the three GPU-gated full-loss tests. Environment: Runpod Secure Cloud, `nvcr.io/nvidia/nemo-rl:v0.7.0`, NVIDIA H100 80 GB, driver 580.126.09, Python 3.13.14, PyTorch 2.11.0+cu130. The current-head patch-equivalent rebase was not rerun on GPU.
