### PR TITLE
feat: fp32 LM head in vLLM and MCore + fix max-length handling

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -139,6 +139,17 @@ policy: &POLICY_BASE
         apply_rope_fusion: True
         bias_activation_fusion: True
         defer_fp32_logits: False
+        # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+        # the logits dominates generation/training logprob mismatch
+        # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+        # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+        # multiplicative error worse, because both otherwise round to the same grid.
+        # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+        # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+        fp32_lm_head: False
+        # Keep the transformer residual stream in fp32; small additional reduction in
+        # gen/train logprob mismatch on top of fp32_lm_head.
+        fp32_residual_connection: False
         moe_per_layer_logging: False
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"

--- a/examples/configs/distillation_math_megatron.yaml
+++ b/examples/configs/distillation_math_megatron.yaml
@@ -86,6 +86,17 @@ policy: &POLICY_BASE
         bias_activation_fusion: True
         moe_per_layer_logging: False
         defer_fp32_logits: False
+        # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+        # the logits dominates generation/training logprob mismatch
+        # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+        # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+        # multiplicative error worse, because both otherwise round to the same grid.
+        # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+        # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+        fp32_lm_head: False
+        # Keep the transformer residual stream in fp32; small additional reduction in
+        # gen/train logprob mismatch on top of fp32_lm_head.
+        fp32_residual_connection: False
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"
         moe_shared_expert_overlap: false

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -178,6 +178,17 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+    # the logits dominates generation/training logprob mismatch
+    # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+    # multiplicative error worse, because both otherwise round to the same grid.
+    # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+    # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+    fp32_lm_head: False
+    # Keep the transformer residual stream in fp32; small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -236,6 +236,17 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+    # the logits dominates generation/training logprob mismatch
+    # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+    # multiplicative error worse, because both otherwise round to the same grid.
+    # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+    # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+    fp32_lm_head: False
+    # Keep the transformer residual stream in fp32; small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -172,6 +172,17 @@ policy:
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
     defer_fp32_logits: False
+    # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+    # the logits dominates generation/training logprob mismatch
+    # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+    # multiplicative error worse, because both otherwise round to the same grid.
+    # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+    # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+    fp32_lm_head: False
+    # Keep the transformer residual stream in fp32; small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: False
     moe_per_layer_logging: False
 
     optimizer:
@@ -370,6 +381,17 @@ value:
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
     defer_fp32_logits: False
+    # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+    # the logits dominates generation/training logprob mismatch
+    # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+    # multiplicative error worse, because both otherwise round to the same grid.
+    # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+    # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+    fp32_lm_head: False
+    # Keep the transformer residual stream in fp32; small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: False
     moe_per_layer_logging: False
 
     optimizer:

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -164,6 +164,17 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    # Compute the LM output-layer GEMM in fp32 rather than bf16. bf16 rounding of
+    # the logits dominates generation/training logprob mismatch
+    # (train/token_mult_prob_error). Pair with NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: enabling it on only one engine makes the
+    # multiplicative error worse, because both otherwise round to the same grid.
+    # False | True (full fp32, ~2x cost on the logprob pass) | "tf32" (fp32 head
+    # on TF32 tensor cores: numerically identical here, ~baseline speed; preferred).
+    fp32_lm_head: False
+    # Keep the transformer residual stream in fp32; small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -566,6 +566,83 @@ def _patch_vllm_radio_layerscale_loader(logger) -> None:
     logger.info("Successfully patched vLLM RADIO LayerScale loading.")
 
 
+def _patch_vllm_nemotron_h_fp32_lm_head(logger) -> None:
+    """Compute NemotronH logits with an fp32 LM head (MiniMax-M1-style).
+
+    bf16 rounding of the logits GEMM output is the dominant contributor to
+    generation/training logprob mismatch (train/token_mult_prob_error). With
+    this patch the sampled-token logprobs come from fp32 logits, matching a
+    trainer that enables megatron_cfg.fp32_lm_head.
+
+    This must be a source patch (not a monkeypatch): the model executes in
+    vLLM's EngineCore worker subprocesses, which import vllm independently of
+    this process. The patched code is opt-in at runtime via
+    NRL_VLLM_FP32_LM_HEAD=1 (set it through policy.generation.vllm_cfg.env_vars
+    so worker processes inherit it). Costs one fp32 copy of the vocab-sharded
+    head weight per rank.
+    """
+    try:
+        file_to_patch = _get_vllm_file("model_executor/models/nemotron_h.py")
+    except RuntimeError:
+        logger.warning("Could not locate nemotron_h.py for the fp32 LM head patch.")
+        return
+
+    old_snippet = """        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits"""
+    new_snippet = """        import os as _os
+
+        if _os.environ.get("NRL_VLLM_FP32_LM_HEAD", "0") == "1":
+            # NeMo-RL patch: fp32 LM head (MiniMax-M1-style). bf16 rounding of
+            # the logits is the dominant gen/train logprob mismatch source.
+            _fp32_head = getattr(self, "_nrl_lm_head_fp32", None)
+            if _fp32_head is None and not torch.cuda.is_current_stream_capturing():
+                # Skipped under graph capture: an allocation there lives in the
+                # graph's memory pool and is not valid for later eager replays.
+                # Capture output is discarded anyway, so bf16 is fine for it.
+                import copy as _copy
+
+                _fp32_head = _copy.deepcopy(self.lm_head).float()
+                # object.__setattr__ bypasses nn.Module.__setattr__: registering
+                # this as a submodule would add a vocab-sized parameter to
+                # named_parameters(), which the refit weight mapping is built from.
+                object.__setattr__(self, "_nrl_lm_head_fp32", _fp32_head)
+                self._nrl_lm_head_fp32_dirty = False
+                print(
+                    "[fp32_lm_head] built fp32 head in forward shape=%s"
+                    % (tuple(_fp32_head.weight.shape),),
+                    flush=True,
+                )
+            elif _fp32_head is not None and getattr(
+                self, "_nrl_lm_head_fp32_dirty", False
+            ):
+                # Refreshed in place: replacing the module would leave any
+                # captured CUDA graph pointing at the old storage.
+                _fp32_head.weight.data.copy_(self.lm_head.weight)
+                if getattr(_fp32_head, "bias", None) is not None:
+                    _fp32_head.bias.data.copy_(self.lm_head.bias)
+                self._nrl_lm_head_fp32_dirty = False
+                print("[fp32_lm_head] refreshed cached head in forward", flush=True)
+            if _fp32_head is not None:
+                return self.logits_processor(_fp32_head, hidden_states.float())
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits"""
+
+    with _locked_file_patch(file_to_patch) as (content, write_back):
+        if "NRL_VLLM_FP32_LM_HEAD" in content:
+            logger.info("NemotronH fp32 LM head patch already present.")
+            return
+        if content.count(old_snippet) != 1:
+            logger.warning(
+                "NemotronH fp32 LM head patch anchor not found exactly once "
+                "in %s; patch not applied.",
+                file_to_patch,
+            )
+            return
+        write_back(content.replace(old_snippet, new_snippet, 1))
+
+    logger.info("Applied NemotronH fp32 LM head source patch.")
+
+
 def ensure_vllm_source_compat() -> None:
     """Apply interpreter-independent vLLM source-compat patches.
 
@@ -634,3 +711,4 @@ def _apply_vllm_patches(
     _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)
     _patch_vllm_shm_broadcast_bind_retry(patch_logger)
     _patch_vllm_radio_layerscale_loader(patch_logger)
+    _patch_vllm_nemotron_h_fp32_lm_head(patch_logger)

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -180,6 +180,38 @@ def _read_mtp_layer_weights_from_checkpoint(
     return weights
 
 
+def _resolve_lm_head_owner(model: Any) -> Any:
+    """Return the module that owns ``lm_head`` for ``model``, or None.
+
+    Sheds vLLM runtime wrappers first (``CUDAGraphWrapper``, ``UBatchWrapper``,
+    anything exposing ``unwrap()``), then descends into multimodal wrappers
+    that delegate ``compute_logits`` to a ``language_model``. Falls back to a
+    ``named_modules`` scan so future wrapper shapes still resolve. The result is
+    the module whose ``compute_logits`` the fp32-head source patch runs in.
+    """
+    seen = 0
+    while (
+        model is not None
+        and not isinstance(model, torch.nn.Module)
+        and callable(getattr(type(model), "unwrap", None))
+        and seen < 8
+    ):
+        model = model.unwrap()
+        seen += 1
+    if model is None:
+        return None
+    if getattr(model, "lm_head", None) is not None:
+        return model
+    inner = getattr(model, "language_model", None)
+    if inner is not None and getattr(inner, "lm_head", None) is not None:
+        return inner
+    if isinstance(model, torch.nn.Module):
+        for _, module in model.named_modules():
+            if getattr(module, "lm_head", None) is not None:
+                return module
+    return None
+
+
 class VllmInternalWorkerExtension:
     # True once the MTP drafter has been served by a one-time disk load (see
     # load_mtp_weights_from_disk); refit then leaves those static weights alone.
@@ -598,6 +630,32 @@ class VllmInternalWorkerExtension:
         # lifecycle), so this is where the fp32 LM head cache is invalidated.
         self._mark_fp32_lm_head_dirty()
 
+    def _fp32_lm_head_targets(self) -> list[tuple[str, Any]]:
+        """Resolve the modules whose ``compute_logits`` owns an ``lm_head``.
+
+        The fp32 LM head source patch lives in the text model's
+        ``compute_logits`` (``nemotron_h.py``) and stores its cache on that
+        module. ``model_runner.model`` is frequently *not* that module:
+
+        - under ``CUDAGraphMode.FULL*`` vLLM wraps it in ``CUDAGraphWrapper``
+          (``UBatchWrapper`` when micro-batching), and
+        - multimodal checkpoints (``NemotronH_Nano_VL_V2``) wrap the text model
+          as ``language_model`` and delegate ``compute_logits`` to it.
+
+        Resolve through both so refit sync and dirty-marking act on the same
+        object the patch reads from. Returns ``(label, module)`` pairs; the
+        drafter entry is omitted when there is no drafter.
+        """
+        targets: list[tuple[str, Any]] = []
+        for label, model in (
+            ("policy", self.model_runner.model),
+            ("drafter", self._get_drafter_model()),
+        ):
+            if model is None:
+                continue
+            targets.append((label, _resolve_lm_head_owner(model)))
+        return targets
+
     def _mark_fp32_lm_head_dirty(self) -> None:
         """Flag the NRL_VLLM_FP32_LM_HEAD cached head for refresh.
 
