### PR TITLE
fix: tolerate read-only installs in the vLLM runtime patcher

### DIFF
--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import os
 from contextlib import contextmanager
 from importlib.util import find_spec
@@ -47,15 +48,15 @@ def _get_vllm_file(relative_path: str) -> str:
 
 
 @contextmanager
-def _locked_file_patch(file_path: str):
+def _locked_file_patch(file_path: str, logger):
     """Yield (content, writer) under an exclusive file lock.
 
-    On read-only installs (baked container venvs) the lock cannot be created --
-    but neither can any concurrent writer, so proceed lockless. The writer then
-    degrades to a warning: a patch whose effect is required at runtime has to
-    be baked into the image instead.
+    The writer reports whether it wrote, so a caller only claims a patch landed
+    when it did. On a read-only install (a baked container venv) the lock cannot
+    be created -- but neither can any concurrent writer, so the read proceeds
+    lockless and the writer declines: the patch has to be baked into the image
+    instead, and the caller says so rather than logging success.
     """
-    import errno
     import fcntl
 
     lock_path = file_path + ".patch_lock"
@@ -67,16 +68,15 @@ def _locked_file_patch(file_path: str):
         with open(file_path, "r") as f:
             content = f.read()
 
-        def warn_only(new_content: str) -> None:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "Read-only install: cannot patch %s at runtime; bake the "
-                "patch into the image if its effect is required.",
+        def decline(new_content: str) -> bool:
+            logger.warning(
+                "Read-only install: cannot patch %s at runtime. Bake the patch "
+                "into the image; its effect is absent from this process.",
                 file_path,
             )
+            return False
 
-        yield content, warn_only
+        yield content, decline
         return
     try:
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
@@ -84,9 +84,10 @@ def _locked_file_patch(file_path: str):
         with open(file_path, "r") as f:
             content = f.read()
 
-        def write_back(new_content: str):
+        def write_back(new_content: str) -> bool:
             with open(file_path, "w") as f:
                 f.write(new_content)
+            return True
 
         yield content, write_back
     finally:
@@ -95,7 +96,7 @@ def _locked_file_patch(file_path: str):
 
 
 def _patch_vllm_init_workers_ray(
-    py_executable: str, extra_env_vars: list[str] | None
+    py_executable: str, extra_env_vars: list[str] | None, logger
 ) -> bool:
     """Patch vLLM's Ray executor env propagation and worker runtime_env.
 
@@ -141,12 +142,11 @@ def _patch_vllm_init_workers_ray(
     )
 
     applied = False
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if new_line in content:
             applied = True  # already patched by another worker on this node
         elif old_line in content:
-            write_back(content.replace(old_line, new_line))
-            applied = True
+            applied = write_back(content.replace(old_line, new_line))
 
     env_vars_to_copy = ["RAY_ENABLE_UV_RUN_RUNTIME_ENV", *(extra_env_vars or [])]
     existing = os.environ.get("VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", "")
@@ -189,7 +189,7 @@ def _patch_vllm_llama_eagle3_own_lm_head(logger) -> None:
         "        self.logits_processor = LogitsProcessor(\n"
     )
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if "self.has_own_lm_head = (" in content:
             logger.info("llama_eagle3 lm_head ownership patch already applied.")
             return
@@ -204,9 +204,10 @@ def _patch_vllm_llama_eagle3_own_lm_head(logger) -> None:
             return
 
         content = content.replace(old_snippet, new_snippet, 1)
-        write_back(content)
+        written = write_back(content)
 
-    logger.info("Successfully patched llama_eagle3 lm_head ownership.")
+    if written:
+        logger.info("Successfully patched llama_eagle3 lm_head ownership.")
 
 
 def _patch_vllm_tool_parser_namespace_tool(logger) -> None:
@@ -251,7 +252,7 @@ def _patch_vllm_tool_parser_namespace_tool(logger) -> None:
         "\n"
     )
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if "except ImportError:  # openai < 2.25.0 predates namespace tools" in content:
             logger.info("vLLM NamespaceTool openai compat patch already applied.")
             return
@@ -266,9 +267,10 @@ def _patch_vllm_tool_parser_namespace_tool(logger) -> None:
             return
 
         content = content.replace(old_snippet, new_snippet, 1)
-        write_back(content)
+        written = write_back(content)
 
-    logger.info("Successfully patched vLLM NamespaceTool import for openai compat.")
+    if written:
+        logger.info("Successfully patched vLLM NamespaceTool import for openai compat.")
 
 
 def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
@@ -347,7 +349,7 @@ def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
         "            return get_open_port()\n"
     )
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if marker in content:
             logger.info("vLLM RayExecutorV2 TCPStore port patch already applied.")
             return
@@ -480,7 +482,7 @@ def _patch_vllm_shm_broadcast_bind_retry(logger) -> None:
         "                    )\n"
     )
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if marker in content:
             logger.info("vLLM MessageQueue bind-retry patch already applied.")
             return
@@ -575,7 +577,7 @@ def _patch_vllm_radio_layerscale_loader(logger) -> None:
         return loaded_params
 """
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if new_snippet in content:
             logger.info("vLLM RADIO LayerScale loader patch already applied.")
             return
