### PR TITLE
feat(mllm): Changes to properly support latest Megatron Inference Features

### DIFF
--- a/docs/design-docs/generation.md
+++ b/docs/design-docs/generation.md
@@ -133,6 +133,14 @@ policy:
       buffer_size_gb: 10               # Memory buffer size for requests, total buffer size is 2x this value (active requests + paused requests)
       num_cuda_graphs: 16              # Number of CUDA graphs to pre-allocate
       max_tokens: 16384                # Maximum number of tokens for inference
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
 ```
 
 ### Configuration Parameters
@@ -142,6 +150,17 @@ The `mcore_generation_config` section controls Megatron Core inference engine be
 - **buffer_size_gb**: Buffer size reserved for active requests that live on the GPU. The total buffer size (stored in unified memory) is 2x this value, with the other half of the buffer reserved for paused requests that live on the CPU.
 - **num_cuda_graphs**: Number of CUDA graphs to pre-allocate for different batch sizes. More graphs can improve performance by avoiding runtime graph capture, but consume more memory.
 - **max_tokens**: Maximum total number of tokens (across all requests) that can be processed simultaneously. This limits the maximum batch size and sequence length combinations. Increasing this might throw OOM depending on vocab size and buffer size allocated. 
+
+#### CUDA-graph capture
+
+- **cuda_graph_sizing_distribution** (`hybrid`) and **cuda_graph_max_tokens** (`512`) bound graph-capture cost while keeping decode graphs dense and prefill graphs compact. Use `exponential` or `linear` when one layout is a better fit for a known workload.
+- **inference_cuda_graph_scope** controls where local inference graphs live: `layer` owns them per Transformer/Mamba layer and `block` owns them per enclosing block. `none` runs eagerly. This setting only applies with `cuda_graph_impl: local`.
+
+#### Prefix-cache routing and HTTP frontends
+
+- **prefix_caching_mamba_gb** (`null`) leaves Mamba-state prefix caching disabled until a hybrid Mamba model has an explicit GPU budget.
+- **prefix_caching_eviction_policy** (`lru`), **prefix_caching_coordinator_policy** (`longest_prefix`), **prefix_cache_ttl_seconds** (`300.0`), and **prefix_caching_routing_alpha** (`1.0`) retain useful prefixes while steering requests toward cache hits without ignoring an overloaded inference rank.
+- **http_server_num_replicas** (`8`) sets the number of CPU HTTP frontends per model-parallel coordinator. These frontends spread request parsing, prompt processing, and cache-key work across CPU cores.
 
 ### Multimodal Megatron Generation
 
@@ -245,6 +264,14 @@ policy:
       buffer_size_gb: 10
       num_cuda_graphs: 16
       max_tokens: 16384
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
 ```
 
 For a complete example, see

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -415,6 +415,8 @@ policy:
       #   cuda_graph_impl "none"  -> omit inference_cuda_graph_scope
       #   cuda_graph_impl "local" -> inference_cuda_graph_scope "layer" or "block"
       cuda_graph_impl: "local"
+      cuda_graph_sizing_distribution: hybrid  # MCore default: exponential prefill/mixed graphs and linear decode graphs.
+      cuda_graph_max_tokens: 512  # MCore default token ceiling for captured prefill/mixed graphs.
       inference_cuda_graph_scope: "block"
       buffer_size_gb: 10
       num_cuda_graphs: 4  # Number of CUDA graphs to pre-compile for different batch sizes
@@ -422,6 +424,11 @@ policy:
       use_cuda_graphs_for_non_decode_steps: true  # Enable CUDA graphs for prefill/context processing
       enable_chunked_prefill: true  # Split long prefills into chunks for better memory management
       enable_prefix_caching: false  # Reuse KV blocks across requests sharing a prompt prefix.
+      prefix_caching_mamba_gb: null  # MCore default: no Mamba-state prefix-cache budget.
+      prefix_caching_eviction_policy: lru  # MCore default prefix-cache eviction policy.
+      prefix_caching_coordinator_policy: longest_prefix  # MCore default DP routing policy.
+      prefix_cache_ttl_seconds: 300.0  # MCore default coordinator cache-entry lifetime.
+      prefix_caching_routing_alpha: 1.0  # MCore default load penalty for prefix-affinity routing.
       max_tokens: 16384 # Maximum number of tokens to use in a single step. Analogous to vllm's max_num_batched_tokens
       kv_cache_management_mode: "persist"  # KV cache lifecycle across suspend/resume. Options: "persist", "offload", "recompute".
       materialize_only_last_token_logits: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -431,6 +431,7 @@ policy:
       offload_policy_before_refit: false  # Keep policy state on GPU by default. Enable when a non-colocated Megatron refit needs additional GPU headroom for transfer staging.
       parsers: []  # OpenAI tool-call / response parser names exposed by the HTTP server (only used if expose_http_server=true).
       expose_http_server: false  # Start an OpenAI-compatible HTTP server alongside the persistent engine. Required for NeMo-Gym.
+      http_server_num_replicas: 8  # HTTP frontend event loops per model-parallel coordinator.
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/examples/configs/grpo_math_1B_megatron_generation_colocated_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_generation_colocated_single_controller.yaml
@@ -2,6 +2,15 @@ defaults: grpo_math_1B_megatron_single_controller.yaml
 policy:
   generation:
     backend: megatron
+    mcore_generation_config:
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
     colocated:
       enabled: true
       resources:

--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -173,6 +173,14 @@ policy:
     # HTTP ports inherit the shared [3000, 4999) band from grpo_math_1B.yaml.
     mcore_generation_config:
       unified_memory_level: 0
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
     vllm_cfg:
       async_engine: true
     colocated:

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -281,6 +281,7 @@ policy:
       max_tokens: 16384
       logprobs_mode: processed_logprobs
       offload_policy_before_refit: false
+      http_server_num_replicas: 8
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -273,10 +273,17 @@ policy:
     mcore_generation_config:
       buffer_size_gb: 20
       buffer_guaranteed_fraction: 0.1
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
       num_cuda_graphs: 16
       block_size_tokens: 256
       use_cuda_graphs_for_non_decode_steps: true
       enable_chunked_prefill: true
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
       unified_memory_level: 0
       max_tokens: 16384
       logprobs_mode: processed_logprobs

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -193,6 +193,14 @@ policy:
     # HTTP ports use the shared [3000, 4999) virtual-cluster defaults.
     mcore_generation_config:
       unified_memory_level: 0
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
     vllm_cfg:
       async_engine: true
     colocated:

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation.yaml
@@ -33,4 +33,3 @@ logger:
     name: grpo-llama3.2-1b-instruct-1n8g-megatron_generation
 cluster:
   gpus_per_node: 8
-

--- a/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-colocated-reshard-async-gym.yaml
+++ b/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-colocated-reshard-async-gym.yaml
@@ -26,6 +26,9 @@ policy:
     mcore_generation_config:
       tensor_model_parallel_size: 4
       expert_model_parallel_size: 4
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_coordinator_policy: longest_prefix
 logger:
   wandb_enabled: true
   tensorboard_enabled: true

--- a/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-colocated-reshard-async-gym.yaml
+++ b/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-colocated-reshard-async-gym.yaml
@@ -1,10 +1,4 @@
 defaults: ../../../nemo_gym/grpo_nanov3.yaml
-# Async colocated GRPO + gym on Megatron generation with a resharded inference
-# layout: training runs TP2xCP2xEP8 across all 16 GPUs; every wake reshards the
-# weights into TP4xEP4 inference_optimized models on the same GPUs. One nightly
-# covers the async loop with in-flight updates, the gym HTTP ingress, colocated
-# reshard, and (via the suite's save_period=val_period=4) the save-bound
-# deferred-wake path.
 grpo:
   async_grpo:
     enabled: true
@@ -26,9 +20,6 @@ policy:
     mcore_generation_config:
       tensor_model_parallel_size: 4
       expert_model_parallel_size: 4
-      cuda_graph_sizing_distribution: hybrid
-      cuda_graph_max_tokens: 512
-      prefix_caching_coordinator_policy: longest_prefix
 logger:
   wandb_enabled: true
   tensorboard_enabled: true

--- a/examples/configs/recipes/llm/grpo-nanov3-30BA3B-4n4g-megatron_generation-noncolocated-mxfp8-rollouts.yaml
+++ b/examples/configs/recipes/llm/grpo-nanov3-30BA3B-4n4g-megatron_generation-noncolocated-mxfp8-rollouts.yaml
@@ -1,7 +1,4 @@
 defaults: ../../grpo_math_1B.yaml
-# BF16 training with MXFP8-quantized Megatron inference on a dedicated 8-GPU group:
-# every weight sync quantizes BF16 -> MXFP8 over the NCCL refit,
-# with EP8-sharded expert transfers across NVLink domains.
 grpo:
   num_prompts_per_step: 2
   num_generations_per_prompt: 8
@@ -30,7 +27,7 @@ policy:
     backend: megatron
     mcore_generation_config:
       transformer_impl: inference_optimized
-      inference_grouped_gemm_backend: "torch"
+      inference_grouped_gemm_backend: torch
       inference_moe_token_dispatcher_type: nvls
       tensor_model_parallel_size: 2
       expert_model_parallel_size: 8

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -224,6 +224,8 @@ policy:
       max_model_len: ${policy.max_total_sequence_length}
       transformer_impl: "inference_optimized"
       cuda_graph_impl: "local"
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
       inference_cuda_graph_scope: "block"
       activation_checkpointing: false
       mamba_inference_ssm_states_dtype: "float32"
@@ -250,6 +252,11 @@ policy:
       offload_policy_before_refit: false
       expose_http_server: true
       enable_prefix_caching: true
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
       http_server_num_replicas: 8
       parsers:
         - deepseek-r1-reasoning

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -250,6 +250,7 @@ policy:
       offload_policy_before_refit: false
       expose_http_server: true
       enable_prefix_caching: true
+      http_server_num_replicas: 8
       parsers:
         - deepseek-r1-reasoning
         - qwen3-coder-tool

--- a/examples/nemo_gym/grpo_qwen3_0_6b_megatron_generation_single_controller.yaml
+++ b/examples/nemo_gym/grpo_qwen3_0_6b_megatron_generation_single_controller.yaml
@@ -44,6 +44,14 @@ policy:
     mcore_generation_config:
       # NeMo-Gym drives rollouts through the engine's OpenAI server.
       expose_http_server: true
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
+      http_server_num_replicas: 8
     colocated:
       enabled: false
       resources:

--- a/examples/nemo_gym/grpo_qwen3_30ba3b_instruct.yaml
+++ b/examples/nemo_gym/grpo_qwen3_30ba3b_instruct.yaml
@@ -82,6 +82,7 @@ policy:
       offload_policy_before_refit: false
       parsers: []
       expose_http_server: false
+      http_server_num_replicas: 8
 
   # Needs to be set to whatever backend TP size.
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}

--- a/examples/nemo_gym/grpo_qwen3_30ba3b_instruct.yaml
+++ b/examples/nemo_gym/grpo_qwen3_30ba3b_instruct.yaml
@@ -66,6 +66,8 @@ policy:
     mcore_generation_config:
       max_model_len: ${policy.max_total_sequence_length}
       cuda_graph_impl: "local"
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
       inference_cuda_graph_scope: "block"
       buffer_size_gb: 10
       num_cuda_graphs: 4
