### PR TITLE
feat: let recipes register out-of-tree Megatron-Bridge model bridges

### DIFF
--- a/docs/design-docs/training-backends.md
+++ b/docs/design-docs/training-backends.md
@@ -57,6 +57,33 @@ dictionaries follow the hierarchy of nested model-config objects. NeMo
 RL-specific settings such as optimizer, scheduler, checkpointing, and
 environment variables remain under their existing `megatron_cfg` sections.
 
+#### Out-of-tree model bridges
+
+Megatron Bridge resolves a model through bridges registered at import time and
+has no plugin auto-discovery, so a bridge defined outside the package is invisible
+unless something imports it first. List the modules that register yours in
+`policy.megatron_cfg.bridge_plugins`:
+
+```yaml
+policy:
+  megatron_cfg:
+    enabled: true
+    bridge_plugins:
+      - my_bridges.llama_variant
+```
+
+These are dotted module paths, not file paths — the difference from
+`policy.generation.vllm_cfg.reasoning_parser_plugin`, which takes a file. Each must
+be importable from the process that resolves the model: the Megatron policy worker,
+which is a Ray actor rather than the driver, so the module has to be installed in
+the worker environment or reachable inside the Ray working directory. A module that
+cannot be imported fails at setup naming the config key; one that imports but
+registers nothing surfaces later as the ordinary unsupported-architecture error.
+
+`examples/converters/convert_megatron_to_hf.py` reads the same key from the run's
+saved config, so a checkpoint trained with a custom bridge converts back to
+Hugging Face without extra flags.
+
 #### Fine-grained activation CPU offload
 
 Fine-grained activation offloading asynchronously moves selected module-input

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -182,7 +182,9 @@ policy:
     # Arbitrary overrides applied recursively to the Megatron Bridge model
     # provider before model instantiation. Do not duplicate first-class fields.
     model_overrides: {}
-    # Modules imported in the worker to register out-of-tree Megatron-Bridge bridges.
+    # Dotted module paths (not file paths) imported before the model is
+    # resolved, so out-of-tree Megatron-Bridge bridges register themselves.
+    # Must be importable from the worker process. null disables.
     bridge_plugins: null
     checkpoint:
       async_save: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -182,6 +182,8 @@ policy:
     # Arbitrary overrides applied recursively to the Megatron Bridge model
     # provider before model instantiation. Do not duplicate first-class fields.
     model_overrides: {}
+    # Modules imported in the worker to register out-of-tree Megatron-Bridge bridges.
+    bridge_plugins: null
     checkpoint:
       async_save: true
       ckpt_assume_constant_structure: true

--- a/examples/converters/convert_megatron_to_hf.py
+++ b/examples/converters/convert_megatron_to_hf.py
@@ -17,6 +17,7 @@ import argparse
 import yaml
 
 from nemo_rl.models.megatron.community_import import export_model_from_megatron
+from nemo_rl.models.policy.utils import import_bridge_plugins
 
 """ NOTE: this script requires mcore. Make sure to launch with the mcore extra:
 uv run --extra mcore python examples/converters/convert_megatron_to_hf.py \
@@ -81,6 +82,10 @@ def main():
     )
     tokenizer_name = config["policy"]["tokenizer"]["name"]
     hf_overrides = config["policy"].get("hf_overrides", {}) or {}
+
+    # A custom bridge registers on import, and export resolves the same
+    # architecture the run trained, so the converter needs the plugins too.
+    import_bridge_plugins(config["policy"]["megatron_cfg"].get("bridge_plugins"))
 
     export_model_from_megatron(
         hf_model_name=model_name,

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -327,6 +327,9 @@ class MegatronCheckpointConfig(TypedDict, total=False):
 class MegatronConfig(TypedDict):
     enabled: Literal[True]
     env_vars: NotRequired[dict[str, str] | None]
+    # Modules imported in the worker before model import, so out-of-tree
+    # Megatron-Bridge bridges can register (import side effect).
+    bridge_plugins: NotRequired[list[str] | None]
     # Arbitrary model-provider attributes applied recursively to the Megatron
     # Bridge model config before model instantiation. Keys must match configurable
     # provider fields and must not duplicate first-class megatron_cfg fields.

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import importlib
 import os
 import traceback
 import warnings
@@ -127,6 +128,19 @@ def resolve_policy_worker_cls(default_cls: str, config: dict) -> str:
     if config.get("quant_cfg") is None:
         return default_cls
     return POLICY_WORKER_OVERRIDES.get(default_cls, default_cls)
+
+
+def import_bridge_plugins(module_names: list[str] | None) -> None:
+    """Import modules whose side effects register out-of-tree Megatron-Bridge bridges.
+
+    Megatron-Bridge dispatches on architecture names collected at import time and
+    has no plugin auto-discovery, so a bridge defined outside the package must be
+    imported before ``AutoBridge`` resolves the model. Modules are listed in
+    ``megatron_cfg.bridge_plugins`` — the Megatron analog of
+    ``vllm_cfg.reasoning_parser_plugin``.
+    """
+    for module_name in module_names or []:
+        importlib.import_module(module_name)
 
 
 def resolve_model_class(model_name: str) -> Any:

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -140,7 +140,15 @@ def import_bridge_plugins(module_names: list[str] | None) -> None:
     ``vllm_cfg.reasoning_parser_plugin``.
     """
     for module_name in module_names or []:
-        importlib.import_module(module_name)
+        try:
+            importlib.import_module(module_name)
+        except ImportError as e:
+            raise ImportError(
+                f"policy.megatron_cfg.bridge_plugins lists {module_name!r}, which "
+                "could not be imported. These are dotted module paths, not file "
+                "paths, and must be importable from the process that resolves the "
+                "model -- the Megatron policy worker, or the HF converter."
+            ) from e
 
 
 def resolve_model_class(model_name: str) -> Any:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -108,6 +108,7 @@ from nemo_rl.models.policy.utils import (
     connect_rollout_engines_from_distributed,
     disconnect_rollout_engines_from_distributed,
     get_runtime_env_for_policy_worker,
+    import_bridge_plugins,
     send_hf_buckets_via_ipc_actor_impl,
 )
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
@@ -493,6 +494,9 @@ class MegatronPolicyWorkerImpl(
             f"device drift after setup_distributed: current_device="
             f"{torch.cuda.current_device()}, LOCAL_RANK={local_rank}."
         )
+
+        # Import side effects register out-of-tree bridges before AutoBridge runs.
+        import_bridge_plugins(config["megatron_cfg"].get("bridge_plugins"))
 
         # Step 2: Validate and setup model paths
         hf_model_name, pretrained_path, pt_checkpoint_exists = validate_model_paths(

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -645,6 +645,21 @@ class TestImportBridgePlugins:
     def test_absent_and_empty_are_noops(self, module_names):
         import_bridge_plugins(module_names)
 
-    def test_missing_module_raises(self):
-        with pytest.raises(ModuleNotFoundError):
+    def test_missing_module_names_the_config_key(self):
+        with pytest.raises(ImportError, match="bridge_plugins") as excinfo:
             import_bridge_plugins(["nemo_rl_no_such_bridge_plugin"])
+        assert "nemo_rl_no_such_bridge_plugin" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, ModuleNotFoundError)
+
+    def test_a_plugin_that_fails_to_import_names_the_config_key(
+        self, tmp_path, monkeypatch
+    ):
+        """The realistic failure: the plugin exists but its own imports are broken."""
+        mod = tmp_path / "broken_bridge_plugin.py"
+        mod.write_text("import nemo_rl_no_such_dependency\n")
+        monkeypatch.syspath_prepend(str(tmp_path))
+        try:
+            with pytest.raises(ImportError, match="bridge_plugins"):
+                import_bridge_plugins(["broken_bridge_plugin"])
+        finally:
+            sys.modules.pop("broken_bridge_plugin", None)

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -30,6 +30,7 @@ from nemo_rl.models.policy.utils import (
     calculate_aligned_size,
     ensure_teacher_ipc_buffer,
     get_megatron_checkpoint_dir,
+    import_bridge_plugins,
     rebuild_cuda_tensor_from_ipc,
     stream_weights_via_ipc_zmq_impl,
 )