@@ -586,9 +588,10 @@ def _patch_vllm_radio_layerscale_loader(logger) -> None:
                 file_to_patch,
             )
             return
-        write_back(content.replace(old_snippet, new_snippet, 1))
+        written = write_back(content.replace(old_snippet, new_snippet, 1))
 
-    logger.info("Successfully patched vLLM RADIO LayerScale loading.")
+    if written:
+        logger.info("Successfully patched vLLM RADIO LayerScale loading.")
 
 
 def _patch_vllm_glm_decoder_sequence_parallel_moe(logger) -> None:
@@ -631,7 +634,7 @@ def _patch_vllm_glm_decoder_sequence_parallel_moe(logger) -> None:
         )
 """
 
-    with _locked_file_patch(file_to_patch) as (content, write_back):
+    with _locked_file_patch(file_to_patch, logger) as (content, write_back):
         if new_snippet in content:
             logger.info("vLLM GLM decoder SP-MoE patch already applied.")
             return
@@ -642,9 +645,10 @@ def _patch_vllm_glm_decoder_sequence_parallel_moe(logger) -> None:
                 file_to_patch,
             )
             return
-        write_back(content.replace(old_snippet, new_snippet, 1))
+        written = write_back(content.replace(old_snippet, new_snippet, 1))
 
-    logger.info("Successfully disabled decoder-level SP-MoE for GLM DSA models.")
+    if written:
+        logger.info("Successfully disabled decoder-level SP-MoE for GLM DSA models.")
 
 
 def ensure_vllm_source_compat() -> None:
@@ -681,7 +685,9 @@ def _apply_vllm_patches(
     # Reporting the same way in both cases either cries wolf or hides a real
     # break, so branch on it.
     uses_v1_executor = not envs.VLLM_USE_RAY_V2_EXECUTOR_BACKEND
-    applied = _patch_vllm_init_workers_ray(py_executable, extra_env_vars)
+    applied = _patch_vllm_init_workers_ray(
+        py_executable, extra_env_vars, patch_logger
+    )
 
     if applied and uses_v1_executor:
         patch_logger.info(

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -48,11 +48,36 @@ def _get_vllm_file(relative_path: str) -> str:
 
 @contextmanager
 def _locked_file_patch(file_path: str):
-    """Yield (content, writer) under an exclusive file lock."""
+    """Yield (content, writer) under an exclusive file lock.
+
+    On read-only installs (baked container venvs) the lock cannot be created --
+    but neither can any concurrent writer, so proceed lockless. The writer then
+    degrades to a warning: a patch whose effect is required at runtime has to
+    be baked into the image instead.
+    """
+    import errno
     import fcntl
 
     lock_path = file_path + ".patch_lock"
-    lock_fd = open(lock_path, "w")
+    try:
+        lock_fd = open(lock_path, "w")
+    except OSError as e:
+        if e.errno not in (errno.EROFS, errno.EACCES):
+            raise
+        with open(file_path, "r") as f:
+            content = f.read()
+
+        def warn_only(new_content: str) -> None:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Read-only install: cannot patch %s at runtime; bake the "
+                "patch into the image if its effect is required.",
+                file_path,
+            )
+
+        yield content, warn_only
+        return
     try:
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
 

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -702,12 +702,15 @@ def _apply_vllm_patches(
         )
     elif uses_v1_executor:
         patch_logger.error(
-            "vllm v1 _init_workers_ray patch did NOT apply: the "
-            "'self._init_workers_ray(placement_group)' anchor was not found, "
-            "and VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0 selects the v1 executor "
-            "that depends on it. Ray workers will launch under the wrong "
-            "interpreter. Either the anchor moved upstream, or unset "
-            "VLLM_USE_RAY_V2_EXECUTOR_BACKEND to use RayExecutorV2."
+            "vllm v1 _init_workers_ray patch did NOT apply, and "
+            "VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0 selects the v1 executor that "
+            "depends on it. Ray workers will launch under the wrong "
+            "interpreter. Either the "
+            "'self._init_workers_ray(placement_group)' anchor moved upstream, "
+            "or the install is read-only and a preceding warning says so -- in "
+            "which case bake the patch into the image. Unsetting "
+            "VLLM_USE_RAY_V2_EXECUTOR_BACKEND to use RayExecutorV2 also avoids "
+            "the dependency."
         )
     else:
         patch_logger.info(

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -685,9 +685,7 @@ def _apply_vllm_patches(
     # Reporting the same way in both cases either cries wolf or hides a real
     # break, so branch on it.
     uses_v1_executor = not envs.VLLM_USE_RAY_V2_EXECUTOR_BACKEND
-    applied = _patch_vllm_init_workers_ray(
-        py_executable, extra_env_vars, patch_logger
-    )
+    applied = _patch_vllm_init_workers_ray(py_executable, extra_env_vars, patch_logger)
 
     if applied and uses_v1_executor:
         patch_logger.info(

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -246,7 +246,7 @@ def test_ray_extra_env_vars_merge_is_additive(
     else:
         monkeypatch.setenv("VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", existing)
 
-    patches._patch_vllm_init_workers_ray("py", extra)
+    patches._patch_vllm_init_workers_ray("py", extra, logging.getLogger(__name__))
 
     assert os.environ["VLLM_RAY_EXTRA_ENV_VARS_TO_COPY"] == expected
 
@@ -258,7 +258,10 @@ def test_init_workers_ray_reports_a_missing_anchor(monkeypatch, tmp_path):
     monkeypatch.setattr(patches, "_get_vllm_file", lambda _r: str(ray_executor))
     monkeypatch.delenv("VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", raising=False)
 
-    assert patches._patch_vllm_init_workers_ray("py", None) is False
+    assert (
+        patches._patch_vllm_init_workers_ray("py", None, logging.getLogger(__name__))
+        is False
+    )
     # The env merge still has to happen; it is independent of the file patch.
     assert os.environ["VLLM_RAY_EXTRA_ENV_VARS_TO_COPY"] == (
         "RAY_ENABLE_UV_RUN_RUNTIME_ENV"
@@ -271,11 +274,21 @@ def test_init_workers_ray_reports_success_and_is_idempotent(monkeypatch, tmp_pat
     ray_executor.write_text("self._init_workers_ray(placement_group)\n")
     monkeypatch.setattr(patches, "_get_vllm_file", lambda _r: str(ray_executor))
 
-    assert patches._patch_vllm_init_workers_ray("py-exec", None) is True
+    assert (
+        patches._patch_vllm_init_workers_ray(
+            "py-exec", None, logging.getLogger(__name__)
+        )
+        is True
+    )
     once = ray_executor.read_text()
     assert 'runtime_env={"py_executable": "py-exec"}' in once
 
-    assert patches._patch_vllm_init_workers_ray("py-exec", None) is True
+    assert (
+        patches._patch_vllm_init_workers_ray(
+            "py-exec", None, logging.getLogger(__name__)
+        )
+        is True
+    )
     assert ray_executor.read_text() == once
 
 
@@ -284,9 +297,10 @@ def test_locked_file_patch_writes_under_lock_on_writable_install(tmp_path):
     target = tmp_path / "target.py"
     target.write_text("ORIGINAL")
 
-    with patches._locked_file_patch(
-        str(target), logging.getLogger(__name__)
-    ) as (content, write_back):
+    with patches._locked_file_patch(str(target), logging.getLogger(__name__)) as (
+        content,
+        write_back,
+    ):
         assert content == "ORIGINAL"
         write_back("PATCHED")
 
@@ -315,9 +329,10 @@ def test_locked_file_patch_degrades_to_lockless_read_on_read_only_install(
     monkeypatch.setattr(builtins, "open", refuse_the_lock)
 
     with caplog.at_level(logging.WARNING):
-        with patches._locked_file_patch(
-            str(target), logging.getLogger(__name__)
-        ) as (content, write_back):
+        with patches._locked_file_patch(str(target), logging.getLogger(__name__)) as (
+            content,
+            write_back,
+        ):
             assert content == "ORIGINAL"
             assert write_back("MUST_NOT_LAND") is False
 

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -31,6 +31,8 @@ The two port patches ship their own suites. These cover the remaining patches:
 """
 
 import ast