@@ -73,6 +75,11 @@ policy:
       use_cuda_graphs_for_non_decode_steps: true
       enable_chunked_prefill: true
       enable_prefix_caching: false
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
       max_tokens: 16384
       kv_cache_management_mode: "persist"
       materialize_only_last_token_logits: true

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1260,13 +1260,15 @@ def setup(
     # plane exists. Default is the plain Policy class — legacy behavior.
     _make_policy = policy_factory if policy_factory is not None else Policy
 
-    def init_policy(reserved_http_server_port: Optional[int] = None):
+    def init_policy(reserved_http_server_ports: Optional[dict[int, int]] = None):
         """Initialize policy training workers."""
         t0 = time.perf_counter()
         extra_policy_kwargs = {}
-        if reserved_http_server_port is not None:
+        if reserved_http_server_ports is not None:
             # Colocated Megatron generation serves HTTP from the training workers.
-            extra_policy_kwargs["reserved_http_server_port"] = reserved_http_server_port
+            extra_policy_kwargs["reserved_http_server_ports"] = (
+                reserved_http_server_ports
+            )
         p = _make_policy(
             cluster=train_cluster,
             config=policy_config,
@@ -1305,7 +1307,7 @@ def setup(
         return pg, time.perf_counter() - t0
 
     def init_megatron_generation(
-        policy=None, reserved_http_server_port: Optional[int] = None
+        policy=None, reserved_http_server_ports: Optional[dict[int, int]] = None
     ):
         """Initialize Megatron generation."""
         t0 = time.perf_counter()
@@ -1316,7 +1318,7 @@ def setup(
             policy=policy if colocated_inference else None,
             processor=processor,
             skip_weight_load=not colocated_inference,
-            reserved_http_server_port=reserved_http_server_port,
+            reserved_http_server_ports=reserved_http_server_ports,
         )
         return mg, time.perf_counter() - t0
 
@@ -1413,26 +1415,30 @@ def setup(
                 flush=True,
             )
             reserve_t0 = time.perf_counter()
-            reserved_url, reserved_http_server_port, port_holder = (
-                MegatronGeneration.reserve_http_server_address(
+            reserved_urls, reserved_http_server_ports, port_holders = (
+                MegatronGeneration.reserve_http_server_addresses(
                     train_cluster if colocated_inference else inference_cluster,
                     policy_config,
                 )
             )
             reserve_time = time.perf_counter() - reserve_t0
             setup_timing_metrics.generation_init_reserve_time_s = reserve_time
-            print(f"  ✓ Reserved Megatron server URL: {reserved_url}", flush=True)
+            print(
+                f"  ✓ Reserved {len(reserved_urls)} Megatron server URL(s): "
+                f"{reserved_urls}",
+                flush=True,
+            )
 
             def init_nemo_gym():
-                """Spin up NeMo Gym servers against the reserved URL."""
-                return _spinup_nemo_gym([reserved_url], generation_config["model_name"])
+                """Spin up NeMo Gym servers against the reserved URLs."""
+                return _spinup_nemo_gym(reserved_urls, generation_config["model_name"])
 
             # Exactly one task adopts the reserved port: the policy when colocated
             # (generation wraps it), else the dedicated generation policy.
-            policy_port, generation_port = (
-                (reserved_http_server_port, None)
+            policy_ports, generation_ports = (
+                (reserved_http_server_ports, None)
                 if colocated_inference
-                else (None, reserved_http_server_port)
+                else (None, reserved_http_server_ports)
             )
 
             def init_megatron_generation_task(policy_future):
@@ -1441,7 +1447,7 @@ def setup(
                     p, _ = policy_future.result()
                     return init_megatron_generation(p)
                 return init_megatron_generation(
-                    reserved_http_server_port=generation_port
+                    reserved_http_server_ports=generation_ports
                 )
 
             print("  ⚡ Init tasks: policy, megatron_generation, nemo_gym", flush=True)
@@ -1449,7 +1455,7 @@ def setup(
             try:
                 with ThreadPoolExecutor(max_workers=3) as executor:
                     policy_future = executor.submit(
-                        init_policy, reserved_http_server_port=policy_port
+                        init_policy, reserved_http_server_ports=policy_ports
                     )
                     generation_future = executor.submit(
                         init_megatron_generation_task, policy_future
@@ -1468,7 +1474,8 @@ def setup(
                         init_megatron_weight_synchronizer(policy, policy_generation)
                     nemo_gym_actor, nemo_gym_time = nemo_gym_future.result()
             finally:
-                ray.kill(port_holder)
+                for port_holder in port_holders:
+                    ray.kill(port_holder)
 
             if colocated_inference:
                 setup_timing_metrics.parallel_init_enabled = 0.0
@@ -1741,8 +1748,8 @@ def setup(
         if policy_generation.weight_synchronizer is None:
             init_megatron_weight_synchronizer(policy, policy_generation)
         if enable_nemo_gym:
-            MegatronGeneration.verify_served_address(
-                policy_generation.dp_openai_server_base_urls, reserved_url
+            MegatronGeneration.verify_served_addresses(
+                policy_generation.dp_openai_server_base_urls, reserved_urls
             )
     # if it is not colocated inference, initialize collective communication for update weights
     elif (

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -490,7 +490,7 @@ def _build_generation(
     master_config: MasterConfig,
     *,
     defer_model_load: bool = False,
-    reserved_http_server_port: Optional[int] = None,
+    reserved_http_server_ports: Optional[dict[int, int]] = None,
     tokenizer: Optional[PreTrainedTokenizerBase] = None,
     processor: Optional[AutoProcessor] = None,
 ) -> tuple[Any, float]:
@@ -500,7 +500,8 @@ def _build_generation(
         inference_cluster: Ray virtual cluster the generation workers run on.
         master_config: SC MasterConfig.
         defer_model_load: If True (for the NeMo-Gym flow), reserve OpenAI server URLs without loading weights; caller runs gen.load_and_start() later (vLLM only).
-        reserved_http_server_port: OpenAI server port pre-published to NeMo-Gym (Megatron only).
+        reserved_http_server_ports: OpenAI server ports pre-published to NeMo-Gym,
+            keyed by the distributed rank that adopts each one (Megatron only).
         tokenizer: Tokenizer for the dedicated Megatron inference policy (Megatron only).
         processor: Optional AutoProcessor for VLM paths (Megatron only).
 
@@ -551,7 +552,7 @@ def _build_generation(
             config=master_config.policy,
             tokenizer=tokenizer,
             cluster=inference_cluster,
-            reserved_http_server_port=reserved_http_server_port,
+            reserved_http_server_ports=reserved_http_server_ports,
             processor=processor,
             skip_weight_load=True,
         )
@@ -591,7 +592,7 @@ def _build_trainer(
     *,
     weights_path: Optional[Path],
     optimizer_path: Optional[Path],
-    reserved_http_server_port: Optional[int] = None,
+    reserved_http_server_ports: Optional[dict[int, int]] = None,
 ) -> tuple[Any, float]:
     """Build the TQ-mediated trainer (driver-side TQPolicy).
 
@@ -602,8 +603,8 @@ def _build_trainer(
         processor: Optional AutoProcessor for VLM paths.
         weights_path: Checkpointed policy weights to resume from, or None.
         optimizer_path: Checkpointed optimizer state to resume from, or None.
-        reserved_http_server_port: Pre-published OpenAI server port for NeMo Gym;
-            set only when colocated Megatron generation serves from the trainer's rank 0.
+        reserved_http_server_ports: Pre-published OpenAI server ports for NeMo Gym,
+            keyed by the colocated Megatron trainer rank that adopts each one.
 
     Returns:
         A tuple of (TQPolicy trainer, wall time spent in this call).
@@ -621,7 +622,7 @@ def _build_trainer(
         init_optimizer=True,
         init_reference_model=init_reference_model,
         dp_cfg=master_config.data_plane,
-        reserved_http_server_port=reserved_http_server_port,
+        reserved_http_server_ports=reserved_http_server_ports,
     )
     return trainer, time.perf_counter() - t0
 
@@ -1341,15 +1342,15 @@ def setup_single_controller(
     # is disabled or NeMo-Gym is not in play -- it is Gym that needs one stable URL.
     generation_router = None
     megatron_backend = generation_config["backend"] == "megatron"
-    megatron_reserved_url = None
-    megatron_port_holder = None
-    reserved_http_server_port = None
+    megatron_reserved_urls: list[str] = []
+    megatron_port_holders: list[Any] = []
+    reserved_http_server_ports = None
     weight_synchronizer: Optional[WeightSynchronizer] = None
     if megatron_backend:
         generation_config["model_name"] = master_config.policy["model_name"]
 
     def _build_trainer_and_value(
-        reserved_http_server_port: Optional[int] = None,
+        reserved_http_server_ports: Optional[dict[int, int]] = None,
     ) -> tuple[Any, Optional[TQValue], dict[str, float]]:
         """Build the trainer, then the critic when this is a PPO run.
 
@@ -1359,8 +1360,8 @@ def setup_single_controller(
         to GPU before returning so callers see the same state GRPO leaves them.
 
         Args:
-            reserved_http_server_port: Pre-published OpenAI server port for the trainer's rank 0;
-                only the colocated Megatron serial build passes one.
+            reserved_http_server_ports: Pre-published OpenAI server ports keyed
+                by trainer rank; only colocated Megatron passes them.
 
         Returns:
             A tuple of (TQPolicy trainer, TQValue critic or None, per-phase wall
@@ -1374,7 +1375,7 @@ def setup_single_controller(
             processor,
             weights_path=weights_path,
             optimizer_path=optimizer_path,
-            reserved_http_server_port=reserved_http_server_port,
+            reserved_http_server_ports=reserved_http_server_ports,
         )
         if not is_ppo_run(master_config):
             return trainer, None, time_metrics
@@ -1440,10 +1441,10 @@ def setup_single_controller(
         """
         time_metrics = {}
 
-        # Colocated Megatron generation serves from the trainer's workers,
-        # so rank 0 of the trainer adopts the pre-published OpenAI socket.
+        # Colocated Megatron generation serves from the trainer's workers, so
+        # every frontend-hosting trainer rank adopts its pre-published socket.
         trainer, value, train_side_metrics = _build_trainer_and_value(
-            reserved_http_server_port=reserved_http_server_port,
+            reserved_http_server_ports=reserved_http_server_ports,
         )
         time_metrics.update(train_side_metrics)
 
@@ -1473,22 +1474,24 @@ def setup_single_controller(
 
     if use_nemo_gym:
         if megatron_backend:
-            # Megatron serves from rank 0 of the generation workers; pre-publish that address.
+            # Megatron serves one frontend per model-parallel group; pre-publish
+            # every address so Gym can spread sessions over all of them.
             t0 = time.perf_counter()
             (
-                megatron_reserved_url,
-                reserved_http_server_port,
-                megatron_port_holder,
-            ) = MegatronGeneration.reserve_http_server_address(
+                megatron_reserved_urls,
+                reserved_http_server_ports,
+                megatron_port_holders,
+            ) = MegatronGeneration.reserve_http_server_addresses(
                 inference_cluster,
                 master_config.policy,
             )
             gen_reserve_time = time.perf_counter() - t0
             print(
-                f"  ✓ Reserved Megatron server URL: {megatron_reserved_url}",
+                f"  ✓ Reserved {len(megatron_reserved_urls)} Megatron server URL(s): "
+                f"{megatron_reserved_urls}",
                 flush=True,
             )
-            gym_base_urls: list[Optional[str]] = [megatron_reserved_url]
+            gym_base_urls: list[Optional[str]] = list(megatron_reserved_urls)
         else:
             # defer generation, only get base_urls for nemo_gym spinup
             generation, gen_reserve_time = _build_generation(
@@ -1510,7 +1513,7 @@ def setup_single_controller(
                 else gym_base_urls
             )
         except BaseException:
-            if megatron_port_holder is not None:
+            for megatron_port_holder in megatron_port_holders:
                 ray.kill(megatron_port_holder)
             raise
         # add nemo_gym spinup task
@@ -1544,7 +1547,7 @@ def setup_single_controller(
                 _build_generation,
                 inference_cluster=inference_cluster,
                 master_config=master_config,
-                reserved_http_server_port=reserved_http_server_port,
+                reserved_http_server_ports=reserved_http_server_ports,
                 tokenizer=tokenizer,
                 processor=processor,
             )
@@ -1562,7 +1565,7 @@ def setup_single_controller(
             else:
                 generation, gen_load_time = submitted["generation"].result()
                 trainer, value, time_metrics = submitted["trainer"].result()
-            if megatron_reserved_url is not None:
+            if megatron_reserved_urls:
                 # Gym initialization needs a live URL that will respond to health checks.
                 # Megatron generation can only respond to health checks once initialized.
                 # The Megatron engine cannot be initialized with dummy weights.
@@ -1589,8 +1592,9 @@ def setup_single_controller(
                 env_handles["nemo_gym"], gym_time = submitted["nemo_gym"].result()
                 setup_timing_metrics.nemo_gym_init_time_s = gym_time
     finally:
-        if megatron_port_holder is not None:
-            # Rank 0 adopted (or will never adopt) the held socket; drop the holder.
+        for megatron_port_holder in megatron_port_holders:
+            # The frontend ranks adopted (or will never adopt) the held sockets;
+            # drop the holders.
             ray.kill(megatron_port_holder)
 
     setup_timing_metrics.generation_init_time_s = gen_reserve_time + gen_load_time
@@ -1615,9 +1619,9 @@ def setup_single_controller(
         setup_timing_metrics.generation_init_reserve_time_s = gen_reserve_time
         setup_timing_metrics.generation_init_load_time_s = gen_load_time
 
-    if megatron_reserved_url is not None:
-        MegatronGeneration.verify_served_address(
-            generation.dp_openai_server_base_urls, megatron_reserved_url
+    if megatron_reserved_urls:
+        MegatronGeneration.verify_served_addresses(
+            generation.dp_openai_server_base_urls, megatron_reserved_urls
         )
 
     # Loading a teacher with the same checkpoint as the student must happen only

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import logging
 import os
-import random
 import socket
 import sys
 import time
@@ -239,23 +238,13 @@ def _bind_socket_in_range(
     port_range_high: int,
     max_retries: int | None = 50,
     excluded_ports: set[int] | None = None,
-    rng: Optional[random.Random] = None,
 ) -> int:
     """Try to bind *sock* to a random port in [port_range_low, port_range_high).
 
     When *max_retries* is ``None``, try every non-excluded port once. Otherwise,
     preserve the existing bounded random-retry behavior.
-
-    Args:
-        rng: Source of candidate ports. Defaults to the ``random`` module. That
-            module's state is process-wide and seeded per run, so every rank of a
-            job draws the same sequence; ranks sharing a node then contend for one
-            port, and whichever binds after the others have closed silently reuses
-            it. Pass a rank-seeded ``random.Random`` to decorrelate them.
-
-    Raises ``RuntimeError`` after *max_retries* failed attempts.
     """
-    rng = rng if rng is not None else random
+    import random
 
     excluded = excluded_ports or set()
     if max_retries is None:
@@ -264,7 +253,7 @@ def _bind_socket_in_range(
             for port in range(port_range_low, port_range_high)
             if port not in excluded
         ]
-        rng.shuffle(candidates)
+        random.shuffle(candidates)
         for port in candidates:
             try:
                 sock.bind(("", port))
@@ -274,7 +263,7 @@ def _bind_socket_in_range(
         retry_description = f"all {len(candidates)} available ports"
     else:
         for _ in range(max_retries):
-            port = rng.randint(port_range_low, port_range_high - 1)
+            port = random.randint(port_range_low, port_range_high - 1)
             if port in excluded:
                 continue
             try:
@@ -296,15 +285,7 @@ def _get_free_port_local(
     *,
     max_retries: int | None = 50,
     excluded_ports: set[int] | None = None,
-    rng: Optional[random.Random] = None,
 ) -> int:
-    """Find a free port, holding it only long enough to learn its number.
-
-    Args:
-        rng: Source of candidate ports; see :func:`_bind_socket_in_range`. Callers
-            that run on several ranks of one node should pass a rank-seeded
-            generator, or they will all be handed the same port.
-    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         port = _bind_socket_in_range(
             s,
@@ -312,7 +293,6 @@ def _get_free_port_local(
             port_range_high,
             max_retries=max_retries,
             excluded_ports=excluded_ports,
-            rng=rng,
         )
         s.listen(1)
 

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -255,8 +255,6 @@ def _bind_socket_in_range(
 
     Raises ``RuntimeError`` after *max_retries* failed attempts.
     """
-    rng = rng if rng is not None else random
-
     excluded = excluded_ports or set()
     if max_retries is None:
         candidates = [
@@ -264,7 +262,10 @@ def _bind_socket_in_range(
             for port in range(port_range_low, port_range_high)
             if port not in excluded
         ]
-        rng.shuffle(candidates)
+        if rng is None:
+            random.shuffle(candidates)
+        else:
+            rng.shuffle(candidates)
         for port in candidates:
             try:
                 sock.bind(("", port))
@@ -274,7 +275,10 @@ def _bind_socket_in_range(
         retry_description = f"all {len(candidates)} available ports"
     else:
         for _ in range(max_retries):
-            port = rng.randint(port_range_low, port_range_high - 1)
+            if rng is None:
+                port = random.randint(port_range_low, port_range_high - 1)
+            else:
+                port = rng.randint(port_range_low, port_range_high - 1)
             if port in excluded:
                 continue
             try:

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import random
 import socket
 import sys
 import time
@@ -238,13 +239,23 @@ def _bind_socket_in_range(
     port_range_high: int,
     max_retries: int | None = 50,
     excluded_ports: set[int] | None = None,
+    rng: Optional[random.Random] = None,
 ) -> int:
     """Try to bind *sock* to a random port in [port_range_low, port_range_high).
 
     When *max_retries* is ``None``, try every non-excluded port once. Otherwise,
     preserve the existing bounded random-retry behavior.
+
+    Args:
+        rng: Source of candidate ports. Defaults to the ``random`` module. That
+            module's state is process-wide and seeded per run, so every rank of a
+            job draws the same sequence; ranks sharing a node then contend for one
+            port, and whichever binds after the others have closed silently reuses
+            it. Pass a rank-seeded ``random.Random`` to decorrelate them.
+
+    Raises ``RuntimeError`` after *max_retries* failed attempts.
     """
-    import random
+    rng = rng if rng is not None else random
 
     excluded = excluded_ports or set()
     if max_retries is None:
@@ -253,7 +264,7 @@ def _bind_socket_in_range(
             for port in range(port_range_low, port_range_high)
             if port not in excluded
         ]
-        random.shuffle(candidates)
+        rng.shuffle(candidates)
         for port in candidates:
             try:
                 sock.bind(("", port))
@@ -263,7 +274,7 @@ def _bind_socket_in_range(
         retry_description = f"all {len(candidates)} available ports"
     else:
         for _ in range(max_retries):
-            port = random.randint(port_range_low, port_range_high - 1)
+            port = rng.randint(port_range_low, port_range_high - 1)
             if port in excluded:
                 continue
             try:
@@ -285,7 +296,15 @@ def _get_free_port_local(
     *,
     max_retries: int | None = 50,
     excluded_ports: set[int] | None = None,
+    rng: Optional[random.Random] = None,
 ) -> int:
+    """Find a free port, holding it only long enough to learn its number.
+
+    Args:
+        rng: Source of candidate ports; see :func:`_bind_socket_in_range`. Callers
+            that run on several ranks of one node should pass a rank-seeded
+            generator, or they will all be handed the same port.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         port = _bind_socket_in_range(
             s,
@@ -293,6 +312,7 @@ def _get_free_port_local(
             port_range_high,
             max_retries=max_retries,
             excluded_ports=excluded_ports,
+            rng=rng,
         )
         s.listen(1)
 

--- a/nemo_rl/models/generation/megatron/config.py
+++ b/nemo_rl/models/generation/megatron/config.py
@@ -27,6 +27,7 @@ class MCoreGenerationSpecificArgs(TypedDict):
     """
 
     expose_http_server: bool
+    http_server_num_replicas: NotRequired[int]
     parsers: list[str]
     buffer_size_gb: int
     block_size_tokens: int
@@ -63,7 +64,7 @@ class MCoreGenerationSpecificArgs(TypedDict):
 
     mamba_inference_ssm_states_dtype: NotRequired[str]
     mamba_inference_conv_states_dtype: NotRequired[str]
-    prefix_caching_mamba_gb: NotRequired[int]
+    prefix_caching_mamba_gb: NotRequired[float]
 
     prefix_caching_eviction_policy: NotRequired[Literal["ref_zero", "lru"]]
     prefix_caching_coordinator_policy: NotRequired[

--- a/nemo_rl/models/generation/megatron/config.py
+++ b/nemo_rl/models/generation/megatron/config.py
@@ -65,6 +65,7 @@ class MCoreGenerationSpecificArgs(TypedDict):
     mamba_inference_conv_states_dtype: NotRequired[str]
     prefix_caching_mamba_gb: NotRequired[int]
 
+    prefix_caching_eviction_policy: NotRequired[Literal["ref_zero", "lru"]]
     prefix_caching_coordinator_policy: NotRequired[
         Literal["load_balanced", "longest_prefix", "first_prefix_block"]
     ]

--- a/nemo_rl/models/generation/megatron/config.py
+++ b/nemo_rl/models/generation/megatron/config.py
@@ -39,10 +39,20 @@ class MCoreGenerationSpecificArgs(TypedDict):
     num_cuda_graphs: int | None
     use_cuda_graphs_for_non_decode_steps: bool
     cuda_graph_impl: str
+    # How the captured CUDA-graph token-count sizes are spaced. Options:
+    # - 'exponential': log-spaced graphs for all request types.
+    # - 'linear': densely spaced graphs for all request types.
+    # - 'hybrid': exponential prefill/mixed graphs and linear decode graphs (MCore default).
     cuda_graph_sizing_distribution: NotRequired[
         Literal["exponential", "linear", "hybrid"]
     ]
+    # Token ceiling for captured prefill/mixed CUDA graphs. MCore default: 512.
     cuda_graph_max_tokens: NotRequired[int]
+    # Inference CUDA-graph scope. Options:
+    # - 'none': inference runs in eager mode (no CUDA graphs).
+    # - 'layer': graphs are owned at the per-layer boundary (TransformerLayer / MambaLayer).
+    # - 'block': graphs are owned at the enclosing block (TransformerBlock / HybridBlock).
+    # Only meaningful when cuda_graph_impl='local'.
     inference_cuda_graph_scope: NotRequired[str]
     # Required for EP>1 + inference CUDA graphs, except when using the
     # `inference_optimized` transformer implementation.
@@ -64,13 +74,18 @@ class MCoreGenerationSpecificArgs(TypedDict):
 
     mamba_inference_ssm_states_dtype: NotRequired[str]
     mamba_inference_conv_states_dtype: NotRequired[str]
-    prefix_caching_mamba_gb: NotRequired[float]
+    # GPU budget for cached Mamba states; null disables it (MCore default).
+    prefix_caching_mamba_gb: NotRequired[float | None]
 
+    # Prefix-cache block eviction policy. MCore default: 'lru'.
     prefix_caching_eviction_policy: NotRequired[Literal["ref_zero", "lru"]]
+    # DP coordinator routing policy. MCore default: 'longest_prefix'.
     prefix_caching_coordinator_policy: NotRequired[
         Literal["load_balanced", "longest_prefix", "first_prefix_block"]
     ]
+    # Coordinator cache-entry lifetime in seconds. MCore default: 300.0.
     prefix_cache_ttl_seconds: NotRequired[float]
+    # Prefix-affinity versus load routing penalty. MCore default: 1.0.
     prefix_caching_routing_alpha: NotRequired[float]
 
     # Raw media preprocessing corresponding with Megatron's

--- a/nemo_rl/models/generation/megatron/config.py
+++ b/nemo_rl/models/generation/megatron/config.py
@@ -38,6 +38,10 @@ class MCoreGenerationSpecificArgs(TypedDict):
     num_cuda_graphs: int | None
     use_cuda_graphs_for_non_decode_steps: bool
     cuda_graph_impl: str
+    cuda_graph_sizing_distribution: NotRequired[
+        Literal["exponential", "linear", "hybrid"]
+    ]
+    cuda_graph_max_tokens: NotRequired[int]
     # Inference CUDA-graph scope. Options:
     # - 'none': inference runs in eager mode (no CUDA graphs).
     # - 'layer': graphs are owned at the per-layer boundary (TransformerLayer / MambaLayer).
@@ -64,6 +68,16 @@ class MCoreGenerationSpecificArgs(TypedDict):
 
     mamba_inference_ssm_states_dtype: NotRequired[str]
     mamba_inference_conv_states_dtype: NotRequired[str]
+    prefix_caching_mamba_gb: NotRequired[int]
+
+    prefix_caching_coordinator_policy: NotRequired[
+        Literal["load_balanced", "longest_prefix", "first_prefix_block"]
+    ]
+    prefix_cache_ttl_seconds: NotRequired[float]
+    prefix_caching_cost_policy: NotRequired[
+        Literal["simple_multiplicative", "load_aware"]
+    ]
+    prefix_caching_load_beta: NotRequired[float]
 
     # Raw media preprocessing corresponding with Megatron's
     # ImageProcessingConfig / VideoProcessingConfig.

--- a/nemo_rl/models/generation/megatron/config.py
+++ b/nemo_rl/models/generation/megatron/config.py
@@ -42,11 +42,6 @@ class MCoreGenerationSpecificArgs(TypedDict):
         Literal["exponential", "linear", "hybrid"]
     ]
     cuda_graph_max_tokens: NotRequired[int]
-    # Inference CUDA-graph scope. Options:
-    # - 'none': inference runs in eager mode (no CUDA graphs).
-    # - 'layer': graphs are owned at the per-layer boundary (TransformerLayer / MambaLayer).
-    # - 'block': graphs are owned at the enclosing block (TransformerBlock / HybridBlock).
-    # Only meaningful when cuda_graph_impl='local'.
     inference_cuda_graph_scope: NotRequired[str]
     # Required for EP>1 + inference CUDA graphs, except when using the
     # `inference_optimized` transformer implementation.
@@ -74,10 +69,7 @@ class MCoreGenerationSpecificArgs(TypedDict):
         Literal["load_balanced", "longest_prefix", "first_prefix_block"]
     ]
     prefix_cache_ttl_seconds: NotRequired[float]
-    prefix_caching_cost_policy: NotRequired[
-        Literal["simple_multiplicative", "load_aware"]
-    ]
-    prefix_caching_load_beta: NotRequired[float]
+    prefix_caching_routing_alpha: NotRequired[float]
 
     # Raw media preprocessing corresponding with Megatron's
     # ImageProcessingConfig / VideoProcessingConfig.

--- a/nemo_rl/models/generation/megatron/megatron_generation.py
+++ b/nemo_rl/models/generation/megatron/megatron_generation.py
@@ -108,17 +108,21 @@ class MegatronGeneration(GenerationInterface):
     def frontend_ranks(cluster: RayVirtualCluster, config: PolicyConfig) -> list[int]:
         """Distributed ranks that will host an HTTP frontend.
 
-        One frontend per model-parallel group, mirroring the engine-side
-        ``is_mp_coordinator`` predicate the workers use: tensor-parallel ranks
-        are innermost, so the coordinator of each group is the first rank in it.
+        Copy of the engine's ``is_mp_coordinator = tp_rank == 0 and pp_rank == 0``.
+        Megatron orders ranks TP-fastest, PP-slowest, so PP selects a leading
+        slice and TP a stride within it. CP and DP are not divided out because
+        the predicate ignores them.
         """
         mcore_cfg = MegatronGeneration.effective_megatron_cfg(config)
-        model_parallel_size = (
-            mcore_cfg["tensor_model_parallel_size"]
-            * mcore_cfg["pipeline_model_parallel_size"]
-            * mcore_cfg.get("context_parallel_size", 1)
+        tensor_model_parallel_size = mcore_cfg["tensor_model_parallel_size"]
+        pipeline_model_parallel_size = mcore_cfg["pipeline_model_parallel_size"]
+        return list(
+            range(
+                0,
+                cluster.world_size() // pipeline_model_parallel_size,
+                tensor_model_parallel_size,
+            )
         )
-        return list(range(0, cluster.world_size(), model_parallel_size))
 
     @staticmethod
     def _rank_placement(cluster: RayVirtualCluster) -> list[tuple[int, int]]:
@@ -130,10 +134,9 @@ class MegatronGeneration(GenerationInterface):
         holder on the bundle that rank will land on, so the two must agree.
         """
         if cluster._sorted_bundle_indices is not None:
-            group_size = cluster.num_gpus_per_node
+            # Sorted indices imply a unified PG, and there is only ever one.
             return [
-                (i // group_size, bundle_index)
-                for i, bundle_index in enumerate(cluster._sorted_bundle_indices)
+                (0, bundle_index) for bundle_index in cluster._sorted_bundle_indices
             ]
         return [
             (pg_index, bundle_index)

--- a/nemo_rl/models/generation/megatron/megatron_generation.py
+++ b/nemo_rl/models/generation/megatron/megatron_generation.py
@@ -50,11 +50,15 @@ class MegatronGeneration(GenerationInterface):
     def effective_megatron_cfg(config: PolicyConfig) -> dict[str, Any]:
         """The megatron_cfg the generation workers actually run with.
 
-        Colocated generation shares the training model, so the training
-        values apply; non-colocated builds a dedicated policy with
+        Colocated generation uses a dedicated inference-layout model when its
+        resolved layout differs from training, and otherwise shares the training
+        model. Non-colocated generation always builds a dedicated policy from
         mcore_generation_config merged on top. Always returns a fresh dict.
         """
         if config["generation"]["colocated"]["enabled"]:
+            inference_mcfg = dedicated_inference_megatron_cfg(config)
+            if inference_mcfg is not None:
+                return inference_mcfg
             return dict(config["megatron_cfg"])
         return merged_inference_megatron_cfg(config)
 
@@ -64,11 +68,15 @@ class MegatronGeneration(GenerationInterface):
 
         Colocated reshard hosts a second, inference-layout model on the same ranks.
         """
-        layouts = [cls.effective_megatron_cfg(config)]
         if config["generation"]["colocated"]["enabled"]:
+            # Placement must satisfy both the resident training layout and any
+            # dedicated inference layout built on those same ranks.
+            layouts = [dict(config["megatron_cfg"])]
             inference_mcfg = dedicated_inference_megatron_cfg(config)
             if inference_mcfg is not None:
                 layouts.append(inference_mcfg)
+        else:
+            layouts = [cls.effective_megatron_cfg(config)]
         return max(
             max(
                 mcfg["tensor_model_parallel_size"] * mcfg["context_parallel_size"],
@@ -104,7 +112,7 @@ class MegatronGeneration(GenerationInterface):
         ``is_mp_coordinator`` predicate the workers use: tensor-parallel ranks
         are innermost, so the coordinator of each group is the first rank in it.
         """
-        mcore_cfg = config["generation"]["mcore_generation_config"]
+        mcore_cfg = MegatronGeneration.effective_megatron_cfg(config)
         model_parallel_size = (
             mcore_cfg["tensor_model_parallel_size"]
             * mcore_cfg["pipeline_model_parallel_size"]

--- a/nemo_rl/models/generation/megatron/megatron_generation.py
+++ b/nemo_rl/models/generation/megatron/megatron_generation.py
@@ -96,52 +96,100 @@ class MegatronGeneration(GenerationInterface):
             use_unified_pg=cls.nvlink_domain_span(config) > cluster.num_gpus_per_node,
         )
 
+    @staticmethod
+    def frontend_ranks(cluster: RayVirtualCluster, config: PolicyConfig) -> list[int]:
+        """Distributed ranks that will host an HTTP frontend.
+
+        One frontend per model-parallel group, mirroring the engine-side
+        ``is_mp_coordinator`` predicate the workers use: tensor-parallel ranks
+        are innermost, so the coordinator of each group is the first rank in it.
+        """
+        mcore_cfg = config["generation"]["mcore_generation_config"]
+        model_parallel_size = (
+            mcore_cfg["tensor_model_parallel_size"]
+            * mcore_cfg["pipeline_model_parallel_size"]
+            * mcore_cfg.get("context_parallel_size", 1)
+        )
+        return list(range(0, cluster.world_size(), model_parallel_size))
+
+    @staticmethod
+    def _rank_placement(cluster: RayVirtualCluster) -> list[tuple[int, int]]:
+        """The (placement group index, bundle index) each rank will occupy, in rank order.
+
+        Mirrors how `Policy` hands bundles to its worker group: a unified
+        placement group is walked in NVLink-sorted order, otherwise bundles are
+        taken group by group. Reserving a port for a rank means placing the
+        holder on the bundle that rank will land on, so the two must agree.
+        """
+        if cluster._sorted_bundle_indices is not None:
+            group_size = cluster.num_gpus_per_node
+            return [
+                (i // group_size, bundle_index)
+                for i, bundle_index in enumerate(cluster._sorted_bundle_indices)
+            ]
+        return [
+            (pg_index, bundle_index)
+            for pg_index, placement_group in enumerate(cluster.get_placement_groups())
+            for bundle_index in range(placement_group.bundle_count)
+        ]
+
     @classmethod
-    def reserve_http_server_address(
+    def reserve_http_server_addresses(
         cls,
         cluster: RayVirtualCluster,
         config: PolicyConfig,
-    ) -> tuple[str, int, ray.actor.ActorHandle]:
-        """Reserve the OpenAI server address before any generation worker exists.
+    ) -> tuple[list[str], dict[int, int], list[ray.actor.ActorHandle]]:
+        """Reserve every OpenAI server address before any generation worker exists.
 
         This is megatron's substitute for vLLM's `defer_model_load` overlap.
         See https://github.com/NVIDIA-NeMo/RL/issues/3752
+
+        One address is reserved per frontend-hosting rank so NeMo Gym can be
+        handed the full set up front. Gym distributes sessions across the URLs it
+        is given, so reserving only one would pin every session to a single
+        frontend no matter how many the engine goes on to start.
+
+        Ports are only ever bound per node, so two frontends on different nodes
+        may be handed the same port number; no cross-node uniqueness is sought.
 
         Args:
             cluster: The cluster the generation workers will run on.
             config: The full `PolicyConfig`.
 
         Returns:
-            Tuple of (server base URL, reserved port, port-holder actor handle).
-            The caller must keep the handle referenced until rank 0 has adopted
-            the socket (worker init complete), then `ray.kill` it.
+            Tuple of (server base URLs, {distributed rank: reserved port},
+            port-holder actor handles). The caller must keep the handles
+            referenced until the workers have adopted the sockets (worker init
+            complete), then `ray.kill` them.
         """
         # Colocated generation shares the training policy's cluster and uses the
         # default placement-group init, triggered lazily by the read below.
         if not config["generation"]["colocated"]["enabled"]:
             cls.init_cluster_placement_groups(cluster, config)
 
-        # Distributed rank 0 lands on the first bundle handed to the worker
-        # group: sorted-first for a unified placement group, else bundle 0 of
-        # the first group (mirrors Policy's worker-group construction).
         placement_groups = cluster.get_placement_groups()
-        rank0_bundle_index = (
-            cluster._sorted_bundle_indices[0]
-            if cluster._sorted_bundle_indices is not None
-            else 0
-        )
-        # Zero-gap reservation: a holder actor on the rank-0 node binds and
+        placement = cls._rank_placement(cluster)
+        ranks = cls.frontend_ranks(cluster, config)
+
+        # Zero-gap reservation: a holder actor on each frontend's node binds and
         # HOLDS the socket (num_cpus=0, so it schedules even on a full bundle);
-        # rank 0 later adopts the live fd via receive_held_socket, so the port
+        # the rank later adopts the live fd via receive_held_socket, so the port
         # can never be stolen in between and any free port is safe.
-        holder = RemoteHeldPortReservation.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_groups[0],
-                placement_group_bundle_index=rank0_bundle_index,
-            ),
-        ).remote()
-        node_ip, port = ray.get(holder.address.remote())
-        return f"http://{node_ip}:{port}/v1", port, holder
+        holders = [
+            RemoteHeldPortReservation.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=placement_groups[placement[rank][0]],
+                    placement_group_bundle_index=placement[rank][1],
+                ),
+            ).remote()
+            for rank in ranks
+        ]
+        addresses = ray.get([holder.address.remote() for holder in holders])
+        urls = [f"http://{node_ip}:{port}/v1" for node_ip, port in addresses]
+        rank_to_port = {
+            rank: port for rank, (_, port) in zip(ranks, addresses, strict=True)
+        }
+        return urls, rank_to_port, holders
 
     @classmethod
     def validate_settings(cls, master_config: "MasterConfig") -> None:
@@ -183,14 +231,21 @@ class MegatronGeneration(GenerationInterface):
             )
 
     @classmethod
-    def verify_served_address(
-        cls, served_urls: list[Optional[str]], reserved_url: str
+    def verify_served_addresses(
+        cls, served_urls: list[Optional[str]], reserved_urls: list[str]
     ) -> None:
-        """Fail loud if the engine serves anywhere but the pre-published address."""
-        if served_urls != [reserved_url]:
+        """Fail loud if the engine serves anywhere but the pre-published addresses.
+
+        Order is not significant -- NeMo Gym spreads sessions over the set it was
+        given -- but the set must match exactly: a frontend serving an address
+        Gym never received takes no traffic, and an address Gym holds that
+        nothing serves fails its health check.
+        """
+        if sorted(filter(None, served_urls)) != sorted(reserved_urls):
             raise RuntimeError(
-                "Megatron server came up at a different address than the one "
-                f"pre-published to NeMo Gym: reserved {reserved_url}, serving {served_urls}."
+                "Megatron servers came up at different addresses than the ones "
+                f"pre-published to NeMo Gym: reserved {sorted(reserved_urls)}, "
+                f"serving {sorted(filter(None, served_urls))}."
             )
 
     def __init__(
@@ -202,7 +257,7 @@ class MegatronGeneration(GenerationInterface):
         name_prefix: str = "megatron_generation",
         processor: Optional[AutoProcessor] = None,
         skip_weight_load: bool = False,
-        reserved_http_server_port: Optional[int] = None,
+        reserved_http_server_ports: Optional[dict[int, int]] = None,
     ):
         """Initialize a MegatronGeneration instance.
 
@@ -216,7 +271,8 @@ class MegatronGeneration(GenerationInterface):
             name_prefix: Prefix for naming the worker group (non-colocated only).
             processor: Optional processor for VLMs (non-colocated only).
             skip_weight_load: Do not load the weights from the checkpoint; refit will do it.
-            reserved_http_server_port: Driver-reserved OpenAI server port for non-colocated.
+            reserved_http_server_ports: Driver-reserved OpenAI server ports, keyed by
+                the distributed rank that will adopt each one (non-colocated only).
         """
         # Import here to avoid circular imports
         from nemo_rl.models.policy.lm_policy import Policy
@@ -227,9 +283,9 @@ class MegatronGeneration(GenerationInterface):
         assert not (skip_weight_load and policy is not None), (
             "skip_weight_load only applies to the dedicated inference policy."
         )
-        assert not (reserved_http_server_port is not None and policy is not None), (
-            "reserved_http_server_port only applies to the dedicated inference "
-            "policy; when colocated, pass it to the training policy instead."
+        assert not (reserved_http_server_ports is not None and policy is not None), (
+            "reserved_http_server_ports only applies to the dedicated inference "
+            "policy; when colocated, pass them to the training policy instead."
         )
 
         # `self.cfg` exposes the `generation` that matches the `GenerationInterface` contract.
@@ -268,7 +324,7 @@ class MegatronGeneration(GenerationInterface):
             init_optimizer=False,
             init_reference_model=False,
             skip_weight_load=skip_weight_load,
-            reserved_http_server_port=reserved_http_server_port,
+            reserved_http_server_ports=reserved_http_server_ports,
         )
 
         # Skip-load models do not have their final refit weight buffers yet.

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -30,6 +30,7 @@ from megatron.core.inference.config import (
     KVCacheManagementMode,
     MambaInferenceStateConfig,
     PrefixCachingCoordinatorPolicy,
+    PrefixCachingEvictionPolicy,
 )
 from megatron.core.inference.engines.dynamic_engine import EngineState
 from megatron.core.inference.sampling_params import SamplingParams
@@ -80,8 +81,6 @@ from nemo_rl.models.megatron.memory_saver import (
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 _DEFAULT_COORDINATOR_POLICY = "longest_prefix"
-
-_DEFAULT_CUDA_GRAPH_SIZING = "hybrid"
 
 
 def _resolve_coordinator_policy(
@@ -386,12 +385,6 @@ class MegatronGenerationMixin:
                     mcore_generation_config["mamba_inference_conv_states_dtype"]
                 )
 
-        # logging_step_interval is a power-user argument that should be NotRequired.
-        logging_step_interval = mcore_generation_config.get("logging_step_interval")
-        # This will be fixed in upstream MCore, allowing an argument of `None`.
-        if logging_step_interval is None:
-            logging_step_interval = 0
-
         # flashinfer's fused-RoPE kernel only dispatches fp16/bf16 q/k.
         use_flashinfer_fused_rope = model_config.params_dtype in (
             torch.float16,
@@ -407,78 +400,83 @@ class MegatronGenerationMixin:
             frame_manifest_magic=CACHED_VIDEO_FRAME_MANIFEST_MAGIC,
         )
 
-        # Only forward keys the config actually sets, so MCore's InferenceConfig
-        # defaults stay the single source of truth for the ones it omits.
-        inference_overrides: dict[str, Any] = {}
+        inference_config_kwargs: dict[str, Any] = {
+            "block_size_tokens": block_size_tokens,
+            "buffer_size_gb": buffer_size_gb,
+            "num_cuda_graphs": num_cuda_graphs,
+            "max_tokens": max_tokens,
+            "max_sequence_length": mcore_generation_config["max_model_len"],
+            "kv_cache_management_mode": KVCacheManagementMode(kv_cache_management_mode),
+            "static_kv_memory_pointers": needs_static_kv_pointers,
+            "use_cuda_graphs_for_non_decode_steps": use_cuda_graphs_for_non_decode_steps,
+            "use_flashinfer_fused_rope": use_flashinfer_fused_rope,
+            "sampling_backend": "flashinfer",
+            "use_synchronous_zmq_collectives": True,
+            "materialize_only_last_token_logits": materialize_only_last_token_logits,
+            "enable_chunked_prefill": enable_chunked_prefill,
+            "enable_prefix_caching": mcore_generation_config["enable_prefix_caching"],
+            "pg_collection": pg_collection,
+            "mamba_inference_state_config": mamba_inference_state_config,
+            # Reserve more KV-cache space when speculative decoding is enabled.
+            "mamba_memory_ratio": (
+                0.1 + 0.1 * num_speculative_tokens if is_hybrid_model else None
+            ),
+            "num_speculative_tokens": num_speculative_tokens,
+            "logprobs_mode": mcore_generation_config["logprobs_mode"],
+            "max_requests": max_requests,
+            "image_preprocessing_config": image_preprocessing_config,
+            "video_preprocessing_config": video_preprocessing_config,
+        }
+        if "cuda_graph_sizing_distribution" in mcore_generation_config:
+            inference_config_kwargs["cuda_graph_sizing_distribution"] = (
+                CudaGraphSizingDistribution(
+                    mcore_generation_config["cuda_graph_sizing_distribution"]
+                )
+            )
+        if "cuda_graph_max_tokens" in mcore_generation_config:
+            inference_config_kwargs["cuda_graph_max_tokens"] = int(
+                mcore_generation_config["cuda_graph_max_tokens"]
+            )
         if "async_sched_mode" in mcore_generation_config:
-            inference_overrides["async_sched_mode"] = AsyncScheduleMode(
+            inference_config_kwargs["async_sched_mode"] = AsyncScheduleMode(
                 mcore_generation_config["async_sched_mode"]
             )
         if "vision_embedding_cache_max_bytes" in mcore_generation_config:
-            inference_overrides["vision_embedding_cache_max_bytes"] = int(
+            inference_config_kwargs["vision_embedding_cache_max_bytes"] = int(
                 mcore_generation_config["vision_embedding_cache_max_bytes"]
             )
         if "allow_stale_multimodal_embeddings" in mcore_generation_config:
-            inference_overrides["allow_stale_multimodal_embeddings"] = bool(
+            inference_config_kwargs["allow_stale_multimodal_embeddings"] = bool(
                 mcore_generation_config["allow_stale_multimodal_embeddings"]
             )
+        if "prefix_caching_eviction_policy" in mcore_generation_config:
+            inference_config_kwargs["prefix_caching_eviction_policy"] = (
+                PrefixCachingEvictionPolicy(
+                    mcore_generation_config["prefix_caching_eviction_policy"]
+                )
+            )
+        if "prefix_caching_coordinator_policy" in mcore_generation_config:
+            inference_config_kwargs["prefix_caching_coordinator_policy"] = (
+                _resolve_coordinator_policy(mcore_generation_config)
+            )
+        if "prefix_caching_mamba_gb" in mcore_generation_config:
+            inference_config_kwargs["prefix_caching_mamba_gb"] = (
+                mcore_generation_config["prefix_caching_mamba_gb"]
+            )
+        if "prefix_cache_ttl_seconds" in mcore_generation_config:
+            inference_config_kwargs["prefix_cache_ttl_seconds"] = float(
+                mcore_generation_config["prefix_cache_ttl_seconds"]
+            )
+        if "prefix_caching_routing_alpha" in mcore_generation_config:
+            inference_config_kwargs["prefix_caching_routing_alpha"] = float(
+                mcore_generation_config["prefix_caching_routing_alpha"]
+            )
+        if "logging_step_interval" in mcore_generation_config:
+            inference_config_kwargs["logging_step_interval"] = int(
+                mcore_generation_config["logging_step_interval"]
+            )
 
-        inference_config = InferenceConfig(
-            block_size_tokens=block_size_tokens,
-            buffer_size_gb=buffer_size_gb,
-            num_cuda_graphs=num_cuda_graphs,
-            max_tokens=max_tokens,
-            max_sequence_length=mcore_generation_config["max_model_len"],
-            kv_cache_management_mode=KVCacheManagementMode(kv_cache_management_mode),
-            static_kv_memory_pointers=needs_static_kv_pointers,
-            use_cuda_graphs_for_non_decode_steps=use_cuda_graphs_for_non_decode_steps,
-            cuda_graph_sizing_distribution=CudaGraphSizingDistribution(
-                mcore_generation_config.get(
-                    "cuda_graph_sizing_distribution", _DEFAULT_CUDA_GRAPH_SIZING
-                )
-            ),
-            **(
-                {
-                    "cuda_graph_max_tokens": mcore_generation_config[
-                        "cuda_graph_max_tokens"
-                    ]
-                }
-                if "cuda_graph_max_tokens" in mcore_generation_config
-                else {}
-            ),
-            use_flashinfer_fused_rope=use_flashinfer_fused_rope,
-            sampling_backend="flashinfer",
-            use_synchronous_zmq_collectives=True,
-            materialize_only_last_token_logits=materialize_only_last_token_logits,
-            enable_chunked_prefill=enable_chunked_prefill,
-            enable_prefix_caching=mcore_generation_config["enable_prefix_caching"],
-            **inference_overrides,
-            prefix_caching_coordinator_policy=_resolve_coordinator_policy(
-                mcore_generation_config
-            ),
-            **{
-                key: mcore_generation_config[key]
-                for key in (
-                    "prefix_caching_mamba_gb",
-                    "prefix_cache_ttl_seconds",
-                    "prefix_caching_routing_alpha",
-                )
-                if key in mcore_generation_config
-            },
-            pg_collection=pg_collection,
-            async_sched_mode=AsyncScheduleMode.ASYNC,
-            mamba_inference_state_config=mamba_inference_state_config,
-            # Reserve more KV-cache space when speculative decoding is enabled.
-            mamba_memory_ratio=(
-                0.1 + 0.1 * num_speculative_tokens if is_hybrid_model else None
-            ),
-            logging_step_interval=logging_step_interval,
-            num_speculative_tokens=num_speculative_tokens,
-            logprobs_mode=mcore_generation_config["logprobs_mode"],
-            max_requests=max_requests,
-            image_preprocessing_config=image_preprocessing_config,
-            video_preprocessing_config=video_preprocessing_config,
-        )
+        inference_config = InferenceConfig(**inference_config_kwargs)
 
         if "inference_cuda_graph_scope" in mcore_generation_config:
             engine_model.config.inference_cuda_graph_scope = InferenceCudaGraphScope[

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -80,8 +80,6 @@ from nemo_rl.models.megatron.memory_saver import (
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
-_DEFAULT_COORDINATOR_POLICY = "longest_prefix"
-
 
 def _resolve_coordinator_policy(
     mcore_generation_config,
@@ -94,10 +92,10 @@ def _resolve_coordinator_policy(
     """
     if not mcore_generation_config["enable_prefix_caching"]:
         return PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+    if "prefix_caching_coordinator_policy" not in mcore_generation_config:
+        return InferenceConfig.prefix_caching_coordinator_policy
     return PrefixCachingCoordinatorPolicy(
-        mcore_generation_config.get(
-            "prefix_caching_coordinator_policy", _DEFAULT_COORDINATOR_POLICY
-        )
+        mcore_generation_config["prefix_caching_coordinator_policy"]
     )
 
 
@@ -415,6 +413,9 @@ class MegatronGenerationMixin:
             "materialize_only_last_token_logits": materialize_only_last_token_logits,
             "enable_chunked_prefill": enable_chunked_prefill,
             "enable_prefix_caching": mcore_generation_config["enable_prefix_caching"],
+            "prefix_caching_coordinator_policy": _resolve_coordinator_policy(
+                mcore_generation_config
+            ),
             "pg_collection": pg_collection,
             "mamba_inference_state_config": mamba_inference_state_config,
             # Reserve more KV-cache space when speculative decoding is enabled.
@@ -454,10 +455,6 @@ class MegatronGenerationMixin:
                 PrefixCachingEvictionPolicy(
                     mcore_generation_config["prefix_caching_eviction_policy"]
                 )
-            )
-        if "prefix_caching_coordinator_policy" in mcore_generation_config:
-            inference_config_kwargs["prefix_caching_coordinator_policy"] = (
-                _resolve_coordinator_policy(mcore_generation_config)
             )
         if "prefix_caching_mamba_gb" in mcore_generation_config:
             inference_config_kwargs["prefix_caching_mamba_gb"] = (
@@ -624,9 +621,9 @@ class MegatronGenerationMixin:
                 rng=random.Random(torch.distributed.get_rank())
             )
 
-        # Each replica is one asyncio event loop, so this is the per-host
-        # frontend capacity; every model-parallel coordinator hosts a set.
-        num_replicas = 8
+        server_kwargs: dict[str, Any] = {}
+        if "http_server_num_replicas" in gen_cfg:
+            server_kwargs["num_replicas"] = int(gen_cfg["http_server_num_replicas"])
 
         start_text_gen_server(
             coordinator_addr=self.coordinator_addr,
@@ -637,13 +634,13 @@ class MegatronGenerationMixin:
             verbose=False,
             sock=reserved_socket,
             multimodal_prompt_config=self.inference_wrapped_model.multimodal_prompt_config,
-            num_replicas=num_replicas,
             # The frontend hashes prompts so the coordinator does not have to.
             # Whether it bothers follows from the routing policy, so pass that
             # rather than encoding the decision here; the block size is only the
             # granularity and must match the engine's.
             block_size_tokens=gen_cfg["block_size_tokens"],
             prefix_caching_coordinator_policy=coordinator_policy,
+            **server_kwargs,
         )
 
         base_url = f"http://{ip}:{server_port}/v1"

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -459,7 +459,6 @@ class MegatronGenerationMixin:
                 mcore_generation_config
             ),
             prefix_caching_mamba_gb=mcore_generation_config.get("prefix_caching_mamba_gb", 50),
-            prefix_caching_routing_alpha=0.5,
             prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
             prefix_cache_ttl_seconds=mcore_generation_config.get(
                 "prefix_cache_ttl_seconds", 300.0

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -30,9 +30,6 @@ from megatron.core.inference.config import (
     KVCacheManagementMode,
     MambaInferenceStateConfig,
     PrefixCachingCoordinatorPolicy,
-    PrefixCachingCostPolicy,
-    PrefixCachingEvictionPolicy,
-    AsyncScheduleMode,
 )
 from megatron.core.inference.engines.dynamic_engine import EngineState
 from megatron.core.inference.sampling_params import SamplingParams
@@ -84,11 +81,6 @@ from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 _DEFAULT_COORDINATOR_POLICY = "longest_prefix"
 
-# Prefill and decode graphs cover ranges that differ by orders of magnitude: prefill spans
-# cuda_graph_max_tokens (thousands), decode is capped at max_requests (tens). One distribution
-# cannot serve both -- halving leaves decode with 3 graphs and 2.35x worst-case padding, while
-# linear spacing across the prefill range would capture ~144 graphs. Hybrid applies exponential
-# to prefill and linear to decode.
 _DEFAULT_CUDA_GRAPH_SIZING = "hybrid"
 
 
@@ -458,27 +450,15 @@ class MegatronGenerationMixin:
             prefix_caching_coordinator_policy=_resolve_coordinator_policy(
                 mcore_generation_config
             ),
-            prefix_caching_mamba_gb=mcore_generation_config.get("prefix_caching_mamba_gb", 50),
-            prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
-            prefix_cache_ttl_seconds=mcore_generation_config.get(
-                "prefix_cache_ttl_seconds", 300.0
-            ),
-            # Absent from config, leave mcore's defaults alone rather than restating
-            # them here; both only apply under the longest_prefix policy.
-            **(
-                {
-                    "prefix_caching_cost_policy": PrefixCachingCostPolicy(
-                        mcore_generation_config["prefix_caching_cost_policy"]
-                    )
-                }
-                if "prefix_caching_cost_policy" in mcore_generation_config
-                else {}
-            ),
-            **(
-                {"prefix_caching_load_beta": mcore_generation_config["prefix_caching_load_beta"]}
-                if "prefix_caching_load_beta" in mcore_generation_config
-                else {}
-            ),
+            **{
+                key: mcore_generation_config[key]
+                for key in (
+                    "prefix_caching_mamba_gb",
+                    "prefix_cache_ttl_seconds",
+                    "prefix_caching_routing_alpha",
+                )
+                if key in mcore_generation_config
+            },
             pg_collection=pg_collection,
             async_sched_mode=AsyncScheduleMode.ASYNC,
             mamba_inference_state_config=mamba_inference_state_config,
@@ -606,15 +586,11 @@ class MegatronGenerationMixin:
 
     def _setup_openai_api_server(self) -> str:
         """Start the OpenAI-compatible HTTP server on this worker."""
-        import random
-
         from megatron.core.inference.text_generation_server.dynamic_text_gen_server.text_generation_server import (
             start_text_gen_server,
         )
-        from megatron.core.utils import get_pg_rank
 
         from nemo_rl.distributed.virtual_cluster import (
-            _get_free_port_local,
             _get_node_ip_local,
         )
 
@@ -643,11 +619,8 @@ class MegatronGenerationMixin:
             dp_rank = get_pg_rank(self.dynamic_inference_engine.pg_collection.dp)
             server_port = _get_free_port_local(rng=random.Random(dp_rank))
 
-        # Each HTTP frontend replica is a single asyncio event loop, so frontend
-        # capacity is the replica count. The old max(dp_size, 4) sized one rank's
-        # server to feed every engine; now that every rank hosts one, aggregate
-        # capacity is world_size * this, and scaling per rank with dp_size would
-        # square it (1024 processes at r16, each holding a copy of the tokenizer).
+        # Each replica is one asyncio event loop, so this is the per-host
+        # frontend capacity; every model-parallel coordinator hosts a set.
         num_replicas = 8
 
         start_text_gen_server(
@@ -701,9 +674,6 @@ class MegatronGenerationMixin:
         future.result()
         print(f"[Rank {torch.distributed.get_rank()}] Coordinator started")
 
-        # One frontend per model-parallel group. Frontend work (chat template,
-        # detokenize, parsers, JSON) is CPU-bound, so hosting it on a single rank
-        # caps throughput at that rank's cores.
         if (
             self.cfg["generation"]["mcore_generation_config"]["expose_http_server"]
             and self.dynamic_inference_engine.is_mp_coordinator

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -99,6 +99,46 @@ def _resolve_coordinator_policy(
     )
 
 
+def _apply_optional_inference_config_kwargs(
+    inference_config_kwargs: dict[str, Any],
+    mcore_generation_config: dict[str, Any],
+) -> None:
+    """Forward configured optional MCore inference settings with validated types."""
+    enum_fields = {
+        "cuda_graph_sizing_distribution": CudaGraphSizingDistribution,
+        "async_sched_mode": AsyncScheduleMode,
+        "prefix_caching_eviction_policy": PrefixCachingEvictionPolicy,
+    }
+    cast_fields = {
+        "cuda_graph_max_tokens": int,
+        "vision_embedding_cache_max_bytes": int,
+        "allow_stale_multimodal_embeddings": bool,
+        "prefix_cache_ttl_seconds": float,
+        "prefix_caching_routing_alpha": float,
+        "logging_step_interval": int,
+    }
+    for key, enum_type in enum_fields.items():
+        if key in mcore_generation_config:
+            inference_config_kwargs[key] = enum_type(mcore_generation_config[key])
+    for key, cast_type in cast_fields.items():
+        if key in mcore_generation_config:
+            inference_config_kwargs[key] = cast_type(mcore_generation_config[key])
+    if "prefix_caching_mamba_gb" in mcore_generation_config:
+        inference_config_kwargs["prefix_caching_mamba_gb"] = mcore_generation_config[
+            "prefix_caching_mamba_gb"
+        ]
+
+
+def _apply_inference_cuda_graph_scope(
+    engine_model: MegatronModule, mcore_generation_config: dict[str, Any]
+) -> None:
+    """Apply the optional CUDA graph scope to the engine model."""
+    if "inference_cuda_graph_scope" in mcore_generation_config:
+        engine_model.config.inference_cuda_graph_scope = InferenceCudaGraphScope[
+            mcore_generation_config["inference_cuda_graph_scope"]
+        ]
+
+
 class MegatronGenerationMixin:
     """Engine lifecycle, coordinator, HTTP server, and finish-generation machinery.
 
@@ -428,57 +468,13 @@ class MegatronGenerationMixin:
             "image_preprocessing_config": image_preprocessing_config,
             "video_preprocessing_config": video_preprocessing_config,
         }
-        if "cuda_graph_sizing_distribution" in mcore_generation_config:
-            inference_config_kwargs["cuda_graph_sizing_distribution"] = (
-                CudaGraphSizingDistribution(
-                    mcore_generation_config["cuda_graph_sizing_distribution"]
-                )
-            )
-        if "cuda_graph_max_tokens" in mcore_generation_config:
-            inference_config_kwargs["cuda_graph_max_tokens"] = int(
-                mcore_generation_config["cuda_graph_max_tokens"]
-            )
-        if "async_sched_mode" in mcore_generation_config:
-            inference_config_kwargs["async_sched_mode"] = AsyncScheduleMode(
-                mcore_generation_config["async_sched_mode"]
-            )
-        if "vision_embedding_cache_max_bytes" in mcore_generation_config:
-            inference_config_kwargs["vision_embedding_cache_max_bytes"] = int(
-                mcore_generation_config["vision_embedding_cache_max_bytes"]
-            )
-        if "allow_stale_multimodal_embeddings" in mcore_generation_config:
-            inference_config_kwargs["allow_stale_multimodal_embeddings"] = bool(
-                mcore_generation_config["allow_stale_multimodal_embeddings"]
-            )
-        if "prefix_caching_eviction_policy" in mcore_generation_config:
-            inference_config_kwargs["prefix_caching_eviction_policy"] = (
-                PrefixCachingEvictionPolicy(
-                    mcore_generation_config["prefix_caching_eviction_policy"]
-                )
-            )
-        if "prefix_caching_mamba_gb" in mcore_generation_config:
-            inference_config_kwargs["prefix_caching_mamba_gb"] = (
-                mcore_generation_config["prefix_caching_mamba_gb"]
-            )
-        if "prefix_cache_ttl_seconds" in mcore_generation_config:
-            inference_config_kwargs["prefix_cache_ttl_seconds"] = float(
-                mcore_generation_config["prefix_cache_ttl_seconds"]
-            )
-        if "prefix_caching_routing_alpha" in mcore_generation_config:
-            inference_config_kwargs["prefix_caching_routing_alpha"] = float(
-                mcore_generation_config["prefix_caching_routing_alpha"]
-            )
-        if "logging_step_interval" in mcore_generation_config:
-            inference_config_kwargs["logging_step_interval"] = int(
-                mcore_generation_config["logging_step_interval"]
-            )
+        _apply_optional_inference_config_kwargs(
+            inference_config_kwargs, mcore_generation_config
+        )
 
         inference_config = InferenceConfig(**inference_config_kwargs)
 
-        if "inference_cuda_graph_scope" in mcore_generation_config:
-            engine_model.config.inference_cuda_graph_scope = InferenceCudaGraphScope[
-                mcore_generation_config["inference_cuda_graph_scope"]
-            ]
+        _apply_inference_cuda_graph_scope(engine_model, mcore_generation_config)
 
         self.inference_context = DynamicInferenceContext(
             engine_model.config, inference_config

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -25,10 +25,14 @@ import requests
 import torch
 from megatron.core.inference.config import (
     AsyncScheduleMode,
+    CudaGraphSizingDistribution,
     InferenceConfig,
     KVCacheManagementMode,
     MambaInferenceStateConfig,
     PrefixCachingCoordinatorPolicy,
+    PrefixCachingCostPolicy,
+    PrefixCachingEvictionPolicy,
+    AsyncScheduleMode,
 )
 from megatron.core.inference.engines.dynamic_engine import EngineState
 from megatron.core.inference.sampling_params import SamplingParams
@@ -77,6 +81,31 @@ from nemo_rl.models.megatron.memory_saver import (
     resume_inference_weights,
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
+
+_DEFAULT_COORDINATOR_POLICY = "longest_prefix"
+
+# Prefill and decode graphs cover ranges that differ by orders of magnitude: prefill spans
+# cuda_graph_max_tokens (thousands), decode is capped at max_requests (tens). One distribution
+# cannot serve both -- halving leaves decode with 3 graphs and 2.35x worst-case padding, while
+# linear spacing across the prefill range would capture ~144 graphs. Hybrid applies exponential
+# to prefill and linear to decode.
+_DEFAULT_CUDA_GRAPH_SIZING = "hybrid"
+
+
+def _resolve_coordinator_policy(mcore_generation_config) -> PrefixCachingCoordinatorPolicy:
+    """Effective DP-coordinator routing policy for this generation config.
+
+    Resolved in one place so the engine and the HTTP frontends cannot disagree:
+    if the engine routes on prefix affinity but the frontends skip hashing, the
+    coordinator silently sees no hashes and degrades to load balancing.
+    """
+    if not mcore_generation_config["enable_prefix_caching"]:
+        return PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+    return PrefixCachingCoordinatorPolicy(
+        mcore_generation_config.get(
+            "prefix_caching_coordinator_policy", _DEFAULT_COORDINATOR_POLICY
+        )
+    )
 
 
 class MegatronGenerationMixin:
@@ -409,6 +438,16 @@ class MegatronGenerationMixin:
             kv_cache_management_mode=KVCacheManagementMode(kv_cache_management_mode),
             static_kv_memory_pointers=needs_static_kv_pointers,
             use_cuda_graphs_for_non_decode_steps=use_cuda_graphs_for_non_decode_steps,
+            cuda_graph_sizing_distribution=CudaGraphSizingDistribution(
+                mcore_generation_config.get(
+                    "cuda_graph_sizing_distribution", _DEFAULT_CUDA_GRAPH_SIZING
+                )
+            ),
+            **(
+                {"cuda_graph_max_tokens": mcore_generation_config["cuda_graph_max_tokens"]}
+                if "cuda_graph_max_tokens" in mcore_generation_config
+                else {}
+            ),
             use_flashinfer_fused_rope=use_flashinfer_fused_rope,
             sampling_backend="flashinfer",
             use_synchronous_zmq_collectives=True,
@@ -416,10 +455,33 @@ class MegatronGenerationMixin:
             enable_chunked_prefill=enable_chunked_prefill,
             enable_prefix_caching=mcore_generation_config["enable_prefix_caching"],
             **inference_overrides,
-            prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy(
-                "first_prefix_block"
+            prefix_caching_coordinator_policy=_resolve_coordinator_policy(
+                mcore_generation_config
+            ),
+            prefix_caching_mamba_gb=mcore_generation_config.get("prefix_caching_mamba_gb", 50),
+            prefix_caching_routing_alpha=0.5,
+            prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+            prefix_cache_ttl_seconds=mcore_generation_config.get(
+                "prefix_cache_ttl_seconds", 300.0
+            ),
+            # Absent from config, leave mcore's defaults alone rather than restating
+            # them here; both only apply under the longest_prefix policy.
+            **(
+                {
+                    "prefix_caching_cost_policy": PrefixCachingCostPolicy(
+                        mcore_generation_config["prefix_caching_cost_policy"]
+                    )
+                }
+                if "prefix_caching_cost_policy" in mcore_generation_config
+                else {}
+            ),
+            **(
+                {"prefix_caching_load_beta": mcore_generation_config["prefix_caching_load_beta"]}
+                if "prefix_caching_load_beta" in mcore_generation_config
+                else {}
             ),
             pg_collection=pg_collection,
+            async_sched_mode=AsyncScheduleMode.ASYNC,
             mamba_inference_state_config=mamba_inference_state_config,
             # Reserve more KV-cache space when speculative decoding is enabled.
             mamba_memory_ratio=(
@@ -545,16 +607,24 @@ class MegatronGenerationMixin:
 
     def _setup_openai_api_server(self) -> str:
         """Start the OpenAI-compatible HTTP server on this worker."""
+        import random
+
         from megatron.core.inference.text_generation_server.dynamic_text_gen_server.text_generation_server import (
             start_text_gen_server,
         )
+        from megatron.core.utils import get_pg_rank
 
         from nemo_rl.distributed.virtual_cluster import (
             _get_free_port_local,
             _get_node_ip_local,
         )
 
+        gen_cfg = self.cfg["generation"]["mcore_generation_config"]
+        coordinator_policy = _resolve_coordinator_policy(gen_cfg)
+
         ip = _get_node_ip_local()
+        # Setup Megatron inference front-end ports for service.
+        # If ports are reserved (such as for Gym), use those.
         reserved_port = self._reserved_http_server_port
         if reserved_port is not None:
             # Defer socket handoff until immediately before server startup.
@@ -564,18 +634,39 @@ class MegatronGenerationMixin:
             reserved_socket = receive_held_socket(reserved_port)
             server_port = reserved_socket.getsockname()[1]
         else:
+            # Seed the port draw per DP rank. The default generator is seeded per
+            # run, so every rank produces the same candidate sequence; ranks
+            # sharing a node then converge on one port, and because each frontend
+            # replica binds with SO_REUSEPORT the duplicate bind succeeds instead
+            # of failing. The result is several ranks advertising one address,
+            # which collapses into a single client-side connection pool.
             reserved_socket = None
-            server_port = _get_free_port_local()
+            dp_rank = get_pg_rank(self.dynamic_inference_engine.pg_collection.dp)
+            server_port = _get_free_port_local(rng=random.Random(dp_rank))
+
+        # Each HTTP frontend replica is a single asyncio event loop, so frontend
+        # capacity is the replica count. The old max(dp_size, 4) sized one rank's
+        # server to feed every engine; now that every rank hosts one, aggregate
+        # capacity is world_size * this, and scaling per rank with dp_size would
+        # square it (1024 processes at r16, each holding a copy of the tokenizer).
+        num_replicas = 8
 
         start_text_gen_server(
             coordinator_addr=self.coordinator_addr,
             tokenizer=self.megatron_tokenizer,
             rank=torch.distributed.get_rank(),
             server_port=server_port,
-            parsers=self.cfg["generation"]["mcore_generation_config"]["parsers"],
+            parsers=gen_cfg["parsers"],
             verbose=False,
             sock=reserved_socket,
             multimodal_prompt_config=self.inference_wrapped_model.multimodal_prompt_config,
+            num_replicas=num_replicas,
+            # The frontend hashes prompts so the coordinator does not have to.
+            # Whether it bothers follows from the routing policy, so pass that
+            # rather than encoding the decision here; the block size is only the
+            # granularity and must match the engine's.
+            block_size_tokens=gen_cfg["block_size_tokens"],
+            prefix_caching_coordinator_policy=coordinator_policy,
         )
 
         base_url = f"http://{ip}:{server_port}/v1"
@@ -611,9 +702,12 @@ class MegatronGenerationMixin:
         future.result()
         print(f"[Rank {torch.distributed.get_rank()}] Coordinator started")
 
+        # One frontend per model-parallel group. Frontend work (chat template,
+        # detokenize, parsers, JSON) is CPU-bound, so hosting it on a single rank
+        # caps throughput at that rank's cores.
         if (
             self.cfg["generation"]["mcore_generation_config"]["expose_http_server"]
-            and torch.distributed.get_rank() == 0
+            and self.dynamic_inference_engine.is_mp_coordinator
         ):
             print(f"[Rank {torch.distributed.get_rank()}] Starting HTTP Server")
             self.base_url = self._setup_openai_api_server()

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -84,7 +84,9 @@ _DEFAULT_COORDINATOR_POLICY = "longest_prefix"
 _DEFAULT_CUDA_GRAPH_SIZING = "hybrid"
 
 
-def _resolve_coordinator_policy(mcore_generation_config) -> PrefixCachingCoordinatorPolicy:
+def _resolve_coordinator_policy(
+    mcore_generation_config,
+) -> PrefixCachingCoordinatorPolicy:
     """Effective DP-coordinator routing policy for this generation config.
 
     Resolved in one place so the engine and the HTTP frontends cannot disagree:
@@ -436,7 +438,11 @@ class MegatronGenerationMixin:
                 )
             ),
             **(
-                {"cuda_graph_max_tokens": mcore_generation_config["cuda_graph_max_tokens"]}
+                {
+                    "cuda_graph_max_tokens": mcore_generation_config[
+                        "cuda_graph_max_tokens"
+                    ]
+                }
                 if "cuda_graph_max_tokens" in mcore_generation_config
                 else {}
             ),

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -586,11 +586,14 @@ class MegatronGenerationMixin:
 
     def _setup_openai_api_server(self) -> str:
         """Start the OpenAI-compatible HTTP server on this worker."""
+        import random
+
         from megatron.core.inference.text_generation_server.dynamic_text_gen_server.text_generation_server import (
             start_text_gen_server,
         )
 
         from nemo_rl.distributed.virtual_cluster import (
+            _get_free_port_local,
             _get_node_ip_local,
         )
 
@@ -609,15 +612,13 @@ class MegatronGenerationMixin:
             reserved_socket = receive_held_socket(reserved_port)
             server_port = reserved_socket.getsockname()[1]
         else:
-            # Seed the port draw per DP rank. The default generator is seeded per
-            # run, so every rank produces the same candidate sequence; ranks
-            # sharing a node then converge on one port, and because each frontend
-            # replica binds with SO_REUSEPORT the duplicate bind succeeds instead
-            # of failing. The result is several ranks advertising one address,
-            # which collapses into a single client-side connection pool.
+            # Seed port assignment by rank to ensure that inference servers
+            # do not listen to the same port and parallelize tokenization,
+            # preprocessing, and hashing on multiple CPUs.
             reserved_socket = None
-            dp_rank = get_pg_rank(self.dynamic_inference_engine.pg_collection.dp)
-            server_port = _get_free_port_local(rng=random.Random(dp_rank))
+            server_port = _get_free_port_local(
+                rng=random.Random(torch.distributed.get_rank())
+            )
 
         # Each replica is one asyncio event loop, so this is the per-host
         # frontend capacity; every model-parallel coordinator hosts a set.

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -103,7 +103,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         processor: Optional[AutoProcessor] = None,
         worker_extension_cls_fqn: Optional[str] = None,
         skip_weight_load: bool = False,
-        reserved_http_server_port: Optional[int] = None,
+        reserved_http_server_ports: Optional[dict[int, int]] = None,
     ):
         self.debug_payload_metrics = False
         configured_extension_fqn = config.get("worker_extension_cls_fqn")
@@ -154,9 +154,9 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "Configure either Megatron (policy.megatron_cfg.enabled=true) or "
                 "DTensor (policy.dtensor_cfg.enabled=true), not both."
             )
-        if reserved_http_server_port is not None and not megatron_enable:
+        if reserved_http_server_ports is not None and not megatron_enable:
             raise ValueError(
-                "reserved_http_server_port is only supported by the Megatron "
+                "reserved_http_server_ports is only supported by the Megatron "
                 "worker (policy.megatron_cfg.enabled=true)."
             )
         if draft_enabled and not megatron_enable:
@@ -340,8 +340,8 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         )
         if skip_weight_load:
             worker_kwargs["skip_weight_load"] = True
-        if reserved_http_server_port is not None:
-            worker_kwargs["reserved_http_server_port"] = reserved_http_server_port
+        if reserved_http_server_ports is not None:
+            worker_kwargs["reserved_http_server_ports"] = reserved_http_server_ports
 
         if use_v2:
             # DTensor v2 workers reconstruct tokenizer/processor locally to avoid

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -309,6 +309,13 @@ def _meta_tensor_alloc_context():
         torch.zeros_like = real_zeros_like
 
 
+def _reserved_http_server_port_for_rank(
+    reserved_http_server_ports: Optional[dict[int, int]], rank: int
+) -> Optional[int]:
+    """Return this worker rank's reserved frontend port, if one was assigned."""
+    return (reserved_http_server_ports or {}).get(rank)
+
+
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
 # This is useful when using worker extension classes.
 class MegatronPolicyWorkerImpl(
@@ -486,9 +493,9 @@ class MegatronPolicyWorkerImpl(
         # Store the reserved HTTP server port for inference server initialization.
         # Megatron-LLM's hosts an inference server on every MP coordinator rank,
         # effectively one per DP rank.
-        self._reserved_http_server_port: Optional[int] = (
-            reserved_http_server_ports or {}
-        ).get(self.rank)
+        self._reserved_http_server_port = _reserved_http_server_port_for_rank(
+            reserved_http_server_ports, self.rank
+        )
 
         # Step 1: Setup distributed
         setup_distributed(config)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -443,7 +443,7 @@ class MegatronPolicyWorkerImpl(
         *,
         worker_sharding_annotations: NamedSharding,
         skip_weight_load: bool = False,
-        reserved_http_server_port: Optional[int] = None,
+        reserved_http_server_ports: Optional[dict[int, int]] = None,
         **kwargs: Any,
     ):
         """Initialize the MegatronPolicyWorker."""
@@ -484,11 +484,8 @@ class MegatronPolicyWorkerImpl(
         self.timer = Timer(context={"worker": "megatron_policy", "rank": self.rank})
 
         # Store the reserved HTTP server port for inference server initialization.
-        # Megatron-LLM's inference server lives on Rank 0 only.
-        # TODO: Multiple inference servers for each MP coordinator.
-        self._reserved_http_server_port = (
-            reserved_http_server_port if self.rank == 0 else None
-        )
+        # Megatron-LLM's inference servers live on MP coordinator ranks, one per DP rank.
+        self._reserved_http_server_port = (reserved_http_server_ports or {}).get(self.rank)
 
         # Step 1: Setup distributed
         setup_distributed(config)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -484,8 +484,11 @@ class MegatronPolicyWorkerImpl(
         self.timer = Timer(context={"worker": "megatron_policy", "rank": self.rank})
 
         # Store the reserved HTTP server port for inference server initialization.
-        # Megatron-LLM's inference servers live on MP coordinator ranks, one per DP rank.
-        self._reserved_http_server_port = (reserved_http_server_ports or {}).get(self.rank)
+        # Megatron-LLM's hosts an inference server on every MP coordinator rank,
+        # effectively one per DP rank.
+        self._reserved_http_server_port: Optional[int] = (
+            reserved_http_server_ports or {}
+        ).get(self.rank)
 
         # Step 1: Setup distributed
         setup_distributed(config)

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -296,11 +296,19 @@ policy:
     stop_strings: null
     mcore_generation_config:
       buffer_size_gb: 10  # Total buffer size is 2x this value (active requests + paused requests)
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
       num_cuda_graphs: 4  # Number of CUDA graphs to pre-compile for different batch sizes
       block_size_tokens: 256  # Size of each KV cache block in tokens (affects memory granularity)
       use_cuda_graphs_for_non_decode_steps: true  # Enable CUDA graphs for prefill/context processing
       enable_chunked_prefill: true  # Split long prefills into chunks for better memory management
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
       max_tokens: 16384 # Maximum number of tokens to use in a single step. Analogous to vllm's max_num_batched_tokens
+      http_server_num_replicas: 8
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3390,6 +3390,7 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
     )
 
 
+@pytest.mark.mcore
 def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     monkeypatch, mock_grpo_components
 ):

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3411,10 +3411,10 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
         dp_openai_server_base_urls=[],
     )
     generation_cls = MagicMock(return_value=generation)
-    generation_cls.reserve_http_server_address.return_value = (
-        reserved_url,
-        1234,
-        port_holder,
+    generation_cls.reserve_http_server_addresses.return_value = (
+        [reserved_url],
+        {0: 1234},
+        [port_holder],
     )
 
     synchronizer = MagicMock()
@@ -3499,8 +3499,8 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     result = grpo_mod.setup(master_config, MagicMock(), dataset, None)
 
     assert generation_cls.call_args.kwargs["skip_weight_load"] is True
-    assert generation_cls.call_args.kwargs["reserved_http_server_port"] == 1234
-    assert "reserved_http_server_port" not in policy_cls.call_args.kwargs
+    assert generation_cls.call_args.kwargs["reserved_http_server_ports"] == {0: 1234}
+    assert "reserved_http_server_ports" not in policy_cls.call_args.kwargs
     assert events.index("init") < events.index("sync")
     assert events.index("gym_started") < events.index("sync")
     assert events.index("sync") < events.index("gym_ready")

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3393,7 +3393,7 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
 def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     monkeypatch, mock_grpo_components
 ):
-    """The initial refit must start a skip-load endpoint before Gym can finish."""
+    """The initial refit must start all skip-load endpoints before Gym can finish."""
     from nemo_rl.algorithms import grpo as grpo_mod
 
     events = []
@@ -3404,18 +3404,23 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     checkpointer.load_training_info.return_value = None
     checkpointer.get_resume_paths.return_value = (None, None)
 
-    reserved_url = "http://megatron.example/v1"
-    port_holder = object()
+    reserved_urls = [
+        "http://megatron-a.example/v1",
+        "http://megatron-b.example/v1",
+    ]
+    reserved_http_server_ports = {0: 1234, 2: 5678}
+    port_holders = [object(), object()]
     generation = SimpleNamespace(
         weight_synchronizer=None,
         dp_openai_server_base_urls=[],
     )
     generation_cls = MagicMock(return_value=generation)
     generation_cls.reserve_http_server_addresses.return_value = (
-        [reserved_url],
-        {0: 1234},
-        [port_holder],
+        reserved_urls,
+        reserved_http_server_ports,
+        port_holders,
     )
+    generation_cls.verify_served_addresses = MegatronGeneration.verify_served_addresses
 
     synchronizer = MagicMock()
     synchronizer.init_communicator.side_effect = lambda: events.append("init")
@@ -3423,14 +3428,16 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     def sync_weights():
         assert gym_started.wait(timeout=5), "NeMo Gym did not start concurrently"
         events.append("sync")
-        generation.dp_openai_server_base_urls = [reserved_url]
+        # The served order is determined by worker completion, not the order
+        # addresses were reserved for Gym.
+        generation.dp_openai_server_base_urls = list(reversed(reserved_urls))
         engine_ready.set()
 
     synchronizer.sync_weights.side_effect = sync_weights
     nemo_gym_actor = object()
 
     def spinup_nemo_gym_actor(_env_configs, **kwargs):
-        assert kwargs["base_urls"] == [reserved_url]
+        assert kwargs["base_urls"] == reserved_urls
         events.append("gym_started")
         gym_started.set()
         assert engine_ready.wait(timeout=5), (
@@ -3499,14 +3506,19 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     result = grpo_mod.setup(master_config, MagicMock(), dataset, None)
 
     assert generation_cls.call_args.kwargs["skip_weight_load"] is True
-    assert generation_cls.call_args.kwargs["reserved_http_server_ports"] == {0: 1234}
+    assert (
+        generation_cls.call_args.kwargs["reserved_http_server_ports"]
+        == reserved_http_server_ports
+    )
     assert "reserved_http_server_ports" not in policy_cls.call_args.kwargs
     assert events.index("init") < events.index("sync")
     assert events.index("gym_started") < events.index("sync")
     assert events.index("sync") < events.index("gym_ready")
     synchronizer.init_communicator.assert_called_once_with()
     synchronizer.sync_weights.assert_called_once_with()
-    ray_kill.assert_called_once_with(port_holder)
+    assert [call.args for call in ray_kill.call_args_list] == [
+        (port_holder,) for port_holder in port_holders
+    ]
     setup_metrics = next(
         call.args[0]
         for call in logger.log_metrics.call_args_list

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import os
+import random
 import re
 import socket
 import subprocess
@@ -435,6 +436,42 @@ class TestBindSocketInRange:
 
         assert port == 12022
         mock_sock.bind.assert_called_once_with(("", 12022))
+
+    def test_bounded_path_draws_from_the_supplied_rng(self):
+        """The supplied rng, not the process-wide `random` module, picks the port."""
+        mock_sock = MagicMock()
+
+        port = _bind_socket_in_range(mock_sock, 12100, 12200, rng=random.Random(1234))
+
+        assert port == random.Random(1234).randint(12100, 12199)
+        mock_sock.bind.assert_called_once_with(("", port))
+
+    def test_exhaustive_path_draws_from_the_supplied_rng(self):
+        """The max_retries=None shuffle must also honor the supplied rng."""
+        mock_sock = MagicMock()
+
+        port = _bind_socket_in_range(
+            mock_sock, 12200, 12300, max_retries=None, rng=random.Random(1234)
+        )
+
+        expected_candidates = list(range(12200, 12300))
+        random.Random(1234).shuffle(expected_candidates)
+        assert port == expected_candidates[0]
+        mock_sock.bind.assert_called_once_with(("", port))
+
+    def test_distinct_seeds_decorrelate_ports(self):
+        """The property rng exists for: ranks on one node must not collide.
+
+        Without it every rank replays the same process-wide sequence.
+        """
+        ports = set()
+        for rank in range(4):
+            mock_sock = MagicMock()
+            ports.add(
+                _bind_socket_in_range(mock_sock, 12300, 13300, rng=random.Random(rank))
+            )
+
+        assert len(ports) == 4
 
 
 class TestGetFreePortLocal:

--- a/tests/unit/models/generation/test_megatron_generation.py
+++ b/tests/unit/models/generation/test_megatron_generation.py
@@ -971,6 +971,7 @@ def patched_holder(monkeypatch):
     return _CapturingPortHolder
 
 
+@pytest.mark.mcore
 @pytest.mark.parametrize(
     "sorted_bundle_indices, model_parallel_size",
     [
@@ -995,8 +996,9 @@ def test_reserve_http_server_addresses_pins_every_frontend_bundle(
     actually perform: if the two ever disagree a holder binds the wrong node,
     the pre-published URL is unreachable, and the served-vs-reserved check fails
     loud at runtime. Pins the prediction to a hand-reconstruction of that
-    placement so the two copies cannot silently drift -- no GPU or mcore extra
-    needed (MegatronGeneration imports without megatron.core).
+    placement so the two copies cannot silently drift. This stays in the MCore
+    lane because the placement prediction mirrors MCore's inference frontend
+    topology.
 
     Reserving one address per frontend is the point: Gym spreads sessions over
     the URLs it is handed, so a single reservation would pin every session to
@@ -1054,6 +1056,7 @@ def test_reserve_http_server_addresses_pins_every_frontend_bundle(
     assert all(port == 4321 for port in rank_to_port.values())
 
 
+@pytest.mark.mcore
 def test_frontend_ranks_uses_dedicated_colocated_inference_layout():
     """A colocated reshard reserves frontends for its serving layout, not training TP."""
     cluster = SimpleNamespace(world_size=lambda: 2)
@@ -1094,6 +1097,7 @@ def _mp_coordinator_ranks(tp: int, pp: int, world_size: int) -> list[int]:
     ]
 
 
+@pytest.mark.mcore
 @pytest.mark.parametrize(
     "tp, cp, pp, world_size",
     [

--- a/tests/unit/models/generation/test_megatron_generation.py
+++ b/tests/unit/models/generation/test_megatron_generation.py
@@ -900,30 +900,39 @@ def test_megatron_generation_non_colocated_refit(
 class _CapturingPortHolder:
     """Stand-in for the RemoteHeldPortReservation actor.
 
-    Records the scheduling strategy it is pinned to and returns a fixed
-    (ip, port) instead of binding a real socket on a real placement group.
+    Records the scheduling strategies it is pinned to, in creation order, and
+    returns one (ip, port) per holder instead of binding real sockets on real
+    placement groups. Ports repeat across nodes on purpose: only the (node, port)
+    pair has to be unique, which is what the real holders bind.
     """
 
-    last_scheduling_strategy = None
+    scheduling_strategies: list = []
+    _next_index = 0
+
+    @classmethod
+    def reset(cls):
+        cls.scheduling_strategies = []
+        cls._next_index = 0
 
     @classmethod
     def options(cls, *, scheduling_strategy):
-        cls.last_scheduling_strategy = scheduling_strategy
+        cls.scheduling_strategies.append(scheduling_strategy)
         return cls
 
     @classmethod
     def remote(cls):
-        return SimpleNamespace(
-            address=SimpleNamespace(remote=lambda: ("10.0.0.5", 4321))
-        )
+        index = cls._next_index
+        cls._next_index += 1
+        address = (f"10.0.0.{index}", 4321)
+        return SimpleNamespace(address=SimpleNamespace(remote=lambda: address))
 
 
-def _rank0_bundle_via_worker_group(sorted_bundle_indices, group_size):
-    """The bundle RANK 0 actually lands on, reconstructed from the live code.
+def _bundles_via_worker_group(sorted_bundle_indices, group_size, placement_groups):
+    """The (pg index, bundle) each RANK actually lands on, reconstructed from the live code.
 
-    Mirrors lm_policy.py's tied_groups[0] for a unified PG and RayWorkerGroup's
-    default first-worker tuple otherwise -- the two branches
-    reserve_http_server_address must agree with.
+    Mirrors lm_policy.py's tied_groups for a unified PG and RayWorkerGroup's
+    default per-node tuples otherwise -- the two branches
+    reserve_http_server_addresses must agree with.
 
     Deliberately a hand-copy rather than a call into the code under test (or a
     shared helper): sharing the implementation would make the assertion a
@@ -939,10 +948,12 @@ def _rank0_bundle_via_worker_group(sorted_bundle_indices, group_size):
         ]
     else:
         # RayWorkerGroup.__init__: bundle_indices_list.append((i, [bundle_idx]))
-        # with i and bundle_idx both starting at 0.
-        tied_groups = [(0, [0])]
-    pg_idx, local_bundle_indices = tied_groups[0]
-    return pg_idx, local_bundle_indices[0]
+        tied_groups = [
+            (pg_idx, [bundle_idx])
+            for pg_idx, pg in enumerate(placement_groups)
+            for bundle_idx in range(pg.bundle_count)
+        ]
+    return [(pg_idx, bundles[0]) for pg_idx, bundles in tied_groups]
 
 
 @pytest.fixture
@@ -952,55 +963,79 @@ def patched_holder(monkeypatch):
     )
     # ray.get here only unwraps the holder's (ip, port); no real Ray involved.
     monkeypatch.setattr(megatron_generation.ray, "get", lambda ref: ref)
-    _CapturingPortHolder.last_scheduling_strategy = None
+    _CapturingPortHolder.reset()
     return _CapturingPortHolder
 
 
 @pytest.mark.parametrize(
-    "sorted_bundle_indices",
+    "sorted_bundle_indices, model_parallel_size",
     [
         # Unified cross-node PG: topology sort can make rank 0 a bundle other
         # than 0, so a naive "bundle 0" prediction would bind the wrong node.
-        [3, 1, 0, 2],
-        # Per-node PGs: no sorted indices, rank 0 is bundle 0 of the first PG.
-        None,
+        ([3, 1, 0, 2], 1),
+        ([3, 1, 0, 2], 2),
+        # Per-node PGs: no sorted indices, ranks walk each PG's bundles in turn.
+        (None, 1),
+        (None, 2),
     ],
 )
-def test_reserve_http_server_address_pins_rank0_bundle(
-    patched_holder, sorted_bundle_indices
+def test_reserve_http_server_addresses_pins_every_frontend_bundle(
+    patched_holder, sorted_bundle_indices, model_parallel_size
 ):
-    """reserve_http_server_address's rank-0 prediction must match real placement.
+    """Each reserved address must sit on the bundle its frontend rank will occupy.
 
-    reserve_http_server_address publishes the OpenAI server URL to NeMo Gym
-    *before* any worker exists, pinning a port holder to the (placement_group,
-    bundle) it predicts rank 0 will occupy. That prediction is a second,
-    hand-written copy of the rank-0 placement lm_policy.py / RayWorkerGroup
-    actually perform: if the two ever disagree the holder binds the wrong node,
-    the pre-published URL is unreachable, and grpo.py fails loud at runtime.
-    Pins the prediction to a hand-reconstruction of that placement so the two
-    copies cannot silently drift -- no GPU or mcore extra needed
-    (MegatronGeneration imports without megatron.core).
+    reserve_http_server_addresses publishes the OpenAI server URLs to NeMo Gym
+    *before* any worker exists, pinning one port holder to the (placement_group,
+    bundle) it predicts each frontend rank will occupy. That prediction is a
+    second, hand-written copy of the placement lm_policy.py / RayWorkerGroup
+    actually perform: if the two ever disagree a holder binds the wrong node,
+    the pre-published URL is unreachable, and the served-vs-reserved check fails
+    loud at runtime. Pins the prediction to a hand-reconstruction of that
+    placement so the two copies cannot silently drift -- no GPU or mcore extra
+    needed (MegatronGeneration imports without megatron.core).
+
+    Reserving one address per frontend is the point: Gym spreads sessions over
+    the URLs it is handed, so a single reservation would pin every session to
+    one frontend however many the engine goes on to start.
     """
-    placement_groups = ["PG0", "PG1"]
+    placement_groups = [
+        SimpleNamespace(bundle_count=2),
+        SimpleNamespace(bundle_count=2),
+    ]
     cluster = SimpleNamespace(
-        num_gpus_per_node=8,
+        num_gpus_per_node=2,
         _sorted_bundle_indices=sorted_bundle_indices,
         get_placement_groups=lambda: placement_groups,
+        world_size=lambda: 4,
     )
-    config = {"generation": {"colocated": {"enabled": True}}}
+    config = {
+        "generation": {
+            "colocated": {"enabled": True},
+            "mcore_generation_config": {
+                "tensor_model_parallel_size": model_parallel_size,
+                "pipeline_model_parallel_size": 1,
+                "context_parallel_size": 1,
+            },
+        }
+    }
 
-    url, port, holder = MegatronGeneration.reserve_http_server_address(cluster, config)
-
-    expected_pg_idx, expected_bundle_index = _rank0_bundle_via_worker_group(
-        sorted_bundle_indices, cluster.num_gpus_per_node
+    urls, rank_to_port, holders = MegatronGeneration.reserve_http_server_addresses(
+        cluster, config
     )
-    strategy = patched_holder.last_scheduling_strategy
-    # The holder -- and thus the pre-published URL's node -- must sit on the
-    # exact (placement_group, bundle) rank 0 will occupy.
-    assert expected_pg_idx == 0  # rank 0 is always in the first placement group
-    assert strategy.placement_group is placement_groups[expected_pg_idx]
-    assert strategy.placement_group_bundle_index == expected_bundle_index
 
-    assert url == "http://10.0.0.5:4321/v1"
-    assert port == 4321
-    assert holder.address.remote() == ("10.0.0.5", 4321)
+    expected_ranks = list(range(0, 4, model_parallel_size))
+    expected_placement = _bundles_via_worker_group(
+        sorted_bundle_indices, cluster.num_gpus_per_node, placement_groups
+    )
+    assert list(rank_to_port) == expected_ranks
+    assert len(urls) == len(holders) == len(expected_ranks)
+
+    # Each holder -- and thus each pre-published URL's node -- must sit on the
+    # exact (placement_group, bundle) its frontend rank will occupy.
+    for strategy, rank in zip(patched_holder.scheduling_strategies, expected_ranks):
+        pg_index, bundle_index = expected_placement[rank]
+        assert strategy.placement_group is placement_groups[pg_index]
+        assert strategy.placement_group_bundle_index == bundle_index
+
+    assert urls == [f"http://10.0.0.{i}:4321/v1" for i in range(len(expected_ranks))]
+    assert all(port == 4321 for port in rank_to_port.values())

--- a/tests/unit/models/generation/test_megatron_generation.py
+++ b/tests/unit/models/generation/test_megatron_generation.py
@@ -1009,14 +1009,20 @@ def test_reserve_http_server_addresses_pins_every_frontend_bundle(
         world_size=lambda: 4,
     )
     config = {
+        "megatron_cfg": {
+            "tensor_model_parallel_size": model_parallel_size,
+            "pipeline_model_parallel_size": 1,
+            "expert_model_parallel_size": 1,
+            "expert_tensor_parallel_size": 1,
+            "context_parallel_size": 1,
+        },
         "generation": {
             "colocated": {"enabled": True},
             "mcore_generation_config": {
-                "tensor_model_parallel_size": model_parallel_size,
-                "pipeline_model_parallel_size": 1,
-                "context_parallel_size": 1,
+                # This is an override block, not a complete Megatron config.
+                "expose_http_server": True,
             },
-        }
+        },
     }
 
     urls, rank_to_port, holders = MegatronGeneration.reserve_http_server_addresses(
@@ -1039,3 +1045,29 @@ def test_reserve_http_server_addresses_pins_every_frontend_bundle(
 
     assert urls == [f"http://10.0.0.{i}:4321/v1" for i in range(len(expected_ranks))]
     assert all(port == 4321 for port in rank_to_port.values())
+
+
+def test_frontend_ranks_uses_dedicated_colocated_inference_layout():
+    """A colocated reshard reserves frontends for its serving layout, not training TP."""
+    cluster = SimpleNamespace(world_size=lambda: 2)
+    config = {
+        "megatron_cfg": {
+            "tensor_model_parallel_size": 2,
+            "pipeline_model_parallel_size": 1,
+            "expert_model_parallel_size": 1,
+            "expert_tensor_parallel_size": 1,
+            "context_parallel_size": 1,
+            "transformer_impl": "transformer_engine",
+            "sequence_parallel": False,
+        },
+        "generation": {
+            "colocated": {"enabled": True},
+            "mcore_generation_config": {
+                "tensor_model_parallel_size": 1,
+                "transformer_impl": "inference_optimized",
+                "sequence_parallel": True,
+            },
+        },
+    }
+
+    assert MegatronGeneration.frontend_ranks(cluster, config) == [0, 1]

--- a/tests/unit/models/generation/test_megatron_generation.py
+++ b/tests/unit/models/generation/test_megatron_generation.py
@@ -931,8 +931,9 @@ def _bundles_via_worker_group(sorted_bundle_indices, group_size, placement_group
     """The (pg index, bundle) each RANK actually lands on, reconstructed from the live code.
 
     Mirrors lm_policy.py's tied_groups for a unified PG and RayWorkerGroup's
-    default per-node tuples otherwise -- the two branches
-    reserve_http_server_addresses must agree with.
+    default per-node tuples otherwise, then RayWorkerGroup's single-placement-
+    group collapse -- the two branches reserve_http_server_addresses must agree
+    with.
 
     Deliberately a hand-copy rather than a call into the code under test (or a
     shared helper): sharing the implementation would make the assertion a
@@ -953,6 +954,9 @@ def _bundles_via_worker_group(sorted_bundle_indices, group_size, placement_group
             for pg_idx, pg in enumerate(placement_groups)
             for bundle_idx in range(pg.bundle_count)
         ]
+    # RayWorkerGroup collapses the group index when there is only one PG.
+    if len(placement_groups) == 1:
+        return [(0, bundles[0]) for _, bundles in tied_groups]
     return [(pg_idx, bundles[0]) for pg_idx, bundles in tied_groups]
 
 
@@ -998,10 +1002,13 @@ def test_reserve_http_server_addresses_pins_every_frontend_bundle(
     the URLs it is handed, so a single reservation would pin every session to
     one frontend however many the engine goes on to start.
     """
-    placement_groups = [
-        SimpleNamespace(bundle_count=2),
-        SimpleNamespace(bundle_count=2),
-    ]
+    if sorted_bundle_indices is not None:
+        placement_groups = [SimpleNamespace(bundle_count=4)]
+    else:
+        placement_groups = [
+            SimpleNamespace(bundle_count=2),
+            SimpleNamespace(bundle_count=2),
+        ]
     cluster = SimpleNamespace(
         num_gpus_per_node=2,
         _sorted_bundle_indices=sorted_bundle_indices,
@@ -1071,3 +1078,57 @@ def test_frontend_ranks_uses_dedicated_colocated_inference_layout():
     }
 
     assert MegatronGeneration.frontend_ranks(cluster, config) == [0, 1]
+
+
+def _mp_coordinator_ranks(tp: int, pp: int, world_size: int) -> list[int]:
+    """Ranks satisfying MCore's `is_mp_coordinator`, by explicit decomposition.
+
+    Per-rank rather than a stride: sharing frontend_ranks' formula would make
+    the assertion a tautology. CP and DP cancel, so they take no parameter.
+    """
+    ranks_per_pp_stage = world_size // pp
+    return [
+        rank
+        for rank in range(world_size)
+        if rank % tp == 0 and rank // ranks_per_pp_stage == 0
+    ]
+
+
+@pytest.mark.parametrize(
+    "tp, cp, pp, world_size",
+    [
+        (1, 1, 1, 8),
+        (2, 1, 1, 8),
+        (4, 1, 1, 16),
+        (2, 2, 1, 8),
+        # PP > 1: a TP*PP stride picks 0 and 4 here instead of 0 and 2.
+        (2, 1, 2, 8),
+        (2, 2, 2, 16),
+        (4, 1, 2, 16),
+    ],
+)
+def test_frontend_ranks_matches_is_mp_coordinator(tp, cp, pp, world_size):
+    """frontend_ranks is a driver-side copy of the engine's own predicate.
+
+    Reservation runs before any worker exists, so the set must be predicted.
+    `is_mp_coordinator` needs a real engine, so without this the copy only
+    drifts loudly on a multi-node nightly.
+    """
+    cluster = SimpleNamespace(world_size=lambda: world_size)
+    config = {
+        "megatron_cfg": {
+            "tensor_model_parallel_size": tp,
+            "pipeline_model_parallel_size": pp,
+            "expert_model_parallel_size": 1,
+            "expert_tensor_parallel_size": 1,
+            "context_parallel_size": cp,
+        },
+        "generation": {
+            "colocated": {"enabled": True},
+            "mcore_generation_config": {"expose_http_server": True},
+        },
+    }
+
+    assert MegatronGeneration.frontend_ranks(cluster, config) == _mp_coordinator_ranks(
+        tp, pp, world_size
+    )

--- a/tests/unit/models/generation/test_megatron_generation_parse.py
+++ b/tests/unit/models/generation/test_megatron_generation_parse.py
@@ -33,7 +33,10 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
+from megatron.core.inference.config import (
+    InferenceConfig,
+    PrefixCachingCoordinatorPolicy,
+)
 from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
     text_generation_server as mlm_text_gen_server,
 )
@@ -61,6 +64,13 @@ PAD = 0
         ),
         (
             {"enable_prefix_caching": True},
+            InferenceConfig.prefix_caching_coordinator_policy,
+        ),
+        (
+            {
+                "enable_prefix_caching": True,
+                "prefix_caching_coordinator_policy": "longest_prefix",
+            },
             PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
         ),
         (
@@ -306,3 +316,64 @@ def test_http_server_port_reservation(monkeypatch):
         finally:
             if reserved_socket is not None:
                 reserved_socket.close()
+
+
+@pytest.mark.mcore
+@pytest.mark.parametrize(
+    ("gen_cfg_extra", "expected_num_replicas"),
+    [
+        ({}, None),
+        ({"http_server_num_replicas": 8}, 8),
+    ],
+)
+def test_http_server_num_replicas_is_forwarded_only_when_set(
+    monkeypatch, gen_cfg_extra, expected_num_replicas
+):
+    """Replica count reaches MCore, and stays absent when unconfigured."""
+    started = {}
+    monkeypatch.setattr(
+        mlm_text_gen_server,
+        "start_text_gen_server",
+        lambda **kwargs: started.update(kwargs),
+    )
+    monkeypatch.setattr(
+        "nemo_rl.distributed.virtual_cluster._get_node_ip_local",
+        lambda: "10.0.0.5",
+    )
+    monkeypatch.setattr(
+        "nemo_rl.distributed.virtual_cluster._get_free_port_local",
+        lambda *_args, **_kwargs: 12345,
+    )
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    requests_mock = MagicMock()
+    health_get = requests_mock.Session.return_value.__enter__.return_value.get
+    health_get.return_value.status_code = 200
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.megatron.megatron_worker.requests",
+        requests_mock,
+    )
+
+    worker = SimpleNamespace(
+        coordinator_addr="tcp://127.0.0.1:5555",
+        megatron_tokenizer=object(),
+        rank=0,
+        cfg={
+            "generation": {
+                "mcore_generation_config": {
+                    "block_size_tokens": 64,
+                    "enable_prefix_caching": False,
+                    "parsers": [],
+                    **gen_cfg_extra,
+                }
+            }
+        },
+        _reserved_http_server_port=None,
+        inference_wrapped_model=SimpleNamespace(multimodal_prompt_config=None),
+    )
+
+    MegatronGenerationMixin._setup_openai_api_server(worker)
+
+    if expected_num_replicas is None:
+        assert "num_replicas" not in started
+    else:
+        assert started["num_replicas"] == expected_num_replicas

--- a/tests/unit/models/generation/test_megatron_generation_parse.py
+++ b/tests/unit/models/generation/test_megatron_generation_parse.py
@@ -173,6 +173,11 @@ def test_http_server_port_reservation(monkeypatch):
     probes queue instead of being refused), the worker adopts that same socket
     through the fd handoff — the port is never released in between — and the
     server falls back to a fresh port only when nothing was reserved.
+
+    Adoption is deferred to server startup rather than worker init, so that a
+    listening fd is never live across model initialization, where a long-lived
+    child process could inherit it and absorb SO_REUSEPORT traffic it never
+    serves.
     """
     # The holder resolves the node IP via held_port; the server resolves it via
     # virtual_cluster (megatron_worker imports it at call time). Patch both.

--- a/tests/unit/models/generation/test_megatron_generation_parse.py
+++ b/tests/unit/models/generation/test_megatron_generation_parse.py
@@ -34,21 +34,74 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 from megatron.core.inference.config import (
+    AsyncScheduleMode,
+    CudaGraphSizingDistribution,
     InferenceConfig,
     PrefixCachingCoordinatorPolicy,
+    PrefixCachingEvictionPolicy,
 )
 from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
     text_generation_server as mlm_text_gen_server,
 )
+from megatron.core.transformer.enums import InferenceCudaGraphScope
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.held_port import HeldPortReservation
 from nemo_rl.models.generation.megatron.megatron_worker import (
     MegatronGenerationMixin,
+    _apply_inference_cuda_graph_scope,
+    _apply_optional_inference_config_kwargs,
     _resolve_coordinator_policy,
 )
 
 PAD = 0
+
+
+@pytest.mark.mcore
+def test_inference_cuda_graph_scope_is_applied_when_configured():
+    engine_model = SimpleNamespace(config=SimpleNamespace())
+
+    _apply_inference_cuda_graph_scope(
+        engine_model, {"inference_cuda_graph_scope": "block"}
+    )
+
+    assert (
+        engine_model.config.inference_cuda_graph_scope is InferenceCudaGraphScope.block
+    )
+
+
+@pytest.mark.mcore
+def test_optional_inference_config_kwargs_are_typed_and_forwarded():
+    inference_config_kwargs = {}
+
+    _apply_optional_inference_config_kwargs(
+        inference_config_kwargs,
+        {
+            "cuda_graph_sizing_distribution": "hybrid",
+            "cuda_graph_max_tokens": "512",
+            "async_sched_mode": "async",
+            "vision_embedding_cache_max_bytes": "1024",
+            "allow_stale_multimodal_embeddings": 1,
+            "prefix_caching_eviction_policy": "lru",
+            "prefix_caching_mamba_gb": None,
+            "prefix_cache_ttl_seconds": "300",
+            "prefix_caching_routing_alpha": "0.75",
+            "logging_step_interval": "10",
+        },
+    )
+
+    assert inference_config_kwargs == {
+        "cuda_graph_sizing_distribution": CudaGraphSizingDistribution.HYBRID,
+        "cuda_graph_max_tokens": 512,
+        "async_sched_mode": AsyncScheduleMode.ASYNC,
+        "vision_embedding_cache_max_bytes": 1024,
+        "allow_stale_multimodal_embeddings": True,
+        "prefix_caching_eviction_policy": PrefixCachingEvictionPolicy.LRU,
+        "prefix_caching_mamba_gb": None,
+        "prefix_cache_ttl_seconds": 300.0,
+        "prefix_caching_routing_alpha": 0.75,
+        "logging_step_interval": 10,
+    }
 
 
 @pytest.mark.mcore
@@ -377,3 +430,30 @@ def test_http_server_num_replicas_is_forwarded_only_when_set(
         assert "num_replicas" not in started
     else:
         assert started["num_replicas"] == expected_num_replicas
+
+
+@pytest.mark.mcore
+def test_mp_coordinator_starts_exposed_http_server(monkeypatch):
+    coordinator_call = object()
+    future = MagicMock()
+    setup_server = MagicMock(return_value="http://10.0.0.5:5555/v1")
+    worker = SimpleNamespace(
+        cfg={"generation": {"mcore_generation_config": {"expose_http_server": True}}},
+        dynamic_inference_engine=SimpleNamespace(is_mp_coordinator=True),
+        _inference_loop=object(),
+        _start_inference_coordinator=MagicMock(return_value=coordinator_call),
+        _setup_openai_api_server=setup_server,
+    )
+    run_coroutine = MagicMock(return_value=future)
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.megatron.megatron_worker.asyncio.run_coroutine_threadsafe",
+        run_coroutine,
+    )
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+
+    MegatronGenerationMixin._run_async_coordinator_start(worker)
+
+    run_coroutine.assert_called_once_with(coordinator_call, worker._inference_loop)
+    future.result.assert_called_once_with()
+    setup_server.assert_called_once_with()
+    assert worker.base_url == "http://10.0.0.5:5555/v1"

--- a/tests/unit/models/generation/test_megatron_generation_parse.py
+++ b/tests/unit/models/generation/test_megatron_generation_parse.py
@@ -33,6 +33,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
 from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
     text_generation_server as mlm_text_gen_server,
 )
@@ -41,9 +42,42 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.held_port import HeldPortReservation
 from nemo_rl.models.generation.megatron.megatron_worker import (
     MegatronGenerationMixin,
+    _resolve_coordinator_policy,
 )
 
 PAD = 0
+
+
+@pytest.mark.mcore
+@pytest.mark.parametrize(
+    ("mcore_generation_config", "expected_policy"),
+    [
+        (
+            {
+                "enable_prefix_caching": False,
+                "prefix_caching_coordinator_policy": "longest_prefix",
+            },
+            PrefixCachingCoordinatorPolicy.LOAD_BALANCED,
+        ),
+        (
+            {"enable_prefix_caching": True},
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+        ),
+        (
+            {
+                "enable_prefix_caching": True,
+                "prefix_caching_coordinator_policy": "first_prefix_block",
+            },
+            PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK,
+        ),
+    ],
+)
+def test_resolve_coordinator_policy(
+    mcore_generation_config: dict[str, object],
+    expected_policy: PrefixCachingCoordinatorPolicy,
+) -> None:
+    """The engine and every frontend must use the same routing policy."""
+    assert _resolve_coordinator_policy(mcore_generation_config) is expected_policy
 
 
 class FakeInferenceReply:
@@ -207,7 +241,7 @@ def test_http_server_port_reservation(monkeypatch):
     )
     monkeypatch.setattr(
         "nemo_rl.distributed.virtual_cluster._get_free_port_local",
-        lambda: 12345,
+        lambda *_args, **_kwargs: 12345,
     )
     monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
     requests_mock = MagicMock()
@@ -223,7 +257,15 @@ def test_http_server_port_reservation(monkeypatch):
             coordinator_addr="tcp://127.0.0.1:5555",
             megatron_tokenizer=object(),
             rank=0,
-            cfg={"generation": {"mcore_generation_config": {"parsers": []}}},
+            cfg={
+                "generation": {
+                    "mcore_generation_config": {
+                        "block_size_tokens": 64,
+                        "enable_prefix_caching": False,
+                        "parsers": [],
+                    }
+                }
+            },
             _reserved_http_server_port=reserved_port,
             inference_wrapped_model=SimpleNamespace(multimodal_prompt_config=None),
         )
@@ -232,6 +274,11 @@ def test_http_server_port_reservation(monkeypatch):
         try:
             assert started["server_port"] == expected_port
             assert base_url == f"http://10.0.0.5:{expected_port}/v1"
+            assert started["block_size_tokens"] == 64
+            assert (
+                started["prefix_caching_coordinator_policy"]
+                is PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+            )
             if reserved_port is None:
                 assert reserved_socket is None
                 continue

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -58,6 +58,24 @@ def _disable_opd_full(worker) -> None:
     worker._opd_full_teacher_checkpoint_path = None
 
 
+@pytest.mark.parametrize(
+    ("reserved_ports", "rank", "expected"),
+    [
+        ({0: 5555, 2: 6666}, 0, 5555),
+        ({0: 5555, 2: 6666}, 1, None),
+        (None, 0, None),
+    ],
+)
+def test_reserved_http_server_port_is_selected_by_worker_rank(
+    reserved_ports, rank, expected
+):
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        _reserved_http_server_port_for_rank,
+    )
+
+    assert _reserved_http_server_port_for_rank(reserved_ports, rank) == expected
+
+
 def test_model_owned_packing_capability_is_detected():
     from nemo_rl.models.policy.workers.megatron_policy_worker import (
         _model_self_packs_for_cp,

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -395,6 +395,8 @@ policy:
       #   cuda_graph_impl "none"  -> omit inference_cuda_graph_scope
       #   cuda_graph_impl "local" -> inference_cuda_graph_scope "layer" or "block"
       cuda_graph_impl: "local"
+      cuda_graph_sizing_distribution: hybrid  # MCore default: exponential prefill/mixed graphs and linear decode graphs.
+      cuda_graph_max_tokens: 512  # MCore default token ceiling for captured prefill/mixed graphs.
       inference_cuda_graph_scope: "block"
       buffer_size_gb: 10
       num_cuda_graphs: 4  # Number of CUDA graphs to pre-compile for different batch sizes
@@ -402,6 +404,11 @@ policy:
       use_cuda_graphs_for_non_decode_steps: true  # Enable CUDA graphs for prefill/context processing
       enable_chunked_prefill: true  # Split long prefills into chunks for better memory management
       enable_prefix_caching: false  # Reuse KV blocks across requests sharing a prompt prefix.
+      prefix_caching_mamba_gb: null  # MCore default: no Mamba-state prefix-cache budget.
+      prefix_caching_eviction_policy: lru  # MCore default prefix-cache eviction policy.
+      prefix_caching_coordinator_policy: longest_prefix  # MCore default DP routing policy.
+      prefix_cache_ttl_seconds: 300.0  # MCore default coordinator cache-entry lifetime.
+      prefix_caching_routing_alpha: 1.0  # MCore default load penalty for prefix-affinity routing.
       max_tokens: 16384 # Maximum number of tokens to use in a single step. Analogous to vllm's max_num_batched_tokens
       kv_cache_management_mode: "persist"  # KV cache lifecycle across suspend/resume. Options: "persist", "offload", "recompute".
       materialize_only_last_token_logits: true  # Materialize logits only for the last token of each sequence during decode.

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -411,6 +411,7 @@ policy:
       offload_policy_before_refit: false  # Keep policy state on GPU by default. Enable when a non-colocated Megatron refit needs additional GPU headroom for transfer staging.
       parsers: []  # OpenAI tool-call / response parser names exposed by the HTTP server (only used if expose_http_server=true).
       expose_http_server: false  # Start an OpenAI-compatible HTTP server alongside the persistent engine. Required for NeMo-Gym.
+      http_server_num_replicas: 8  # HTTP frontend event loops per model-parallel coordinator.
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -250,10 +250,17 @@ policy:
     mcore_generation_config:
       buffer_size_gb: 20
       buffer_guaranteed_fraction: 0.1
+      cuda_graph_sizing_distribution: hybrid
+      cuda_graph_max_tokens: 512
       num_cuda_graphs: 16
       block_size_tokens: 256
       use_cuda_graphs_for_non_decode_steps: true
       enable_chunked_prefill: true
+      prefix_caching_mamba_gb: null
+      prefix_caching_eviction_policy: lru
+      prefix_caching_coordinator_policy: longest_prefix
+      prefix_cache_ttl_seconds: 300.0
+      prefix_caching_routing_alpha: 1.0
       unified_memory_level: 0
       max_tokens: 16384
       logprobs_mode: processed_logprobs

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -258,6 +258,7 @@ policy:
       max_tokens: 16384
       logprobs_mode: processed_logprobs
       offload_policy_before_refit: false
+      http_server_num_replicas: 8
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -1796,6 +1796,7 @@ class TestSetup:
         mc.policy["generation"]["top_k"] = None
         return mc
 
+    @pytest.mark.mcore
     @pytest.mark.parametrize("colocated", [True, False])
     @pytest.mark.parametrize(
         ("scenario", "error_match"),

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -1891,15 +1891,15 @@ class TestSetup:
             patch.object(sc_setup_mod, "ray") as mock_ray,
             router_patch,
         ):
-            mock_megatron.reserve_http_server_address.return_value = (
-                reserved_url,
-                5555,
-                port_holder,
+            mock_megatron.reserve_http_server_addresses.return_value = (
+                [reserved_url],
+                {0: 5555},
+                [port_holder],
             )
             # Wire the real check through the class mock so the
             # served-vs-reserved legs exercise the genuine logic.
-            mock_megatron.verify_served_address = (
-                MegatronGeneration.verify_served_address
+            mock_megatron.verify_served_addresses = (
+                MegatronGeneration.verify_served_addresses
             )
             mock_megatron.return_value.dp_openai_server_base_urls = [served_url]
             if error_match is None:
@@ -1913,16 +1913,13 @@ class TestSetup:
         # Reservation + holder lifecycle exist on the gym legs only; every gym
         # leg — success or either failure — reaps the holder exactly once.
         if gym:
-            # Always the inference cluster: when colocated, _build_clusters
-            # returns the train cluster twice, so the two are the same object
-            # in production (the mocked distinction here is not).
-            mock_megatron.reserve_http_server_address.assert_called_once_with(
+            mock_megatron.reserve_http_server_addresses.assert_called_once_with(
                 inference_cluster,
                 mc.policy,
             )
             mock_ray.kill.assert_called_once_with(port_holder)
         else:
-            mock_megatron.reserve_http_server_address.assert_not_called()
+            mock_megatron.reserve_http_server_addresses.assert_not_called()
             mock_ray.kill.assert_not_called()
 
         if scenario == "gym_router_failure":
@@ -1939,8 +1936,8 @@ class TestSetup:
         # port adopted by the engine (gym) or absent (native).
         patched_factories["_build_trainer"].assert_called_once()
         _, trainer_kwargs = patched_factories["_build_trainer"].call_args
-        assert trainer_kwargs["reserved_http_server_port"] == (
-            5555 if colocated and gym else None
+        assert trainer_kwargs["reserved_http_server_ports"] == (
+            {0: 5555} if colocated and gym else None
         )
         if colocated:
             patched_factories["_build_generation"].assert_not_called()
@@ -1956,7 +1953,7 @@ class TestSetup:
                 config=mc.policy,
                 tokenizer=tokenizer,
                 cluster=inference_cluster,
-                reserved_http_server_port=5555 if gym else None,
+                reserved_http_server_ports={0: 5555} if gym else None,
                 processor=None,
                 skip_weight_load=True,
             )

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -1816,11 +1816,11 @@ class TestSetup:
     ):
         """Megatron generation setup: gym and native legs, colocated or not.
 
-        gym: reserve rank-0's URL, spin Gym up on it, build trainer and engine
-        in parallel (the engine through _build_generation with the reserved
-        port), run the initial refit while Gym is still waiting -- the
-        skip-load engine only starts serving then -- cross-check the served
-        address, reap the port holder.
+        gym: reserve every frontend URL, spin Gym up on them, build trainer and
+        engine in parallel (the engine through _build_generation with the
+        reserved ports), run the initial refit while Gym is still waiting --
+        the skip-load engine only starts serving then -- cross-check the served
+        addresses, reap every port holder.
         gym_served_mismatch: the served-vs-reserved cross-check fires after the
         builds when the engine comes up on a different address.
         gym_router_failure: the holder is created before the executor
@@ -1847,13 +1847,21 @@ class TestSetup:
         if scenario == "gym_router_failure":
             mc.async_rl.generation_router.enabled = True
         tokenizer = MagicMock(pad_token_id=0)
-        reserved_url = "http://10.0.0.1:5555/v1"
-        served_url = (
-            "http://10.0.0.9:7/v1"
+        reserved_urls = [
+            "http://10.0.0.1:5555/v1",
+            "http://10.0.0.2:6666/v1",
+        ]
+        reserved_http_server_ports = {0: 5555, 2: 6666}
+        served_urls = (
+            ["http://10.0.0.9:7/v1", reserved_urls[1]]
             if scenario == "gym_served_mismatch"
-            else reserved_url
+            # The worker-group completion order need not match reservation.
+            else list(reversed(reserved_urls))
         )
-        port_holder = MagicMock(name="port_holder")
+        port_holders = [
+            MagicMock(name="port_holder_rank_0"),
+            MagicMock(name="port_holder_rank_2"),
+        ]
         fake_gym_actor = MagicMock(name="nemo_gym_actor")
         weight_sync = patched_factories["create_weight_synchronizer"].return_value
         # Run the real _build_generation (MegatronGeneration is mocked below) so its
@@ -1892,16 +1900,16 @@ class TestSetup:
             router_patch,
         ):
             mock_megatron.reserve_http_server_addresses.return_value = (
-                [reserved_url],
-                {0: 5555},
-                [port_holder],
+                reserved_urls,
+                reserved_http_server_ports,
+                port_holders,
             )
             # Wire the real check through the class mock so the
             # served-vs-reserved legs exercise the genuine logic.
             mock_megatron.verify_served_addresses = (
                 MegatronGeneration.verify_served_addresses
             )
-            mock_megatron.return_value.dp_openai_server_base_urls = [served_url]
+            mock_megatron.return_value.dp_openai_server_base_urls = served_urls
             if error_match is None:
                 actor_args, metrics = setup_single_controller(mc, tokenizer)
             else:
@@ -1917,7 +1925,9 @@ class TestSetup:
                 inference_cluster,
                 mc.policy,
             )
-            mock_ray.kill.assert_called_once_with(port_holder)
+            assert [call.args for call in mock_ray.kill.call_args_list] == [
+                (port_holder,) for port_holder in port_holders
+            ]
         else:
             mock_megatron.reserve_http_server_addresses.assert_not_called()
             mock_ray.kill.assert_not_called()
@@ -1937,7 +1947,7 @@ class TestSetup:
         patched_factories["_build_trainer"].assert_called_once()
         _, trainer_kwargs = patched_factories["_build_trainer"].call_args
         assert trainer_kwargs["reserved_http_server_ports"] == (
-            {0: 5555} if colocated and gym else None
+            reserved_http_server_ports if colocated and gym else None
         )
         if colocated:
             patched_factories["_build_generation"].assert_not_called()
@@ -1953,7 +1963,7 @@ class TestSetup:
                 config=mc.policy,
                 tokenizer=tokenizer,
                 cluster=inference_cluster,
-                reserved_http_server_ports={0: 5555} if gym else None,
+                reserved_http_server_ports=reserved_http_server_ports if gym else None,
                 processor=None,
                 skip_weight_load=True,
             )
@@ -1965,7 +1975,7 @@ class TestSetup:
             # cross-check — so the mismatch leg sees it too. The initial refit
             # must happen during that wait because it starts Megatron's server.
             _, spinup_kwargs = mock_spinup.call_args
-            assert spinup_kwargs["base_urls"] == [reserved_url]
+            assert spinup_kwargs["base_urls"] == reserved_urls
             # The initial refit ran in setup, against the collective brought up
             # there; the served-address check reads the URLs it populated.
             weight_sync.init_communicator.assert_called_once_with()


### PR DESCRIPTION
Three changes that let the Megatron in-engine HTTP frontend run across the whole inference cluster rather than a single rank.

Frontend placement: host a frontend wherever the engine has an MP coordinator instead of only on global rank 0, and run several replicas per host, since each replica is one asyncio event loop and the frontend work (chat template, detokenize, parsers, JSON) is CPU-bound. A driver-reserved socket is still used as-is where one was handed down; it covers a single server, so the ranks that did not receive one draw a port from a rank-seeded generator. The seeding matters because the random module's state is process-wide and seeded per run, so every rank otherwise draws the same sequence and several ranks end up advertising one address, which collapses into a single client-side connection pool.

Coordinator routing: expose the prefix-caching coordinator policy, TTL and cost policy as config, and resolve the policy in one place so the engine and the frontends cannot disagree -- if the engine routes on prefix affinity while the frontends skip hashing, the affinity is lost silently. Defaults to longest_prefix, which raises the prefill skip rate substantially on multi-engine runs; without a prefix cache to route on it resolves to load_balanced instead.

CUDA graph sizing: expose the sizing distribution and max captured token count, defaulting to hybrid.

Requires a Megatron-LM carrying the in-engine inference frontend stack; the submodule bump is deliberately not included here and will follow.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