@@ -609,14 +667,12 @@ class VllmInternalWorkerExtension:
         if os.environ.get("NRL_VLLM_FP32_LM_HEAD", "0") != "1":
             return
         marked = []
-        for label, model in (
-            ("policy", self.model_runner.model),
-            ("drafter", self._get_drafter_model()),
-        ):
-            if model is None:
+        for label, owner in self._fp32_lm_head_targets():
+            if owner is None:
+                marked.append(f"{label}:no-lm-head")
                 continue
-            if getattr(model, "_nrl_lm_head_fp32", None) is not None:
-                model._nrl_lm_head_fp32_dirty = True
+            if getattr(owner, "_nrl_lm_head_fp32", None) is not None:
+                owner._nrl_lm_head_fp32_dirty = True
                 marked.append(label)
             else:
                 # No cache yet: the first compute_logits after this refit builds
@@ -644,31 +700,39 @@ class VllmInternalWorkerExtension:
         """Rebuild the fp32 LM head cache from the weights refit just loaded.
 
         The NRL_VLLM_FP32_LM_HEAD source patch keeps an fp32 copy of lm_head.
-        Engines start on dummy weights, so that copy is stale after every
-        refit. Building it here (eager, post-refit) rather than lazily in
-        compute_logits also keeps the allocation out of any CUDA graph pool.
+        Engines start on dummy weights (``load_format=dummy``) and the patch
+        builds that copy lazily on the first eager forward, which is the
+        warmup pass *before* any refit. Without this sync the copy would hold
+        dummy weights for the whole run while ``compute_logits`` keeps reading
+        it, so the policy would sample from a random head. Building it here
+        (eager, post-refit) rather than lazily in compute_logits also keeps the
+        allocation out of any CUDA graph pool.
 
         Covers the MTP/Eagle3 drafter too when speculative decoding is on: it
         is a separate module with its own head and its own refit stream.
+
+        Raises:
+            RuntimeError: if the policy model has no resolvable ``lm_head``.
+                A silent skip here is exactly the failure mode this guards
+                against, so it is fatal for the policy. Drafters commonly tie
+                their head to the policy's and are allowed to have none.
         """
-        for label, model in (
-            ("policy", self.model_runner.model),
-            ("drafter", self._get_drafter_model()),
-        ):
-            if model is not None:
-                self._sync_fp32_lm_head_for(label, model)
+        for label, owner in self._fp32_lm_head_targets():
+            if owner is None:
+                if label == "policy":
+                    raise RuntimeError(
+                        "[fp32_lm_head] NRL_VLLM_FP32_LM_HEAD=1 but no module "
+                        "owning `lm_head` could be resolved from "
+                        f"model_runner.model ({type(self.model_runner.model).__name__}). "
+                        "The fp32 head cache cannot be refreshed after refit, so "
+                        "generation would run on stale (dummy) head weights."
+                    )
+                logger.info("[fp32_lm_head] %s has no lm_head; skipping", label)
+                continue
+            self._sync_fp32_lm_head_for(label, owner)
 
     def _sync_fp32_lm_head_for(self, label: str, model: Any) -> None:
-        lm_head = getattr(model, "lm_head", None)
-        if lm_head is None:
-            # Drafters commonly tie their head to the policy's; nothing to sync.
-            logger.info(
-                "[fp32_lm_head] %s (%s) has no lm_head; skipping",
-                label,
-                type(model).__name__,
-            )
-            return
-
+        lm_head = model.lm_head
         cached = getattr(model, "_nrl_lm_head_fp32", None)
         if cached is None:
             import copy
@@ -679,8 +743,8 @@ class VllmInternalWorkerExtension:
             # the refit weight mapping is built from.
             object.__setattr__(model, "_nrl_lm_head_fp32", cached)
             print(
-                f"[fp32_lm_head] {label}: built fp32 head cache after refit "
-                f"shape={tuple(cached.weight.shape)}",
+                f"[fp32_lm_head] {label} ({type(model).__name__}): built fp32 head "
+                f"cache after refit shape={tuple(cached.weight.shape)}",
                 flush=True,
             )
         else:
@@ -698,11 +762,26 @@ class VllmInternalWorkerExtension:
             if getattr(cached, "bias", None) is not None:
                 cached.bias.data.copy_(lm_head.bias)
             print(
-                f"[fp32_lm_head] {label}: refreshed fp32 head cache after refit "
-                f"(pre-refresh drift={drift:.6g})",
+                f"[fp32_lm_head] {label} ({type(model).__name__}): refreshed fp32 "
+                f"head cache after refit (pre-refresh drift={drift:.6g})",
                 flush=True,
             )
         model._nrl_lm_head_fp32_dirty = False