+import builtins
+import errno
 import logging
 import os
 
@@ -282,38 +284,52 @@ def test_locked_file_patch_writes_under_lock_on_writable_install(tmp_path):
     target = tmp_path / "target.py"
     target.write_text("ORIGINAL")
 
-    with patches._locked_file_patch(str(target)) as (content, write_back):
+    with patches._locked_file_patch(
+        str(target), logging.getLogger(__name__)
+    ) as (content, write_back):
         assert content == "ORIGINAL"
         write_back("PATCHED")
 
     assert target.read_text() == "PATCHED"
 
 
+@pytest.mark.parametrize("lock_errno", [errno.EROFS, errno.EACCES])
 def test_locked_file_patch_degrades_to_lockless_read_on_read_only_install(
-    tmp_path, caplog
+    tmp_path, caplog, monkeypatch, lock_errno
 ):
-    """EACCES/EROFS on the lock file yields the content and a warn-only writer."""
-    ro_dir = tmp_path / "site-packages"
-    ro_dir.mkdir()
-    target = ro_dir / "target.py"
+    """EROFS/EACCES on the lock file yields the content and a declining writer.
+
+    The errno is injected rather than simulated with chmod: a read-only *mount*
+    raises EROFS, which no mode bit reproduces, and CI runs the container as
+    root, where mode bits are ignored entirely.
+    """
+    target = tmp_path / "target.py"
     target.write_text("ORIGINAL")
