### PR TITLE
fix(loss): min/max packed extrema instead of summing them

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -1898,12 +1898,20 @@ class MseValueLossFn(LossFunction):
             ).item()
 
             # Min/max are per-MB; ppo.py takes min/max across MBs.
+            # +/-inf, not 0.0, for an empty mask: 0.0 is a plausible value and
+            # would win the min against an all-positive critic, silently
+            # flooring the reported range. ClippedPGLossFn uses the same
+            # sentinel for the same reason, and both consumers skip it.
             masked_values = values[mask.bool()]
             values_min = (
-                masked_values.min().item() if masked_values.numel() > 0 else 0.0
+                masked_values.min().item()
+                if masked_values.numel() > 0
+                else float("inf")
             )
             values_max = (
-                masked_values.max().item() if masked_values.numel() > 0 else 0.0
+                masked_values.max().item()
+                if masked_values.numel() > 0
+                else float("-inf")
             )
 
             # Explained variance sufficient statistics.

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -162,10 +162,15 @@ class SequencePackingLossWrapper:
             # aggregate loss and metrics
             loss_accum += loss
             for k, v in metrics.items():
+                # ``*_min``/``*_max`` are extrema, not additive quantities.
+                # Preserve explicitly registered non-suffix metrics while also
+                # covering new loss metrics that follow the suffix contract.
+                is_min = k in _SEQ_METRIC_MIN or k.endswith("_min")
+                is_max = k in _SEQ_METRIC_MAX or k.endswith("_max")
                 if k not in metrics_accum:
-                    if k in _SEQ_METRIC_MIN:
+                    if is_min:
                         metrics_accum[k] = float("inf")
-                    elif k in _SEQ_METRIC_MAX:
+                    elif is_max:
                         metrics_accum[k] = float("-inf")
                     else:
                         metrics_accum[k] = 0
@@ -173,10 +178,10 @@ class SequencePackingLossWrapper:
                 val = v.item() if isinstance(v, torch.Tensor) and v.ndim == 0 else v
 
                 # Skip inf/-inf sentinel values (from sequences with no valid tokens)
-                if k in _SEQ_METRIC_MIN:
+                if is_min:
                     if not math.isinf(val):
                         metrics_accum[k] = min(metrics_accum[k], val)
-                elif k in _SEQ_METRIC_MAX:
+                elif is_max:
                     if not math.isinf(val):
                         metrics_accum[k] = max(metrics_accum[k], val)
                 else:

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -1213,9 +1213,13 @@ def _compute_critic_metrics(value_results: dict[str, Any]) -> dict[str, Any]:
         if key in {"lr", "wd", "global_valid_seqs", "global_valid_toks", "grad_norm"}:
             critic_metrics[metric_name] = np.mean(value).item()
         elif key == "values_min":
-            critic_metrics[metric_name] = np.min(value).item()
+            # Skip the empty-mask sentinel, as the probs_ratio extrema are
+            # handled at :1774 and :2757.
+            finite = [x for x in value if not np.isinf(x)]
+            critic_metrics[metric_name] = np.min(finite).item() if finite else -1.0
         elif key == "values_max":
