### PR TITLE
fix(async): recover from permanently-failed prompt groups instead of hanging 

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -72,6 +72,10 @@ TokenizerType = PreTrainedTokenizerBase
 _MAX_NEMO_GYM_STREAM_RETRIES = 3
 _NEMO_GYM_RETRY_DELAY_BASE_SECONDS = 1.0
 _REPLAY_BUFFER_MAX_BACKOFF_SECONDS = 0.5
+# Safety-net re-check interval for the generation-limit pause. The primary
+# wake-ups are the event set() (weight update / worker failure) and the
+# immediate post-clear() re-check; this only bounds a missed corner case.
+_GENERATION_LIMIT_RECHECK_SECONDS = 60.0
 
 
 def _stamped_task_indices(batch: BatchedDataDict[DatumSpec]) -> list[int]:
@@ -258,7 +262,9 @@ class AsyncTrajectoryCollector:
         self._failure_count: int = 0
         self._fatal_error_message: str | None = None
 
-    def _calculate_target_weights(self, generation_weight_version: int) -> list[int]:
+    def _calculate_target_weights(
+        self, generation_weight_version: int, last_consumed_target: int
+    ) -> list[int]:
         """Calculate target weight versions for given generation weight version.
 
         The list of versions returned enumerate the possible version a generation
@@ -293,9 +299,6 @@ class AsyncTrajectoryCollector:
         # Start at the first target training has not consumed instead. Callers
         # still skip targets <= last_consumed_target, so only genuine holes
         # surface.
-        last_consumed_target = ray.get(
-            self.replay_buffer.get_last_target_weight_already_generated.remote()
-        )
         target_start = min(generation_weight_version + 1, last_consumed_target + 1)
         return list(
             range(target_start, generation_weight_version + generation_lead + 1)
@@ -305,12 +308,14 @@ class AsyncTrajectoryCollector:
         self, generation_weight_version: int
     ) -> Optional[int]:
         """Get the next target weight that needs generation (if any)."""
-        target_weights = self._calculate_target_weights(generation_weight_version)
-        num_prompts = self._num_prompts_per_step
-        max_age_steps = self._max_trajectory_age_steps
         last_consumed_target = ray.get(
             self.replay_buffer.get_last_target_weight_already_generated.remote()
         )
+        target_weights = self._calculate_target_weights(
+            generation_weight_version, last_consumed_target
+        )
+        num_prompts = self._num_prompts_per_step
+        max_age_steps = self._max_trajectory_age_steps
 
         with self._generation_check_lock:
             for target_weight in target_weights:
@@ -380,12 +385,14 @@ class AsyncTrajectoryCollector:
     def _should_pause_for_generation_limits(self) -> bool:
         """Check if collection should be paused due to generation limits."""
         try:
-            target_weights = self._calculate_target_weights(self.current_weight_version)
-            num_prompts = self._num_prompts_per_step
-            max_age_steps = self._max_trajectory_age_steps
             last_consumed_target = ray.get(
                 self.replay_buffer.get_last_target_weight_already_generated.remote()
             )
+            target_weights = self._calculate_target_weights(
+                self.current_weight_version, last_consumed_target
+            )
+            num_prompts = self._num_prompts_per_step
+            max_age_steps = self._max_trajectory_age_steps
 
             with self._generation_check_lock:
                 # Check if any target weight in our range needs generation
@@ -408,6 +415,57 @@ class AsyncTrajectoryCollector:
             return True
         except Exception:
             return False
+
+    def _pause_for_generation_limits(self) -> None:
+        """Pause collection until a target needs generation again.
+
+        Wakes on the ``_generation_limit_cleared`` event (weight updates and
+        failed-worker cleanup call ``set()``). Two recovery paths guard the
+        wake against being lost:
+
+        - Immediately after ``clear()``, the pause condition is re-checked: a
+          worker's ``set()`` that landed between the caller's pause check and
+          the ``clear()`` would otherwise be erased and its wake missed.
+        - The wait is bounded by ``_GENERATION_LIMIT_RECHECK_SECONDS`` and the
+          condition is re-checked on every timeout: a permanently-failed
+          prompt group leaves the buffer short forever, so training cannot
+          step and no weight update ever fires the event; re-evaluating lets
+          the loop resume and gap-fill the shortfall with fresh prompts.
+        """
+        self._generation_limit_cleared.clear()
+        # Primary race recovery: never lose a set() that raced the clear().
+        if not self._should_pause_for_generation_limits():
+            self._generation_limit_cleared.set()
+            return
+
+        # Only log warning once per weight version
+        if self._last_limit_warning_version != self.current_weight_version:
+            target_weights = self._calculate_target_weights(
+                self.current_weight_version,
+                ray.get(
+                    self.replay_buffer.get_last_target_weight_already_generated.remote()
+                ),
+            )
+            print(
+                f"⏸️ Pausing collection: all target weights {target_weights} for weight version {self.current_weight_version} "
+                f"already exist in buffer. Waiting for weight update..."
+            )
+            self._last_limit_warning_version = self.current_weight_version
+
+        with self._efficiency_timer.time("idle/generation_limit_pause"):
+            while not self._generation_limit_cleared.is_set() and self.running:
+                self._generation_limit_cleared.wait(
+                    timeout=_GENERATION_LIMIT_RECHECK_SECONDS
+                )
+                if self._generation_limit_cleared.is_set() or not self.running:
+                    break
+                if not self._should_pause_for_generation_limits():
+                    print(
+                        "🔓 Generation-limit pause released by re-check: "
+                        "a target needs more trajectories (likely a "
+                        "failed prompt group) — resuming to gap-fill"
+                    )
+                    break
 
     def start_collection(
         self, dataloader: StatefulDataLoader | CyclingDataLoader
@@ -482,43 +540,7 @@ class AsyncTrajectoryCollector:
 
                 # Check if generation limits require pausing collection
                 if self._should_pause_for_generation_limits() and self.running:
-                    self._generation_limit_cleared.clear()
-
-                    # Only log warning once per weight version
-                    if self._last_limit_warning_version != self.current_weight_version:
-                        target_weights = self._calculate_target_weights(
-                            self.current_weight_version
-                        )
-                        print(
-                            f"⏸️ Pausing collection: all target weights {target_weights} for weight version {self.current_weight_version} "
-                            f"already exist in buffer. Waiting for weight update..."
-                        )
-                        self._last_limit_warning_version = self.current_weight_version
-
-                    # Wait for generation limits to clear, but re-check the
-                    # pause condition periodically: an unbounded wait deadlocks
-                    # when a prompt group fails permanently (e.g. deterministic
-                    # context-overflow 500s) after the pause leaves the buffer
-                    # short forever — training can't step, so no weight update
-                    # ever fires this event. Re-evaluating lets the loop wake
-                    # up and gap-fill the shortfall with new prompts.
-                    with self._efficiency_timer.time("idle/generation_limit_pause"):
-                        while (
-                            not self._generation_limit_cleared.is_set() and self.running
-                        ):
-                            self._generation_limit_cleared.wait(timeout=60.0)
-                            if (
-                                self._generation_limit_cleared.is_set()
-                                or not self.running
-                            ):
-                                break
-                            if not self._should_pause_for_generation_limits():
-                                print(
-                                    "🔓 Generation-limit pause released by re-check: "
-                                    "a target needs more trajectories (likely a "
-                                    "failed prompt group) — resuming to gap-fill"
-                                )
-                                break
+                    self._pause_for_generation_limits()
 
                     # Double-check we're still running after being woken up
                     if not self.running:

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -286,7 +286,20 @@ class AsyncTrajectoryCollector:
                 )
             ]
 
-        return [generation_weight_version + i for i in range(1, generation_lead + 1)]
+        # A permanently-failed prompt group (e.g. deterministic
+        # context-overflow rejections) leaves an unconsumed target at or below
+        # the current weight version short; starting the window at current+1
+        # would make gap-filling skip that hole forever and stall training.
+        # Start at the first target training has not consumed instead. Callers
+        # still skip targets <= last_consumed_target, so only genuine holes
+        # surface.
+        last_consumed_target = ray.get(
+            self.replay_buffer.get_last_target_weight_already_generated.remote()
+        )
+        target_start = min(generation_weight_version + 1, last_consumed_target + 1)
+        return list(
+            range(target_start, generation_weight_version + generation_lead + 1)
+        )
 
     def _get_next_target_for_generation(
         self, generation_weight_version: int
@@ -482,9 +495,30 @@ class AsyncTrajectoryCollector:
                         )
                         self._last_limit_warning_version = self.current_weight_version
 
-                    # Efficiently wait for generation limits to be cleared (no polling!)
+                    # Wait for generation limits to clear, but re-check the
+                    # pause condition periodically: an unbounded wait deadlocks
+                    # when a prompt group fails permanently (e.g. deterministic
+                    # context-overflow 500s) after the pause leaves the buffer
+                    # short forever — training can't step, so no weight update
+                    # ever fires this event. Re-evaluating lets the loop wake
+                    # up and gap-fill the shortfall with new prompts.
                     with self._efficiency_timer.time("idle/generation_limit_pause"):
-                        self._generation_limit_cleared.wait()
+                        while (
+                            not self._generation_limit_cleared.is_set() and self.running
+                        ):
+                            self._generation_limit_cleared.wait(timeout=60.0)
+                            if (
+                                self._generation_limit_cleared.is_set()
+                                or not self.running
+                            ):
+                                break
+                            if not self._should_pause_for_generation_limits():
+                                print(
+                                    "🔓 Generation-limit pause released by re-check: "
+                                    "a target needs more trajectories (likely a "
+                                    "failed prompt group) — resuming to gap-fill"
+                                )
+                                break
 
                     # Double-check we're still running after being woken up
                     if not self.running:

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -2223,7 +2223,11 @@ class TestAsyncTrajectoryCollector:
         assert collector.current_weight_version == 2
         assert collector._generation_lead_steps == 3
         assert collector._max_trajectory_age_steps == 5
-        assert collector._calculate_target_weights(2) == [3, 4, 5]
+        assert collector._calculate_target_weights(2, last_consumed_target=2) == [
+            3,
+            4,
+            5,
+        ]
 
     def test_collector_grpo_window_remains_fixed(self):
         collector = self.create_local_collector()
@@ -2231,14 +2235,124 @@ class TestAsyncTrajectoryCollector:
         assert collector.current_weight_version == 0
         assert collector._generation_lead_steps == 2
         assert collector._max_trajectory_age_steps == 2
-        assert collector._calculate_target_weights(0) == [0, 1, 2]
+        # Initial version: the window includes the current version and ignores
+        # last_consumed_target.
+        assert collector._calculate_target_weights(0, last_consumed_target=-1) == [
+            0,
+            1,
+            2,
+        ]
 
         collector.set_weight_version(5)
 
         assert collector.current_weight_version == 5
         assert collector._generation_lead_steps == 2
         assert collector._max_trajectory_age_steps == 2
-        assert collector._calculate_target_weights(5) == [6, 7]
+        # Steady state (training consumed the current version): unchanged
+        # window starting at current + 1.
+        assert collector._calculate_target_weights(5, last_consumed_target=5) == [
+            6,
+            7,
+        ]
+
+    def test_collector_window_extends_to_unconsumed_failed_targets(self):
+        """A short target at or below the current version stays visible.
+
+        A permanently-failed prompt group leaves its target unconsumed; the
+        window must extend down to last_consumed + 1 so gap-filling can
+        regenerate it instead of stalling training (callers skip targets at or
+        below last_consumed_target, so only genuine holes surface).
+        """
+        collector = self.create_local_collector()
+        collector.set_weight_version(5)
+
+        # Training consumed through 2; targets 3..5 are holes left by failed
+        # groups and must be part of the window alongside the lookahead 6..7.
+        assert collector._calculate_target_weights(5, last_consumed_target=2) == [
+            3,
+            4,
+            5,
+            6,
+            7,
+        ]
+
+    def test_generation_limit_pause_recovers_set_racing_clear(self):
+        """A set() racing the clear() must not be lost.
+
+        Interleaving: the collection loop decides to pause, a worker calls
+        set() (e.g. failed-worker cleanup), then the loop's clear() erases the
+        wake. The immediate post-clear re-check must notice the condition no
+        longer holds, restore the event, and return without waiting.
+        """
+        collector = self.create_local_collector()
+        # The worker's set() happened just before the pause path ran; by the
+        # time _pause_for_generation_limits re-checks, a target needs
+        # generation again.
+        collector._should_pause_for_generation_limits = mock.MagicMock(
+            return_value=False
+        )
+        collector._generation_limit_cleared.set()
+
+        start = time.perf_counter()
+        collector._pause_for_generation_limits()
+        elapsed = time.perf_counter() - start
+
+        assert collector._generation_limit_cleared.is_set()
+        assert elapsed < 1.0
+        collector._should_pause_for_generation_limits.assert_called_once()
+
+    def test_generation_limit_pause_rechecks_after_timeout(self):
+        """The bounded wait re-checks the pause condition and resumes.
+
+        With no weight update ever arriving (the failed-group deadlock), the
+        pause must wake on its own once a target needs trajectories again.
+        """
+        collector = self.create_local_collector()
+        collector.running = True
+        # Skip the once-per-version warning branch (it queries the replay
+        # buffer, which is a bare mock here).
+        collector._last_limit_warning_version = collector.current_weight_version
+        # Pause holds at clear() time and on the first timed re-check, then a
+        # gap opens (failed group) and the pause must release.
+        collector._should_pause_for_generation_limits = mock.MagicMock(
+            side_effect=[True, True, False]
+        )
+        with mock.patch(
+            "nemo_rl.algorithms.async_utils.trajectory_collector._GENERATION_LIMIT_RECHECK_SECONDS",
+            0.05,
+        ):
+            start = time.perf_counter()
+            collector._pause_for_generation_limits()
+            elapsed = time.perf_counter() - start
+
+        assert elapsed < 5.0
+        assert not collector._generation_limit_cleared.is_set()
+        assert collector._should_pause_for_generation_limits.call_count == 3
+
+    def test_generation_limit_pause_wakes_on_event_set(self):
+        """The normal wake path (weight update set()) is unaffected."""
+        collector = self.create_local_collector()
+        collector.running = True
+        # Skip the once-per-version warning branch (it queries the replay
+        # buffer, which is a bare mock here).
+        collector._last_limit_warning_version = collector.current_weight_version
+        collector._should_pause_for_generation_limits = mock.MagicMock(
+            return_value=True
+        )
+
+        def _release() -> None:
+            time.sleep(0.1)
+            collector._generation_limit_cleared.set()
+
+        releaser = threading.Thread(target=_release)
+        releaser.start()
+        start = time.perf_counter()
+        collector._pause_for_generation_limits()
+        elapsed = time.perf_counter() - start
+        releaser.join()
+
+        assert collector._generation_limit_cleared.is_set()
+        assert elapsed < 5.0
 
     def test_collector_rejects_generation_lead_above_validity_age(self):
         collector = self.create_local_collector()


### PR DESCRIPTION
  ## What does this PR do?
  
  Fixes a deadlock in the async trajectory collector: when a prompt group fails permanently, training hangs forever at the buffer wait while every generation node idles.
  
  ## The deadlock
  
  A prompt group that fails on every retry (for example, a prompt that the generation engine deterministically rejects because it exceeds `max_model_len`) leaves its target weight version short in the replay buffer. Two collector behaviors then combine:
  
  1. **Gap-filling cannot see the hole.** `_calculate_target_weights` starts the target window at `generation_weight_version + 1`. A short target *at or below* the current weight version is therefore never returned, and `last_consumed_target` is only used by the callers to *skip* targets — never to widen the window — so no worker is ever dispatched to regenerate the missing trajectories.
  2. **The pause never wakes.** `_collection_loop` parks on an unbounded `_generation_limit_cleared.wait()`. That event is set by a weight update — but training cannot step without the missing trajectories, so the update never comes.
  
  Observed in production on a 32-node async GRPO VLM run: one over-long prompt failed on every attempt, and the trainer sat at `Wait iteration N` with a frozen buffer size for the rest of the job while 100+ GPUs idled.
  
  ## The fix
  
  - `_calculate_target_weights`: extend the window down to the first target training has not consumed — `target_start = min(current + 1, last_consumed+ 1)`. Both callers already skip targets `<= last_consumed_target`, so only genuine holes surface and steady-state behavior is unchanged.
  - `_collection_loop`: bound the generation-limit pause with a 60-second re-check of `_should_pause_for_generation_limits()`, so the collector wakes up and gap-fills the shortfall with fresh prompts instead of deadlocking. The fast path (event set promptly by a weight update) is unchanged.
  
  ## Validation
  
  Deployed on the failing production run: the previously-hung workload recovered the failed group via gap-fill and trained 50 steps to completion across multiple resumed windows, with no recurrence of the stall. Steady-state runs (no failed groups) show identical scheduling behavior, since the  widened window only produces targets the callers would otherwise skip.