### PR TITLE
fix(vllm): respect explicitly configured load_format instead of forcing dummy 

### DIFF
--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -78,7 +78,15 @@ def configure_generation_config(
     # vLLM setting shared by the standard and managed Dynamo backends.
     if config["backend"] in ("vllm", "dynamo"):
         vllm_backed_config = cast(VllmConfig, config)
-        vllm_backed_config["vllm_cfg"]["load_format"] = "auto" if is_eval else "dummy"
+        # Default load_format rather than forcing it: "dummy" relies on the
+        # trainer->generation refit to supply every weight, which silently
+        # breaks models with modules the refit does not cover (e.g. a VLM
+        # vision tower stays randomly initialized, producing fluent text with
+        # blind image understanding). Recipes that need real weights at
+        # startup can set policy.generation.vllm_cfg.load_format=auto.
+        vllm_backed_config["vllm_cfg"].setdefault(
+            "load_format", "auto" if is_eval else "dummy"
+        )
 
     if config["backend"] == "vllm":
         config = cast(VllmConfig, config)


### PR DESCRIPTION
## What does this PR do?

`configure_generation_config` unconditionally overwrites `vllm_cfg.load_format` with `"dummy"` for every training run, discarding any value set in the recipe YAML. This PR changes the assignment to `setdefault`, so an explicitly configured `load_format` is honored while the existing defaults (`dummy` for training, `auto` for eval) are preserved for configs that do not set the key.

## Why

With `load_format="dummy"`, the generation engine starts with random weights and depends entirely on the trainer→generation refit to supply every parameter. For models with modules the refit does not cover — e.g. a VLM whose vision tower is not part of the refit mapping — those modules stay **randomly initialized for the entire run**.

The failure is silent and easy to misdiagnose:

- The language stack does receive real weights via refit, so the model produces fluent, mostly well-formatted text.
- Anything conditioned on the uncovered module is garbage.
- Nothing errors or warns.

## How it was found

On a vision pointing/tracking GRPO task (async GRPO + NeMo Gym, Megatron backend for training, vLLM for generation), step-1 rewards — which should reflect the base checkpoint's zero-shot ability — came out at ~0.09, near random-guess level. The diagnostic signature was: ~60% of generations parsed as well-formatted answers, generations were full-length and non-truncated, but localization accuracy was at chance (box IoU 0.077, point-in-mask 0.03–0.25).

A/B on the identical model/data/recipe, flipping only this setting:

| load_format at startup | step-1 reward |
|---|---|
| `dummy` (forced, current behavior) | 0.05–0.09 |
| `auto` (recipe value, honored by this PR) | 0.53–0.60 |

With `auto`, subsequent training steps behave normally as well.

## Scope / compatibility

- Recipes that do not set `vllm_cfg.load_format` see no behavior change (`setdefault` fills the same value the old assignment wrote).
- The downstream forced overrides remain untouched: sparse refit transports still force `auto`, and non-MTP speculative decoding still forces `auto` with its existing warning.
- A follow-up worth considering (not in this PR): have the refit path validate coverage and fail loudly when the target model contains parameters that no refit mapping touches while `load_format="dummy"` is in effect.