-            critic_metrics[metric_name] = np.max(value).item()
+            finite = [x for x in value if not np.isinf(x)]
+            critic_metrics[metric_name] = np.max(finite).item() if finite else -1.0
         elif isinstance(value, (np.ndarray, list)):
             critic_metrics[metric_name] = np.sum(value).item()
         else:

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -509,7 +509,7 @@ def automodel_forward_backward(
                     ## scale by the number of global batches so we get the correct
                     ## value when summing metrics across all microbatches
                     for k in metrics.keys():
-                        if "_min" in k or "_max" in k:
+                        if k.endswith(("_min", "_max")):
                             continue
 
                         metrics[k] /= num_global_batches

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -947,7 +947,7 @@ class DTensorPolicyWorkerImpl(
                             ## scale by the number of global batches so we get the correct
                             ## value when summing metrics across all microbatches
                             for k in loss_metrics.keys():
-                                if "_min" in k or "_max" in k:
+                                if k.endswith(("_min", "_max")):
                                     continue
                                 loss_metrics[k] /= num_global_batches
                             num_valid_samples = loss_metrics["num_valid_samples"]

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1202,7 +1202,7 @@ class MegatronPolicyWorkerImpl(
                     for x in losses_reduced:
                         loss_metrics = {}
                         for k in x.keys():
-                            if "_min" in k or "_max" in k:
+                            if k.endswith(("_min", "_max")):
                                 loss_metrics[k] = x[k]
                             else:
                                 loss_metrics[k] = x[k] / num_global_batches
@@ -2029,7 +2029,7 @@ class MegatronPolicyWorkerImpl(
         for m in state["all_mb_metrics"]:
             out: dict[str, Any] = {}
             for k, v in m.items():
-                if "_min" in k or "_max" in k:
+                if k.endswith(("_min", "_max")):
                     out[k] = v
                 else:
                     out[k] = _scale_metric(k, v)

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -614,7 +614,7 @@ class MegatronValueWorkerImpl(TQWorkerMixin, AbstractPolicyWorker):
                     for x in losses_reduced:
                         loss_metrics = {}
                         for k in x.keys():
-                            if "_min" in k or "_max" in k:
+                            if k.endswith(("_min", "_max")):
                                 loss_metrics[k] = x[k]
                             else:
                                 loss_metrics[k] = x[k] / num_global_batches

--- a/tests/unit/algorithms/test_packed_metric_aggregation.py
+++ b/tests/unit/algorithms/test_packed_metric_aggregation.py
@@ -83,6 +83,44 @@ def _packed_and_unpacked(value_rows, sample_mask):
     return unpacked, packed
 
 
+class _AdditiveControlLossFn:
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        data: BatchedDataDict,
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        del logits, global_valid_seqs, global_valid_toks
+        value = data["values"].sum()
+        return value.new_zeros(()), {
+            "latency_minibatch": value,
+            "latency_maximum": value,
+        }
+
+
+def test_embedded_extrema_substrings_do_not_make_metrics_extrema() -> None:
+    """Only suffixes classify extrema; ordinary metric names remain additive."""
+    data, values = _batch([[1.0, 2.0], [3.0, 4.0]], [1, 1])
+    cu_seqlens = torch.tensor([0, 2, 4], dtype=torch.int32)
+    wrapper = SequencePackingLossWrapper(
+        loss_fn=_AdditiveControlLossFn(),
+        prepare_fn=_value_prepare_fn,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+    )
+
+    _, metrics = wrapper(
+        values.reshape(1, -1, 1),
+        data,
+        data["sample_mask"].sum(),
+        data["token_mask"].sum(),
+    )
+
+    assert metrics["latency_minibatch"] == pytest.approx(10.0)
+    assert metrics["latency_maximum"] == pytest.approx(10.0)
+
+
 def test_packing_reports_the_true_value_range():
     """Summed extrema are not extrema -- and the reported minimum flips sign.
 

--- a/tests/unit/algorithms/test_packed_metric_aggregation.py
+++ b/tests/unit/algorithms/test_packed_metric_aggregation.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Packing must not change what a metric means.
+
+``SequencePackingLossWrapper`` folds per-sequence metric dicts into one. Sums
+are right for globally normalized metrics and wrong for extrema, and the
+workers that consume this dict downstream already tell the two apart by the
+``_min``/``_max`` suffix (megatron_value_worker.py:611 and four sibling sites).
+"""
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.loss.loss_functions import MseValueLossConfig, MseValueLossFn
+from nemo_rl.algorithms.loss.wrapper import SequencePackingLossWrapper
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _value_prepare_fn(logits, data, loss_fn=None, **kwargs):
+    """Stand-in for megatron_value_worker._value_loss_prepare_fn.
+
+    That function all-gathers across CP and shifts; neither applies here, so
+    this keeps only the part the wrapper's contract depends on -- the key the
+    loss is called with.
+    """
+    del loss_fn, kwargs
+    return {"logits": logits}, data
+
+
+def _batch(value_rows, sample_mask):
+    values = torch.tensor(value_rows, dtype=torch.float32)
+    data = BatchedDataDict(
+        {
+            "values": values.clone(),
+            "returns": torch.zeros_like(values),
+            "token_mask": torch.ones_like(values),
+            "sample_mask": torch.tensor(sample_mask, dtype=torch.float32),
+        }
+    )
+    return data, values
+
+
+def _packed_and_unpacked(value_rows, sample_mask):
+    """Run the same values both ways and return (unpacked_metrics, packed_metrics)."""
+    loss_fn = MseValueLossFn(MseValueLossConfig())
+    data, values = _batch(value_rows, sample_mask)
+    logits = values.unsqueeze(-1)
+    global_valid_seqs = data["sample_mask"].sum()
+    global_valid_toks = (data["token_mask"] * data["sample_mask"].unsqueeze(-1)).sum()
+
+    unpacked_loss, unpacked = loss_fn(
+        logits, data, global_valid_seqs, global_valid_toks
+    )
+
+    seq_len = values.shape[1]
+    cu_seqlens = torch.tensor(
+        [i * seq_len for i in range(len(value_rows) + 1)], dtype=torch.int32
+    )
+    wrapper = SequencePackingLossWrapper(
+        loss_fn=loss_fn,
+        prepare_fn=_value_prepare_fn,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+    )
+    packed_loss, packed = wrapper(
+        logits.reshape(1, -1, 1), data, global_valid_seqs, global_valid_toks
+    )
+
+    # The loss must be untouched by anything here; if it moves, the test is
+    # measuring the wrong thing.
+    assert packed_loss.item() == pytest.approx(unpacked_loss.item(), abs=1e-6)
+    return unpacked, packed
+
+
+def test_packing_reports_the_true_value_range():
+    """Summed extrema are not extrema -- and the reported minimum flips sign.
+
+    Three sequences spanning -3..9. Summing the per-sequence minima gives
+    -3 + 1 + 6 = 4, so ``critic/values_min`` reports a positive number for a
+    critic whose predictions go negative. It is the diagnostic operators read
+    to catch a value head drifting, and the error grows with packing density.
+    """
+    unpacked, packed = _packed_and_unpacked(
+        [[-3.0, -1.0, 2.0], [1.0, 4.0, 2.0], [6.0, 9.0, 7.0]], [1, 1, 1]
+    )
+
+    assert unpacked["values_min"] == pytest.approx(-3.0)
+    assert unpacked["values_max"] == pytest.approx(9.0)
+    assert packed["values_min"] == pytest.approx(unpacked["values_min"])
+    assert packed["values_max"] == pytest.approx(unpacked["values_max"])
+
+
+def test_a_fully_masked_sequence_does_not_floor_the_reported_minimum():
+    """The empty-mask sentinel must not be a plausible value.
+
+    ``sample_mask`` is ``loss_multiplier``, which ``overlong_filtering`` zeroes
+    per sample -- and under packing one filtered sample in a pack is enough. A
+    0.0 sentinel would win the min against this all-positive critic and report
+    0.0 instead of 3.0, so it has to be +/-inf and be skipped, as
+    ClippedPGLossFn's already is.
+    """
+    unpacked, packed = _packed_and_unpacked(
+        [[3.0, 5.0, 4.0], [6.0, 9.0, 7.0], [8.0, 8.5, 8.2]], [1, 1, 0]
+    )
+
+    assert unpacked["values_min"] == pytest.approx(3.0)
+    assert packed["values_min"] == pytest.approx(3.0)
+    assert packed["values_max"] == pytest.approx(9.0)
+
+
+def test_globally_normalized_metrics_are_still_summed():
+    """Only extrema changed: everything else must still add up across sequences."""
+    unpacked, packed = _packed_and_unpacked(
+        [[-3.0, -1.0, 2.0], [1.0, 4.0, 2.0], [6.0, 9.0, 7.0]], [1, 1, 1]
+    )
+
+    for key in ("values_mean", "returns_mean", "returns_sq_mean", "residual_sq_mean"):
+        assert packed[key] == pytest.approx(unpacked[key], abs=1e-5), key
+
+
+def test_an_all_masked_microbatch_reports_the_sentinel_fallback():
+    """Every sequence filtered: there is no value range, and inf must not leak."""
+    import numpy as np
+
+    from nemo_rl.algorithms.ppo import _compute_critic_metrics
+
+    _, packed = _packed_and_unpacked([[3.0, 5.0, 4.0], [6.0, 9.0, 7.0]], [0, 0])
+    assert np.isinf(packed["values_min"])
+
+    critic = _compute_critic_metrics(
+        {
+            "grad_norm": torch.tensor(0.0),
+            "loss": torch.tensor(0.0),
+            "all_mb_metrics": {"values_min": [packed["values_min"]]},
+        }
+    )
+    assert critic["critic/values_min"] == pytest.approx(-1.0)

--- a/tests/unit/algorithms/test_packed_metric_aggregation.py
+++ b/tests/unit/algorithms/test_packed_metric_aggregation.py
@@ -14,9 +14,9 @@
 """Packing must not change what a metric means.
 
 ``SequencePackingLossWrapper`` folds per-sequence metric dicts into one. Sums
-are right for globally normalized metrics and wrong for extrema, and the
-workers that consume this dict downstream already tell the two apart by the
-``_min``/``_max`` suffix (megatron_value_worker.py:611 and four sibling sites).
+are right for globally normalized metrics and wrong for extrema. Most extrema
+use the ``_min``/``_max`` suffix; explicitly registered exceptions must keep
+their reduction as new metrics are added.
 """
 
 import pytest
@@ -96,6 +96,7 @@ class _AdditiveControlLossFn:
         return value.new_zeros(()), {
             "latency_minibatch": value,
             "latency_maximum": value,
+            "opd_full_decomposition_error": value,
         }
 
 
@@ -119,6 +120,7 @@ def test_embedded_extrema_substrings_do_not_make_metrics_extrema() -> None:
 
     assert metrics["latency_minibatch"] == pytest.approx(10.0)
     assert metrics["latency_maximum"] == pytest.approx(10.0)
+    assert metrics["opd_full_decomposition_error"] == pytest.approx(7.0)
 
 
 def test_packing_reports_the_true_value_range():

--- a/tests/unit/models/policy/test_megatron_split_parity.py
+++ b/tests/unit/models/policy/test_megatron_split_parity.py
@@ -152,9 +152,9 @@ def _run_split(
 
 def _reduce_metric(key: str, values: list) -> float:
     """Collapse a per-microbatch metric list the way grpo.py's reducer does."""
-    if "_min" in key:
+    if key.endswith("_min"):
         return float(np.min(values))
-    if "_max" in key:
+    if key.endswith("_max"):
         return float(np.max(values))
     if key in ("lr", "wd", "global_valid_seqs", "global_valid_toks"):
         return float(np.mean(values))


### PR DESCRIPTION
## What does this PR do?

Fixes packed min/max diagnostics that were being summed as additive metrics.

`SequencePackingLossWrapper` and the worker aggregators recognize extrema by the explicit `_min` / `_max` suffix contract. Names that merely contain those substrings in the middle remain additive. Current main's registered MOPD exception, `opd_full_decomposition_error`, keeps its max reduction even though it does not use the suffix. Fully masked value samples retain the existing sentinel behavior, and an all-sentinel critic step maps to `-1.0` like policy metrics.

Losses and gradients are unchanged.

## Validation

Current head `4a5af89017bd2bf51a9fa4cd32ba81ec59de7f20`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- packed metric and critic aggregation regressions: **8 passed**
- covers suffix extrema, embedded-substring additive names, the registered MOPD exception, and all-sentinel behavior
- Ruff check, Ruff format check, and `git diff --check`: passed

An earlier pre-refresh head also passed the gated Megatron split-parity test on two real H100s. It ran two optimizer steps through freshly initialized sync and split policies and compared the loss curve, grad norm, and every reduced per-microbatch metric.

| topology | result | elapsed |
| --- | ---: | ---: |
| DP=2, TP=1 | 1 passed | 494.22 s |
| DP=1, TP=2 | 1 passed | 367.62 s |

Environment: 2× NVIDIA H100 80 GB, `nvcr.io/nvidia/nemo-rl:v0.7.0`, Python 3.13, PyTorch 2.11.0+cu130, CUDA 13, and `NCCL_NVLS_ENABLE=0`. The current-head rebase and MOPD regression were verified locally; the 2-GPU parity test was not rerun after that refresh.
