### PR TITLE
fix(vlm): match training-side image tiling to the rollout's placeholder runs

### DIFF
--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -15,7 +15,6 @@
 import base64
 import inspect
 import logging
-import math
 import re
 import uuid
 from collections import defaultdict
@@ -23,7 +22,6 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from io import BytesIO
-from types import SimpleNamespace
 from typing import Any, Optional, Union
 
 import requests
@@ -43,6 +41,12 @@ MULTIMODAL_CONTENT_TYPES = frozenset(
     {*IMAGE_CONTENT_TYPES, *VIDEO_CONTENT_TYPES, *AUDIO_CONTENT_TYPES}
 )
 NEMO_GYM_IMAGE_ENCODE_MAX_WORKERS = 8
+# Provenance marker set on user messages whose media tensors were attached
+# rollout-matched (repaired to the rollout's per-image placeholder runs). The
+# driver-side static reattach must not overwrite such media; key presence
+# alone is not provenance (targets may carry placeholder or stale payloads
+# that the reattach is expected to replace).
+ROLLOUT_MATCHED_MEDIA_KEY = "_rollout_matched_media"
 
 # List of allowed placeholder strings for different media types in the dataset string
 # e.g. "This is an example of <image>"
@@ -103,70 +107,6 @@ def uses_image_placeholder(processor: Any) -> bool:
     return type(processor).__name__ in _PLACEHOLDER_STYLE_PROCESSOR_NAMES
 
 
-def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
-    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
-    tokenizer = getattr(processor, "tokenizer", None)
-    if tokenizer is None or not uses_image_placeholder(processor):
-        return None
-    tokens = [
-        getattr(processor, "image_token", "<image>"),
-        getattr(processor, "image_start_token", "<img>"),
-        getattr(processor, "image_end_token", "</img>"),
-    ]
-    ids = tokenizer.convert_tokens_to_ids(tokens)
-    unk_id = getattr(tokenizer, "unk_token_id", None)
-    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
-        return None
-    return int(ids[0]), int(ids[1]), int(ids[2])
-
-
-def supports_image_placeholder_run_parity(processor: Any) -> bool:
-    """Whether rollout tokens can be parsed into per-image placeholder runs."""
-    return get_image_placeholder_token_ids(processor) is not None
-
-
-def count_image_placeholder_runs(
-    token_ids: "Sequence[int] | torch.Tensor", processor: Any
-) -> list[int]:
-    """Per-image placeholder run lengths from rollout token ids, in order.
-
-    The rollout engine (and this processor) expand each image to
-    ``<img><image>*N</img>``; each run's N is the exact number of projected
-    media features the model expects for that image.
-    """
-    placeholder_ids = get_image_placeholder_token_ids(processor)
-    if placeholder_ids is None:
-        raise ValueError(
-            f"{type(processor).__name__} does not expose image placeholder "
-            "tokens; cannot count image placeholder runs."
-        )
-    image_id, start_id, end_id = placeholder_ids
-    if isinstance(token_ids, torch.Tensor):
-        token_ids = token_ids.tolist()
-    runs: list[int] = []
-    current: "int | None" = None
-    for token in token_ids:
-        if token == start_id:
-            if current is not None:
-                raise ValueError("Nested <img> region in rollout tokens.")
-            current = 0
-        elif token == end_id:
-            if current is None:
-                raise ValueError("Unmatched </img> in rollout tokens.")
-            runs.append(current)
-            current = None
-        elif token == image_id:
-            if current is None:
-                raise ValueError(
-                    "Image placeholder token outside an <img>...</img> region "
-                    "in rollout tokens."
-                )
-            current += 1
-    if current is not None:
-        raise ValueError("Unterminated <img> region in rollout tokens.")
-    return runs
-
-
 def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
     """(width, height) of an image source, without decoding pixel data."""
     if isinstance(source, Image.Image):
@@ -183,47 +123,6 @@ def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
             return image.width, image.height
     image = resolve_to_image(source)
     return image.width, image.height
