### PR TITLE
fix(ci): set TMS_CUDA_MAJOR via uv extra-build-variables

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -477,10 +477,7 @@ jobs:
           enable-cache: true
 
       - name: Generate lockfile
-        run: |
-          export TMS_CUDA_MAJOR="$(sed -nE 's/^ARG[[:space:]]+BASE_IMAGE=.*cuda([0-9]+)\..*/\1/p' docker/Dockerfile | head -1)"
-          test -n "$TMS_CUDA_MAJOR"
-          uv lock
+        run: uv lock
 
       - name: Package lockfile
         id: package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -594,6 +594,11 @@ fast-hadamard-transform = [{ requirement = "torch", match-runtime = true }]
 nv-grouped-gemm = [{ requirement = "torch", match-runtime = true }]
 flash_mla = [{ requirement = "torch", match-runtime = true }]
 
+# torch-memory-saver's build backend reads TMS_CUDA_MAJOR at build time. Keep this in
+# sync with docker/Dockerfile's BASE_IMAGE CUDA major version (currently cuda13.x).
+[tool.uv.extra-build-variables]
+torch-memory-saver = { TMS_CUDA_MAJOR = "13" }
+
 # Needed when building from source
 [[tool.uv.dependency-metadata]]
 name = "flash-attn"


### PR DESCRIPTION
## Summary
* torch-memory-saver's build backend needs `TMS_CUDA_MAJOR` when uv builds it during `uv lock`. Declare it once via `[tool.uv.extra-build-variables]` in `pyproject.toml` so every caller of `uv lock`/`uv sync` (GitHub Actions, nemo-ci, local dev) picks it up automatically — no per-CI-system shell/sed logic needed.
* Reverts the GitHub Actions-only workaround from #3862 (sed-derive + export before `uv lock`), which this supersedes.

## Test plan
- [ ] `uv lock` succeeds and lockfile includes torch-memory-saver without manually exporting `TMS_CUDA_MAJOR`
- [ ] CI "Generate lockfile" step passes