-    ro_dir.chmod(0o555)
-    if os.access(ro_dir, os.W_OK):  # root ignores mode bits (e.g. CI containers)
-        pytest.skip("cannot simulate a read-only install as root")
-    try:
-        with caplog.at_level(logging.WARNING):
-            with patches._locked_file_patch(str(target)) as (content, write_back):
-                assert content == "ORIGINAL"
-                write_back("MUST_NOT_LAND")
-        assert target.read_text() == "ORIGINAL"
-        assert not (ro_dir / "target.py.patch_lock").exists()
-        assert "Read-only install" in caplog.text
-    finally:
-        ro_dir.chmod(0o755)
+    real_open = builtins.open
+
+    def refuse_the_lock(file, mode="r", *args, **kwargs):
+        if str(file).endswith(".patch_lock"):
+            raise OSError(lock_errno, os.strerror(lock_errno), str(file))
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", refuse_the_lock)
+
+    with caplog.at_level(logging.WARNING):
+        with patches._locked_file_patch(
+            str(target), logging.getLogger(__name__)
+        ) as (content, write_back):
+            assert content == "ORIGINAL"
+            assert write_back("MUST_NOT_LAND") is False
+
+    assert target.read_text() == "ORIGINAL"
+    assert not (tmp_path / "target.py.patch_lock").exists()
+    assert "Read-only install" in caplog.text
 
 
 def test_locked_file_patch_still_raises_on_unrelated_oserror(tmp_path):
     """Only EROFS/EACCES trigger the fallback; anything else propagates."""
     with pytest.raises(FileNotFoundError):