-
-
-def predicted_static_image_num_tokens(
-    processor: Any, image_sizes: list[tuple[int, int]]
-) -> "list[int] | None":
-    """Predict per-image token counts of the processor's static image path.
-
-    Mirrors the budget selection in the checkpoint's image processor
-    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
-    for the grid math, so it costs no pixel work. Returns None when the
-    processor does not expose the needed hooks (callers must then assume the
-    static output is unverified and attach rollout-matched media themselves).
-    """
-    image_processor = getattr(processor, "image_processor", None)
-    required = (
-        "max_model_len",
-        "min_num_patches",
-        "max_num_patches",
-        "_compute_target_patches",
-    )
-    if image_processor is None or not all(
-        hasattr(image_processor, name) for name in required
-    ):
-        return None
-    downsample = getattr(image_processor, "_downsample_factor", None)
-    if not downsample:
-        ratio = getattr(image_processor, "downsample_ratio", None)
-        if not ratio:
-            return None
-        downsample = int(round(1.0 / ratio))
-    budget = (image_processor.max_model_len - 4) * downsample**2
-    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
-    max_patches = image_processor.max_num_patches
-    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
-    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
-    num_tokens = []
-    for width, height in image_sizes:
-        shim = SimpleNamespace(width=width, height=height)
-        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
-        num_tokens.append((grid_w * grid_h) // downsample**2)
-    return num_tokens
 
 
 class PackedTensor:
@@ -1144,122 +1043,6 @@ def _image_num_tokens_from_processed(processed: dict[str, Any]) -> list[int]:
     return [int(item) for item in value]
 
 
-def _closest_aspect_grid(
-    target_patches: int, height: int, width: int, divisor: int
-) -> tuple[int, int]:
-    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
-    units = divisor * divisor
-    if target_patches <= 0 or target_patches % units:
-        raise ValueError(
-            f"Rollout image placeholder run implies {target_patches} patches, "
-            f"which is not a positive multiple of the pixel-shuffle factor "
-            f"squared ({units}); the rollout tokens do not describe a valid "
-            "image tile."
-        )
-    base = target_patches // units
-    aspect = math.log(max(height, 1) / max(width, 1))
-    best: "tuple[float, int, int] | None" = None
-    for low in range(1, math.isqrt(base) + 1):
-        if base % low:
-            continue
-        high = base // low
-        for h_units, w_units in ((low, high), (high, low)):
-            grid_h, grid_w = h_units * divisor, w_units * divisor
-            score = abs(math.log(grid_h / grid_w) - aspect)
-            if best is None or score < best[0]:
-                best = (score, grid_h, grid_w)
-    assert best is not None
-    return best[1], best[2]
-
-
-def _process_single_image_at_num_tokens(
-    processor: Any, image: Image.Image, num_tokens: int
-) -> dict[str, Any]:
-    """Run the processor on one image, pinned to an exact media token count."""
-    image_processor = processor.image_processor
-    image_token = getattr(processor, "image_token", "<image>")
-    downsample = getattr(image_processor, "_downsample_factor", None) or int(
-        round(1.0 / image_processor.downsample_ratio)
-    )
-
-    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
-        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
-        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
-        # patches. Instance mutation is the only knob: the wrapper's
-        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
-        # run this on a single thread with no awaits in between (same pattern
-        # as the processor's own _is_video_mode flag).
-        original = image_processor.max_model_len
-        try:
-            image_processor.max_model_len = num_tokens + 4
-            return dict(
-                processor(text=image_token, images=[single_image], return_tensors=None)
-            )
-        finally:
-            image_processor.max_model_len = original
-
-    processed = run_pinned(image)
-    if _image_num_tokens_from_processed(processed) == [num_tokens]:
-        return processed
-
-    # Grid rounding is not idempotent for every (size, budget); force the exact
-    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
-    # patches passes _compute_target_patches unchanged under the pinned budget.
-    grid_h, grid_w = _closest_aspect_grid(
-        num_tokens * downsample * downsample, image.height, image.width, downsample
-    )
-    patch = image_processor.patch_size
-    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
-    processed = run_pinned(resized)
-    actual = _image_num_tokens_from_processed(processed)
-    if actual != [num_tokens]:
-        raise ValueError(
-            "Cannot match the rollout's image tiling: the rollout expanded a "
-            f"{image.width}x{image.height} image to {num_tokens} placeholder "
-            f"tokens, but the training processor produced {actual[0]} tokens "
-            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
-            "train on misaligned media."
-        )
-    return processed
-
-
-def _reprocess_images_at_rollout_budgets(
-    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
-) -> dict[str, Any]:
-    """Re-run the processor per image at the rollout's exact per-image budget."""
-    parts = [
-        _process_single_image_at_num_tokens(processor, image, count)
-        for image, count in zip(images, expected_num_tokens, strict=True)
-    ]
-    pixel_values: list[torch.Tensor] = []
-    imgs_sizes: list[list[int]] = []
-    input_ids: list[torch.Tensor] = []
-    for part in parts:
-        tile = part["pixel_values"]
-        if isinstance(tile, list):
-            tile = torch.as_tensor(tile[0])
-        else:
-            tile = torch.as_tensor(tile)
-            if tile.ndim == 4:
-                tile = tile[0]
-        pixel_values.append(tile)
-        imgs_sizes.extend(
-            [int(h), int(w)]
-            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
-        )
-        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
-    merged: dict[str, Any] = {
-        "input_ids": torch.cat(input_ids, dim=1),
-        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
-        "num_tokens": list(expected_num_tokens),
-        "num_patches": [1] * len(images),
-    }
-    merged["pixel_values"] = (
-        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
-    )
-    return merged
-
-
 def attach_image_model_inputs_to_message(
     message: dict[str, Any],
     *,
@@ -1303,11 +1086,21 @@ def attach_image_model_inputs_to_message(
     if expected_num_tokens_per_image is not None:
         expected = [int(count) for count in expected_num_tokens_per_image]
         if _image_num_tokens_from_processed(processed) != expected:
-            processed = _reprocess_images_at_rollout_budgets(
-                processor, images, expected
+            # Local import: the exact-count repair is Nemotron-processor
+            # specific and lives with the other Nemotron helpers.
+            from nemo_rl.environments.nemotron_utils import (
+                reprocess_images_at_rollout_budgets,
             )
+
+            processed = reprocess_images_at_rollout_budgets(processor, images, expected)
             # Corrected tiles may be ragged even when the originals were not.
             allow_ragged_output = len(images) > 1
+            # Explicit provenance for the driver-side static reattach: only a
+            # REPAIRED turn carries media that differs from the statically
+            # budgeted prompt copy and must not be overwritten. Unrepaired
+            # turns keep no marker, so the reattach still restores the shared
+            # tensor set across a prompt group's repeated rows.
+            message[ROLLOUT_MATCHED_MEDIA_KEY] = True
     if allow_ragged_output:
         processed = _materialize_ragged_pixel_values(processed, processor)
     model_inputs = extract_multimodal_model_inputs(processor, processed)

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -15,6 +15,7 @@
 import base64
 import inspect
 import logging
+import math
 import re
 import uuid
 from collections import defaultdict
@@ -22,6 +23,7 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from io import BytesIO
+from types import SimpleNamespace
 from typing import Any, Optional, Union
 
 import requests
@@ -99,6 +101,129 @@ def uses_image_placeholder(processor: Any) -> bool:
         rather than tokenized ``apply_chat_template``.
     """
     return type(processor).__name__ in _PLACEHOLDER_STYLE_PROCESSOR_NAMES
+
+
+def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
+    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None or not uses_image_placeholder(processor):
+        return None
+    tokens = [
+        getattr(processor, "image_token", "<image>"),
+        getattr(processor, "image_start_token", "<img>"),
+        getattr(processor, "image_end_token", "</img>"),
+    ]
+    ids = tokenizer.convert_tokens_to_ids(tokens)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
+        return None
+    return int(ids[0]), int(ids[1]), int(ids[2])
+
+
+def supports_image_placeholder_run_parity(processor: Any) -> bool:
+    """Whether rollout tokens can be parsed into per-image placeholder runs."""
+    return get_image_placeholder_token_ids(processor) is not None
+
+
+def count_image_placeholder_runs(
+    token_ids: "Sequence[int] | torch.Tensor", processor: Any
+) -> list[int]:
+    """Per-image placeholder run lengths from rollout token ids, in order.
+
+    The rollout engine (and this processor) expand each image to
+    ``<img><image>*N</img>``; each run's N is the exact number of projected
+    media features the model expects for that image.
+    """
+    placeholder_ids = get_image_placeholder_token_ids(processor)
+    if placeholder_ids is None:
+        raise ValueError(
+            f"{type(processor).__name__} does not expose image placeholder "
+            "tokens; cannot count image placeholder runs."
+        )
+    image_id, start_id, end_id = placeholder_ids
+    if isinstance(token_ids, torch.Tensor):
+        token_ids = token_ids.tolist()
+    runs: list[int] = []
+    current: "int | None" = None
+    for token in token_ids:
+        if token == start_id:
+            if current is not None:
+                raise ValueError("Nested <img> region in rollout tokens.")
+            current = 0
+        elif token == end_id:
+            if current is None:
+                raise ValueError("Unmatched </img> in rollout tokens.")
+            runs.append(current)
+            current = None
+        elif token == image_id:
+            if current is None:
+                raise ValueError(
+                    "Image placeholder token outside an <img>...</img> region "
+                    "in rollout tokens."
+                )
+            current += 1
+    if current is not None:
+        raise ValueError("Unterminated <img> region in rollout tokens.")
+    return runs
+
+
+def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
+    """(width, height) of an image source, without decoding pixel data."""
+    if isinstance(source, Image.Image):
+        return source.width, source.height
+    if isinstance(source, str) and source.startswith("data:"):
+        _, encoded = source.split(",", 1)
+        with Image.open(BytesIO(base64.b64decode(encoded))) as image:
+            return image.width, image.height
+    if isinstance(source, str) and source.startswith("file://"):
+        with Image.open(source.removeprefix("file://")) as image:
+            return image.width, image.height
+    if isinstance(source, str) and not source.startswith(("http://", "https://")):
+        with Image.open(source) as image:
+            return image.width, image.height
+    image = resolve_to_image(source)
+    return image.width, image.height
+
+
+def predicted_static_image_num_tokens(
+    processor: Any, image_sizes: list[tuple[int, int]]
+) -> "list[int] | None":
+    """Predict per-image token counts of the processor's static image path.
+
+    Mirrors the budget selection in the checkpoint's image processor
+    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
+    for the grid math, so it costs no pixel work. Returns None when the
+    processor does not expose the needed hooks (callers must then assume the
+    static output is unverified and attach rollout-matched media themselves).
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    required = (
+        "max_model_len",
+        "min_num_patches",
+        "max_num_patches",
+        "_compute_target_patches",
+    )
+    if image_processor is None or not all(
+        hasattr(image_processor, name) for name in required
+    ):
+        return None
+    downsample = getattr(image_processor, "_downsample_factor", None)
+    if not downsample:
+        ratio = getattr(image_processor, "downsample_ratio", None)
+        if not ratio:
+            return None
+        downsample = int(round(1.0 / ratio))
+    budget = (image_processor.max_model_len - 4) * downsample**2
+    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
+    max_patches = image_processor.max_num_patches
+    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
+    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
+    num_tokens = []
+    for width, height in image_sizes:
+        shim = SimpleNamespace(width=width, height=height)
+        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
+        num_tokens.append((grid_w * grid_h) // downsample**2)
+    return num_tokens
 
 
 class PackedTensor:
@@ -1007,16 +1132,161 @@ def _restore_tensors(processed: dict[str, Any]) -> None:
                 continue
 
 
+def _image_num_tokens_from_processed(processed: dict[str, Any]) -> list[int]:
+    value = processed.get("num_tokens")
+    if value is None:
+        raise ValueError(
+            "Processor output has no per-image 'num_tokens'; cannot verify "
+            "image parity with the rollout tokens."
+        )
+    if isinstance(value, torch.Tensor):
+        return [int(item) for item in value.tolist()]
+    return [int(item) for item in value]
+
+
+def _closest_aspect_grid(
+    target_patches: int, height: int, width: int, divisor: int
+) -> tuple[int, int]:
+    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
+    units = divisor * divisor
+    if target_patches <= 0 or target_patches % units:
+        raise ValueError(
+            f"Rollout image placeholder run implies {target_patches} patches, "
+            f"which is not a positive multiple of the pixel-shuffle factor "
+            f"squared ({units}); the rollout tokens do not describe a valid "
+            "image tile."
+        )
+    base = target_patches // units
+    aspect = math.log(max(height, 1) / max(width, 1))
+    best: "tuple[float, int, int] | None" = None
+    for low in range(1, math.isqrt(base) + 1):
+        if base % low:
+            continue
+        high = base // low
+        for h_units, w_units in ((low, high), (high, low)):
+            grid_h, grid_w = h_units * divisor, w_units * divisor
+            score = abs(math.log(grid_h / grid_w) - aspect)
+            if best is None or score < best[0]:
+                best = (score, grid_h, grid_w)
+    assert best is not None
+    return best[1], best[2]
+
+
+def _process_single_image_at_num_tokens(
+    processor: Any, image: Image.Image, num_tokens: int
+) -> dict[str, Any]:
+    """Run the processor on one image, pinned to an exact media token count."""
+    image_processor = processor.image_processor
+    image_token = getattr(processor, "image_token", "<image>")
+    downsample = getattr(image_processor, "_downsample_factor", None) or int(
+        round(1.0 / image_processor.downsample_ratio)
+    )
+
+    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
+        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
+        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
+        # patches. Instance mutation is the only knob: the wrapper's
+        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
+        # run this on a single thread with no awaits in between (same pattern
+        # as the processor's own _is_video_mode flag).
+        original = image_processor.max_model_len
+        try:
+            image_processor.max_model_len = num_tokens + 4
+            return dict(
+                processor(text=image_token, images=[single_image], return_tensors=None)
+            )
+        finally:
+            image_processor.max_model_len = original
+
+    processed = run_pinned(image)
+    if _image_num_tokens_from_processed(processed) == [num_tokens]:
+        return processed
+
+    # Grid rounding is not idempotent for every (size, budget); force the exact
+    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
+    # patches passes _compute_target_patches unchanged under the pinned budget.
+    grid_h, grid_w = _closest_aspect_grid(
+        num_tokens * downsample * downsample, image.height, image.width, downsample
+    )
+    patch = image_processor.patch_size
+    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
+    processed = run_pinned(resized)
+    actual = _image_num_tokens_from_processed(processed)
+    if actual != [num_tokens]:
+        raise ValueError(
+            "Cannot match the rollout's image tiling: the rollout expanded a "
+            f"{image.width}x{image.height} image to {num_tokens} placeholder "
+            f"tokens, but the training processor produced {actual[0]} tokens "
+            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
+            "train on misaligned media."
+        )
+    return processed
+
+
+def _reprocess_images_at_rollout_budgets(
+    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
+) -> dict[str, Any]:
+    """Re-run the processor per image at the rollout's exact per-image budget."""
+    parts = [
+        _process_single_image_at_num_tokens(processor, image, count)
+        for image, count in zip(images, expected_num_tokens, strict=True)
+    ]
+    pixel_values: list[torch.Tensor] = []
+    imgs_sizes: list[list[int]] = []
+    input_ids: list[torch.Tensor] = []
+    for part in parts:
+        tile = part["pixel_values"]
+        if isinstance(tile, list):
+            tile = torch.as_tensor(tile[0])
+        else:
+            tile = torch.as_tensor(tile)
+            if tile.ndim == 4:
+                tile = tile[0]
+        pixel_values.append(tile)
+        imgs_sizes.extend(
+            [int(h), int(w)]
+            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
+        )
+        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
+    merged: dict[str, Any] = {
+        "input_ids": torch.cat(input_ids, dim=1),
+        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
+        "num_tokens": list(expected_num_tokens),
+        "num_patches": [1] * len(images),
+    }
+    merged["pixel_values"] = (
+        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
+    )
+    return merged
+
+
 def attach_image_model_inputs_to_message(
     message: dict[str, Any],
     *,
     images: list[Image.Image],
     processor: Any,
     pad_dynamic_image_shapes: bool = False,
+    expected_num_tokens_per_image: "Sequence[int] | None" = None,
 ) -> None:
-    """Attach processor-owned image tensors without replacing rollout tokens."""
+    """Attach processor-owned image tensors without replacing rollout tokens.
+
+    When ``expected_num_tokens_per_image`` is given (per-image placeholder run
+    lengths read off the rollout's token ids), the processor output is verified
+    against it and mismatching turns are re-processed at the rollout's exact
+    per-image budgets, so the training-side projected feature count always
+    matches the rollout placeholders. Raises ValueError when parity cannot be
+    established, rather than attaching misaligned media.
+    """
     if not images or processor is None:
         return
+    if expected_num_tokens_per_image is not None and len(
+        expected_num_tokens_per_image
+    ) != len(images):
+        raise ValueError(
+            f"Got {len(images)} images but {len(expected_num_tokens_per_image)} "
+            "rollout placeholder runs for this turn. Refusing to train on "
+            "misaligned media."
+        )
 
     image_token = getattr(processor, "image_token", "<image>")
     # Processors that emit dynamic per-image resolutions return a ragged CHW list
@@ -1030,6 +1300,14 @@ def attach_image_model_inputs_to_message(
         return_tensors=None if allow_ragged_output else "pt",
     )
     processed = dict(processed)
+    if expected_num_tokens_per_image is not None:
+        expected = [int(count) for count in expected_num_tokens_per_image]
+        if _image_num_tokens_from_processed(processed) != expected:
+            processed = _reprocess_images_at_rollout_budgets(
+                processor, images, expected
+            )
+            # Corrected tiles may be ragged even when the originals were not.
+            allow_ragged_output = len(images) > 1
     if allow_ragged_output:
         processed = _materialize_ragged_pixel_values(processed, processor)
     model_inputs = extract_multimodal_model_inputs(processor, processed)

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -34,9 +34,13 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.data.multimodal_utils import (
     attach_image_model_inputs_to_message,
+    count_image_placeholder_runs,
     encode_images_in_examples,
     extract_input_image_sources_from_responses_messages,
+    image_size_from_source,
+    predicted_static_image_num_tokens,
     resolve_to_image,
+    supports_image_placeholder_run_parity,
     uses_image_placeholder,
 )
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
@@ -608,6 +612,7 @@ def _attach_multimodal_data_to_user_message(
     images: list[Image.Image],
     processor: Any,
     pad_dynamic_image_shapes: bool = False,
+    expected_num_tokens_per_image: "list[int] | None" = None,
 ) -> None:
     """Attach per-turn multimodal tensors to ``user_message``.
 
@@ -624,6 +629,7 @@ def _attach_multimodal_data_to_user_message(
         images=images,
         processor=processor,
         pad_dynamic_image_shapes=pad_dynamic_image_shapes,
+        expected_num_tokens_per_image=expected_num_tokens_per_image,
     )
 
 
@@ -973,6 +979,47 @@ Depending on your data shape, you may want to change these values."""
             and initial_media_matches_raw_input
             and returned_media_matches_raw_input
         )
+        parity_processor = (
+            processor
+            if processor is not None
+            and supports_image_placeholder_run_parity(processor)
+            else None
+        )
+        # Dedup omission is only safe when the statically-budgeted tensors the
+        # driver pre-attached provably match the rollout's per-image expansion.
+        # vLLM sizes image tiles per request (shrinking as prompts approach
+        # max_model_len), so budget-bound rows must be attached here, from the
+        # rollout tokens, instead.
+        if (
+            initial_multimodal_data_omitted
+            and parity_processor is not None
+            and raw_initial_sources
+        ):
+            first_trainable_item = next(
+                (
+                    item
+                    for item in response["output"]
+                    if _is_trainable_output_item(item)
+                ),
+                None,
+            )
+            predicted = predicted_static_image_num_tokens(
+                parity_processor,
+                [image_size_from_source(source) for source in raw_initial_sources],
+            )
+            first_turn_runs = (
+                count_image_placeholder_runs(
+                    first_trainable_item["prompt_token_ids"], parity_processor
+                )
+                if first_trainable_item is not None
+                else []
+            )
+            if (
+                predicted is None
+                or len(first_turn_runs) < len(predicted)
+                or first_turn_runs[: len(predicted)] != predicted
+            ):
+                initial_multimodal_data_omitted = False
         if initial_multimodal_data_omitted:
             media_messages, _ = _without_initial_image_sources(
                 media_messages, raw_initial_sources
@@ -1071,6 +1118,29 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                 images_this_turn = (
                     per_turn_images[turn_idx] if turn_idx < len(per_turn_images) else []
                 )
+                expected_num_tokens: "list[int] | None" = None
+                if images_this_turn and parity_processor is not None:
+                    turn_runs = count_image_placeholder_runs(
+                        new_prompt_token_ids, parity_processor
+                    )
+                    # Under dedup omission, turn 0's leading runs belong to the
+                    # initial images whose (verified) tensors the driver
+                    # restores; only the trailing runs are attached here.
+                    omitted_leading_runs = (
+                        len(raw_initial_sources)
+                        if initial_multimodal_data_omitted and turn_idx == 0
+                        else 0
+                    )
+                    if len(turn_runs) != omitted_leading_runs + len(images_this_turn):
+                        raise ValueError(
+                            f"Rollout/image mismatch on NeMo Gym turn {turn_idx}: "
+                            f"the prompt delta contains {len(turn_runs)} image "
+                            f"placeholder runs but {len(images_this_turn)} images "
+                            f"were collected for this turn (plus "
+                            f"{omitted_leading_runs} deduplicated initial images). "
+                            "Refusing to train on misaligned media."
+                        )
+                    expected_num_tokens = turn_runs[omitted_leading_runs:]
                 _attach_multimodal_data_to_user_message(
                     user_message,
                     images=images_this_turn,
@@ -1082,6 +1152,7 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                     pad_dynamic_image_shapes=getattr(
                         self, "_pad_dynamic_image_shapes", False
                     ),
+                    expected_num_tokens_per_image=expected_num_tokens,
                 )
             # Valid tool calls go through the structured API (tool_calls field) and get
             # executed by NeMo-Gym. If tool call patterns appear in the text content instead,

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -34,14 +34,16 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.data.multimodal_utils import (
     attach_image_model_inputs_to_message,
-    count_image_placeholder_runs,
     encode_images_in_examples,
     extract_input_image_sources_from_responses_messages,
     image_size_from_source,
-    predicted_static_image_num_tokens,
     resolve_to_image,
-    supports_image_placeholder_run_parity,
     uses_image_placeholder,
+)
+from nemo_rl.environments.nemotron_utils import (
+    count_image_placeholder_runs,
+    predicted_static_image_num_tokens,
+    supports_image_placeholder_run_parity,
 )
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import (

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -33,6 +33,9 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.data.multimodal_utils import (
+    NATIVE_MULTIMODAL_KEYS,
+    ROLLOUT_MATCHED_MEDIA_KEY,
+    PackedTensor,
     attach_image_model_inputs_to_message,
     encode_images_in_examples,
     extract_input_image_sources_from_responses_messages,
@@ -41,6 +44,7 @@ from nemo_rl.data.multimodal_utils import (
     uses_image_placeholder,
 )
 from nemo_rl.environments.nemotron_utils import (
+    RolloutGeometryUnderdetermined,
     count_image_placeholder_runs,
     predicted_static_image_num_tokens,
     supports_image_placeholder_run_parity,
@@ -1037,6 +1041,10 @@ Depending on your data shape, you may want to change these values."""
         turn_idx = 0
 
         nemo_rl_message_log = []
+        # Set when a turn's rollout image tiling cannot be reproduced without
+        # inferring geometry from token counts; the whole sample then carries
+        # no media and is flagged for loss masking.
+        media_geometry_failed = False
         seen_token_ids: List[int] = []
         batch_decode_items = []
         for output_item_dict in nemo_gym_result["response"]["output"]:
@@ -1116,7 +1124,7 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                 user_message["routed_experts"] = routed_experts[prompt_start:prompt_end]
             nemo_rl_message_log.append(user_message)
 
-            if processor is not None:
+            if processor is not None and not media_geometry_failed:
                 images_this_turn = (
                     per_turn_images[turn_idx] if turn_idx < len(per_turn_images) else []
                 )
@@ -1143,19 +1151,33 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                             "Refusing to train on misaligned media."
                         )
                     expected_num_tokens = turn_runs[omitted_leading_runs:]
-                _attach_multimodal_data_to_user_message(
-                    user_message,
-                    images=images_this_turn,
-                    processor=processor,
-                    # Read with a default, like _processor above: this method is
-                    # called unbound against lightweight stand-ins that define
-                    # only what they exercise, so a bare attribute access turns
-                    # an unrelated test into an AttributeError.
-                    pad_dynamic_image_shapes=getattr(
-                        self, "_pad_dynamic_image_shapes", False
-                    ),
-                    expected_num_tokens_per_image=expected_num_tokens,
-                )
+                try:
+                    _attach_multimodal_data_to_user_message(
+                        user_message,
+                        images=images_this_turn,
+                        processor=processor,
+                        # Read with a default, like _processor above: this method is
+                        # called unbound against lightweight stand-ins that define
+                        # only what they exercise, so a bare attribute access turns
+                        # an unrelated test into an AttributeError.
+                        pad_dynamic_image_shapes=getattr(
+                            self, "_pad_dynamic_image_shapes", False
+                        ),
+                        expected_num_tokens_per_image=expected_num_tokens,
+                    )
+                except RolloutGeometryUnderdetermined as exc:
+                    # The rollout's tiling for some image on this turn cannot be
+                    # reproduced without guessing geometry. Guessing risks
+                    # training against different pixels than generated the
+                    # rollout, so drop ALL media from this sample instead: the
+                    # per-row media validity mask then treats its placeholder
+                    # ids as ordinary tokens (no Megatron alignment to satisfy)
+                    # and the sample is flagged for loss masking below.
+                    media_geometry_failed = True
+                    print(
+                        "[NemoGym] Dropping media and masking sample: "
+                        f"turn {turn_idx}: {exc}"
+                    )
             # Valid tool calls go through the structured API (tool_calls field) and get
             # executed by NeMo-Gym. If tool call patterns appear in the text content instead,
             # the call was invalid and never executed — flag it so training can penalize it.
@@ -1242,6 +1264,28 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                     container[key], _ = _without_initial_image_sources(
                         container[key], raw_initial_sources
                     )
+
+        if media_geometry_failed:
+            # Strip every media tensor already attached to this sample (partial
+            # media would leave Megatron with fewer projected features than
+            # placeholder tokens), mark each user turn so the driver-side
+            # static reattach does not restore misaligned tensors, and flag the
+            # sample so GRPO masks it from the loss.
+            for message in nemo_rl_message_log:
+                if message.get("role") != "user":
+                    continue
+                for key in [
+                    key
+                    for key, value in message.items()
+                    if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS
+                ]:
+                    del message[key]
+                message[ROLLOUT_MATCHED_MEDIA_KEY] = True
+            instance_config = nemo_gym_result.get("instance_config")
+            if not isinstance(instance_config, dict):
+                instance_config = {}
+                nemo_gym_result["instance_config"] = instance_config
+            instance_config["mask_sample"] = True
 
         result = {
             "message_log": nemo_rl_message_log,

--- a/nemo_rl/environments/nemotron_utils.py
+++ b/nemo_rl/environments/nemotron_utils.py
@@ -14,7 +14,9 @@
 
 import copy
 import math
+from collections.abc import Sequence
 from functools import lru_cache
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -22,6 +24,11 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 from transformers import AutoConfig
+
+from nemo_rl.data.multimodal_utils import (
+    _image_num_tokens_from_processed,
+    uses_image_placeholder,
+)
 
 NEMOTRON_VIDEO_PROCESSOR_NAMES = frozenset(
     {
@@ -358,3 +365,230 @@ def process_nemotron_video_frames(
         "pixel_values": torch.stack(pixel_values),
         "imgs_sizes": torch.tensor(image_sizes, dtype=torch.int32),
     }
+
+
+# --- Rollout/train image-tiling parity helpers (Nemotron placeholder-style
+# processors). The rollout engine expands each image to <img><image>*N</img>;
+# these helpers read those runs back as the authoritative per-image budgets
+# and force the training-side processor to reproduce them exactly.
+
+
+def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
+    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None or not uses_image_placeholder(processor):
+        return None
+    tokens = [
+        getattr(processor, "image_token", "<image>"),
+        getattr(processor, "image_start_token", "<img>"),
+        getattr(processor, "image_end_token", "</img>"),
+    ]
+    ids = tokenizer.convert_tokens_to_ids(tokens)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
+        return None
+    return int(ids[0]), int(ids[1]), int(ids[2])
+
+
+def supports_image_placeholder_run_parity(processor: Any) -> bool:
+    """Whether rollout tokens can be parsed into per-image placeholder runs."""
+    return get_image_placeholder_token_ids(processor) is not None
+
+
+def count_image_placeholder_runs(
+    token_ids: "Sequence[int] | torch.Tensor", processor: Any
+) -> list[int]:
+    """Per-image placeholder run lengths from rollout token ids, in order.
+
+    The rollout engine (and this processor) expand each image to
+    ``<img><image>*N</img>``; each run's N is the exact number of projected
+    media features the model expects for that image.
+    """
+    placeholder_ids = get_image_placeholder_token_ids(processor)
+    if placeholder_ids is None:
+        raise ValueError(
+            f"{type(processor).__name__} does not expose image placeholder "
+            "tokens; cannot count image placeholder runs."
+        )
+    image_id, start_id, end_id = placeholder_ids
+    if isinstance(token_ids, torch.Tensor):
+        token_ids = token_ids.tolist()
+    runs: list[int] = []
+    current: "int | None" = None
+    for token in token_ids:
+        if token == start_id:
+            if current is not None:
+                raise ValueError("Nested <img> region in rollout tokens.")
+            current = 0
+        elif token == end_id:
+            if current is None:
+                raise ValueError("Unmatched </img> in rollout tokens.")
+            runs.append(current)
+            current = None
+        elif token == image_id:
+            if current is None:
+                raise ValueError(
+                    "Image placeholder token outside an <img>...</img> region "
+                    "in rollout tokens."
+                )
+            current += 1
+    if current is not None:
+        raise ValueError("Unterminated <img> region in rollout tokens.")
+    return runs
+
+
+def predicted_static_image_num_tokens(
+    processor: Any, image_sizes: list[tuple[int, int]]
+) -> "list[int] | None":
+    """Predict per-image token counts of the processor's static image path.
+
+    Mirrors the budget selection in the checkpoint's image processor
+    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
+    for the grid math, so it costs no pixel work. Returns None when the
+    processor does not expose the needed hooks (callers must then assume the
+    static output is unverified and attach rollout-matched media themselves).
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    required = (
+        "max_model_len",
+        "min_num_patches",
+        "max_num_patches",
+        "_compute_target_patches",
+    )
+    if image_processor is None or not all(
+        hasattr(image_processor, name) for name in required
+    ):
+        return None
+    downsample = getattr(image_processor, "_downsample_factor", None)
+    if not downsample:
+        ratio = getattr(image_processor, "downsample_ratio", None)
+        if not ratio:
+            return None
+        downsample = int(round(1.0 / ratio))
+    budget = (image_processor.max_model_len - 4) * downsample**2
+    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
+    max_patches = image_processor.max_num_patches
+    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
+    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
+    num_tokens = []
+    for width, height in image_sizes:
+        shim = SimpleNamespace(width=width, height=height)
+        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
+        num_tokens.append((grid_w * grid_h) // downsample**2)
+    return num_tokens
+
+
+def _closest_aspect_grid(
+    target_patches: int, height: int, width: int, divisor: int
+) -> tuple[int, int]:
+    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
+    units = divisor * divisor
+    if target_patches <= 0 or target_patches % units:
+        raise ValueError(
+            f"Rollout image placeholder run implies {target_patches} patches, "
+            f"which is not a positive multiple of the pixel-shuffle factor "
+            f"squared ({units}); the rollout tokens do not describe a valid "
+            "image tile."
+        )
+    base = target_patches // units
+    aspect = math.log(max(height, 1) / max(width, 1))
+    best: "tuple[float, int, int] | None" = None
+    for low in range(1, math.isqrt(base) + 1):
+        if base % low:
+            continue
+        high = base // low
+        for h_units, w_units in ((low, high), (high, low)):
+            grid_h, grid_w = h_units * divisor, w_units * divisor
+            score = abs(math.log(grid_h / grid_w) - aspect)
+            if best is None or score < best[0]:
+                best = (score, grid_h, grid_w)
+    assert best is not None
+    return best[1], best[2]
+
+
+def _process_single_image_at_num_tokens(
+    processor: Any, image: Image.Image, num_tokens: int
+) -> dict[str, Any]:
+    """Run the processor on one image, pinned to an exact media token count."""
+    image_processor = processor.image_processor
+    image_token = getattr(processor, "image_token", "<image>")
+    downsample = getattr(image_processor, "_downsample_factor", None) or int(
+        round(1.0 / image_processor.downsample_ratio)
+    )
+
+    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
+        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
+        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
+        # patches. Instance mutation is the only knob: the wrapper's
+        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
+        # run this on a single thread with no awaits in between (same pattern
+        # as the processor's own _is_video_mode flag).
+        original = image_processor.max_model_len
+        try:
+            image_processor.max_model_len = num_tokens + 4
+            return dict(
+                processor(text=image_token, images=[single_image], return_tensors=None)
+            )
+        finally:
+            image_processor.max_model_len = original
+
+    processed = run_pinned(image)
+    if _image_num_tokens_from_processed(processed) == [num_tokens]:
+        return processed
+
+    # Grid rounding is not idempotent for every (size, budget); force the exact
+    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
+    # patches passes _compute_target_patches unchanged under the pinned budget.
+    grid_h, grid_w = _closest_aspect_grid(
+        num_tokens * downsample * downsample, image.height, image.width, downsample
+    )
+    patch = image_processor.patch_size
+    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
+    processed = run_pinned(resized)
+    actual = _image_num_tokens_from_processed(processed)
+    if actual != [num_tokens]:
+        raise ValueError(
+            "Cannot match the rollout's image tiling: the rollout expanded a "
+            f"{image.width}x{image.height} image to {num_tokens} placeholder "
+            f"tokens, but the training processor produced {actual[0]} tokens "
+            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
+            "train on misaligned media."
+        )
+    return processed
+
+
+def reprocess_images_at_rollout_budgets(
+    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
+) -> dict[str, Any]:
+    """Re-run the processor per image at the rollout's exact per-image budget."""
+    parts = [
+        _process_single_image_at_num_tokens(processor, image, count)
+        for image, count in zip(images, expected_num_tokens, strict=True)
+    ]
+    pixel_values: list[torch.Tensor] = []
+    imgs_sizes: list[list[int]] = []
+    input_ids: list[torch.Tensor] = []
+    for part in parts:
+        tile = part["pixel_values"]
+        if isinstance(tile, list):
+            tile = torch.as_tensor(tile[0])
+        else:
+            tile = torch.as_tensor(tile)
+            if tile.ndim == 4:
+                tile = tile[0]
+        pixel_values.append(tile)
+        imgs_sizes.extend(
+            [int(h), int(w)]
+            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
+        )
+        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
+    merged: dict[str, Any] = {
+        "input_ids": torch.cat(input_ids, dim=1),
+        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
+        "num_tokens": list(expected_num_tokens),
+        "num_patches": [1] * len(images),
+    }
+    merged["pixel_values"] = (
+        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
+    )
+    return merged

--- a/nemo_rl/environments/nemotron_utils.py
+++ b/nemo_rl/environments/nemotron_utils.py
@@ -478,32 +478,16 @@ def predicted_static_image_num_tokens(
     return num_tokens
 
 
-def _closest_aspect_grid(
-    target_patches: int, height: int, width: int, divisor: int
-) -> tuple[int, int]:
-    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
-    units = divisor * divisor
-    if target_patches <= 0 or target_patches % units:
-        raise ValueError(
-            f"Rollout image placeholder run implies {target_patches} patches, "
-            f"which is not a positive multiple of the pixel-shuffle factor "
-            f"squared ({units}); the rollout tokens do not describe a valid "
-            "image tile."
-        )
-    base = target_patches // units
-    aspect = math.log(max(height, 1) / max(width, 1))
-    best: "tuple[float, int, int] | None" = None
-    for low in range(1, math.isqrt(base) + 1):
-        if base % low:
-            continue
-        high = base // low
-        for h_units, w_units in ((low, high), (high, low)):
-            grid_h, grid_w = h_units * divisor, w_units * divisor
-            score = abs(math.log(grid_h / grid_w) - aspect)
-            if best is None or score < best[0]:
-                best = (score, grid_h, grid_w)
-    assert best is not None
-    return best[1], best[2]
+class RolloutGeometryUnderdetermined(ValueError):
+    """The rollout's image token count cannot be reproduced without guessing.
+
+    A placeholder-run length does not uniquely identify the rollout engine's
+    preprocessing grid (several grids share one product), so when re-running
+    the processor under the rollout's own budget fails to reproduce the count,
+    inferring a grid from the count risks training against different pixels
+    and feature ordering than generated the rollout. Callers must treat the
+    affected sample as unusable media rather than guess.
+    """
 
 
 def _process_single_image_at_num_tokens(
@@ -533,28 +517,25 @@ def _process_single_image_at_num_tokens(
             image_processor.max_model_len = original
 
     processed = run_pinned(image)
-    if _image_num_tokens_from_processed(processed) == [num_tokens]:
+    actual = _image_num_tokens_from_processed(processed)
+    if actual == [num_tokens]:
         return processed
 
-    # Grid rounding is not idempotent for every (size, budget); force the exact
-    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
-    # patches passes _compute_target_patches unchanged under the pinned budget.
-    grid_h, grid_w = _closest_aspect_grid(
-        num_tokens * downsample * downsample, image.height, image.width, downsample
+    # The pinned budget replays the rollout engine's own decision procedure;
+    # when even that does not reproduce the rollout's count, the count alone
+    # cannot recover the geometry: several (grid_h, grid_w) factorizations
+    # share the product num_tokens*ds^2, and picking one that differs from the
+    # rollout's would pass count validation while training on different pixels
+    # and spatial feature ordering. Fail instead of inferring.
+    raise RolloutGeometryUnderdetermined(
+        "Cannot reproduce the rollout's image tiling: the rollout expanded a "
+        f"{image.width}x{image.height} image to {num_tokens} placeholder "
+        f"tokens, but the training processor produced {actual[0]} tokens under "
+        f"the rollout's own budget (downsample={downsample}). The token count "
+        "does not uniquely identify the preprocessing grid, so the geometry "
+        "is not inferred from it; this image's media cannot be matched to the "
+        "rollout without the engine's per-image grid metadata."
     )
-    patch = image_processor.patch_size
-    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
-    processed = run_pinned(resized)
-    actual = _image_num_tokens_from_processed(processed)
-    if actual != [num_tokens]:
-        raise ValueError(
-            "Cannot match the rollout's image tiling: the rollout expanded a "
-            f"{image.width}x{image.height} image to {num_tokens} placeholder "
-            f"tokens, but the training processor produced {actual[0]} tokens "
-            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
-            "train on misaligned media."
-        )
-    return processed
 
 
 def reprocess_images_at_rollout_budgets(

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -786,9 +786,18 @@ class AsyncNemoGymRolloutImpl:
             rollout_inputs, timer, timer_prefix
         )
         source_message_log = input_sample["message_log"]
-        attach_static_multimodal_payload(prompt_message_log, source_message_log)
+        # The prompt log and each completion's log can alias the same message
+        # dictionaries; share one processed-id set so a rollout-matched marker
+        # consumed on one view cannot leave later views free to overwrite the
+        # repaired media.
+        processed_target_ids: set[int] = set()
+        attach_static_multimodal_payload(
+            prompt_message_log, source_message_log, processed_target_ids
+        )
         for completion in completions:
-            attach_static_multimodal_payload(completion.message_log, source_message_log)
+            attach_static_multimodal_payload(
+                completion.message_log, source_message_log, processed_target_ids
+            )
 
         timer.stop(f"{timer_prefix}/total")
         rollout_metrics.update(timer.get_timing_metrics("sum"))

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -233,8 +233,14 @@ def attach_static_multimodal_payload(
         )
     for source, target in zip(source_users, target_users):
         for key, value in source.items():
-            if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS:
-                target[key] = value
+            if not (isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS):
+                continue
+            if key in target:
+                # The Gym actor attached rollout-matched media for this turn
+                # (e.g. after vetoing dedup omission on a budget-bound row);
+                # never overwrite it with the statically-budgeted prompt copy.
+                continue
+            target[key] = value
 
 
 def _add_r3_fallback_metrics(

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -43,6 +43,7 @@ from nemo_rl.data.llm_message_utils import (
     get_keys_from_message_log,
 )
 from nemo_rl.data.multimodal_utils import (
+    ROLLOUT_MATCHED_MEDIA_KEY,
     NATIVE_MULTIMODAL_KEYS,
     VLLM_MULTIMODAL_DATA_KEYS,
     PackedTensor,
@@ -232,15 +233,16 @@ def attach_static_multimodal_payload(
             "turns than the source prompt."
         )
     for source, target in zip(source_users, target_users):
+        if target.pop(ROLLOUT_MATCHED_MEDIA_KEY, False):
+            # The Gym actor attached rollout-matched media for this turn (e.g.
+            # after vetoing dedup omission on a budget-bound row); never
+            # overwrite it with the statically-budgeted prompt copy. Key
+            # presence alone is not provenance: targets may carry placeholder
+            # or stale payloads that this copy is expected to replace.
+            continue
         for key, value in source.items():
-            if not (isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS):
-                continue
-            if key in target:
-                # The Gym actor attached rollout-matched media for this turn
-                # (e.g. after vetoing dedup omission on a budget-bound row);
-                # never overwrite it with the statically-budgeted prompt copy.
-                continue
-            target[key] = value
+            if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS:
+                target[key] = value
 
 
 def _add_r3_fallback_metrics(

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -208,19 +208,37 @@ def _reattach_static_multimodal_payloads_to_result(
     result: dict[str, Any],
     source_message_log: list[dict[str, Any]],
 ) -> None:
-    """Restore static media to each Gym-authored message-log representation."""
+    """Restore static media to each Gym-authored message-log representation.
+
+    ``input_message_log`` is a slice of ``message_log``, so the two views alias
+    the same message dictionaries; share one processed-id set so each message
+    is handled once and a rollout-matched marker consumed while processing one
+    view cannot expose the same message to overwriting via the other.
+    """
+    processed_target_ids: set[int] = set()
     for log_key in ("input_message_log", "message_log"):
         target_log = result.get(log_key)
         if not target_log:
             continue
-        attach_static_multimodal_payload(target_log, source_message_log)
+        attach_static_multimodal_payload(
+            target_log, source_message_log, processed_target_ids
+        )
 
 
 def attach_static_multimodal_payload(
     target_message_log: list[dict[str, Any]],
     source_message_log: list[dict[str, Any]],
+    processed_target_ids: "set[int] | None" = None,
 ) -> None:
-    """Copy policy-ready media from static source turns to Gym-authored turns."""
+    """Copy policy-ready media from static source turns to Gym-authored turns.
+
+    Callers that attach to several views of the same rollout (e.g. a result's
+    ``input_message_log`` and ``message_log``, or a prompt log and its
+    completions) may alias the same message dictionaries across views. Pass one
+    shared ``processed_target_ids`` set across those calls: each unique message
+    is then processed exactly once, so a rollout-matched marker consumed on the
+    first view cannot leave later views free to overwrite the repaired media.
+    """
     source_users = [
         message for message in source_message_log if message.get("role") == "user"
     ]
@@ -233,6 +251,10 @@ def attach_static_multimodal_payload(
             "turns than the source prompt."
         )
     for source, target in zip(source_users, target_users):
+        if processed_target_ids is not None:
+            if id(target) in processed_target_ids:
+                continue
+            processed_target_ids.add(id(target))
         if target.pop(ROLLOUT_MATCHED_MEDIA_KEY, False):
             # The Gym actor attached rollout-matched media for this turn (e.g.
             # after vetoing dedup omission on a budget-bound row); never

--- a/tests/unit/environments/test_nemo_gym_geometry_failsoft.py
+++ b/tests/unit/environments/test_nemo_gym_geometry_failsoft.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from PIL import Image
+
+import nemo_rl.environments.nemo_gym as nemo_gym_module
+from nemo_rl.data.multimodal_utils import ROLLOUT_MATCHED_MEDIA_KEY, PackedTensor
+from nemo_rl.environments.nemo_gym import NemoGym
+from nemo_rl.environments.nemotron_utils import (
+    RolloutGeometryUnderdetermined,
+    _process_single_image_at_num_tokens,
+)
+
+
+class _Tokenizer:
+    def batch_decode(self, batch):
+        return [" ".join(map(str, token_ids)) for token_ids in batch]
+
+
+class _PinnedMismatchImageProcessor:
+    """Image processor whose pinned run never reproduces the requested count."""
+
+    max_model_len = 4096
+    downsample_ratio = 0.5
+    patch_size = 16
+
+
+class _PinnedMismatchProcessor:
+    image_token = "<image>"
+    image_processor = _PinnedMismatchImageProcessor()
+
+    def __call__(self, text, images, return_tensors):
+        # Whatever the pinned budget asks for, produce one token too many, so
+        # the count can never be reproduced without inferring a grid.
+        return {"num_tokens": [self.image_processor.max_model_len - 4 + 1]}
+
+
+def test_unreproducible_tiling_raises_instead_of_inferring_a_grid():
+    processor = _PinnedMismatchProcessor()
+    image = Image.new("RGB", (1152, 256))
+    with pytest.raises(RolloutGeometryUnderdetermined, match="does not uniquely"):
+        _process_single_image_at_num_tokens(processor, image, 288)
+    # The pinned-budget mutation is rolled back even on failure.
+    assert processor.image_processor.max_model_len == 4096
+
+
+def test_geometry_failure_strips_media_masks_sample_and_marks_turns(monkeypatch):
+    """A mid-sample geometry failure must not leave partial media behind.
+
+    Turn 0 attaches media successfully; turn 1 fails. The sample must come
+    back with no media on any turn (partial media would leave Megatron with
+    fewer projected features than placeholder tokens), every user turn marked
+    rollout-matched so the driver-side static reattach does not restore
+    misaligned tensors, and the sample flagged for loss masking.
+    """
+    calls = {"n": 0}
+
+    def fake_attach(user_message, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            user_message["pixel_values"] = PackedTensor(
+                torch.ones(1, 1), dim_to_pack=0
+            )
+        else:
+            raise RolloutGeometryUnderdetermined("count is ambiguous")
+
+    monkeypatch.setattr(
+        nemo_gym_module, "_attach_multimodal_data_to_user_message", fake_attach
+    )
+
+    nemo_gym_result = {
+        "response": {
+            "output": [
+                {
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3],
+                    "generation_log_probs": [-0.1],
+                },
+                {
+                    "prompt_token_ids": [1, 2, 3, 4, 5],
+                    "generation_token_ids": [6, 7],
+                    "generation_log_probs": [-0.2, -0.3],
+                },
+            ]
+        },
+        "responses_create_params": {"input": []},
+    }
+
+    class _MockSelf:
+        cfg = {}
+        _processor = object()
+
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _MockSelf(), {}, nemo_gym_result, _Tokenizer()
+        )
+    )
+
+    user_messages = [
+        message for message in result["message_log"] if message["role"] == "user"
+    ]
+    assert len(user_messages) == 2
+    for message in user_messages:
+        assert not any(
+            isinstance(value, PackedTensor) for value in message.values()
+        ), "media must be stripped from every turn after a geometry failure"
+        assert message[ROLLOUT_MATCHED_MEDIA_KEY] is True
+    assert nemo_gym_result["instance_config"]["mask_sample"] is True
+    # Only turns before the failure ever attached; the failing turn stopped it.
+    assert calls["n"] == 2

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -213,6 +213,48 @@ def test_attach_image_model_inputs_is_a_noop_without_images_or_processor():
     assert set(message) == {"role", "content", "token_ids"}
 
 
+def test_reattach_preserves_rollout_matched_media_marker():
+    """Media the Gym actor attached rollout-matched must not be overwritten.
+
+    Provenance is the explicit marker, not key presence: an unmarked
+    placeholder value is still replaced (see the neighboring test), while a
+    marked turn keeps its actor-attached tensors and the marker is consumed.
+    """
+    from nemo_rl.data.multimodal_utils import ROLLOUT_MATCHED_MEDIA_KEY
+
+    static_image = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
+    rollout_matched = PackedTensor(torch.tensor([[9.0]]), dim_to_pack=0)
+    original_logs = [
+        [
+            {"role": "user", "content": "first", "pixel_values": static_image},
+        ]
+    ]
+    results = [
+        {
+            "_initial_multimodal_data_omitted": True,
+            "input_message_log": [
+                {"role": "user", "content": "first"},
+            ],
+            "message_log": [
+                {
+                    "role": "user",
+                    "content": "first",
+                    "pixel_values": rollout_matched,
+                    ROLLOUT_MATCHED_MEDIA_KEY: True,
+                },
+            ],
+        }
+    ]
+
+    _reattach_original_multimodal_payloads(results, original_logs)
+
+    marked_user = results[0]["message_log"][0]
+    assert marked_user["pixel_values"] is rollout_matched
+    assert ROLLOUT_MATCHED_MEDIA_KEY not in marked_user
+    # The unmarked representation is still restored from the static source.
+    assert results[0]["input_message_log"][0]["pixel_values"] is static_image
+
+
 def test_reattach_original_multimodal_payloads_is_media_only_and_turn_aligned():
     first_image = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
     second_image = PackedTensor(torch.tensor([[2.0]]), dim_to_pack=0)

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -2520,3 +2520,38 @@ def test_run_async_nemo_gym_rollout(
     1. In nemo_rl/experience/rollouts.py::run_async_nemo_gym_rollout, the sampling params are passed appropriately
     2. In nemo_rl/models/generation/vllm/vllm_worker_async.py::VllmAsyncGenerationWorker::_setup_vllm_server::create_chat_completion, the sampling params (like top_k) are set as appropriate
     """
+
+
+def test_reattach_preserves_marker_across_aliased_message_log_views():
+    """Production shape: ``input_message_log`` is a slice of ``message_log``.
+
+    Both views reference the same message dictionary; consuming the
+    rollout-matched marker while processing one view must not leave the other
+    view free to overwrite the repaired media with the static payload.
+    """
+    from nemo_rl.data.multimodal_utils import ROLLOUT_MATCHED_MEDIA_KEY
+    static_image = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
+    rollout_matched = PackedTensor(torch.tensor([[9.0]]), dim_to_pack=0)
+    original_logs = [
+        [{"role": "user", "content": "first", "pixel_values": static_image}]
+    ]
+    shared_message = {
+        "role": "user",
+        "content": "first",
+        "pixel_values": rollout_matched,
+        ROLLOUT_MATCHED_MEDIA_KEY: True,
+    }
+    message_log = [shared_message]
+    results = [
+        {
+            "_initial_multimodal_data_omitted": True,
+            "input_message_log": message_log[:1],
+            "message_log": message_log,
+        }
+    ]
+
+    _reattach_original_multimodal_payloads(results, original_logs)
+
+    assert results[0]["input_message_log"][0] is shared_message
+    assert shared_message["pixel_values"] is rollout_matched
+    assert ROLLOUT_MATCHED_MEDIA_KEY not in shared_message


### PR DESCRIPTION
## What does this PR do?

Fixes a train/generation image-tiling mismatch that crashes async GRPO VLM training mid-run:

```
ValueError: Expanded-sequence media alignment failed: found 32160 valid
placeholders for 40800 projected features.
```

## The bug

A VLM sample needs the number of vision features in the training tensors to equal the number of image-placeholder tokens in the sequence — the model forward merges features into placeholder positions one-to-one.

Those two counts are computed by different components:

- **Generation (vLLM)** sizes image tiles *per request*, shrinking them as the prompt approaches `max_model_len`. The rollout's token ids reflect that choice.
- **Training (attach path)** re-processes the original images through the HF processor, which only knows its **static config budget** and cannot see what the engine chose for this request.

On most rows both sides agree, so the bug is invisible. On budget-bound rows (large frames + long text — e.g. 16 frames at 2400×1080 in a near-32k prompt) the engine shrinks tiles (2010 tokens/image) while the training side produces its static count (2550/image) → 40800 features vs 32160 placeholders → hard crash on every rank, at whatever step first samples such a row.

## The fix

Use the rollout itself as ground truth instead of trying to mirror the engine's budget arithmetic (which lives in engine internals and can drift):

1. **`multimodal_utils`** — parse per-image `<img><image>*N</img>` placeholder runs out of the rollout token ids; the run lengths are exactly the feature counts the model will demand. Verify the processor's native output against them; on mismatch, re-process each image pinned to the exact count (the image processor's `max_model_len` clamp is the budget lever, with a deterministic exact-grid resize fallback). If parity cannot be established, raise a clear error instead of attaching misaligned media.
2. **`nemo_gym` actor** — pass each turn's placeholder runs into the attach. With `deduplicate_multimodal_data: true`, keep the media omission only when the statically-budgeted pre-attached tensors provably match the rollout's first-turn runs (predicted via the processor's own grid math); otherwise attach rollout-matched tensors actor-side.
3. **`rollouts`** — the driver-side static reattach never overwrites media the actor already attached. Video rows are unaffected: their tensors attach at datum time and their turns carry no extracted images, so the parity logic never engages for them.

Non-binding rows (the common case) take a fast path — the batched processor call is verified against the runs and used as-is, so behavior and cost are unchanged.

## Validation

- Offline against the checkpoint processor: exact-count repair across a 7-size × 7-budget sweep (processor state restored after each pinned call); the crash row (16×2400×1080 pinned to 2010/image) yields exactly 32160 feature tokens; non-binding rows byte-match the previous fast path; the dedup-omission predictor matches the native processor on uniform and mixed-size batches.
- In production: the failing 32-node run resumed from checkpoint, passed the previously fatal batch, and trained to completion (50 steps) with no alignment errors and healthy reward progression.

## Notes for reviewers

- The placeholder-run grammar (`<img><image>*N</img>`) and the `num_tokens` output key follow the NemotronH Omni processor family; processors that don't expose these degrade gracefully (parity checks are skipped, current behavior preserved).
- Budget-bound dedup rows lose media dedup for that row (the actor ships rollout-matched tensors); a follow-up could restore sharing with a repair-at-reattach cache if such rows are common in a workload.