### PR TITLE
fix(ppo): reject use_dynamic_sampling instead of resizing the batch for it

### DIFF
--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -447,18 +447,8 @@ def setup(
     batch_multiplier = ppo_config.batch_multiplier
     dataloader_batch_size = ppo_config.num_prompts_per_step
     if ppo_config.use_dynamic_sampling:
-        # PPO implements no filtering for this knob. ``dynamic_sampling`` was
-        # copied into this module but has never been called from any commit
-        # since it was added -- ``grpo.py`` holds the only production call
-        # site, and it reaches ``grpo.py``'s own copy. Accepting the flag scaled
-        # the rollout batch by ``batch_multiplier`` and then trained on all of
-        # it, so ``num_prompts_per_step`` silently stopped meaning what it
-        # says and the LR schedule, ``consumed_samples``, and every per-step
-        # metric were computed against a different batch size than the recipe
-        # declares. Async PPO already rejects the flag
-        # (``examples/run_ppo.py``), as does the SingleController path
-        # (``single_controller_utils/config.py``); the synchronous driver was
-        # the one that neither implemented nor refused it.
+        # PPO never calls its dynamic-sampling helper. Accepting this flag only
+        # enlarged the rollout batch and then trained on every generated sample.
         raise NotImplementedError(
             "ppo.use_dynamic_sampling=true is not supported: PPO does not "
             "implement dynamic sampling, so enabling it would resize the "

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -449,8 +449,8 @@ def setup(
     if ppo_config.use_dynamic_sampling:
         # PPO implements no filtering for this knob. ``dynamic_sampling`` was
         # copied into this module but has never been called from any commit
-        # since it was added -- ``grpo.py:3226`` is the only call site in the
-        # tree, and it reaches ``grpo.py``'s copy. Accepting the flag scaled
+        # since it was added -- ``grpo.py`` holds the only production call
+        # site, and it reaches ``grpo.py``'s own copy. Accepting the flag scaled
         # the rollout batch by ``batch_multiplier`` and then trained on all of
         # it, so ``num_prompts_per_step`` silently stopped meaning what it
         # says and the LR schedule, ``consumed_samples``, and every per-step

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -446,12 +446,28 @@ def setup(
     # Validate batch_multiplier
     batch_multiplier = ppo_config.batch_multiplier
     dataloader_batch_size = ppo_config.num_prompts_per_step
-    if not ppo_config.use_dynamic_sampling:
-        assert batch_multiplier == 1, (
-            "batch_multiplier>1 can only be used if use_dynamic_sampling=True"
+    if ppo_config.use_dynamic_sampling:
+        # PPO implements no filtering for this knob. ``dynamic_sampling`` was
+        # copied into this module but has never been called from any commit
+        # since it was added -- ``grpo.py:3226`` is the only call site in the
+        # tree, and it reaches ``grpo.py``'s copy. Accepting the flag scaled
+        # the rollout batch by ``batch_multiplier`` and then trained on all of
+        # it, so ``num_prompts_per_step`` silently stopped meaning what it
+        # says and the LR schedule, ``consumed_samples``, and every per-step
+        # metric were computed against a different batch size than the recipe
+        # declares. Async PPO already rejects the flag
+        # (``examples/run_ppo.py``), as does the SingleController path
+        # (``single_controller_utils/config.py``); the synchronous driver was
+        # the one that neither implemented nor refused it.
+        raise NotImplementedError(
+            "ppo.use_dynamic_sampling=true is not supported: PPO does not "
+            "implement dynamic sampling, so enabling it would resize the "
+            "rollout batch without filtering it. Set it to false, or use GRPO."
         )
-    else:
-        dataloader_batch_size = int(dataloader_batch_size * batch_multiplier)
+    assert batch_multiplier == 1, (
+        "ppo.batch_multiplier>1 only has an effect under dynamic sampling, "
+        "which PPO does not support."
+    )
 
     dataloader = StatefulDataLoader(
         dataset,

--- a/tests/unit/algorithms/test_ppo.py
+++ b/tests/unit/algorithms/test_ppo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import nullcontext
+import pathlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -2736,3 +2737,67 @@ def test_validate_dispatches_rollout_by_engine_mode(monkeypatch, async_engine):
     unselected_rollout = sync_rollout if async_engine else async_rollout
     selected_rollout.assert_called_once()
     unselected_rollout.assert_not_called()
+
+
+class TestDynamicSamplingIsRejected:
+    """``ppo.use_dynamic_sampling`` has no implementation on the PPO path.
+
+    ``nemo_rl.algorithms.ppo.dynamic_sampling`` was copied from ``grpo.py`` but
+    has never been called from any commit since it was added -- ``grpo.py:3226``
+    is the tree's only call site and it reaches ``grpo.py``'s own copy. Setup
+    nonetheless accepted the flag and scaled the rollout batch by
+    ``batch_multiplier``, so the batch grew and nothing filtered it.
+
+    Async PPO already refuses the flag (``examples/run_ppo.py``) and so does
+    the SingleController path (``single_controller_utils/config.py``); the
+    synchronous driver was the one that neither implemented nor refused it.
+    """
+
+    @staticmethod
+    def _master_config(**ppo_overrides):
+        from omegaconf import OmegaConf
+
+        from nemo_rl.algorithms.ppo import MasterConfig
+        from nemo_rl.utils.config import register_omegaconf_resolvers
+
+        register_omegaconf_resolvers()
+        config_path = (
+            pathlib.Path(__file__).parents[3] / "examples/configs/ppo_math_1B.yaml"
+        )
+        cfg = OmegaConf.load(config_path)
+        for key, value in ppo_overrides.items():
+            cfg.ppo[key] = value
+        return MasterConfig(**OmegaConf.to_container(cfg, resolve=True))
+
+    @staticmethod
+    def _run_setup(master_config):
+        from nemo_rl.algorithms.ppo import setup
+
+        return setup(
+            master_config=master_config,
+            tokenizer=MagicMock(),
+            dataset=MagicMock(),
+            val_dataset=None,
+        )
+
+    def test_enabling_it_is_refused_at_setup(self):
+        """Before this guard, setup sized the dataloader and carried on."""
+        with pytest.raises(NotImplementedError, match="use_dynamic_sampling"):
+            self._run_setup(self._master_config(use_dynamic_sampling=True))
+
+    def test_batch_multiplier_is_still_guarded(self):
+        """The multiplier only ever meant anything under dynamic sampling."""
+        with pytest.raises(AssertionError, match="batch_multiplier"):
+            self._run_setup(
+                self._master_config(use_dynamic_sampling=False, batch_multiplier=2.0)
+            )
+
+    def test_the_shipped_default_is_not_refused(self):
+        """The guard must not fire on the config as shipped.
+
+        Setup fails later on the mock dataset -- that is what keeps this from
+        passing vacuously if the guard were made unconditional.
+        """
+        with pytest.raises(Exception) as excinfo:
+            self._run_setup(self._master_config())
+        assert "use_dynamic_sampling" not in str(excinfo.value)

--- a/tests/unit/algorithms/test_ppo.py
+++ b/tests/unit/algorithms/test_ppo.py
@@ -2740,18 +2740,7 @@ def test_validate_dispatches_rollout_by_engine_mode(monkeypatch, async_engine):
 
 
 class TestDynamicSamplingIsRejected:
-    """``ppo.use_dynamic_sampling`` has no implementation on the PPO path.
-
-    ``nemo_rl.algorithms.ppo.dynamic_sampling`` was copied from ``grpo.py`` but
-    has never been called from any commit since it was added -- ``grpo.py``
-    holds the only production call site, reaching its own copy. Setup
-    nonetheless accepted the flag and scaled the rollout batch by
-    ``batch_multiplier``, so the batch grew and nothing filtered it.
-
-    Async PPO already refuses the flag (``examples/run_ppo.py``) and so does
-    the SingleController path (``single_controller_utils/config.py``); the
-    synchronous driver was the one that neither implemented nor refused it.
-    """
+    """The synchronous PPO path must reject its unimplemented sampling knob."""
 
     @staticmethod
     def _master_config(**ppo_overrides):
@@ -2792,12 +2781,18 @@ class TestDynamicSamplingIsRejected:
                 self._master_config(use_dynamic_sampling=False, batch_multiplier=2.0)
             )
 
-    def test_the_shipped_default_is_not_refused(self):
-        """The guard must not fire on the config as shipped.
+    def test_the_shipped_default_is_not_refused(self, monkeypatch):
+        """The shipped config must advance past the dynamic-sampling guard."""
 
-        Setup fails later on the mock dataset -- that is what keeps this from
-        passing vacuously if the guard were made unconditional.
-        """
-        with pytest.raises(Exception) as excinfo:
+        class ReachedDataloader(Exception):
+            pass
+
+        import nemo_rl.algorithms.ppo as ppo_mod
+
+        monkeypatch.setattr(
+            ppo_mod,
+            "StatefulDataLoader",
+            MagicMock(side_effect=ReachedDataloader),
+        )
+        with pytest.raises(ReachedDataloader):
             self._run_setup(self._master_config())
-        assert "use_dynamic_sampling" not in str(excinfo.value)

--- a/tests/unit/algorithms/test_ppo.py
+++ b/tests/unit/algorithms/test_ppo.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import nullcontext
 import pathlib
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -2743,8 +2743,8 @@ class TestDynamicSamplingIsRejected:
     """``ppo.use_dynamic_sampling`` has no implementation on the PPO path.
 
     ``nemo_rl.algorithms.ppo.dynamic_sampling`` was copied from ``grpo.py`` but
-    has never been called from any commit since it was added -- ``grpo.py:3226``
-    is the tree's only call site and it reaches ``grpo.py``'s own copy. Setup
+    has never been called from any commit since it was added -- ``grpo.py``
+    holds the only production call site, reaching its own copy. Setup
     nonetheless accepted the flag and scaled the rollout batch by
     ``batch_multiplier``, so the batch grew and nothing filtered it.
 


### PR DESCRIPTION
## What does this PR do?

Rejects `ppo.use_dynamic_sampling: true` during setup because synchronous PPO does not implement sample filtering for it.

Previously the flag either did nothing (`batch_multiplier: 1`) or resized the dataloader without filtering (`batch_multiplier > 1`). That changed the effective batch and could fail only after generation. The adjacent multiplier guard also pointed users toward enabling the unsupported flag.

The guard now fails early with a clear message. The existing dead helper is left untouched; implementing PPO dynamic sampling is a separate design question because PPO uses a critic/GAE rather than GRPO's per-prompt reward-variance filter.

Defaults are unchanged: the shipped PPO config sets the flag to `false` and `batch_multiplier` to `1`.

## Validation

Current head `f492fd8f5a2aa0246d663fb47d3509872da522c8`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- `tests/unit/algorithms/test_ppo.py`: **99 passed, 7 skipped** (GPU-gated)
- caller-level setup coverage verifies the unsupported flag is rejected, the multiplier guard remains, and the default config is accepted
- Ruff check, Ruff format check, and `git diff --check`: passed

This is setup/config validation, so no GPU workload is required.
