### PR TITLE
perf(gym): keep health checks off rollout event loop

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -375,16 +375,19 @@ class NemoGym(EnvironmentInterface):
                 "serve rollouts until it is spun up again."
             )
 
-    def health_check(self) -> None:
+    async def health_check(self) -> None:
         """Raise if the Gym head server or any subprocess server has died.
 
         Thin wrapper over NeMo-Gym's own ``RunHelper.poll``, which is what ``gym env
         start`` calls every 60s from ``run_forever``. NeMo-RL only calls ``rh.start``,
         so without this the check Gym already implements never runs and a dead tool
         server surfaces as unexplained rollout timeouts instead of a named process.
+
+        Run the synchronous poll in a worker thread so this probe does not block
+        concurrent rollouts on the actor's event loop.
         """
         self._require_spinup()
-        self.rh.poll()
+        await asyncio.to_thread(self.rh.poll)
 
     def _spinup(self) -> None:
         """Start the NeMo-Gym head server and rollout collection helper.

--- a/tests/unit/environments/test_nemo_gym_health.py
+++ b/tests/unit/environments/test_nemo_gym_health.py
@@ -95,8 +95,22 @@ class TestHealthCheck:
     def test_a_healthy_gym_polls_the_run_helper(self):
         env = _unspun()
         env.rh = _FakeRunHelper()
-        env.health_check()
+        asyncio.run(env.health_check())
         assert env.rh.polls == 1
+
+    def test_poll_runs_off_the_actor_event_loop(self, monkeypatch):
+        env = _unspun()
+        env.rh = _FakeRunHelper()
+        submitted = []
+
+        async def _to_thread(function):
+            submitted.append(function)
+            function()
+
+        monkeypatch.setattr(asyncio, "to_thread", _to_thread)
+        asyncio.run(env.health_check())
+
+        assert submitted == [env.rh.poll]
 
     def test_a_dead_subprocess_server_propagates_with_its_name(self):
         env = _unspun()
@@ -104,21 +118,19 @@ class TestHealthCheck:
             RuntimeError("Process `workplace_assistant` finished unexpectedly!")
         )
         with pytest.raises(RuntimeError, match="workplace_assistant"):
-            env.health_check()
+            asyncio.run(env.health_check())
 
 
 class TestUnspunActor:
     def test_health_check_explains_the_restarted_actor_state(self):
         with pytest.raises(RuntimeError, match="_spinup\\(\\) was never called"):
-            _unspun().health_check()
+            asyncio.run(_unspun().health_check())
 
     def test_run_rollouts_refuses_rather_than_raising_attribute_error(self):
         env = _unspun()
         with pytest.raises(RuntimeError, match="_spinup\\(\\) was never called"):
             # run_rollouts is an async generator, so the guard fires on first advance.
             gen = env.run_rollouts([{"agent_ref": {"name": "a"}}], None, "timing/x")
-            import asyncio
-
             asyncio.run(anext(gen))
 
     def test_shutdown_is_a_noop_so_teardown_does_not_mask_the_real_error(self):


### PR DESCRIPTION
## Summary

The `NemoGym` Ray actor runs rollout coroutines on an asyncio event loop. Its synchronous `health_check()` method called `RunHelper.poll()` on that same loop every time the stall watchdog checked Gym subprocesses. While the poll ran, ready rollout coroutines could not advance, and the delay affected more in-flight work as the actor became saturated.

This change makes `health_check()` asynchronous and sends the synchronous process poll to a worker thread with `asyncio.to_thread()`. The actor event loop yields while the poll runs, so it can continue advancing rollout coroutines. Process failures still propagate through the existing health-check result, and the controller keeps its existing timeout and stall-action behavior.

```mermaid
flowchart LR
    subgraph Before[Before: synchronous health check]
        W1[Stall watchdog] -->|health_check.remote| E1[NemoGym actor event loop]
        E1 --> P1[RunHelper.poll]
        P1 -. blocks event loop .-> R1[Rollout coroutines wait]
    end

    subgraph After[After: asynchronous health check]
        W2[Stall watchdog] -->|health_check.remote| E2[NemoGym actor event loop]
        E2 -->|asyncio.to_thread| T2[Worker thread runs RunHelper.poll]
        E2 --> R2[Rollout coroutines continue]
        T2 -->|result or exception| E2
    end
```

## Test plan

- [x] Run `uv run pytest tests/unit/environments/test_nemo_gym_health.py -q`.
- [x] Run the repository pre-commit hooks for the modified files.