-        with patches._locked_file_patch(str(tmp_path / "missing" / "target.py")):
+        with patches._locked_file_patch(
+            str(tmp_path / "missing" / "target.py"), logging.getLogger(__name__)
+        ):
             pass

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -275,3 +275,45 @@ def test_init_workers_ray_reports_success_and_is_idempotent(monkeypatch, tmp_pat
 
     assert patches._patch_vllm_init_workers_ray("py-exec", None) is True
     assert ray_executor.read_text() == once
+
+
+def test_locked_file_patch_writes_under_lock_on_writable_install(tmp_path):
+    """The normal path still locks, yields content, and lands the write."""
+    target = tmp_path / "target.py"
+    target.write_text("ORIGINAL")
+
+    with patches._locked_file_patch(str(target)) as (content, write_back):
+        assert content == "ORIGINAL"
+        write_back("PATCHED")
+
+    assert target.read_text() == "PATCHED"
+
+
+def test_locked_file_patch_degrades_to_lockless_read_on_read_only_install(
+    tmp_path, caplog
+):
+    """EACCES/EROFS on the lock file yields the content and a warn-only writer."""
+    ro_dir = tmp_path / "site-packages"
+    ro_dir.mkdir()
+    target = ro_dir / "target.py"
+    target.write_text("ORIGINAL")
+    ro_dir.chmod(0o555)
+    if os.access(ro_dir, os.W_OK):  # root ignores mode bits (e.g. CI containers)
+        pytest.skip("cannot simulate a read-only install as root")
+    try:
+        with caplog.at_level(logging.WARNING):
+            with patches._locked_file_patch(str(target)) as (content, write_back):
+                assert content == "ORIGINAL"
+                write_back("MUST_NOT_LAND")
+        assert target.read_text() == "ORIGINAL"
+        assert not (ro_dir / "target.py.patch_lock").exists()
+        assert "Read-only install" in caplog.text
+    finally:
+        ro_dir.chmod(0o755)
+
+
+def test_locked_file_patch_still_raises_on_unrelated_oserror(tmp_path):
+    """Only EROFS/EACCES trigger the fallback; anything else propagates."""
+    with pytest.raises(FileNotFoundError):
+        with patches._locked_file_patch(str(tmp_path / "missing" / "target.py")):
+            pass


### PR DESCRIPTION
# What does this PR do ?

Makes the vLLM runtime patcher tolerate read-only installs instead of crashing every generation worker at startup.

## Background

`_locked_file_patch` creates `<file>.patch_lock` inside vLLM's site-packages before checking whether the patch is even needed. On container images whose venvs are baked in and mounted read-only (e.g. pyxis/enroot on Slurm mounts the container rootfs as a read-only tmpfs), that `open()` raises `EROFS` and the worker dies — even when the target file already carries the patch.

## Changes

- If creating the lock file fails with `EROFS`/`EACCES`, read the target locklessly — on a read-only install no concurrent writer can exist either.
- The writer degrades to a warning telling the operator to bake the patch into the image if its effect is required.
- Any other `OSError` still raises.

# Issues

N/A

# Usage

N/A — behavior change only on read-only installs, where startup previously crashed.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Tests cover all three paths in `tests/unit/models/generation/test_vllm_patches.py`: the writable path still locks and writes, the read-only path yields content with a warn-only writer and creates no lock file, and unrelated `OSError`s still propagate. The read-only test skips under root, where mode bits cannot simulate a read-only install.