+        # An fp32 copy of a bf16/fp16 tensor is exact, so any mismatch here
+        # means the cache and the live head have diverged (wrong module, wrong
+        # storage). Cheap sample; fail loudly rather than train on it.
+        probe = slice(0, 4096)
+        mismatch = (
+            (cached.weight.flatten()[probe] - lm_head.weight.flatten()[probe].float())
+            .abs()
+            .max()
+            .item()
+        )
+        if mismatch != 0.0:
+            raise RuntimeError(
+                f"[fp32_lm_head] {label}: fp32 head cache does not match lm_head "
+                f"after sync (max abs diff {mismatch:.6g})"
+            )
 
     @contextmanager
     def _weight_update_lifecycle(

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -216,6 +216,9 @@ class VllmInternalWorkerExtension:
     # True once the MTP drafter has been served by a one-time disk load (see
     # load_mtp_weights_from_disk); refit then leaves those static weights alone.
     _mtp_drafter_from_disk: bool = False
+    # fp32 LM head (NRL_VLLM_FP32_LM_HEAD) once-per-worker log gates.
+    _nrl_fp32_dirty_logged: bool = False
+    _nrl_fp32_refresh_logged: bool = False
     _sparse_delta_applier: Any = None
     _nrl_named_parameters: dict[str, torch.nn.Parameter]
 
@@ -643,18 +646,12 @@ class VllmInternalWorkerExtension:
           as ``language_model`` and delegate ``compute_logits`` to it.
 
         Resolve through both so refit sync and dirty-marking act on the same
-        object the patch reads from. Returns ``(label, module)`` pairs; the
-        drafter entry is omitted when there is no drafter.
+        object the patch reads from. Only the policy is covered: the
+        speculative drafter (``NemotronHMTP``) has its own, unpatched
+        ``compute_logits`` in a separate model file, so an fp32 copy of its
+        head would cost ~512 MiB/rank and never be read.
         """
-        targets: list[tuple[str, Any]] = []
-        for label, model in (
-            ("policy", self.model_runner.model),
-            ("drafter", self._get_drafter_model()),
-        ):
-            if model is None:
-                continue
-            targets.append((label, _resolve_lm_head_owner(model)))
-        return targets
+        return [("policy", _resolve_lm_head_owner(self.model_runner.model))]
 
     def _mark_fp32_lm_head_dirty(self) -> None:
         """Flag the NRL_VLLM_FP32_LM_HEAD cached head for refresh.
@@ -708,27 +705,20 @@ class VllmInternalWorkerExtension:
         (eager, post-refit) rather than lazily in compute_logits also keeps the
         allocation out of any CUDA graph pool.
 
-        Covers the MTP/Eagle3 drafter too when speculative decoding is on: it
-        is a separate module with its own head and its own refit stream.
-
         Raises:
             RuntimeError: if the policy model has no resolvable ``lm_head``.
                 A silent skip here is exactly the failure mode this guards
-                against, so it is fatal for the policy. Drafters commonly tie
-                their head to the policy's and are allowed to have none.
+                against (see ``_fp32_lm_head_targets``), so it is fatal.
         """
         for label, owner in self._fp32_lm_head_targets():
             if owner is None:
-                if label == "policy":
-                    raise RuntimeError(
-                        "[fp32_lm_head] NRL_VLLM_FP32_LM_HEAD=1 but no module "
-                        "owning `lm_head` could be resolved from "
-                        f"model_runner.model ({type(self.model_runner.model).__name__}). "
-                        "The fp32 head cache cannot be refreshed after refit, so "
-                        "generation would run on stale (dummy) head weights."
-                    )
-                logger.info("[fp32_lm_head] %s has no lm_head; skipping", label)
-                continue
+                raise RuntimeError(
+                    "[fp32_lm_head] NRL_VLLM_FP32_LM_HEAD=1 but no module owning "
+                    f"`lm_head` could be resolved for {label} from "
+                    f"model_runner.model ({type(self.model_runner.model).__name__}). "
+                    "The fp32 head cache cannot be refreshed after refit, so "
+                    "generation would run on stale (dummy) head weights."
+                )
             self._sync_fp32_lm_head_for(label, owner)
 
     def _sync_fp32_lm_head_for(self, label: str, model: Any) -> None:
@@ -761,11 +751,18 @@ class VllmInternalWorkerExtension:
             cached.weight.data.copy_(lm_head.weight)
             if getattr(cached, "bias", None) is not None:
                 cached.bias.data.copy_(lm_head.bias)
-            print(
+            # Runs every refit on every rank: print the first refresh (the
+            # dummy-weights -> real-weights transition, whose drift is the
+            # useful signal) and demote the rest to debug.
+            message = (
                 f"[fp32_lm_head] {label} ({type(model).__name__}): refreshed fp32 "
-                f"head cache after refit (pre-refresh drift={drift:.6g})",
-                flush=True,
+                f"head cache after refit (pre-refresh drift={drift:.6g})"
             )
+            if not self._nrl_fp32_refresh_logged:
+                self._nrl_fp32_refresh_logged = True
+                print(message, flush=True)
+            else:
+                logger.debug(message)
         model._nrl_lm_head_fp32_dirty = False
         # An fp32 copy of a bf16/fp16 tensor is exact, so any mismatch here
         # means the cache and the live head have diverged (wrong module, wrong

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import gc
 import logging
+import os
 import re
 import socket
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -592,6 +593,39 @@ class VllmInternalWorkerExtension:
         # MTP drafters co-trained with the policy receive their weights from the
         # policy stream (no `draft.` prefix), so feed it the policy weights too.
         self._maybe_refit_mtp_drafter(policy_weights)
+        # Every refit transport funnels through here (collective, IPC, NCCL
+        # reshard, and the checkpoint engine, which bypasses the weight-update
+        # lifecycle), so this is where the fp32 LM head cache is invalidated.
+        self._mark_fp32_lm_head_dirty()
+
+    def _mark_fp32_lm_head_dirty(self) -> None:
+        """Flag the NRL_VLLM_FP32_LM_HEAD cached head for refresh.
+
+        The patch keeps an fp32 copy of lm_head that the just-loaded weights
+        supersede; compute_logits refreshes it in place on the next forward.
+        Set on every batch of a multi-batch refit so the copy stays dirty until
+        the whole update lands.
+        """
+        if os.environ.get("NRL_VLLM_FP32_LM_HEAD", "0") != "1":
+            return
+        marked = []
+        for label, model in (
+            ("policy", self.model_runner.model),
+            ("drafter", self._get_drafter_model()),
+        ):
+            if model is None:
+                continue
+            if getattr(model, "_nrl_lm_head_fp32", None) is not None:
+                model._nrl_lm_head_fp32_dirty = True
+                marked.append(label)
+            else:
+                # No cache yet: the first compute_logits after this refit builds
+                # it, which is already correct (post-refit) weights.
+                marked.append(f"{label}:none-yet")
+        # Logged once per worker: _load_weights runs per refit batch.
+        if not getattr(self, "_nrl_fp32_dirty_logged", False):
+            self._nrl_fp32_dirty_logged = True
+            print(f"[fp32_lm_head] refit marked: {marked}", flush=True)
 
     def _get_sparse_delta_applier(self) -> Any:
         if self._sparse_delta_applier is None:
@@ -605,6 +639,70 @@ class VllmInternalWorkerExtension:
                 self.device,
             )
         return self._sparse_delta_applier
+
+    def _sync_fp32_lm_head(self) -> None:
+        """Rebuild the fp32 LM head cache from the weights refit just loaded.
+
+        The NRL_VLLM_FP32_LM_HEAD source patch keeps an fp32 copy of lm_head.
+        Engines start on dummy weights, so that copy is stale after every
+        refit. Building it here (eager, post-refit) rather than lazily in
+        compute_logits also keeps the allocation out of any CUDA graph pool.
+
+        Covers the MTP/Eagle3 drafter too when speculative decoding is on: it
+        is a separate module with its own head and its own refit stream.
+        """
+        for label, model in (
+            ("policy", self.model_runner.model),
+            ("drafter", self._get_drafter_model()),
+        ):
+            if model is not None:
+                self._sync_fp32_lm_head_for(label, model)
+
+    def _sync_fp32_lm_head_for(self, label: str, model: Any) -> None:
+        lm_head = getattr(model, "lm_head", None)
+        if lm_head is None:
+            # Drafters commonly tie their head to the policy's; nothing to sync.
+            logger.info(
+                "[fp32_lm_head] %s (%s) has no lm_head; skipping",
+                label,
+                type(model).__name__,
+            )
+            return
+
+        cached = getattr(model, "_nrl_lm_head_fp32", None)
+        if cached is None:
+            import copy
+
+            cached = copy.deepcopy(lm_head).float()
+            # Bypass nn.Module.__setattr__: registering this as a submodule
+            # would add a vocab-sized parameter to named_parameters(), which
+            # the refit weight mapping is built from.
+            object.__setattr__(model, "_nrl_lm_head_fp32", cached)
+            print(
+                f"[fp32_lm_head] {label}: built fp32 head cache after refit "
+                f"shape={tuple(cached.weight.shape)}",
+                flush=True,
+            )
+        else:
+            probe = slice(0, 16)
+            drift = (
+                (
+                    cached.weight.flatten()[probe]
+                    - lm_head.weight.flatten()[probe].float()
+                )
+                .abs()
+                .max()
+                .item()
+            )
+            cached.weight.data.copy_(lm_head.weight)
+            if getattr(cached, "bias", None) is not None:
+                cached.bias.data.copy_(lm_head.bias)
+            print(
+                f"[fp32_lm_head] {label}: refreshed fp32 head cache after refit "
+                f"(pre-refresh drift={drift:.6g})",
+                flush=True,
+            )
+        model._nrl_lm_head_fp32_dirty = False
 
     @contextmanager
     def _weight_update_lifecycle(
@@ -623,6 +721,8 @@ class VllmInternalWorkerExtension:
                     self.model_runner.model, self.model_config, self.device
                 )
             self._maybe_process_mtp_drafter_after_loading()
+            if os.environ.get("NRL_VLLM_FP32_LM_HEAD", "0") == "1":
+                self._sync_fp32_lm_head()
 
         yield finalize
         # Preserve the IPC lifetime boundary: the COMPLETE ACK is sent before

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -440,9 +440,13 @@ class VllmAsyncGenerationWorkerImpl(
                 """Clamp the request's max output tokens so that input + output <= max_model_len."""
                 remaining = self.model_config.max_model_len - len(prompt_token_ids)
                 if remaining <= 0:
+                    # Phrasing matters: the Gym vllm_model proxy classifies an
+                    # overflow by looking for "context length" in the response
+                    # body, so keep that wording here.
                     raise ValueError(
                         f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
-                        f"max_model_len ({self.model_config.max_model_len}). "
+                        f"the model's maximum context length "
+                        f"({self.model_config.max_model_len}). "
                         f"No room for output tokens."
                     )
                 max_tokens = min(request_max_tokens, remaining)
@@ -777,11 +781,24 @@ class VllmAsyncGenerationWorkerImpl(
                 generator = await openai_serving_chat.create_chat_completion(
                     request, raw_request
                 )
-            except VLLMValidationError as e:
+            except (VLLMValidationError, ValueError) as e:
                 # vLLM raises VLLMValidationError for prompts exceeding
                 # max_model_len during tokenization, instead of returning an
                 # ErrorResponse. Convert to HTTP 400 so the Gym proxy can
                 # detect context-length overflow and handle it gracefully.
+                #
+                # The renderer and _clamp_max_tokens raise a plain ValueError
+                # for the same condition. Without this, it escapes as a 500 and
+                # the Gym vllm_model proxy's handler never fires: it keys on
+                # `e.status == 400 and "context length" in body`, turning the
+                # overflow into an empty completion with finish_reason="length"
+                # (responses_api_models/vllm_model/app.py). A 500 instead burns
+                # the retry budget and then fails the rollout.
+                # Any other ValueError is a real error: let it 500.
+                if not isinstance(e, VLLMValidationError) and (
+                    "context length" not in str(e)
+                ):
+                    raise
                 return JSONResponse(
                     content={
                         "error": {

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -57,6 +57,34 @@ from nemo_rl.models.generation.openai_server_utils import (
 
 LOGGER = logging.getLogger(__name__)
 
+# NeMo Gym's vllm_model proxy recovers from a prompt that overflows the context
+# window by turning the failure into an empty completion with
+# finish_reason="length" instead of failing the rollout. That handler keys on
+# HTTP 400 *and* this marker appearing in the response body (see
+# responses_api_models/vllm_model/app.py). Both halves of that contract are
+# asserted in tests/unit/models/generation/test_vllm_context_length_overflow.py;
+# do not reword without updating the proxy.
+CONTEXT_LENGTH_ERROR_MARKER = "context length"
+
+
+def context_length_overflow_message(prompt_len: int, max_model_len: int) -> str:
+    """Message for a prompt that leaves no room for output tokens."""
+    return (
+        f"Prompt length ({prompt_len}) fills or exceeds the model's maximum "
+        f"{CONTEXT_LENGTH_ERROR_MARKER} ({max_model_len}). "
+        f"No room for output tokens."
+    )
+
+
+def is_context_length_error(exc: BaseException) -> bool:
+    """Whether ``exc`` reports a prompt that exceeds the model's context window.
+
+    vLLM signals this several ways: VLLMValidationError from tokenization, and
+    a plain ValueError from the online renderer or from the max-token clamp.
+    Only the message is reliable across those paths.
+    """
+    return CONTEXT_LENGTH_ERROR_MARKER in str(exc)
+
 
 class VllmAsyncGenerationWorkerImpl(
     VllmAsyncCheckpointEngineRpcMixin, BaseVllmGenerationWorker
@@ -440,14 +468,10 @@ class VllmAsyncGenerationWorkerImpl(
                 """Clamp the request's max output tokens so that input + output <= max_model_len."""
                 remaining = self.model_config.max_model_len - len(prompt_token_ids)
                 if remaining <= 0:
-                    # Phrasing matters: the Gym vllm_model proxy classifies an
-                    # overflow by looking for "context length" in the response
-                    # body, so keep that wording here.
                     raise ValueError(
-                        f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
-                        f"the model's maximum context length "
-                        f"({self.model_config.max_model_len}). "
-                        f"No room for output tokens."
+                        context_length_overflow_message(
+                            len(prompt_token_ids), self.model_config.max_model_len
+                        )
                     )
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
@@ -795,8 +819,8 @@ class VllmAsyncGenerationWorkerImpl(
                 # (responses_api_models/vllm_model/app.py). A 500 instead burns
                 # the retry budget and then fails the rollout.
                 # Any other ValueError is a real error: let it 500.
-                if not isinstance(e, VLLMValidationError) and (
-                    "context length" not in str(e)
+                if not isinstance(e, VLLMValidationError) and not (
+                    is_context_length_error(e)
                 ):
                     raise
                 return JSONResponse(

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -476,6 +476,62 @@ def _resolve_iter_dir_from_root(path: str, not_found_msg: str) -> str:
     return os.path.join(path, iter_subdirs[-1])
 
 
+def apply_fp32_lm_head(model_chunks: list, use_tf32: bool = False) -> None:
+    """Run the LM output-layer GEMM in fp32 (MiniMax-M1-style, arXiv:2506.13585).
+
+    bf16 rounding of the logits (magnitude ~15-30, bf16 ulp 0.125-0.25) is the
+    dominant contributor to generation/training logprob mismatch
+    (train/token_mult_prob_error). Upcasting the head input and weight to fp32
+    removes that rounding. The casts are part of the autograd graph, so
+    training gradients flow to the bf16 weight through the fp32 cast.
+
+    Note: has no effect on the fused linear+CE path
+    (megatron_cfg.use_fused_linear_logprobs), which bypasses output_layer's
+    standalone forward.
+
+    With ``use_tf32`` (megatron_cfg.fp32_lm_head: "tf32"), the fp32 head GEMM
+    runs with TF32 tensor cores. The inputs are exact bf16 values (<= 8-bit
+    mantissa), so TF32's 10-bit input rounding loses nothing; accumulation and
+    output stay fp32. Numerically equivalent to full fp32 here, at near-bf16
+    tensor-core throughput.
+    """
+    if not isinstance(model_chunks, (list, tuple)):
+        model_chunks = [model_chunks]
+    for chunk in model_chunks:
+        module = chunk
+        while hasattr(module, "module"):
+            module = module.module
+        output_layer = getattr(module, "output_layer", None)
+        if output_layer is None:
+            continue  # not the last pipeline stage
+        original_forward = output_layer.forward
+
+        def _fp32_forward(
+            input_,
+            *args,
+            weight=None,
+            _orig_forward=original_forward,
+            _layer=output_layer,
+            _tf32=use_tf32,
+            **kwargs,
+        ):
+            w = weight if weight is not None else _layer.weight
+            if not _tf32:
+                return _orig_forward(input_.float(), *args, weight=w.float(), **kwargs)
+            prev = torch.backends.cuda.matmul.allow_tf32
+            torch.backends.cuda.matmul.allow_tf32 = True
+            try:
+                return _orig_forward(input_.float(), *args, weight=w.float(), **kwargs)
+            finally:
+                torch.backends.cuda.matmul.allow_tf32 = prev
+
+        output_layer.forward = _fp32_forward
+        print(
+            "[fp32_lm_head] output layer will compute logits in fp32"
+            + (" (tf32 tensor cores)" if use_tf32 else "")
+        )
+
+
 def validate_model_paths(config: PolicyConfig) -> tuple[str, str, bool]:
     """Validate and setup model paths.
 
@@ -690,6 +746,14 @@ def setup_model_config(
     # Optional layernorm epsilon
     if "layernorm_epsilon" in config["megatron_cfg"]:
         model_cfg.layernorm_epsilon = config["megatron_cfg"]["layernorm_epsilon"]
+
+    # Optional fp32 residual stream. Reduces generation/training logprob
+    # mismatch (train/token_mult_prob_error) by accumulating the residual in
+    # fp32; supported by both transformer and mamba layers.
+    if "fp32_residual_connection" in config["megatron_cfg"]:
+        model_cfg.fp32_residual_connection = config["megatron_cfg"][
+            "fp32_residual_connection"
+        ]
 
     # Provider objects loaded from checkpoint metadata otherwise retain the
     # serialized defaults. Apply explicit recipe controls before model

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -476,6 +476,33 @@ def _resolve_iter_dir_from_root(path: str, not_found_msg: str) -> str:
     return os.path.join(path, iter_subdirs[-1])
 
 
+def _resolve_output_layer_owner(chunk: Any) -> Any:
+    """Return the module that owns ``output_layer`` for a Megatron model chunk.
+
+    Sheds the ``Float16Module`` / DDP ``.module`` wrappers, then the multimodal
+    wrappers that nest the language model instead of exposing ``output_layer``
+    themselves: ``NemotronOmniModel.thinker`` / ``.language_model`` and
+    ``NemotronVLModel.llava_model.language_model`` / ``.language_model``. The
+    descent stops as soon as a module exposes ``output_layer`` so plain
+    ``GPTModel`` / ``MambaModel`` chunks resolve to themselves. Mirrors the
+    unwrap chain in ``freeze_moe_router``.
+    """
+    module = chunk
+    while hasattr(module, "module"):
+        module = module.module
+    for _ in range(4):
+        if getattr(module, "output_layer", None) is not None:
+            break
+        for attr in ("thinker", "llava_model", "language_model"):
+            inner = getattr(module, attr, None)
+            if inner is not None:
+                module = inner
+                break
+        else:
+            break
+    return module
+
+
 def apply_fp32_lm_head(model_chunks: list, use_tf32: bool = False) -> None:
     """Run the LM output-layer GEMM in fp32 (MiniMax-M1-style, arXiv:2506.13585).
 
@@ -498,11 +525,25 @@ def apply_fp32_lm_head(model_chunks: list, use_tf32: bool = False) -> None:
     if not isinstance(model_chunks, (list, tuple)):
         model_chunks = [model_chunks]
     for chunk in model_chunks:
-        module = chunk
-        while hasattr(module, "module"):
-            module = module.module
+        module = _resolve_output_layer_owner(chunk)
         output_layer = getattr(module, "output_layer", None)
         if output_layer is None:
+            # Zero matches must not look like success: on the chunk that owns
+            # the head, silently wrapping nothing leaves the trainer in bf16
+            # while vLLM (NRL_VLLM_FP32_LM_HEAD) runs fp32, which is worse than
+            # disabling the feature on both sides. ``post_process`` is how
+            # Megatron marks that chunk (GPTModel, MambaModel/HybridModel,
+            # NemotronVLModel, NemotronOmniModel all carry it).
+            if getattr(module, "post_process", False) or getattr(
+                chunk, "post_process", False
+            ):
+                raise ValueError(
+                    "fp32_lm_head is enabled but no output_layer was found on a "
+                    f"post_process model chunk of type {type(module).__name__} "
+                    f"(chunk type {type(chunk).__name__}). The trainer would run "
+                    "the LM head in bf16 while generation runs fp32, which is "
+                    "worse than disabling both."
+                )
             continue  # not the last pipeline stage
         original_forward = output_layer.forward
 

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -476,6 +476,44 @@ def _resolve_iter_dir_from_root(path: str, not_found_msg: str) -> str:
     return os.path.join(path, iter_subdirs[-1])
 
 
+def validate_fp32_lm_head_config(config: PolicyConfig) -> None:
+    """Reject an fp32 LM head that is enabled on only one engine.
+
+    ``megatron_cfg.fp32_lm_head`` and vLLM's ``NRL_VLLM_FP32_LM_HEAD`` (set via
+    ``generation.vllm_cfg.env_vars``) must agree: with bf16 heads on both sides
+    the logits round to the same grid, so enabling fp32 on one side alone makes
+    train/token_mult_prob_error *worse* than leaving the feature off. The
+    fused linear+CE path bypasses ``output_layer`` entirely, so the trainer
+    head would silently stay bf16 there too.
+
+    Only checked when generation uses the vLLM backend; SFT/DPO have no
+    generation engine to disagree with.
+    """
+    megatron_cfg = config.get("megatron_cfg") or {}
+    trainer_fp32 = bool(megatron_cfg.get("fp32_lm_head"))
+    generation = config.get("generation") or {}
+    if generation.get("backend") != "vllm":
+        return
+    env_vars = (generation.get("vllm_cfg") or {}).get("env_vars") or {}
+    vllm_fp32 = str(env_vars.get("NRL_VLLM_FP32_LM_HEAD", "0")) == "1"
+    if trainer_fp32 != vllm_fp32:
+        raise ValueError(
+            "fp32 LM head must be enabled on both engines or neither: "
+            f"megatron_cfg.fp32_lm_head={megatron_cfg.get('fp32_lm_head')!r} but "
+            f"generation.vllm_cfg.env_vars.NRL_VLLM_FP32_LM_HEAD="
+            f"{env_vars.get('NRL_VLLM_FP32_LM_HEAD')!r}. A one-sided fp32 head "
+            "increases the generation/training logprob mismatch instead of "
+            "reducing it."
+        )
+    if trainer_fp32 and megatron_cfg.get("use_fused_linear_logprobs", False):
+        raise ValueError(
+            "megatron_cfg.fp32_lm_head has no effect with "
+            "use_fused_linear_logprobs=true (the fused linear+CE kernel bypasses "
+            "output_layer), which would leave the trainer in bf16 while vLLM "
+            "runs fp32. Disable one of them."
+        )
+
+
 def _resolve_output_layer_owner(chunk: Any) -> Any:
     """Return the module that owns ``output_layer`` for a Megatron model chunk.
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -369,6 +369,22 @@ class MegatronConfig(TypedDict):
     # If True, defer the casting of logits to float32 until the backward pass.
     # If you are using logprob_chunk_size, you must set this to True.
     defer_fp32_logits: NotRequired[bool]
+    # Compute the LM output-layer GEMM in fp32 instead of bf16. bf16 rounding of
+    # the logits is the dominant source of generation/training logprob mismatch
+    # (train/token_mult_prob_error). Set the matching NRL_VLLM_FP32_LM_HEAD=1 in
+    # generation.vllm_cfg.env_vars: applying this to only one engine makes the
+    # multiplicative error worse, since both otherwise round to the same grid.
+    #   False   - bf16 head (default)
+    #   True    - full fp32 head (~2x cost on the logprob pass)
+    #   "tf32"  - fp32 head on TF32 tensor cores; numerically identical here
+    #             because the inputs are already exact bf16 values, at ~baseline
+    #             speed. Prefer this.
+    # No effect when use_fused_linear_logprobs is set, which bypasses the
+    # output layer's standalone forward.
+    fp32_lm_head: NotRequired[bool | Literal["tf32"]]
+    # Keep the transformer residual stream in fp32. Small additional reduction in
+    # gen/train logprob mismatch on top of fp32_lm_head.
+    fp32_residual_connection: NotRequired[bool]
     # gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: bool
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -549,6 +549,11 @@ class MegatronPolicyWorkerImpl(
 
         self.mcore_state = model_and_optimizer_state.state
         self.model = model_and_optimizer_state.model
+        fp32_lm_head = self.cfg["megatron_cfg"].get("fp32_lm_head")
+        if fp32_lm_head:
+            from nemo_rl.models.megatron.setup import apply_fp32_lm_head
+
+            apply_fp32_lm_head(self.model, use_tf32=(fp32_lm_head == "tf32"))
         self.optimizer = model_and_optimizer_state.optimizer
         self.scheduler = model_and_optimizer_state.scheduler
         self.checkpointing_context = model_and_optimizer_state.checkpointing_context

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -76,6 +76,7 @@ from nemo_rl.models.megatron.pipeline_parallel import (
 )
 from nemo_rl.models.megatron.router_replay import router_replay_enabled
 from nemo_rl.models.megatron.setup import (
+    apply_fp32_lm_head,
     build_inference_model,
     finalize_megatron_setup,
     handle_model_import,
@@ -551,8 +552,6 @@ class MegatronPolicyWorkerImpl(
         self.model = model_and_optimizer_state.model
         fp32_lm_head = self.cfg["megatron_cfg"].get("fp32_lm_head")
         if fp32_lm_head:
-            from nemo_rl.models.megatron.setup import apply_fp32_lm_head
-
             apply_fp32_lm_head(self.model, use_tf32=(fp32_lm_head == "tf32"))
         self.optimizer = model_and_optimizer_state.optimizer
         self.scheduler = model_and_optimizer_state.scheduler

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -77,6 +77,7 @@ from nemo_rl.models.megatron.pipeline_parallel import (
 from nemo_rl.models.megatron.router_replay import router_replay_enabled
 from nemo_rl.models.megatron.setup import (
     apply_fp32_lm_head,
+    validate_fp32_lm_head_config,
     build_inference_model,
     finalize_megatron_setup,
     handle_model_import,
@@ -550,6 +551,7 @@ class MegatronPolicyWorkerImpl(
 
         self.mcore_state = model_and_optimizer_state.state
         self.model = model_and_optimizer_state.model
+        validate_fp32_lm_head_config(self.cfg)
         fp32_lm_head = self.cfg["megatron_cfg"].get("fp32_lm_head")
         if fp32_lm_head:
             apply_fp32_lm_head(self.model, use_tf32=(fp32_lm_head == "tf32"))

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -582,3 +582,138 @@ def test_maybe_process_mtp_drafter_after_loading_noop_when_disk_loaded(monkeypat
     ext._maybe_process_mtp_drafter_after_loading()
 
     process_weights.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# fp32 LM head refit sync (NRL_VLLM_FP32_LM_HEAD)
+#
+# Regression tests for the production failure where the fp32 head cache was
+# built from dummy weights during warmup and never refreshed: the sync looked
+# for `lm_head` on `model_runner.model`, which was a CUDAGraphWrapper around a
+# NemotronH_Nano_VL_V2 that nests the text model as `language_model`.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLMHead(torch.nn.Module):
+    def __init__(self, vocab: int = 8, hidden: int = 4):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.randn(vocab, hidden, dtype=torch.bfloat16), requires_grad=False
+        )
+
+
+class _FakeTextModel(torch.nn.Module):
+    """Stands in for NemotronHForCausalLM: owns lm_head and compute_logits."""
+
+    def __init__(self):
+        super().__init__()
+        self.lm_head = _FakeLMHead()
+
+
+class _FakeVLModel(torch.nn.Module):
+    """Stands in for NemotronH_Nano_VL_V2: no lm_head, delegates to language_model."""
+
+    def __init__(self):
+        super().__init__()
+        self.language_model = _FakeTextModel()
+
+
+class _FakeCUDAGraphWrapper:
+    """Mirrors vllm.compilation.cuda_graph.CUDAGraphWrapper's attribute rules."""
+
+    def __init__(self, runnable):
+        self.runnable = runnable
+
+    def __getattr__(self, key):
+        if hasattr(self.runnable, key):
+            return getattr(self.runnable, key)
+        raise AttributeError(key)
+
+    def unwrap(self):
+        return self.runnable
+
+
+def _make_fp32_head_extension(backend, model, drafter_model=None):
+    ext = backend.VllmInternalWorkerExtension.__new__(
+        backend.VllmInternalWorkerExtension
+    )
+    ext.model_runner = SimpleNamespace(
+        model=model,
+        drafter=SimpleNamespace(model=drafter_model) if drafter_model else None,
+    )
+    return ext
+
+
+@pytest.mark.vllm
+def test_resolve_lm_head_owner_descends_wrappers_and_language_model():
+    from nemo_rl.models.generation.vllm import vllm_backend as backend
+
+    text = _FakeTextModel()
+    assert backend._resolve_lm_head_owner(text) is text
+
+    vl = _FakeVLModel()
+    assert backend._resolve_lm_head_owner(vl) is vl.language_model
+    assert backend._resolve_lm_head_owner(_FakeCUDAGraphWrapper(vl)) is (
+        vl.language_model
+    )
+    assert backend._resolve_lm_head_owner(_FakeCUDAGraphWrapper(text)) is text
+
+    assert backend._resolve_lm_head_owner(torch.nn.Module()) is None
+    assert backend._resolve_lm_head_owner(None) is None
+
+
+@pytest.mark.vllm
+def test_sync_fp32_lm_head_builds_then_refreshes_on_language_model(monkeypatch):
+    from nemo_rl.models.generation.vllm import vllm_backend as backend
+
+    monkeypatch.setenv("NRL_VLLM_FP32_LM_HEAD", "1")
+    vl = _FakeVLModel()
+    text = vl.language_model
+    ext = _make_fp32_head_extension(backend, _FakeCUDAGraphWrapper(vl))
+
+    # First refit: engines start on dummy weights, so the cache must be built
+    # on the module that owns lm_head (the text model), not the wrapper.
+    ext._sync_fp32_lm_head()
+    cached = text._nrl_lm_head_fp32
+    assert cached.weight.dtype == torch.float32
+    torch.testing.assert_close(cached.weight, text.lm_head.weight.float())
+    assert text._nrl_lm_head_fp32_dirty is False
+    assert "_nrl_lm_head_fp32" not in dict(text.named_parameters())
+    assert not hasattr(vl, "_nrl_lm_head_fp32")
+
+    # Second refit lands new weights in place (nccl_reshard / sparse paths).
+    with torch.no_grad():
+        text.lm_head.weight.copy_(torch.randn_like(text.lm_head.weight))
+    ext._mark_fp32_lm_head_dirty()
+    assert text._nrl_lm_head_fp32_dirty is True
+
+    ext._sync_fp32_lm_head()
+    assert text._nrl_lm_head_fp32 is cached, "refresh must be in place"
+    torch.testing.assert_close(cached.weight, text.lm_head.weight.float())
+    assert text._nrl_lm_head_fp32_dirty is False
+
+
+@pytest.mark.vllm
+def test_sync_fp32_lm_head_raises_when_policy_has_no_lm_head(monkeypatch):
+    from nemo_rl.models.generation.vllm import vllm_backend as backend
+
+    monkeypatch.setenv("NRL_VLLM_FP32_LM_HEAD", "1")
+    ext = _make_fp32_head_extension(backend, _FakeCUDAGraphWrapper(torch.nn.Module()))
+
+    with pytest.raises(RuntimeError, match="no module owning `lm_head`"):
+        ext._sync_fp32_lm_head()
+
+
+@pytest.mark.vllm
+def test_sync_fp32_lm_head_tolerates_drafter_without_lm_head(monkeypatch):
+    from nemo_rl.models.generation.vllm import vllm_backend as backend
+
+    monkeypatch.setenv("NRL_VLLM_FP32_LM_HEAD", "1")
+    text = _FakeTextModel()
+    # Eagle3/MTP drafters commonly tie their head to the policy's.
+    ext = _make_fp32_head_extension(backend, text, drafter_model=torch.nn.Module())
+
+    ext._sync_fp32_lm_head()
+    torch.testing.assert_close(
+        text._nrl_lm_head_fp32.weight, text.lm_head.weight.float()
+    )

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -705,15 +705,20 @@ def test_sync_fp32_lm_head_raises_when_policy_has_no_lm_head(monkeypatch):
 
 
 @pytest.mark.vllm
-def test_sync_fp32_lm_head_tolerates_drafter_without_lm_head(monkeypatch):
+def test_sync_fp32_lm_head_ignores_the_drafter(monkeypatch):
     from nemo_rl.models.generation.vllm import vllm_backend as backend
 
     monkeypatch.setenv("NRL_VLLM_FP32_LM_HEAD", "1")
     text = _FakeTextModel()
-    # Eagle3/MTP drafters commonly tie their head to the policy's.
-    ext = _make_fp32_head_extension(backend, text, drafter_model=torch.nn.Module())
+    # NemotronHMTP has its own head but its compute_logits is not patched, so an
+    # fp32 copy there (~512 MiB/rank) would never be read. Must not be built.
+    drafter = _FakeTextModel()
+    ext = _make_fp32_head_extension(backend, text, drafter_model=drafter)
 
     ext._sync_fp32_lm_head()
+    ext._mark_fp32_lm_head_dirty()
     torch.testing.assert_close(
         text._nrl_lm_head_fp32.weight, text.lm_head.weight.float()
     )
+    assert not hasattr(drafter, "_nrl_lm_head_fp32")
+    assert not hasattr(drafter, "_nrl_lm_head_fp32_dirty")

--- a/tests/unit/models/generation/test_vllm_context_length_overflow.py
+++ b/tests/unit/models/generation/test_vllm_context_length_overflow.py
@@ -12,27 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Guards the context-length overflow contract with the NeMo Gym vLLM proxy.
+"""Pins the context-length overflow contract between NeMo-RL and NeMo Gym.
 
 When a prompt no longer fits the context window, Gym's vllm_model proxy ends
-the rollout gracefully — it returns an empty completion with
+the rollout gracefully -- it returns an empty completion with
 finish_reason="length" rather than failing the sample. That recovery only
-happens when our chat endpoint answers with HTTP 400 *and* a body Gym
-recognises:
+happens when this repo's chat endpoint answers with HTTP 400 *and* a body Gym
+classifies as an overflow.
 
-    # Gym responses_api_models/vllm_model/app.py
-    is_out_of_context_length = e.status == 400 and (
-        "context length" in result_content_str or "max_tokens" in result_content_str
-    )
+Neither side can see the whole contract, and breaking it is silent: the
+rollout just burns its retry budget on 500s and fails. So rather than restating
+Gym's rule here (a copy would stay green while Gym drifted), these tests
+evaluate Gym's *actual* predicate, lifted from its source at
+``responses_api_models/vllm_model/app.py``. A change on either side that breaks
+the alignment fails the test:
 
-Both halves are easy to break from either side: returning 500 (an uncaught
-ValueError), or rewording the message so the substring check misses. Either
-regression is silent — the rollout just burns its retry budget and fails — so
-the predicate is mirrored here rather than described in prose.
+* reword our message, or return a status other than 400 -> Gym's expression
+  evaluates False against what we send;
+* change Gym's substrings, status check, or variable names -> the extracted
+  expression stops accepting our response, or stops being found at all.
 """
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import nemo_rl
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     CONTEXT_LENGTH_ERROR_MARKER,
     context_length_overflow_message,
@@ -40,10 +47,46 @@ from nemo_rl.models.generation.vllm.vllm_worker_async import (
 )
 
 
+GYM_PROXY_SOURCE = (
+    Path(nemo_rl.__file__).resolve().parents[1]
+    / "3rdparty/Gym-workspace/Gym/responses_api_models/vllm_model/app.py"
+)
+GYM_PREDICATE_VAR = "is_out_of_context_length"
+
+
+def _gym_overflow_predicates() -> list[ast.expr]:
+    """Lift Gym's overflow classifier expressions out of its source.
+
+    Returns every right-hand side assigned to ``is_out_of_context_length`` (the
+    proxy applies the same rule on more than one path). Evaluating these keeps
+    the test honest: it exercises Gym's real rule, not a restatement of it.
+    """
+    tree = ast.parse(GYM_PROXY_SOURCE.read_text())
+    predicates = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            getattr(target, "id", "") == GYM_PREDICATE_VAR for target in node.targets
+        )
+    ]
+    assert predicates, (
+        f"no `{GYM_PREDICATE_VAR}` assignment in {GYM_PROXY_SOURCE}. Gym's "
+        "overflow handling moved or was renamed; re-point this test at it and "
+        "confirm NeMo-RL still satisfies the new rule."
+    )
+    return predicates
+
+
 def gym_recovers(status_code: int, body: str) -> bool:
-    """Mirror of Gym's classifier in responses_api_models/vllm_model/app.py."""
-    return status_code == 400 and (
-        "context length" in body or "max_tokens" in body
+    """Whether Gym's own classifier treats this response as an overflow."""
+    namespace = {
+        "e": SimpleNamespace(status=status_code),
+        "result_content_str": body,
+    }
+    return all(
+        bool(eval(compile(ast.Expression(predicate), "<gym-proxy>", "eval"), {}, namespace))
+        for predicate in _gym_overflow_predicates()
     )
 
 

--- a/tests/unit/models/generation/test_vllm_context_length_overflow.py
+++ b/tests/unit/models/generation/test_vllm_context_length_overflow.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guards the context-length overflow contract with the NeMo Gym vLLM proxy.
+
+When a prompt no longer fits the context window, Gym's vllm_model proxy ends
+the rollout gracefully — it returns an empty completion with
+finish_reason="length" rather than failing the sample. That recovery only
+happens when our chat endpoint answers with HTTP 400 *and* a body Gym
+recognises:
+
+    # Gym responses_api_models/vllm_model/app.py
+    is_out_of_context_length = e.status == 400 and (
+        "context length" in result_content_str or "max_tokens" in result_content_str
+    )
+
+Both halves are easy to break from either side: returning 500 (an uncaught
+ValueError), or rewording the message so the substring check misses. Either
+regression is silent — the rollout just burns its retry budget and fails — so
+the predicate is mirrored here rather than described in prose.
+"""
+
+import pytest
+
+from nemo_rl.models.generation.vllm.vllm_worker_async import (
+    CONTEXT_LENGTH_ERROR_MARKER,
+    context_length_overflow_message,
+    is_context_length_error,
+)
+
+
+def gym_recovers(status_code: int, body: str) -> bool:
+    """Mirror of Gym's classifier in responses_api_models/vllm_model/app.py."""
+    return status_code == 400 and (
+        "context length" in body or "max_tokens" in body
+    )
+
+
+# Messages seen in production for the three ways vLLM reports an overflow.
+# The first two are raised as plain ValueError, which is why the endpoint
+# cannot key on VLLMValidationError alone.
+RENDERER_MESSAGE = (
+    "Input length (196905) exceeds model's maximum context length (196608)."
+)
+VLLM_SERVING_MESSAGE = (
+    "This model's maximum context length is 32768 tokens. However, you "
+    "requested 32818 tokens in the messages, Please reduce the length of "
+    "the messages. None"
+)
+CLAMP_MESSAGE = context_length_overflow_message(196614, 196608)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [CLAMP_MESSAGE, RENDERER_MESSAGE, VLLM_SERVING_MESSAGE],
+    ids=["clamp", "renderer", "vllm_serving"],
+)
+def test_overflow_errors_are_detected(message):
+    assert is_context_length_error(ValueError(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "CUDA out of memory",
+        "top_logprobs must be set when requesting token information",
+        "Expected all tensors to be on the same device",
+    ],
+)
+def test_unrelated_errors_are_not_detected(message):
+    """Unrelated ValueErrors must keep surfacing as 500s, not be masked as 400s."""
+    assert not is_context_length_error(ValueError(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [CLAMP_MESSAGE, RENDERER_MESSAGE, VLLM_SERVING_MESSAGE],
+    ids=["clamp", "renderer", "vllm_serving"],
+)
+def test_gym_recovers_from_the_response_we_send(message):
+    """End of the contract: what we return must be what Gym acts on."""
+    assert is_context_length_error(ValueError(message)), (
+        "endpoint would let this escape as a 500"
+    )
+    # The endpoint answers 400 with the exception text as the body.
+    assert gym_recovers(400, message)
+
+
+def test_gym_would_not_recover_from_a_500():
+    """The bug this contract exists to prevent: right body, wrong status."""
+    assert not gym_recovers(500, CLAMP_MESSAGE)
+
+
+def test_clamp_message_reports_both_lengths():
+    """Operators need the actual numbers to tell overflow from a config error."""
+    message = context_length_overflow_message(196614, 196608)
+    assert "196614" in message and "196608" in message
+    assert CONTEXT_LENGTH_ERROR_MARKER in message
+
+
+def test_chat_endpoint_catches_plain_value_error_and_answers_400():
+    """The endpoint must catch ValueError, not just VLLMValidationError.
+
+    The helpers above cannot see this half of the contract: it lives in
+    create_chat_completion, nested inside a Ray actor method. Narrowing the
+    except clause is precisely the regression that used to send Gym a 500 —
+    vLLM's renderer and the max-token clamp both raise a plain ValueError — so
+    the handler is asserted against the source.
+    """
+    import ast
+    from pathlib import Path
+
+    from nemo_rl.models.generation.vllm import vllm_worker_async
+
+    tree = ast.parse(Path(vllm_worker_async.__file__).read_text())
+
+    handlers = [
+        h
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        for h in node.handlers
+        if "VLLMValidationError"
+        in {n.id for n in ast.walk(h.type) if isinstance(n, ast.Name)}
+    ]
+    assert handlers, "no handler for VLLMValidationError found"
+
+    overflow_handlers = [
+        h
+        for h in handlers
+        if "ValueError" in {n.id for n in ast.walk(h.type) if isinstance(n, ast.Name)}
+    ]
+    assert overflow_handlers, (
+        "create_chat_completion must catch plain ValueError alongside "
+        "VLLMValidationError; otherwise renderer/clamp overflows escape as "
+        "HTTP 500 and Gym cannot recover the rollout"
+    )
+
+    returns_400 = any(
+        kw.arg == "status_code" and getattr(kw.value, "value", None) == 400
+        for h in overflow_handlers
+        for call in ast.walk(h)
+        if isinstance(call, ast.Call)
+        for kw in call.keywords
+    )
+    assert returns_400, "the overflow handler must answer HTTP 400"

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -3611,3 +3611,93 @@ class TestForceSyncOptimizerFp32FromModel:
                 f"DistributedOptimizer no longer references {name!r}; "
                 "_force_sync_optimizer_fp32_from_model's level-1 sync is now a silent no-op."
             )
+
+
+# ---------------------------------------------------------------------------
+# apply_fp32_lm_head: output_layer resolution through multimodal wrappers
+# ---------------------------------------------------------------------------
+
+
+class _FakeOutputLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.ones(4, 2, dtype=torch.bfloat16), requires_grad=False
+        )
+        self.seen_dtypes: list[tuple[torch.dtype, torch.dtype]] = []
+
+    def forward(self, input_, *args, weight=None, **kwargs):
+        w = weight if weight is not None else self.weight
+        self.seen_dtypes.append((input_.dtype, w.dtype))
+        return input_ @ w.t()
+
+
+def _assert_fp32_wrapped(output_layer: _FakeOutputLayer) -> None:
+    out = output_layer.forward(torch.ones(3, 2, dtype=torch.bfloat16))
+    assert out.dtype == torch.float32
+    assert output_layer.seen_dtypes == [(torch.float32, torch.float32)]
+
+
+def test_apply_fp32_lm_head_wraps_plain_last_stage_chunk():
+    from nemo_rl.models.megatron.setup import apply_fp32_lm_head
+
+    # Float16Module/DDP-style `.module` nesting around a GPTModel-like chunk.
+    layer = _FakeOutputLayer()
+    chunk = SimpleNamespace(
+        module=SimpleNamespace(output_layer=layer, post_process=True)
+    )
+    apply_fp32_lm_head([chunk])
+    _assert_fp32_wrapped(layer)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        # NemotronVLModel with an LLaVA wrapper: .llava_model.language_model
+        lambda layer: SimpleNamespace(
+            post_process=True,
+            llava_model=SimpleNamespace(
+                language_model=SimpleNamespace(output_layer=layer, post_process=True)
+            ),
+        ),
+        # NemotronVLModel without LLaVA: .language_model
+        lambda layer: SimpleNamespace(
+            post_process=True,
+            llava_model=None,
+            language_model=SimpleNamespace(output_layer=layer, post_process=True),
+        ),
+        # NemotronOmniModel: .thinker.language_model
+        lambda layer: SimpleNamespace(
+            post_process=True,
+            thinker=SimpleNamespace(
+                language_model=SimpleNamespace(output_layer=layer, post_process=True)
+            ),
+        ),
+    ],
+    ids=["vl_llava", "vl_language_model", "omni_thinker"],
+)
+def test_apply_fp32_lm_head_resolves_nested_language_model(build):
+    from nemo_rl.models.megatron.setup import apply_fp32_lm_head
+
+    layer = _FakeOutputLayer()
+    chunk = SimpleNamespace(module=build(layer))
+    apply_fp32_lm_head([chunk])
+    _assert_fp32_wrapped(layer)
+
+
+def test_apply_fp32_lm_head_raises_when_post_process_chunk_has_no_output_layer():
+    from nemo_rl.models.megatron.setup import apply_fp32_lm_head
+
+    # A post_process chunk with no reachable output_layer must not be mistaken
+    # for a non-last pipeline stage: that leaves the trainer in bf16 while
+    # generation runs fp32.
+    chunk = SimpleNamespace(module=SimpleNamespace(post_process=True))
+    with pytest.raises(ValueError, match="no output_layer was found"):
+        apply_fp32_lm_head([chunk])
+
+
+def test_apply_fp32_lm_head_skips_non_last_pipeline_stage():
+    from nemo_rl.models.megatron.setup import apply_fp32_lm_head
+
+    chunk = SimpleNamespace(module=SimpleNamespace(post_process=False))
+    apply_fp32_lm_head([chunk])  # no output_layer, not post_process: no-op

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -3701,3 +3701,61 @@ def test_apply_fp32_lm_head_skips_non_last_pipeline_stage():
 
     chunk = SimpleNamespace(module=SimpleNamespace(post_process=False))
     apply_fp32_lm_head([chunk])  # no output_layer, not post_process: no-op
+
+
+def _fp32_policy_cfg(trainer, vllm_env, fused=False, backend="vllm"):
+    megatron_cfg = {"fp32_lm_head": trainer}
+    if fused:
+        megatron_cfg["use_fused_linear_logprobs"] = True
+    return {
+        "megatron_cfg": megatron_cfg,
+        "generation": {
+            "backend": backend,
+            "vllm_cfg": {"env_vars": vllm_env},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "trainer, vllm_env",
+    [
+        (False, {}),
+        ("tf32", {"NRL_VLLM_FP32_LM_HEAD": 1}),
+        (True, {"NRL_VLLM_FP32_LM_HEAD": "1"}),
+    ],
+)
+def test_validate_fp32_lm_head_config_accepts_matched_engines(trainer, vllm_env):
+    from nemo_rl.models.megatron.setup import validate_fp32_lm_head_config
+
+    validate_fp32_lm_head_config(_fp32_policy_cfg(trainer, vllm_env))
+
+
+@pytest.mark.parametrize(
+    "trainer, vllm_env",
+    [
+        ("tf32", {}),  # trainer fp32, vLLM bf16: the production misconfiguration
+        (False, {"NRL_VLLM_FP32_LM_HEAD": "1"}),  # vLLM fp32, trainer bf16
+    ],
+)
+def test_validate_fp32_lm_head_config_rejects_one_sided(trainer, vllm_env):
+    from nemo_rl.models.megatron.setup import validate_fp32_lm_head_config
+
+    with pytest.raises(ValueError, match="both engines or neither"):
+        validate_fp32_lm_head_config(_fp32_policy_cfg(trainer, vllm_env))
+
+
+def test_validate_fp32_lm_head_config_rejects_fused_logprobs():
+    from nemo_rl.models.megatron.setup import validate_fp32_lm_head_config
+
+    with pytest.raises(ValueError, match="use_fused_linear_logprobs"):
+        validate_fp32_lm_head_config(
+            _fp32_policy_cfg("tf32", {"NRL_VLLM_FP32_LM_HEAD": "1"}, fused=True)
+        )
+
+
+def test_validate_fp32_lm_head_config_ignores_non_vllm_generation():
+    from nemo_rl.models.megatron.setup import validate_fp32_lm_head_config
+
+    # SFT/DPO-style configs have no vLLM engine to disagree with.
+    validate_fp32_lm_head_config({"megatron_cfg": {"fp32_lm_head": "tf32"}})
+    validate_fp32_lm_head_config(_fp32_policy_cfg("tf32", {}, backend="megatron"))

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -119,6 +119,8 @@ policy: &POLICY_BASE
         apply_rope_fusion: True
         bias_activation_fusion: True
         defer_fp32_logits: False
+        fp32_lm_head: False
+        fp32_residual_connection: False
         moe_per_layer_logging: False
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"

--- a/tests/unit/reference_configs/dpo.yaml
+++ b/tests/unit/reference_configs/dpo.yaml
@@ -153,6 +153,8 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    fp32_lm_head: False
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -224,6 +224,8 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    fp32_lm_head: False
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -164,6 +164,8 @@ policy:
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
     defer_fp32_logits: False
+    fp32_lm_head: False
+    fp32_residual_connection: False
     moe_per_layer_logging: False
 
     optimizer:
@@ -342,6 +344,8 @@ value:
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
     defer_fp32_logits: False
+    fp32_lm_head: False
+    fp32_residual_connection: False
     moe_per_layer_logging: False
 
     optimizer:

--- a/tests/unit/reference_configs/sft.yaml
+++ b/tests/unit/reference_configs/sft.yaml
@@ -139,6 +139,8 @@ policy:
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
     bias_activation_fusion: True
     defer_fp32_logits: False
+    fp32_lm_head: False
+    fp32_residual_connection: False
     moe_per_layer_logging: False
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"


### PR DESCRIPTION
# What does this PR do ?

1. Using FP32 for LM head for both vLLM and MCore

2. Handle the situation where model hits max length correctly. There's a handler in gym, but currently nemorl doesn't trigger it. 

# Usage

```
diff --git a/RLVR/nemotron-3.5-super/configs/super35_rlvr_pipeclean_64n.yaml b/RLVR/nemotron-3.5-super/configs/super35_rlvr_pipeclean_64n.yaml
index f318a1b..caf86b6 100644
--- a/RLVR/nemotron-3.5-super/configs/super35_rlvr_pipeclean_64n.yaml
+++ b/RLVR/nemotron-3.5-super/configs/super35_rlvr_pipeclean_64n.yaml
@@ -193,6 +193,17 @@ policy:
     bias_activation_fusion: false
     defer_fp32_logits: true
 
+    # bf16 rounding of the LM-head logits is the dominant source of
+    # generation/training logprob mismatch (train/token_mult_prob_error).
+    # "tf32" runs the head GEMM in fp32 on TF32 tensor cores: numerically
+    # identical to full fp32 here (inputs are already exact bf16 values) but at
+    # ~baseline speed, where fp32_lm_head: true costs ~2x on the logprob pass.
+    # Must be paired with NRL_VLLM_FP32_LM_HEAD=1 below — enabling this on only
+    # one engine makes the multiplicative error worse, since both otherwise
+    # round to the same grid.
+    fp32_lm_head: tf32
+    fp32_residual_connection: true
+
     # Logging
     track_moe_metrics: true
     moe_per_layer_logging: true
@@ -309,6 +320,10 @@ policy:
     vllm_cfg:
       async_engine: true
       precision: ${policy.precision}
+      # Generation-side half of policy.megatron_cfg.fp32_lm_head: computes the
+      # vLLM logits with an fp32 copy of the LM head. Both engines must be set.
+      env_vars:
+        NRL_VLLM_FP32_LM_HEAD: "1"
       kv_cache_dtype: "auto"
       tensor_parallel_size: 4
       pipeline_parallel_size: 1
```
