### PR TITLE
perf: compute selected token logprobs directly

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -83,6 +83,54 @@ def _compute_distributed_log_softmax(
 
 
 @torch.no_grad()
+def _compute_distributed_selected_logprobs(
+    vocab_parallel_logits: torch.Tensor,
+    *,
+    masked_target: torch.Tensor,
+    target_mask: torch.Tensor,
+    group: torch.distributed.ProcessGroup,
+) -> torch.Tensor:
+    """Compute selected-token logprobs without materializing full logprobs.
+
+    The normalization still spans the complete tensor-parallel vocabulary, but
+    the final log-normalizer subtraction is applied only to the selected token
+    from each row instead of every vocabulary element.
+    """
+    logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True)
+    torch.distributed.all_reduce(
+        logits_max,
+        op=torch.distributed.ReduceOp.MAX,
+        group=group,
+    )
+
+    shifted_logits = vocab_parallel_logits - logits_max
+    selected_logits = torch.gather(
+        shifted_logits, -1, masked_target.unsqueeze(-1)
+    ).squeeze(-1)
+
+    # The selected logits have already been gathered, so the full-vocabulary
+    # shifted buffer can be reused for exp/sum instead of allocating another
+    # [batch, sequence, local_vocab] tensor.
+    sum_exp_logits = shifted_logits.exp_().sum(-1, keepdim=True).float()
+    torch.distributed.all_reduce(
+        sum_exp_logits,
+        op=torch.distributed.ReduceOp.SUM,
+        group=group,
+    )
+    selected_logprobs = selected_logits - sum_exp_logits.log().squeeze(-1).to(
+        selected_logits.dtype
+    )
+    selected_logprobs[target_mask] = 0.0
+
+    torch.distributed.all_reduce(
+        selected_logprobs,
+        op=torch.distributed.ReduceOp.SUM,
+        group=group,
+    )
+    return selected_logprobs
+
+
+@torch.no_grad()
 def _compute_distributed_softmax(
     vocab_parallel_logits: torch.Tensor, group: torch.distributed.ProcessGroup
 ) -> torch.Tensor:
@@ -305,19 +353,10 @@ class ChunkedDistributedLogprob(torch.autograd.Function):
             logits = vocab_parallel_logits[:, chunk_start:chunk_end, :]
             logits = logits.to(dtype=torch.float32)
 
-            log_probs = _compute_distributed_log_softmax(
+            log_probs = _compute_distributed_selected_logprobs(
                 logits,
-                group=tp_group,
-            )
-
-            log_probs = torch.gather(
-                log_probs, -1, masked_target[:, chunk_start:chunk_end].unsqueeze(-1)
-            ).squeeze(-1)
-            log_probs[target_mask[:, chunk_start:chunk_end]] = 0.0
-
-            torch.distributed.all_reduce(
-                log_probs,
-                op=torch.distributed.ReduceOp.SUM,
+                masked_target=masked_target[:, chunk_start:chunk_end],
+                target_mask=target_mask[:, chunk_start:chunk_end],
                 group=tp_group,
             )
 

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -89,12 +89,14 @@ def _compute_distributed_selected_logprobs(
     masked_target: torch.Tensor,
     target_mask: torch.Tensor,
     group: torch.distributed.ProcessGroup,
+    reduce_output: bool = True,
 ) -> torch.Tensor:
     """Compute selected-token logprobs without materializing full logprobs.
 
     The normalization still spans the complete tensor-parallel vocabulary, but
     the final log-normalizer subtraction is applied only to the selected token
-    from each row instead of every vocabulary element.
+    from each row instead of every vocabulary element. When ``reduce_output`` is
+    ``False``, the caller owns the final sum-reduction across vocabulary partitions.
     """
     logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True)
     torch.distributed.all_reduce(
@@ -122,11 +124,12 @@ def _compute_distributed_selected_logprobs(
     )
     selected_logprobs[target_mask] = 0.0
 
-    torch.distributed.all_reduce(
-        selected_logprobs,
-        op=torch.distributed.ReduceOp.SUM,
-        group=group,
-    )
+    if reduce_output:
+        torch.distributed.all_reduce(
+            selected_logprobs,
+            op=torch.distributed.ReduceOp.SUM,
+            group=group,
+        )
     return selected_logprobs
 
 
@@ -358,11 +361,17 @@ class ChunkedDistributedLogprob(torch.autograd.Function):
                 masked_target=masked_target[:, chunk_start:chunk_end],
                 target_mask=target_mask[:, chunk_start:chunk_end],
                 group=tp_group,
+                reduce_output=False,
             )
 
             all_log_probs.append(log_probs)
 
         log_probs = torch.cat(all_log_probs, dim=1)
