### PR TITLE
perf(sequence-packing): keep packed-sequence boundaries on CPU

### DIFF
--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -33,6 +33,7 @@ from nemo_rl.distributed.model_utils import (
     get_distillation_topk_logprobs_from_logits,
     get_next_token_logprobs_from_logits,
 )
+from nemo_rl.utils.sequence_lengths import CpuIntTuple
 
 if TYPE_CHECKING:
     from nemo_automodel.components.distributed.context_parallel import (
@@ -345,8 +346,8 @@ def prepare_loss_input(
 
 def _pack_input_ids(
     input_ids: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_q_padded: torch.Tensor,
+    cu_seqlens_q: CpuIntTuple,
+    cu_seqlens_q_padded: CpuIntTuple,
     cp_rank: int = 0,
     cp_size: int = 1,
     roll_shift: int = 0,
@@ -369,14 +370,14 @@ def _pack_input_ids(
             next-token prediction.
     """
     batch_size = input_ids.shape[0]
-    total_packed_len = int(cu_seqlens_q_padded[-1].item()) // cp_size
+    total_packed_len = cu_seqlens_q_padded[-1] // cp_size
     packed = torch.zeros(
         total_packed_len, dtype=input_ids.dtype, device=input_ids.device
     )
     for i in range(batch_size):
-        actual_len = int((cu_seqlens_q[i + 1] - cu_seqlens_q[i]).item())
-        padded_len = int((cu_seqlens_q_padded[i + 1] - cu_seqlens_q_padded[i]).item())
-        packed_start = int(cu_seqlens_q_padded[i].item())
+        actual_len = cu_seqlens_q[i + 1] - cu_seqlens_q[i]
+        padded_len = cu_seqlens_q_padded[i + 1] - cu_seqlens_q_padded[i]
+        packed_start = cu_seqlens_q_padded[i]
         seq = torch.zeros(padded_len, dtype=input_ids.dtype, device=input_ids.device)
         # The packer absorbs bin-level alignment padding into the last
         # sequence's effective length (see _get_pack_sequence_parameters_for_megatron),
@@ -397,8 +398,8 @@ def prepare_packed_loss_input(
     logits: torch.Tensor,
     data: BatchedDataDict[Any],
     loss_fn: LossFunction,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_q_padded: torch.Tensor,
+    cu_seqlens_q: CpuIntTuple,
+    cu_seqlens_q_padded: CpuIntTuple,
     vocab_parallel_rank: Optional[int] = None,
     vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
     context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
@@ -417,8 +418,10 @@ def prepare_packed_loss_input(
         logits: Packed logits from the model [1, T_packed // CP, V // TP].
         data: Microbatch data (unpacked, [B, S]).
         loss_fn: Loss function (must have input_type == LossInputType.LOGPROB).
-        cu_seqlens_q: Unpadded cumulative sequence lengths [B+1].
-        cu_seqlens_q_padded: Padded cumulative sequence lengths [B+1].
+        cu_seqlens_q: Unpadded cumulative sequence lengths [B+1]. CPU-resident
+            values avoid synchronization during target packing.
+        cu_seqlens_q_padded: Padded cumulative sequence lengths [B+1]. CPU-resident
+            values avoid synchronization during target packing and logprob unpacking.
         vocab_parallel_rank: Vocab parallel rank.
         vocab_parallel_group: Vocab parallel group.
         context_parallel_group: Context parallel group.

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -33,7 +33,7 @@ from nemo_rl.distributed.model_utils import (
     get_distillation_topk_logprobs_from_logits,
     get_next_token_logprobs_from_logits,
 )
-from nemo_rl.utils.sequence_lengths import CpuIntTuple
+from nemo_rl.utils.sequence_lengths import CpuIntTuple, to_cpu_int_tuple
 
 if TYPE_CHECKING:
     from nemo_automodel.components.distributed.context_parallel import (
@@ -119,7 +119,9 @@ def pack_rolled_draft_token_mask(
     per-segment left shift.
     """
     packed = _pack_input_ids(
-        token_mask * sample_mask.unsqueeze(-1), cu_seqlens, cu_seqlens_padded
+        token_mask * sample_mask.unsqueeze(-1),
+        to_cpu_int_tuple(cu_seqlens),
+        to_cpu_int_tuple(cu_seqlens_padded),
     )
     return roll_packed_seq_dim(packed, cu_seqlens_padded, seq_dim=1)
 

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -21,6 +21,7 @@ import torch.distributed
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.utils.sequence_lengths import CpuIntTuple
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
@@ -30,8 +31,8 @@ class SequencePackingLossWrapper:
         self,
         loss_fn: LossFunction,
         prepare_fn: Callable[Any, Any],
-        cu_seqlens_q: Tensor,
-        cu_seqlens_q_padded: Optional[Tensor] = None,
+        cu_seqlens_q: CpuIntTuple,
+        cu_seqlens_q_padded: Optional[CpuIntTuple] = None,
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
@@ -55,7 +56,9 @@ class SequencePackingLossWrapper:
         self.loss_fn = loss_fn
         self.prepare_fn = prepare_fn
         self.cu_seqlens_q = cu_seqlens_q
-        self.cu_seqlens_q_padded = cu_seqlens_q_padded
+        self.cu_seqlens_q_padded = (
+            cu_seqlens_q_padded if cu_seqlens_q_padded is not None else cu_seqlens_q
+        )
         self.vocab_parallel_rank = vocab_parallel_rank
         self.vocab_parallel_group = vocab_parallel_group
         self.context_parallel_group = context_parallel_group
@@ -69,23 +72,19 @@ class SequencePackingLossWrapper:
     ) -> tuple[Tensor, dict[str, Any]]:
         """Wraps a loss function to handle sequence packing by doing one sequence at a time to avoid excessive padding."""
         unpadded_cu_seqlens = self.cu_seqlens_q
-        unpadded_seq_lengths = self.cu_seqlens_q[1:] - self.cu_seqlens_q[:-1]
-        if self.cu_seqlens_q_padded is not None:
-            padded_cu_seqlens = self.cu_seqlens_q_padded
-            padded_seq_lengths = (
-                self.cu_seqlens_q_padded[1:] - self.cu_seqlens_q_padded[:-1]
-            )
-        else:
-            padded_cu_seqlens = unpadded_cu_seqlens
-            padded_seq_lengths = unpadded_seq_lengths
+        unpadded_seq_lengths = tuple(
+            end - start
+            for start, end in zip(unpadded_cu_seqlens[:-1], unpadded_cu_seqlens[1:])
+        )
+        padded_cu_seqlens = self.cu_seqlens_q_padded
         seq_starts = padded_cu_seqlens[:-1]
         seq_ends = padded_cu_seqlens[1:]
 
         loss_accum = 0
         metrics_accum = {}
         for seq_idx in range(len(seq_starts)):
-            seq_start = seq_starts[seq_idx].item()
-            seq_end = seq_ends[seq_idx].item()
+            seq_start = seq_starts[seq_idx]
+            seq_end = seq_ends[seq_idx]
 
             # get sequence and unpad all 'data' tensors. The data dict is a BatchedDataDict of unpacked tensors
             seq_data = data.slice(seq_idx, seq_idx + 1)
@@ -111,14 +110,14 @@ class SequencePackingLossWrapper:
                 # Use slicing (clamped end) to avoid narrow() OOB on packed tails.
                 logit_start = seq_start // cp_size
                 logit_end = min(
-                    (seq_start + padded_seq_lengths[seq_idx]) // cp_size,
+                    seq_end // cp_size,
                     next_token_logits.shape[1],
                 )
                 logit_slice_idxs = slice(logit_start, logit_end)
                 next_token_logits_slice = next_token_logits[:, logit_slice_idxs]
             else:
                 logit_start = seq_start // cp_size
-                logit_end = (seq_start + padded_seq_lengths[seq_idx]) // cp_size
+                logit_end = seq_end // cp_size
                 logit_length = logit_end - logit_start
                 next_token_logits_slice = next_token_logits.narrow(
                     1, logit_start, logit_length
@@ -185,8 +184,8 @@ class SequencePackingFusionLossWrapper:
         self,
         loss_fn: LossFunction,
         prepare_fn: Callable[..., Any],
-        cu_seqlens_q: Tensor,
-        cu_seqlens_q_padded: Optional[Tensor] = None,
+        cu_seqlens_q: CpuIntTuple,
+        cu_seqlens_q_padded: Optional[CpuIntTuple] = None,
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.logits_sampling_utils import (
     apply_top_k_top_p,
     need_top_k_or_top_p_filtering,
 )
+from nemo_rl.utils.sequence_lengths import CpuIntTuple
 
 if TYPE_CHECKING:
     # megatron-core (optional "mcore" extra) is imported lazily below so this
@@ -1225,7 +1226,7 @@ def from_parallel_logits_to_logprobs(
 def from_parallel_logits_to_logprobs_packed_sequences(
     vocab_parallel_logits: torch.Tensor,
     target: torch.Tensor,
-    cu_seqlens_padded: torch.Tensor,
+    cu_seqlens_padded: CpuIntTuple,
     unpacked_seqlen: int,
     vocab_start_index: int,
     vocab_end_index: int,
@@ -1245,9 +1246,10 @@ def from_parallel_logits_to_logprobs_packed_sequences(
         target (torch.Tensor): Packed target token indices.
             If target_is_pre_rolled=False: shape [1, T] — unmodified targets, rolled internally.
             If target_is_pre_rolled=True: shape [1, T // CP] — pre-rolled and pre-CP-sharded.
-        cu_seqlens_padded (torch.Tensor): Cumulative sequence lengths tensor with shape [batch_size + 1].
+        cu_seqlens_padded: Cumulative sequence lengths with shape [batch_size + 1].
             cu_seqlens_padded[i] indicates the start position of sequence i in the packed format
-            (full, not CP-adjusted).
+            (full, not CP-adjusted). CPU-resident values avoid synchronization in
+            the host-side packing loops.
         unpacked_seqlen (int): The length of the unpacked sequence tensor.
         vocab_start_index (int): Starting vocabulary index for this worker's partition.
         vocab_end_index (int): Ending vocabulary index for this worker's partition.
@@ -1267,7 +1269,7 @@ def from_parallel_logits_to_logprobs_packed_sequences(
             unpacked_seqlen-1]`` layout, or physical ``[1, T-1]`` layout when
             ``return_packed_layout`` is true.
     """
-    batch_size = cu_seqlens_padded.shape[0] - 1
+    batch_size = len(cu_seqlens_padded) - 1
     cp_size = 1 if cp_group is None else torch.distributed.get_world_size(cp_group)
 
     if not target_is_pre_rolled:
@@ -1281,8 +1283,8 @@ def from_parallel_logits_to_logprobs_packed_sequences(
             target.shape[0] // cp_size, dtype=target.dtype, device=target.device
         )
         for i in range(batch_size):
-            start_idx = cu_seqlens_padded[i].item()
-            end_idx = cu_seqlens_padded[i + 1].item()
+            start_idx = cu_seqlens_padded[i]
+            end_idx = cu_seqlens_padded[i + 1]
 
             seq_targets = target[start_idx:end_idx]
             rolled_seq_targets = seq_targets.roll(shifts=-1, dims=0)
@@ -1351,8 +1353,8 @@ def from_parallel_logits_to_logprobs_packed_sequences(
         # per-sequence cp_allgather
         final_probs = torch.zeros(probs.shape[0] * cp_size, device=probs.device)
         for i in range(batch_size):
-            start_idx = cu_seqlens_padded[i].item()
-            end_idx = cu_seqlens_padded[i + 1].item()
+            start_idx = cu_seqlens_padded[i]
+            end_idx = cu_seqlens_padded[i + 1]
             final_probs[start_idx:end_idx] = allgather_cp_sharded_tensor(
                 probs[start_idx // cp_size : end_idx // cp_size], cp_group, seq_dim=0
             )
@@ -1366,8 +1368,8 @@ def from_parallel_logits_to_logprobs_packed_sequences(
     )
     # Filter out the last token of each sequence
     for i in range(batch_size):
-        start_idx = cu_seqlens_padded[i].item()
-        end_idx = cu_seqlens_padded[i + 1].item()
+        start_idx = cu_seqlens_padded[i]
+        end_idx = cu_seqlens_padded[i + 1]
 
         # Exclude the last position (which has the rolled target from position 0)
         if end_idx - start_idx > 0:

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -62,6 +62,7 @@ from nemo_rl.models.automodel.data import (
     filter_multimodal_kwargs_for_model,
 )
 from nemo_rl.models.policy import PolicyConfig
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 # Union type for any post-processing function
 PostProcessingFunction = Union[
@@ -648,11 +649,14 @@ class LossPostProcessor:
         )
         # Wrap loss function for sequence packing if needed
         if self.enable_seq_packing:
+            cu_seqlens_q = to_cpu_int_tuple(
+                processed_inputs.flash_attn_kwargs.cu_seqlens_q
+            )
             loss_fn = SequencePackingLossWrapper(
                 loss_fn=self.loss_fn,
                 prepare_fn=prepare_loss_input_wrapped,
-                cu_seqlens_q=processed_inputs.flash_attn_kwargs.cu_seqlens_q,
-                cu_seqlens_q_padded=processed_inputs.flash_attn_kwargs.cu_seqlens_q,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_q_padded=cu_seqlens_q,
             )
             loss, loss_metrics = loss_fn(
                 logits,

--- a/nemo_rl/models/megatron/data.py
+++ b/nemo_rl/models/megatron/data.py
@@ -15,7 +15,7 @@
 from contextlib import nullcontext
 from dataclasses import dataclass
 from math import lcm
-from typing import Any, Iterator, Optional, Tuple
+from typing import Any, Iterator, Optional, Sequence, Tuple
 
 import torch
 from megatron.bridge.training.utils.packed_seq_utils import (
@@ -42,6 +42,7 @@ from nemo_rl.utils.r3_trace import (
     r3_trace_verify_forward_enabled,
     trace_cp_routed_experts,
 )
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 
 @dataclass
@@ -982,7 +983,7 @@ def process_global_batch(
 
 def _prepare_vlm_batch_for_megatron(
     input_ids: torch.Tensor,
-    seq_lengths: torch.Tensor,
+    seq_lengths: torch.Tensor | Sequence[int],
     pad_individual_seqs_to_multiple_of: int,
     pad_full_seq_to: Optional[int] = None,
 ) -> tuple[
@@ -1021,12 +1022,9 @@ def _prepare_vlm_batch_for_megatron(
     device = input_ids.device
     align = max(1, pad_individual_seqs_to_multiple_of)
 
-    # One CPU-GPU sync per call via .tolist(); per-seq arithmetic runs on CPU
-    # ints (fast) instead of .item() in a loop (which sync'd per seq).
-    if torch.is_tensor(seq_lengths):
-        lengths_list = seq_lengths.tolist()
-    else:
-        lengths_list = list(seq_lengths)
+    # CPU integers avoid device synchronization. Tensor callers pay at most one
+    # .tolist() transfer here instead of synchronizing once per sequence.
+    lengths_list = list(to_cpu_int_tuple(seq_lengths))
     padded_lens = [_round_up_to_multiple(L, align) for L in lengths_list]
 
     # PP>1: force sum(padded_lens) to a fixed value so every microbatch produces
@@ -1111,7 +1109,7 @@ def _prepare_vlm_batch_for_megatron(
 
 def _pack_sequences_for_megatron(
     input_ids: torch.Tensor,
-    seq_lengths: torch.Tensor,
+    seq_lengths: torch.Tensor | Sequence[int],
     pad_individual_seqs_to_multiple_of: int = 1,
     pad_packed_seq_to_multiple_of: int = 1,
     pad_packed_seq_to: Optional[int] = None,
@@ -1138,6 +1136,7 @@ def _pack_sequences_for_megatron(
         - cu_seqlens_padded: Padded cumulative sequence lengths
     """
     batch_size = input_ids.shape[0]
+    seq_lengths_cpu = to_cpu_int_tuple(seq_lengths)
 
     # Build cumulative sequence lengths (cu_seqlens) and extract valid tokens
     needs_padding = (
@@ -1158,9 +1157,7 @@ def _pack_sequences_for_megatron(
     pad_factor = pad_individual_seqs_to_multiple_of
 
     for b in range(batch_size):
-        seq_len = (
-            seq_lengths[b].item() if torch.is_tensor(seq_lengths[b]) else seq_lengths[b]
-        )
+        seq_len = seq_lengths_cpu[b]
 
         # Extract valid tokens for this sequence
         valid_tokens.append(input_ids[b, :seq_len])
@@ -1203,11 +1200,7 @@ def _pack_sequences_for_megatron(
         all_input_ids = []
         padded_tokens = []
         for b in range(batch_size):
-            seq_len = (
-                seq_lengths[b].item()
-                if torch.is_tensor(seq_lengths[b])
-                else seq_lengths[b]
-            )
+            seq_len = seq_lengths_cpu[b]
             # if last element, pad to the max sequence length
             if b == batch_size - 1 and needs_padding:
                 if pad_packed_seq_to is not None:
@@ -1489,9 +1482,9 @@ def _get_pack_sequence_parameters_for_megatron(
 
 def _unpack_sequences_from_megatron(
     output_tensor: torch.Tensor,
-    seq_lengths: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    cu_seqlens_padded: Optional[torch.Tensor],
+    seq_lengths: torch.Tensor | Sequence[int],
+    cu_seqlens: torch.Tensor | Sequence[int],
+    cu_seqlens_padded: Optional[torch.Tensor | Sequence[int]],
     original_batch_size: int,
     original_seq_length: int,
 ) -> torch.Tensor:
@@ -1510,6 +1503,11 @@ def _unpack_sequences_from_megatron(
     """
     # Remove the batch dimension to get [T, vocab_size]
     output_tensor = output_tensor.squeeze(0)
+    seq_lengths_cpu = to_cpu_int_tuple(seq_lengths)
+    cu_seqlens_cpu = to_cpu_int_tuple(cu_seqlens)
+    cu_seqlens_padded_cpu = (
+        to_cpu_int_tuple(cu_seqlens_padded) if cu_seqlens_padded is not None else None
+    )
 
     # Create a padded output tensor with original shape
     vocab_size = output_tensor.shape[-1]
@@ -1525,16 +1523,14 @@ def _unpack_sequences_from_megatron(
     # Fill in the unpacked output tensor with valid tokens
     for b in range(original_batch_size):
         # Get actual sequence length for this sample
-        seq_len = (
-            seq_lengths[b].item() if torch.is_tensor(seq_lengths[b]) else seq_lengths[b]
-        )
+        seq_len = seq_lengths_cpu[b]
 
-        if cp_size > 1 and cu_seqlens_padded is not None:
+        if cp_size > 1 and cu_seqlens_padded_cpu is not None:
             # When using CP, we need to account for padding
             # Calculate the padded sequence boundaries
             pad_factor = cp_size * 2
             padded_seq_len = ((seq_len + pad_factor - 1) // pad_factor) * pad_factor
-            start_idx = cu_seqlens_padded[b].item()
+            start_idx = cu_seqlens_padded_cpu[b]
 
             # Only copy the valid tokens (not the padding)
             unpacked_output[b, :seq_len] = output_tensor[
@@ -1542,8 +1538,8 @@ def _unpack_sequences_from_megatron(
             ]
         else:
             # No CP, use regular cu_seqlens
-            start_idx = cu_seqlens[b].item()
-            end_idx = cu_seqlens[b + 1].item()
+            start_idx = cu_seqlens_cpu[b]
+            end_idx = cu_seqlens_cpu[b + 1]
 
             # Copy the valid tokens to the unpacked tensor
             unpacked_output[b, :seq_len] = output_tensor[start_idx:end_idx]

--- a/nemo_rl/models/megatron/data.py
+++ b/nemo_rl/models/megatron/data.py
@@ -42,7 +42,15 @@ from nemo_rl.utils.r3_trace import (
     r3_trace_verify_forward_enabled,
     trace_cp_routed_experts,
 )
-from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
+from nemo_rl.utils.sequence_lengths import CpuIntTuple, to_cpu_int_tuple
+
+
+@dataclass(frozen=True)
+class PackedSequenceMetadata:
+    """CPU sequence boundaries retained for loss post-processing."""
+
+    cu_seqlens: tuple[int, ...]
+    cu_seqlens_padded: tuple[int, ...]
 
 
 @dataclass
@@ -61,6 +69,7 @@ class ProcessedInputs:
     routed_experts_cp_sharded: Optional[torch.Tensor] = None
     original_seq_length: Optional[int] = None
     media_token_validity_mask: Optional[torch.Tensor] = None
+    packed_sequence_metadata: Optional[PackedSequenceMetadata] = None
 
 
 @dataclass
@@ -87,6 +96,8 @@ class ProcessedMicrobatch:
         media_token_validity_mask: Which media-token positions actually anchor a
             projected feature, in the model's own token layout. None when the
             batch needs no correction and the model should derive its own.
+        packed_sequence_metadata: CPU cumulative boundaries retained so loss
+            post-processing does not read CUDA scalars after the model forward.
     """
 
     data_dict: BatchedDataDict[Any]
@@ -102,6 +113,43 @@ class ProcessedMicrobatch:
     routed_experts_cp_sharded: Optional[torch.Tensor] = None
     original_seq_length: Optional[int] = None
     media_token_validity_mask: Optional[torch.Tensor] = None
+    packed_sequence_metadata: Optional[PackedSequenceMetadata] = None
+
+
+def _build_packed_sequence_metadata(
+    seq_lengths: CpuIntTuple,
+    *,
+    pad_individual_seqs_to_multiple_of: int,
+    pad_packed_seq_to_multiple_of: int,
+    pad_full_seq_to: Optional[int],
+    use_padded_boundaries_for_unpadded: bool = False,
+) -> PackedSequenceMetadata:
+    """Build the CPU cumulative boundaries used by packed loss preparation."""
+
+    def _cumulative(lengths: CpuIntTuple) -> tuple[int, ...]:
+        values = [0]
+        for length in lengths:
+            values.append(values[-1] + length)
+        return tuple(values)
+
+    unpadded = _cumulative(seq_lengths)
+    padded_lengths = [
+        _round_up_to_multiple(length, pad_individual_seqs_to_multiple_of)
+        for length in seq_lengths
+    ]
+    padded = list(_cumulative(padded_lengths))
+    if padded:
+        if pad_full_seq_to is not None:
+            padded[-1] = pad_full_seq_to
+        elif pad_packed_seq_to_multiple_of > 1:
+            padded[-1] = _round_up_to_multiple(
+                padded[-1], pad_packed_seq_to_multiple_of
+            )
+    padded_tuple = tuple(padded)
+    return PackedSequenceMetadata(
+        cu_seqlens=(padded_tuple if use_padded_boundaries_for_unpadded else unpadded),
+        cu_seqlens_padded=padded_tuple,
+    )
 
 
 def make_processed_microbatch_iterator(
@@ -141,6 +189,11 @@ def make_processed_microbatch_iterator(
     pack_sequences = cfg["sequence_packing"]["enabled"]
 
     for data_dict in raw_iterator:
+        seq_lengths_cpu = None
+        if pack_sequences:
+            assert seq_length_key is not None
+            seq_lengths_cpu = to_cpu_int_tuple(data_dict[seq_length_key])
+
         # Move to GPU
         data_dict = data_dict.to("cuda")
 
@@ -158,6 +211,7 @@ def make_processed_microbatch_iterator(
             straggler_timer=straggler_timer,
             create_packed_seq_padding_mask=create_packed_seq_padding_mask,
             prepad_packed_seq_for_hybridep=prepad_packed_seq_for_hybridep,
+            seq_lengths_cpu=seq_lengths_cpu,
         )
 
         yield ProcessedMicrobatch(
@@ -174,6 +228,7 @@ def make_processed_microbatch_iterator(
             routed_experts_cp_sharded=processed_inputs.routed_experts_cp_sharded,
             original_seq_length=processed_inputs.original_seq_length,
             media_token_validity_mask=processed_inputs.media_token_validity_mask,
+            packed_sequence_metadata=processed_inputs.packed_sequence_metadata,
         )
 
 
@@ -364,6 +419,7 @@ def process_microbatch(
     straggler_timer: Optional[StragglerDetector] = None,
     create_packed_seq_padding_mask: bool = False,
     prepad_packed_seq_for_hybridep: bool = False,
+    seq_lengths_cpu: Optional[CpuIntTuple] = None,
 ) -> ProcessedInputs:
     """Process a microbatch for Megatron model forward pass."""
     if create_packed_seq_padding_mask and model_slices_context_parallel_inputs:
@@ -403,6 +459,7 @@ def process_microbatch(
         mtp_loss_mask = None
         padding_mask = None
         media_token_validity_mask = None
+        packed_sequence_metadata = None
 
         if pack_sequences:
             # For packed sequences with padded input, we need sequence lengths
@@ -415,6 +472,8 @@ def process_microbatch(
 
             # Get sequence lengths and context parallel size
             seq_lengths = data_dict[seq_length_key]
+            if seq_lengths_cpu is None:
+                seq_lengths_cpu = to_cpu_int_tuple(seq_lengths)
 
             if delegate_pack_to_model:
                 has_mtp_loss_mask = "mtp_loss_mask" in data_dict
@@ -457,9 +516,16 @@ def process_microbatch(
                     cu_seqlens_padded,
                 ) = _prepare_vlm_batch_for_megatron(
                     input_ids,
-                    seq_lengths,
+                    seq_lengths_cpu,
                     pad_individual_seqs_to_multiple_of,
                     pad_full_seq_to=pad_full_seq_to,
+                )
+                packed_sequence_metadata = _build_packed_sequence_metadata(
+                    seq_lengths_cpu,
+                    pad_individual_seqs_to_multiple_of=pad_individual_seqs_to_multiple_of,
+                    pad_packed_seq_to_multiple_of=1,
+                    pad_full_seq_to=pad_full_seq_to,
+                    use_padded_boundaries_for_unpadded=True,
                 )
                 if has_mtp_loss_mask:
                     source_mtp_loss_mask = data_dict["mtp_loss_mask"]
@@ -497,12 +563,24 @@ def process_microbatch(
                     cu_seqlens_padded,
                 ) = _pack_sequences_for_megatron(
                     input_ids,
-                    seq_lengths,
+                    seq_lengths_cpu,
                     pad_individual_seqs_to_multiple_of,
                     pad_packed_seq_to_multiple_of,
                     pad_full_seq_to,
                     cp_rank=get_context_parallel_rank(),
                     cp_size=get_context_parallel_world_size(),
+                )
+                packed_sequence_metadata = _build_packed_sequence_metadata(
+                    seq_lengths_cpu,
+                    pad_individual_seqs_to_multiple_of=pad_individual_seqs_to_multiple_of,
+                    pad_packed_seq_to_multiple_of=pad_packed_seq_to_multiple_of,
+                    pad_full_seq_to=pad_full_seq_to,
+                    # The default Megatron packer exposes padded boundaries as
+                    # cu_seqlens_q. Models that slice CP themselves replace
+                    # that field with the true, unpadded boundaries below.
+                    use_padded_boundaries_for_unpadded=(
+                        not model_slices_context_parallel_inputs
+                    ),
                 )
                 if model_slices_context_parallel_inputs:
                     packed_seq_params = PackedSeqParams(
@@ -535,6 +613,7 @@ def process_microbatch(
                     input_ids_cp_sharded = local_input_ids
                 if create_packed_seq_padding_mask:
                     if prepad_packed_seq_for_hybridep:
+                        original_cu_seqlens_padded = cu_seqlens_padded
                         (
                             input_ids,
                             input_ids_cp_sharded,
@@ -549,6 +628,16 @@ def process_microbatch(
                             cp_rank=get_context_parallel_rank(),
                             cp_size=get_context_parallel_world_size(),
                         )
+                        if cu_seqlens_padded is not original_cu_seqlens_padded:
+                            assert packed_sequence_metadata is not None
+                            final_boundaries = (
+                                *packed_sequence_metadata.cu_seqlens_padded[:-1],
+                                input_ids.shape[1],
+                            )
+                            packed_sequence_metadata = PackedSequenceMetadata(
+                                cu_seqlens=final_boundaries,
+                                cu_seqlens_padded=final_boundaries,
+                            )
                     full_padding_mask = get_packed_seq_padding_mask(
                         cu_seqlens=cu_seqlens,
                         cu_seqlens_padded=cu_seqlens_padded,
@@ -652,7 +741,7 @@ def process_microbatch(
                         _,
                     ) = _pack_sequences_for_megatron(
                         data_dict["mtp_loss_mask"],
-                        seq_lengths,
+                        seq_lengths_cpu,
                         pad_individual_seqs_to_multiple_of,
                         pad_packed_seq_to_multiple_of,
                         pad_full_seq_to,
@@ -691,7 +780,7 @@ def process_microbatch(
                         data_dict["media_token_validity_mask"].to(
                             data_dict["input_ids"].dtype
                         ),
-                        seq_lengths,
+                        seq_lengths_cpu,
                         pad_individual_seqs_to_multiple_of,
                         pad_packed_seq_to_multiple_of,
                         pad_full_seq_to,
@@ -775,6 +864,7 @@ def process_microbatch(
         routed_experts_cp_sharded=routed_experts_cp_sharded,
         original_seq_length=original_seq_length,
         media_token_validity_mask=media_token_validity_mask,
+        packed_sequence_metadata=packed_sequence_metadata,
     )
 
 
@@ -1022,8 +1112,8 @@ def _prepare_vlm_batch_for_megatron(
     device = input_ids.device
     align = max(1, pad_individual_seqs_to_multiple_of)
 
-    # One CPU-GPU sync per call via .tolist(); per-seq arithmetic runs on CPU
-    # ints (fast) instead of .item() in a loop (which sync'd per seq).
+    # The production iterator supplies CPU integers captured before H2D. Direct
+    # callers with a tensor pay at most one .tolist() transfer here.
     lengths_list = list(to_cpu_int_tuple(seq_lengths))
     padded_lens = [_round_up_to_multiple(L, align) for L in lengths_list]
 

--- a/nemo_rl/models/megatron/data.py
+++ b/nemo_rl/models/megatron/data.py
@@ -1022,8 +1022,8 @@ def _prepare_vlm_batch_for_megatron(
     device = input_ids.device
     align = max(1, pad_individual_seqs_to_multiple_of)
 
-    # CPU integers avoid device synchronization. Tensor callers pay at most one
-    # .tolist() transfer here instead of synchronizing once per sequence.
+    # One CPU-GPU sync per call via .tolist(); per-seq arithmetic runs on CPU
+    # ints (fast) instead of .item() in a loop (which sync'd per seq).
     lengths_list = list(to_cpu_int_tuple(seq_lengths))
     padded_lens = [_round_up_to_multiple(L, align) for L in lengths_list]
 

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -60,7 +60,7 @@ from nemo_rl.distributed.model_utils import (
     from_parallel_logits_to_logprobs_packed_sequences,
 )
 from nemo_rl.models.megatron.config import MegatronModule
-from nemo_rl.models.megatron.data import ProcessedMicrobatch
+from nemo_rl.models.megatron.data import PackedSequenceMetadata, ProcessedMicrobatch
 from nemo_rl.models.megatron.draft.hidden_capture import (
     get_capture_context,
 )
@@ -305,6 +305,7 @@ def forward_with_post_processing_fn(
     routed_experts_cp_sharded = processed_mb.routed_experts_cp_sharded
     original_seq_length = processed_mb.original_seq_length
     media_token_validity_mask = processed_mb.media_token_validity_mask
+    packed_sequence_metadata = processed_mb.packed_sequence_metadata
 
     if use_router_replay:
         if routed_experts_cp_sharded is None:
@@ -396,6 +397,7 @@ def forward_with_post_processing_fn(
         post_processing_fn_wrapped = post_processing_fn(
             data_dict=data_dict,
             packed_seq_params=packed_seq_params,
+            packed_sequence_metadata=packed_sequence_metadata,
             global_valid_seqs=global_valid_seqs,
             global_valid_toks=global_valid_toks,
         )
@@ -404,7 +406,11 @@ def forward_with_post_processing_fn(
         post_processing_fn_wrapped = post_processing_fn(
             data_dict=data_dict,
             input_ids=input_ids,
-            cu_seqlens_padded=cu_seqlens_padded,
+            cu_seqlens_padded=(
+                packed_sequence_metadata.cu_seqlens_padded
+                if packed_sequence_metadata is not None
+                else cu_seqlens_padded
+            ),
             original_seq_length=original_seq_length,
         )
     elif isinstance(post_processing_fn, TopkLogitsPostProcessor):
@@ -542,6 +548,7 @@ class LossPostProcessor:
         self,
         data_dict: BatchedDataDict[Any],
         packed_seq_params: Optional[PackedSeqParams] = None,
+        packed_sequence_metadata: Optional[PackedSequenceMetadata] = None,
         global_valid_seqs: Optional[torch.Tensor] = None,
         global_valid_toks: Optional[torch.Tensor] = None,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, Any]]]:
@@ -554,6 +561,8 @@ class LossPostProcessor:
         Args:
             data_dict: Batched data dictionary for the current microbatch
             packed_seq_params: Parameters for packed sequences (optional)
+            packed_sequence_metadata: CPU cumulative sequence boundaries retained
+                during input packing.
             global_valid_seqs: Global valid sequence count for loss normalization
             global_valid_toks: Global valid token count for loss normalization
 
@@ -586,11 +595,19 @@ class LossPostProcessor:
                     "Disable fuse_loss for the value model."
                 )
 
-            cu_seqlens_q = to_cpu_int_tuple(packed_seq_params.cu_seqlens_q)
-            padded_boundaries = (
-                packed_seq_params.cu_seqlens_q_padded
-                if packed_seq_params.cu_seqlens_q_padded is not None
+            cu_seqlens_q = to_cpu_int_tuple(
+                packed_sequence_metadata.cu_seqlens
+                if packed_sequence_metadata is not None
                 else packed_seq_params.cu_seqlens_q
+            )
+            padded_boundaries = (
+                packed_sequence_metadata.cu_seqlens_padded
+                if packed_sequence_metadata is not None
+                else (
+                    packed_seq_params.cu_seqlens_q_padded
+                    if packed_seq_params.cu_seqlens_q_padded is not None
+                    else packed_seq_params.cu_seqlens_q
+                )
             )
             cu_seqlens_q_padded = to_cpu_int_tuple(padded_boundaries)
             if fuse_loss:

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -70,6 +70,7 @@ from nemo_rl.models.megatron.router_replay import (
     set_router_replay_forward,
 )
 from nemo_rl.models.policy import PolicyConfig
+from nemo_rl.utils.sequence_lengths import CpuIntTuple, to_cpu_int_tuple
 
 # Union type for any post-processing function (defined after classes below)
 PostProcessingFunction = Union[
@@ -574,6 +575,13 @@ class LossPostProcessor:
         # wrap loss function with loss input preparation
         pack_sequences = self.cfg["sequence_packing"]["enabled"]
         if pack_sequences and packed_seq_params is not None:
+            cu_seqlens_q = to_cpu_int_tuple(packed_seq_params.cu_seqlens_q)
+            padded_boundaries = (
+                packed_seq_params.cu_seqlens_q_padded
+                if packed_seq_params.cu_seqlens_q_padded is not None
+                else packed_seq_params.cu_seqlens_q
+            )
+            cu_seqlens_q_padded = to_cpu_int_tuple(padded_boundaries)
             fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
             if fuse_loss:
                 # The fused path prepares loss via prepare_packed_loss_input and
@@ -597,8 +605,8 @@ class LossPostProcessor:
             loss_fn_wrapped = wrapper_cls(
                 loss_fn=self.loss_fn,
                 prepare_fn=prepare_fn,
-                cu_seqlens_q=packed_seq_params.cu_seqlens_q,
-                cu_seqlens_q_padded=packed_seq_params.cu_seqlens_q_padded,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_q_padded=cu_seqlens_q_padded,
                 vocab_parallel_rank=get_tensor_model_parallel_rank(),
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
@@ -690,7 +698,7 @@ class LogprobsPostProcessor:
         self,
         data_dict: BatchedDataDict[Any],
         input_ids: torch.Tensor,
-        cu_seqlens_padded: torch.Tensor,
+        cu_seqlens_padded: Optional[torch.Tensor | CpuIntTuple],
         original_seq_length: int,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         """Create a post-processing function that computes token log probabilities.
@@ -708,19 +716,24 @@ class LogprobsPostProcessor:
             Callable: Function that takes output tensor and returns (dummy_loss, {"logprobs": token_logprobs})
         """
         unpacked_input_ids = data_dict["input_ids"]
+        cu_seqlens_padded_cpu = None
+        if self.cfg["sequence_packing"]["enabled"]:
+            assert cu_seqlens_padded is not None
+            cu_seqlens_padded_cpu = to_cpu_int_tuple(cu_seqlens_padded)
 
         def processor_fn_inner(output_tensor):
             if self.use_fused_linear_logprobs:
                 token_logprobs = output_tensor.to(torch.float32)
                 token_logprobs = token_logprobs[:, : original_seq_length - 1]
             elif self.cfg["sequence_packing"]["enabled"]:
+                assert cu_seqlens_padded_cpu is not None
                 tp_grp = get_tensor_model_parallel_group()
                 tp_rank = get_tensor_model_parallel_rank()
                 logprob_chunk_size = self.cfg.get("logprob_chunk_size", None)
                 token_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
                     output_tensor,
                     target=input_ids,
-                    cu_seqlens_padded=cu_seqlens_padded,
+                    cu_seqlens_padded=cu_seqlens_padded_cpu,
                     unpacked_seqlen=original_seq_length,
                     vocab_start_index=tp_rank * output_tensor.shape[-1],
                     vocab_end_index=(tp_rank + 1) * output_tensor.shape[-1],

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -575,6 +575,17 @@ class LossPostProcessor:
         # wrap loss function with loss input preparation
         pack_sequences = self.cfg["sequence_packing"]["enabled"]
         if pack_sequences and packed_seq_params is not None:
+            fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
+            if fuse_loss:
+                # The fused path prepares loss via prepare_packed_loss_input and
+                # cannot honor a custom prepare_fn (e.g. the value model's); guard
+                # before reading packed metadata so misconfiguration fails clearly.
+                assert self.prepare_fn is None, (
+                    "sequence_packing.fuse_loss=true does not support a custom "
+                    "prepare_fn (e.g. the value model's value-specific prep). "
+                    "Disable fuse_loss for the value model."
+                )
+
             cu_seqlens_q = to_cpu_int_tuple(packed_seq_params.cu_seqlens_q)
             padded_boundaries = (
                 packed_seq_params.cu_seqlens_q_padded
@@ -582,16 +593,7 @@ class LossPostProcessor:
                 else packed_seq_params.cu_seqlens_q
             )
             cu_seqlens_q_padded = to_cpu_int_tuple(padded_boundaries)
-            fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
             if fuse_loss:
-                # The fused path prepares loss via prepare_packed_loss_input and
-                # cannot honor a custom prepare_fn (e.g. the value model's); guard
-                # rather than silently bypass it.
-                assert self.prepare_fn is None, (
-                    "sequence_packing.fuse_loss=true does not support a custom "
-                    "prepare_fn (e.g. the value model's value-specific prep). "
-                    "Disable fuse_loss for the value model."
-                )
                 wrapper_cls = SequencePackingFusionLossWrapper
                 prepare_fn = partial(
                     prepare_packed_loss_input,

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -104,6 +104,7 @@ from nemo_rl.utils.native_checkpoint import (
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.packed_tensor import packed_broadcast_producer
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 from nemo_rl.utils.timer import Timer
 
 
@@ -917,11 +918,14 @@ class DTensorPolicyWorkerImpl(
                         )
                         # Wrap loss function for sequence packing if needed
                         if self.enable_seq_packing:
+                            cu_seqlens_q = to_cpu_int_tuple(
+                                flash_attn_kwargs.cu_seqlens_q
+                            )
                             loss_fn_ = SequencePackingLossWrapper(
                                 loss_fn=loss_fn,
                                 prepare_fn=prepare_loss_input_wrapped,
-                                cu_seqlens_q=flash_attn_kwargs.cu_seqlens_q,
-                                cu_seqlens_q_padded=flash_attn_kwargs.cu_seqlens_q,
+                                cu_seqlens_q=cu_seqlens_q,
+                                cu_seqlens_q_padded=cu_seqlens_q,
                             )
                             loss, loss_metrics = loss_fn_(
                                 logits,

--- a/nemo_rl/utils/sequence_lengths.py
+++ b/nemo_rl/utils/sequence_lengths.py
@@ -16,7 +16,6 @@ from collections.abc import Sequence
 
 import torch
 
-
 CpuIntTuple = tuple[int, ...]
 
 

--- a/nemo_rl/utils/sequence_lengths.py
+++ b/nemo_rl/utils/sequence_lengths.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sequence
+
+import torch
+
+
+CpuIntTuple = tuple[int, ...]
+
+
+def to_cpu_int_tuple(values: torch.Tensor | Sequence[int]) -> CpuIntTuple:
+    """Normalize sequence metadata at the host/device API boundary.
+
+    A CUDA tensor incurs one synchronization here. Callers should therefore
+    invoke this before the model forward whenever the original CPU values are
+    available. Code below this boundary accepts only :class:`CpuIntTuple`.
+    """
+    if torch.is_tensor(values):
+        return tuple(int(value) for value in values.tolist())
+    return tuple(int(value) for value in values)

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -285,6 +285,7 @@ project-includes = [
   "nemo_rl/utils/prefetch_venvs.py",
   "nemo_rl/utils/r3_trace.py",
   "nemo_rl/utils/routed_experts_codec.py",
+  "nemo_rl/utils/sequence_lengths.py",
   "nemo_rl/utils/timer.py",
   "nemo_rl/utils/venvs.py",
   "nemo_rl/utils/weight_transfer_http.py",

--- a/tests/unit/algorithms/sequence_packing_gradient_actor.py
+++ b/tests/unit/algorithms/sequence_packing_gradient_actor.py
@@ -30,6 +30,7 @@ from nemo_rl.algorithms.loss import (
 )
 from nemo_rl.algorithms.loss.utils import prepare_loss_input
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 
 @ray.remote(num_gpus=1)
@@ -180,7 +181,7 @@ class SequencePackingGradientTestActor:
             cu_seqlens_padded,
         ) = _pack_sequences_for_megatron(
             input_ids,
-            seq_lengths,
+            to_cpu_int_tuple(seq_lengths),
             pad_individual_seqs_to_multiple_of=pad_to_multiple,
             pad_packed_seq_to=max_seq_len * batch_size if cp_size > 1 else None,
             cp_rank=rank,
@@ -216,8 +217,8 @@ class SequencePackingGradientTestActor:
         wrapper = SequencePackingLossWrapper(
             loss_fn=base_loss_fn,
             prepare_fn=prepare_loss_input,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_q=to_cpu_int_tuple(cu_seqlens),
+            cu_seqlens_q_padded=to_cpu_int_tuple(cu_seqlens_padded),
             vocab_parallel_rank=0,
             vocab_parallel_group=tp_group,
             context_parallel_group=cp_group,

--- a/tests/unit/algorithms/test_sequence_packing_fusion.py
+++ b/tests/unit/algorithms/test_sequence_packing_fusion.py
@@ -38,6 +38,7 @@ from nemo_rl.algorithms.loss import (
 )
 from nemo_rl.algorithms.loss.interfaces import LossInputType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 
 def test_prepare_packed_loss_input_preserves_prepacked_layout(monkeypatch):
@@ -178,7 +179,7 @@ def _build_test_case(cp_size, tp_size, my_tp_rank, cp_group):
         cu_seqlens_padded,
     ) = _pack_sequences_for_megatron(
         input_ids,
-        seq_lengths,
+        to_cpu_int_tuple(seq_lengths),
         pad_individual_seqs_to_multiple_of=pad_to_multiple,
         pad_packed_seq_to=max_seq_len * batch_size if cp_size > 1 else None,
         cp_rank=torch.distributed.get_rank(cp_group),
@@ -257,8 +258,8 @@ def _run_compare_sequence_packing_wrappers(rank, world_size, cp_size, tp_size):
     baseline_wrapper = SequencePackingLossWrapper(
         loss_fn=base_loss_fn,
         prepare_fn=prepare_loss_input,
-        cu_seqlens_q=tc["cu_seqlens"],
-        cu_seqlens_q_padded=tc["cu_seqlens_padded"],
+        cu_seqlens_q=to_cpu_int_tuple(tc["cu_seqlens"]),
+        cu_seqlens_q_padded=to_cpu_int_tuple(tc["cu_seqlens_padded"]),
         vocab_parallel_rank=my_tp_rank,
         vocab_parallel_group=tp_group,
         context_parallel_group=cp_group,
@@ -267,8 +268,8 @@ def _run_compare_sequence_packing_wrappers(rank, world_size, cp_size, tp_size):
     candidate_wrapper = SequencePackingFusionLossWrapper(
         loss_fn=base_loss_fn,
         prepare_fn=prepare_packed_loss_input,
-        cu_seqlens_q=tc["cu_seqlens"],
-        cu_seqlens_q_padded=tc["cu_seqlens_padded"],
+        cu_seqlens_q=to_cpu_int_tuple(tc["cu_seqlens"]),
+        cu_seqlens_q_padded=to_cpu_int_tuple(tc["cu_seqlens_padded"]),
         vocab_parallel_rank=my_tp_rank,
         vocab_parallel_group=tp_group,
         context_parallel_group=cp_group,
@@ -341,8 +342,8 @@ def _run_compare_sequence_packing_wrappers_with_sampling(
     baseline_wrapper = SequencePackingLossWrapper(
         loss_fn=base_loss_fn,
         prepare_fn=prepare_loss_input_wrapped,
-        cu_seqlens_q=tc["cu_seqlens"],
-        cu_seqlens_q_padded=tc["cu_seqlens_padded"],
+        cu_seqlens_q=to_cpu_int_tuple(tc["cu_seqlens"]),
+        cu_seqlens_q_padded=to_cpu_int_tuple(tc["cu_seqlens_padded"]),
         vocab_parallel_rank=my_tp_rank,
         vocab_parallel_group=tp_group,
         context_parallel_group=cp_group,
@@ -351,8 +352,8 @@ def _run_compare_sequence_packing_wrappers_with_sampling(
     candidate_wrapper = SequencePackingFusionLossWrapper(
         loss_fn=base_loss_fn,
         prepare_fn=prepare_packed_loss_input_wrapped,
-        cu_seqlens_q=tc["cu_seqlens"],
-        cu_seqlens_q_padded=tc["cu_seqlens_padded"],
+        cu_seqlens_q=to_cpu_int_tuple(tc["cu_seqlens"]),
+        cu_seqlens_q_padded=to_cpu_int_tuple(tc["cu_seqlens_padded"]),
         vocab_parallel_rank=my_tp_rank,
         vocab_parallel_group=tp_group,
         context_parallel_group=cp_group,
@@ -501,7 +502,7 @@ def test_pack_input_ids_last_seq_inflated_beyond_row_width():
     row_width = 7040
     inflated_len = 9472  # 7040 real tokens + 2432 bin-fill deficit
     input_ids = torch.arange(2 * row_width).reshape(2, row_width)
-    cu = torch.tensor([0, row_width, row_width + inflated_len])
+    cu = (0, row_width, row_width + inflated_len)
 
     packed = _pack_input_ids(input_ids, cu, cu, cp_rank=0, cp_size=1, roll_shift=-1)
 
@@ -522,7 +523,7 @@ def test_pack_input_ids_inflated_last_seq_cp_sharded(cp_size):
     row_width = 64
     inflated_len = 96  # deficit of 32 absorbed into the last sequence
     input_ids = torch.arange(1, 2 * row_width + 1).reshape(2, row_width)
-    cu = torch.tensor([0, row_width, row_width + inflated_len])
+    cu = (0, row_width, row_width + inflated_len)
     total = row_width + inflated_len
 
     shards = [
@@ -553,8 +554,8 @@ def test_pack_input_ids_in_bounds_lengths_unchanged():
     from nemo_rl.algorithms.loss.utils import _pack_input_ids
 
     input_ids = torch.arange(2 * 64).reshape(2, 64)
-    cu_q = torch.tensor([0, 40, 40 + 64])  # real lengths 40, 64
-    cu_qp = torch.tensor([0, 48, 48 + 64])  # per-seq alignment padding only
+    cu_q = (0, 40, 40 + 64)  # real lengths 40, 64
+    cu_qp = (0, 48, 48 + 64)  # per-seq alignment padding only
 
     packed = _pack_input_ids(input_ids, cu_q, cu_qp, cp_rank=0, cp_size=1, roll_shift=0)
 
@@ -562,3 +563,18 @@ def test_pack_input_ids_in_bounds_lengths_unchanged():
     assert torch.equal(packed[0, :40], input_ids[0, :40])
     assert packed[0, 40:48].eq(0).all()
     assert torch.equal(packed[0, 48:], input_ids[1])
+
+
+def test_pack_input_ids_with_cpu_boundaries():
+    """CPU cumulative boundaries produce the expected packed targets."""
+    from nemo_rl.algorithms.loss.utils import _pack_input_ids
+
+    input_ids = torch.arange(2 * 16).reshape(2, 16)
+    cu_q = (0, 11, 27)
+    cu_qp = (0, 16, 32)
+
+    actual = _pack_input_ids(
+        input_ids, cu_q, cu_qp, cp_rank=0, cp_size=1, roll_shift=-1
+    )
+    assert actual.shape == (1, 32)
+    assert torch.equal(actual[0, :10], input_ids[0, 1:11])

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -41,6 +41,7 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 
 def test_compute_distributed_selected_logprobs(monkeypatch):
@@ -236,7 +237,7 @@ class ModelUtilsTestActor:
         actual_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
             packed_logits,
             packed_target_ids,
-            cu_seqlens,
+            to_cpu_int_tuple(cu_seqlens),
             seq_len,  # unpacked_seqlen
             vocab_start_index,
             vocab_end_index,
@@ -403,6 +404,8 @@ def _run_packed_sequences_equivalence(rank, world_size, tp_size, cp_size, chunk_
         cu_seqlens_padded[i + 1] = cu_seqlens_padded[i] + padded_seq_lengths[i]
 
     total_padded = int(cu_seqlens_padded[-1].item())
+    cu_seqlens_cpu = to_cpu_int_tuple(cu_seqlens)
+    cu_seqlens_padded_cpu = to_cpu_int_tuple(cu_seqlens_padded)
 
     torch.manual_seed(42)
     unpacked_logits_full = torch.randn(
@@ -433,12 +436,14 @@ def _run_packed_sequences_equivalence(rank, world_size, tp_size, cp_size, chunk_
 
     # --- Path 1: target_is_pre_rolled=False ---
     # Pack raw (unrolled) input_ids to [1, T_padded] using _pack_input_ids.
-    packed_target_raw = _pack_input_ids(input_ids, cu_seqlens, cu_seqlens_padded)
+    packed_target_raw = _pack_input_ids(
+        input_ids, cu_seqlens_cpu, cu_seqlens_padded_cpu
+    )
 
     logprobs_not_pre_rolled = from_parallel_logits_to_logprobs_packed_sequences(
         packed_logits,
         packed_target_raw,
-        cu_seqlens_padded,
+        cu_seqlens_padded_cpu,
         max_seq_len,
         vocab_start_index,
         vocab_end_index,
@@ -451,8 +456,8 @@ def _run_packed_sequences_equivalence(rank, world_size, tp_size, cp_size, chunk_
     # --- Path 2: target_is_pre_rolled=True ---
     packed_target_pre_rolled = _pack_input_ids(
         input_ids,
-        cu_seqlens,
-        cu_seqlens_padded,
+        cu_seqlens_cpu,
+        cu_seqlens_padded_cpu,
         cp_rank=my_cp_rank_val,
         cp_size=cp_size,
         roll_shift=-1,
@@ -461,7 +466,7 @@ def _run_packed_sequences_equivalence(rank, world_size, tp_size, cp_size, chunk_
     logprobs_pre_rolled = from_parallel_logits_to_logprobs_packed_sequences(
         packed_logits,
         packed_target_pre_rolled,
-        cu_seqlens_padded,
+        cu_seqlens_padded_cpu,
         max_seq_len,
         vocab_start_index,
         vocab_end_index,

--- a/tests/unit/models/megatron/test_megatron_data.py
+++ b/tests/unit/models/megatron/test_megatron_data.py
@@ -79,6 +79,38 @@ class TestProcessedMicrobatchDataclass:
         assert torch.equal(microbatch.cu_seqlens_padded, mock_cu_seqlens_padded)
         assert microbatch.routed_experts is None
         assert microbatch.routed_experts_cp_sharded is None
+        assert microbatch.packed_sequence_metadata is None
+
+
+def test_build_packed_sequence_metadata_preserves_cpu_boundaries():
+    """Packed CPU metadata mirrors individual and bin-level padding."""
+    from nemo_rl.models.megatron.data import _build_packed_sequence_metadata
+
+    metadata = _build_packed_sequence_metadata(
+        (5, 9, 7),
+        pad_individual_seqs_to_multiple_of=8,
+        pad_packed_seq_to_multiple_of=32,
+        pad_full_seq_to=None,
+    )
+
+    assert metadata.cu_seqlens == (0, 5, 14, 21)
+    assert metadata.cu_seqlens_padded == (0, 8, 24, 32)
+
+
+def test_build_vlm_packed_sequence_metadata_uses_padded_boundaries():
+    """Self-packing VLM metadata matches its padded PackedSeqParams layout."""
+    from nemo_rl.models.megatron.data import _build_packed_sequence_metadata
+
+    metadata = _build_packed_sequence_metadata(
+        (5, 9),
+        pad_individual_seqs_to_multiple_of=8,
+        pad_packed_seq_to_multiple_of=1,
+        pad_full_seq_to=32,
+        use_padded_boundaries_for_unpadded=True,
+    )
+
+    assert metadata.cu_seqlens == (0, 8, 32)
+    assert metadata.cu_seqlens_padded == (0, 8, 32)
 
 
 @pytest.mark.mcore

--- a/tests/unit/models/megatron/test_megatron_data.py
+++ b/tests/unit/models/megatron/test_megatron_data.py
@@ -37,6 +37,7 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 from tests.unit.models.megatron.megatron_data_actors import (
     GetPackSequenceParametersTestActor,
     PackSequencesTestActor,
@@ -606,7 +607,7 @@ class TestProcessMicrobatch:
             cu_seqlens_padded,
         ) = _pack_sequences_for_megatron(
             input_ids,
-            seq_lengths,
+            to_cpu_int_tuple(seq_lengths),
             pad_individual_seqs_to_multiple_of=4,
             cp_size=1,
         )
@@ -1802,7 +1803,7 @@ def test_shard_routed_experts_for_cp_matches_input_ids_zigzag(cp_size):
         cu_seqlens_padded,
     ) = _pack_sequences_for_megatron(
         input_ids,
-        seq_lengths,
+        to_cpu_int_tuple(seq_lengths),
         pad_individual_seqs_to_multiple_of=pad_to_multiple,
         cp_rank=0,
         cp_size=cp_size,

--- a/tests/unit/models/megatron/test_megatron_data.py
+++ b/tests/unit/models/megatron/test_megatron_data.py
@@ -82,6 +82,7 @@ class TestProcessedMicrobatchDataclass:
         assert microbatch.packed_sequence_metadata is None
 
 
+@pytest.mark.mcore
 def test_build_packed_sequence_metadata_preserves_cpu_boundaries():
     """Packed CPU metadata mirrors individual and bin-level padding."""
     from nemo_rl.models.megatron.data import _build_packed_sequence_metadata
@@ -97,6 +98,7 @@ def test_build_packed_sequence_metadata_preserves_cpu_boundaries():
     assert metadata.cu_seqlens_padded == (0, 8, 24, 32)
 
 
+@pytest.mark.mcore
 def test_build_vlm_packed_sequence_metadata_uses_padded_boundaries():
     """Self-packing VLM metadata matches its padded PackedSeqParams layout."""
     from nemo_rl.models.megatron.data import _build_packed_sequence_metadata

--- a/tests/unit/models/megatron/test_nemotron_omni_model.py
+++ b/tests/unit/models/megatron/test_nemotron_omni_model.py
@@ -47,7 +47,6 @@ from nemo_rl.models.megatron.train import (
     LogprobsPostProcessor,
     megatron_forward_backward,
 )
-from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 pytestmark = pytest.mark.mcore
 
@@ -195,10 +194,11 @@ def _forward(model):
         pixel_values=images,
         imgs_sizes=image_sizes,
     )
+    assert processed.packed_sequence_metadata is not None
     logprobs = from_parallel_logits_to_logprobs_packed_sequences(
         output,
         target=processed.input_ids,
-        cu_seqlens_padded=to_cpu_int_tuple(processed.cu_seqlens_padded),
+        cu_seqlens_padded=processed.packed_sequence_metadata.cu_seqlens_padded,
         unpacked_seqlen=input_ids.shape[1],
         vocab_start_index=parallel_state.get_tensor_model_parallel_rank()
         * output.shape[-1],
@@ -282,10 +282,11 @@ def _forward_dedup_fixture(model, data: BatchedDataDict):
         packed_seq_params=processed.packed_seq_params,
         **multimodal_data,
     )
+    assert processed.packed_sequence_metadata is not None
     logprobs = from_parallel_logits_to_logprobs_packed_sequences(
         output,
         target=processed.input_ids,
-        cu_seqlens_padded=to_cpu_int_tuple(processed.cu_seqlens_padded),
+        cu_seqlens_padded=processed.packed_sequence_metadata.cu_seqlens_padded,
         unpacked_seqlen=input_ids.shape[1],
         vocab_start_index=0,
         vocab_end_index=output.shape[-1],

--- a/tests/unit/models/megatron/test_nemotron_omni_model.py
+++ b/tests/unit/models/megatron/test_nemotron_omni_model.py
@@ -47,6 +47,7 @@ from nemo_rl.models.megatron.train import (
     LogprobsPostProcessor,
     megatron_forward_backward,
 )
+from nemo_rl.utils.sequence_lengths import to_cpu_int_tuple
 
 pytestmark = pytest.mark.mcore
 
@@ -197,7 +198,7 @@ def _forward(model):
     logprobs = from_parallel_logits_to_logprobs_packed_sequences(
         output,
         target=processed.input_ids,
-        cu_seqlens_padded=processed.cu_seqlens_padded,
+        cu_seqlens_padded=to_cpu_int_tuple(processed.cu_seqlens_padded),
         unpacked_seqlen=input_ids.shape[1],
         vocab_start_index=parallel_state.get_tensor_model_parallel_rank()
         * output.shape[-1],
@@ -284,7 +285,7 @@ def _forward_dedup_fixture(model, data: BatchedDataDict):
     logprobs = from_parallel_logits_to_logprobs_packed_sequences(
         output,
         target=processed.input_ids,
-        cu_seqlens_padded=processed.cu_seqlens_padded,
+        cu_seqlens_padded=to_cpu_int_tuple(processed.cu_seqlens_padded),
         unpacked_seqlen=input_ids.shape[1],
         vocab_start_index=0,
         vocab_end_index=output.shape[-1],


### PR DESCRIPTION
# What does this PR do ?

Depends on #3932 . Currently contains the full diff but should only be merged after #3932 

Captures packed-sequence boundaries before the batch moves to CUDA and carries them through the Megatron forward pass. Loss and logprob post-processing can then reuse the CPU metadata without synchronizing after forward.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