@@ -623,3 +624,27 @@ class TestEnsureTeacherIpcBuffer:
         assert s2 is s and h2 is h
         s3, _ = ensure_teacher_ipc_buffer(s, h, 3, 1, 4, 8, torch.float32, dev)
         assert s3 is not s and s3.shape == (3, 1, 4, 8)
+
+
+class TestImportBridgePlugins:
+    """Test cases for the import_bridge_plugins function."""
+
+    def test_imports_listed_modules(self, tmp_path, monkeypatch):
+        mod = tmp_path / "fake_bridge_plugin.py"
+        mod.write_text("import sys\nsys._fake_bridge_plugin_loaded = True\n")
+        monkeypatch.syspath_prepend(str(tmp_path))
+        try:
+            import_bridge_plugins(["fake_bridge_plugin"])
+            assert getattr(sys, "_fake_bridge_plugin_loaded", False)
+        finally:
+            sys.modules.pop("fake_bridge_plugin", None)
+            if hasattr(sys, "_fake_bridge_plugin_loaded"):
+                delattr(sys, "_fake_bridge_plugin_loaded")
+
+    @pytest.mark.parametrize("module_names", [None, []])
+    def test_absent_and_empty_are_noops(self, module_names):
+        import_bridge_plugins(module_names)
+
+    def test_missing_module_raises(self):
+        with pytest.raises(ModuleNotFoundError):
+            import_bridge_plugins(["nemo_rl_no_such_bridge_plugin"])

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -183,6 +183,7 @@ policy:
   megatron_cfg:
     enabled: false
     model_overrides: {}
+    bridge_plugins: null
     checkpoint:
       async_save: true
       ckpt_assume_constant_structure: true


### PR DESCRIPTION
# What does this PR do ?

**Lets a recipe name the modules that register out-of-tree Megatron-Bridge model bridges, so a custom model can be trained and exported without forking NeMo RL.**

Megatron Bridge dispatches on architectures collected at import time and has no plugin auto-discovery, so a bridge defined outside the package is invisible unless something imports it first. `policy.megatron_cfg.bridge_plugins` lists those modules; the Megatron policy worker imports them before the model is resolved, which is upstream of all three `AutoBridge` construction sites (`validate_and_set_config`, `handle_model_import`, `finalize_megatron_setup`). Import is `sys.modules`-cached, so it is idempotent within a worker, and each Ray actor is its own process, so per-worker registration is what is wanted.

`examples/converters/convert_megatron_to_hf.py` gets the same registration: it reads the run's saved config and resolves the same architecture the run trained, so without it a checkpoint trained with a custom bridge could not be converted back to Hugging Face.

An unimportable module fails naming `policy.megatron_cfg.bridge_plugins` and the offending value. The bare `ModuleNotFoundError` otherwise arrives wrapped in a Ray traceback with nothing tying it back to the config.

# Issues

None closed.

# Usage

```yaml
policy:
  megatron_cfg:
    enabled: true
    bridge_plugins:
      - my_bridges.llama_variant
```

These are **dotted module paths, not file paths** — the difference from the vLLM analog this is modelled on, `policy.generation.vllm_cfg.reasoning_parser_plugin`, which takes a file. Each must be importable from the process that resolves the model; the policy worker is a Ray actor, not the driver, so the module has to be installed in the worker environment or reachable inside the Ray working directory. The YAML comment, the error message, and the new docs section all say so, since it is the likeliest way to get this wrong.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* **On scope.** `nemo_rl/models/policy/utils.py` carries a TODO directly above this code asking for a generic plugin-registration hook on `Policy` (a `worker_cls_overrides` registry populated by `nemo_rl.modelopt` on import) so core has no knowledge of ModelOpt-specific worker classes. This PR is deliberately not that: it is Megatron-Bridge-specific, and a general hook needs a per-backend story — what registers, when, and for which worker types — that this change does not owe. If reviewers would rather have the general form first, say so and I will close this in favour of it.
* Documented in `docs/design-docs/training-backends.md` beside `model_overrides`, the neighbouring Megatron escape hatch.
* The unit tests were **not** run locally — `tests/unit/models/policy/test_utils.py` needs the `nemo` module, which is not importable in the environment this was written in.