+        torch.distributed.all_reduce(
+            log_probs,
+            op=torch.distributed.ReduceOp.SUM,
+            group=tp_group,
+        )
 
         if not inference_only:
             # only save for backward when we have inference only=False
@@ -2385,19 +2394,13 @@ class ChunkedDistributedHiddenStatesToLogprobs(torch.autograd.Function):
                 output_weight_layer.T,
             )
             logits = logits.to(dtype=torch.float32).transpose(0, 1).contiguous()
-            log_probs = _compute_distributed_log_softmax(
+            log_probs = _compute_distributed_selected_logprobs(
                 logits,
+                masked_target=masked_target[:, chunk_start:chunk_end],
+                target_mask=target_mask[:, chunk_start:chunk_end],
                 group=tp_group,
+                reduce_output=False,
             )
-
-            log_probs = (
-                torch.gather(
-                    log_probs, -1, masked_target[:, chunk_start:chunk_end].unsqueeze(-1)
-                )
-                .squeeze(-1)
-                .detach()
-            )
-            log_probs[target_mask[:, chunk_start:chunk_end]] = 0.0
 
             all_log_probs.append(log_probs)
 

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -26,6 +26,7 @@ from nemo_rl.distributed.model_utils import (
     DistributedLogprob,
     DistributedLogprobWithSampling,
     _compute_distributed_log_softmax,
+    _compute_distributed_selected_logprobs,
     _get_tokens_on_this_cp_rank,
     allgather_cp_sharded_tensor,
     distributed_vocab_topk,
@@ -40,6 +41,80 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+
+
+def test_compute_distributed_selected_logprobs(monkeypatch):
+    """Selected-token path matches gathering a complete log-softmax tensor."""
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional,
+        "all_reduce",
+        lambda tensor, **kwargs: tensor,
+    )
+
+    torch.manual_seed(42)
+    logits = torch.randn(2, 5, 11, dtype=torch.float32)
+    target = torch.randint(0, logits.shape[-1], (2, 5))
+    target_mask = torch.zeros_like(target, dtype=torch.bool)
+    target_mask[0, 3] = True
+
+    actual = _compute_distributed_selected_logprobs(
+        logits,
+        masked_target=target,
+        target_mask=target_mask,
+        group=None,
+    )
+    expected = (
+        torch.log_softmax(logits, dim=-1).gather(-1, target.unsqueeze(-1)).squeeze(-1)
+    )
+    expected[target_mask] = 0.0
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_compute_distributed_selected_logprobs_tp_shards(monkeypatch):
+    """TP-local selected values reduce to full-vocabulary token logprobs."""
+    torch.manual_seed(123)
+    full_logits = torch.randn(2, 5, 12, dtype=torch.float32)
+    target = torch.randint(0, full_logits.shape[-1], (2, 5))
+    global_max = full_logits.amax(dim=-1, keepdim=True)
+    shifted_full_logits = full_logits - global_max
+    global_sum_exp = shifted_full_logits.exp().sum(dim=-1, keepdim=True)
+    expected = (
+        torch.log_softmax(full_logits, dim=-1)
+        .gather(-1, target.unsqueeze(-1))
+        .squeeze(-1)
+    )
+
+    shard_size = full_logits.shape[-1] // 2
+    for rank in range(2):
+        vocab_start = rank * shard_size
+        vocab_end = vocab_start + shard_size
+        target_mask = (target < vocab_start) | (target >= vocab_end)
+        masked_target = target - vocab_start
+        masked_target[target_mask] = 0
+        remote_selected_logprobs = expected.masked_fill(~target_mask, 0.0)
+
+        def fake_all_reduce(tensor, *, op, group):
+            if op == torch.distributed.ReduceOp.MAX:
+                tensor.copy_(global_max)
+            else:
+                tensor.add_(remote_selected_logprobs)
+
+        monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+        monkeypatch.setattr(
+            torch.distributed.nn.functional,
+            "all_reduce",
+            lambda tensor, **kwargs: global_sum_exp,
+        )
+
+        actual = _compute_distributed_selected_logprobs(
+            full_logits[..., vocab_start:vocab_end].contiguous(),
+            masked_target=masked_target,
+            target_mask=target_mask,
+            group=None,
+        )
+        torch.testing.assert_close(actual, expected)
 
 
 @ray.remote(num_gpus=1)

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -67,6 +67,38 @@ def test_compute_distributed_selected_logprobs(monkeypatch):
     torch.testing.assert_close(actual, expected)
 
 
+def test_compute_distributed_selected_logprobs_without_output_reduce(monkeypatch):
+    """The caller can own the final selected-logprob reduction."""
+    reduce_ops = []
+
+    def fake_all_reduce(tensor, *, op, group):
+        reduce_ops.append(op)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    torch.manual_seed(42)
+    logits = torch.randn(2, 5, 11, dtype=torch.float32)
+    target = torch.randint(0, logits.shape[-1], (2, 5))
+    target_mask = torch.zeros_like(target, dtype=torch.bool)
+
+    actual = _compute_distributed_selected_logprobs(
+        logits,
+        masked_target=target,
+        target_mask=target_mask,
+        group=None,
+        reduce_output=False,
+    )
+    expected = (
+        torch.log_softmax(logits, dim=-1).gather(-1, target.unsqueeze(-1)).squeeze(-1)
+    )
+
+    torch.testing.assert_close(actual, expected)
+    assert reduce_ops == [
+        torch.distributed.ReduceOp.MAX,
+        torch.distributed.ReduceOp.SUM,
+    ]
+
+
 def test_compute_distributed_selected_logprobs_tp_shards(monkeypatch):
     """TP-local selected values reduce to full-vocabulary token logprobs."""
     torch.manual_seed(123)

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -46,11 +46,6 @@ from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
 def test_compute_distributed_selected_logprobs(monkeypatch):
     """Selected-token path matches gathering a complete log-softmax tensor."""
     monkeypatch.setattr(torch.distributed, "all_reduce", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        torch.distributed.nn.functional,
-        "all_reduce",
-        lambda tensor, **kwargs: tensor,
-    )
 
     torch.manual_seed(42)
     logits = torch.randn(2, 5, 11, dtype=torch.float32)
@@ -98,15 +93,12 @@ def test_compute_distributed_selected_logprobs_tp_shards(monkeypatch):
         def fake_all_reduce(tensor, *, op, group):
             if op == torch.distributed.ReduceOp.MAX:
                 tensor.copy_(global_max)
+            elif tensor.shape == global_sum_exp.shape:
+                tensor.copy_(global_sum_exp)
             else:
                 tensor.add_(remote_selected_logprobs)
 
         monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
-        monkeypatch.setattr(
-            torch.distributed.nn.functional,
-            "all_reduce",
-            lambda tensor, **kwargs: global_sum_exp,
-        )
 
         actual = _compute_distributed_selected_logprobs(
             full_logits[..., vocab_start:vocab_end].contiguous(),


### PR DESCRIPTION
# What does this PR do ?

Compute the selected logprobs directly instead of subsequently masking. Doesn't materialize the full vocabulary-sized logprob tensor. This reduces memory use and unnecessary computation.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
