### PR TITLE
fix(async): honor max_num_epochs in async GRPO

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -509,6 +509,40 @@ def shutdown_environments(
                     print(f"Error stopping environment {task_name}: {kill_error}")
 
 
+def _clamp_max_num_steps_to_epochs(
+    grpo_config: GRPOConfig,
+    train_sample_count: int,
+    *,
+    use_multiple_dataloader: bool,
+) -> None:
+    """Lower max_num_steps to the steps max_num_epochs is worth.
+
+    async_grpo_train has no epoch loop -- it consumes the trajectory collector's
+    buffer rather than iterating the dataloader -- so max_num_epochs can only
+    bound it through the step count. Without this the run passes its last epoch
+    and the collector raises on an exhausted dataloader.
+
+    single_controller_utils.setup._clamp_max_num_steps does the same for the
+    single-controller path, which has no epoch loop either. It is not reused
+    here: it imports from this module, it takes the dataloader rather than a
+    step count (multiple dataloaders have no single one to measure), and it has
+    no exemption for them.
+
+    Args:
+        grpo_config: Mutated in place; only max_num_steps changes.
+        train_sample_count: Steps in one epoch, i.e. len(dataloader).
+        use_multiple_dataloader: When set, MultipleDataloaderWrapper is an
+            infinite iterator, so an epoch has no length to derive a bound from
+            and max_num_steps is left alone.
+    """
+    if use_multiple_dataloader or grpo_config.max_num_epochs <= 0:
+        return
+    grpo_config.max_num_steps = min(
+        grpo_config.max_num_steps,
+        grpo_config.max_num_epochs * train_sample_count,
+    )
+
+
 def setup(
     master_config: MasterConfig,
     tokenizer: TokenizerType,
@@ -1193,13 +1227,15 @@ def setup(
 
     weights_path, optimizer_path = checkpointer.get_resume_paths(last_checkpoint_path)
 
+    _clamp_max_num_steps_to_epochs(
+        grpo_config,
+        train_sample_count,
+        use_multiple_dataloader=master_config["data"]["use_multiple_dataloader"],
+    )
+
     if policy_config.get("megatron_cfg", {}).get("enabled", False):
         ## NOTE: this is equal to the total number of scheduler steps
-        total_train_iters = min(
-            grpo_config.max_num_steps,
-            grpo_config.max_num_epochs * train_sample_count,
-        )
-        policy_config["megatron_cfg"]["train_iters"] = total_train_iters
+        policy_config["megatron_cfg"]["train_iters"] = grpo_config.max_num_steps
 
     # Megatron generation expresses recompute-after-refit engine-side via
     # `kv_cache_management_mode="recompute"`; the loop-level flag must agree.

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4447,7 +4447,7 @@ def _raise_if_collector_stopped(
         else "collector errored"
     )
     recovery_advice = (
-        "Increase data.train.max_num_epochs or use a larger dataset."
+        "Increase grpo.max_num_epochs or use a larger dataset."
         if collector_status["data_exhausted"]
         else "Inspect the preceding trajectory collector error."
     )

--- a/tests/unit/algorithms/test_grpo_max_num_steps.py
+++ b/tests/unit/algorithms/test_grpo_max_num_steps.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for _clamp_max_num_steps_to_epochs."""
+
+from nemo_rl.algorithms.grpo import GRPOConfig, _clamp_max_num_steps_to_epochs
+
+
+def _config(max_num_steps: int, max_num_epochs: int) -> GRPOConfig:
+    return GRPOConfig(max_num_steps=max_num_steps, max_num_epochs=max_num_epochs)
+
+
+def test_clamps_to_one_epoch():
+    cfg = _config(max_num_steps=1000000, max_num_epochs=1)
+    _clamp_max_num_steps_to_epochs(cfg, 1425, use_multiple_dataloader=False)
+    assert cfg.max_num_steps == 1425
+
+
+def test_clamps_to_several_epochs():
+    cfg = _config(max_num_steps=1000, max_num_epochs=3)
+    _clamp_max_num_steps_to_epochs(cfg, 100, use_multiple_dataloader=False)
+    assert cfg.max_num_steps == 300
+
+
+def test_keeps_the_smaller_step_budget():
+    cfg = _config(max_num_steps=50, max_num_epochs=1)
+    _clamp_max_num_steps_to_epochs(cfg, 1425, use_multiple_dataloader=False)
+    assert cfg.max_num_steps == 50
+
+
+def test_multiple_dataloaders_are_left_alone():
+    # MultipleDataloaderWrapper is an infinite iterator, so an epoch has no
+    # length and the step budget is the only bound.
+    cfg = _config(max_num_steps=1000000, max_num_epochs=1)
+    _clamp_max_num_steps_to_epochs(cfg, 1425, use_multiple_dataloader=True)
+    assert cfg.max_num_steps == 1000000
+
+
+def test_non_positive_epochs_are_left_alone():
+    # Clamping on 0 would silently budget zero training steps.
+    cfg = _config(max_num_steps=1000000, max_num_epochs=0)
+    _clamp_max_num_steps_to_epochs(cfg, 1425, use_multiple_dataloader=False)
+    assert cfg.max_num_steps == 1000000


### PR DESCRIPTION
# What does this PR do ?

`async_grpo_train` bounds itself with `while step < max_num_steps` and has no epoch loop, since it consumes the trajectory collector's buffer rather than iterating the dataloader. `grpo.max_num_epochs` therefore had no effect on an async run: a config asking for one epoch kept going until the collector reported an exhausted dataloader and raised.

`setup()` already derives the epoch-equivalent step count for the Megatron scheduler budget. This clamps `max_num_steps` with it, which bounds the loop and keeps the scheduler horizon in agreement with the loop it schedules for. Multiple dataloaders are exempt, since `MultipleDataloaderWrapper` is an infinite iterator and an epoch has no length to derive a bound from.

The exhaustion message also pointed at `data.train.max_num_epochs`, which nothing reads; the setting is `grpo.max_num_epochs`.

# Issues

None closed.

# Usage

```yaml
grpo:
  max_num_epochs: 1
  max_num_steps: 1000000   # upper bound; the epoch clamp decides where the run ends
  async_grpo:
    enabled: true
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally?
- [x] Did you add or update any necessary documentation?

# Additional Information

* `tests/unit/algorithms/test_grpo_max_num_steps.py` covers the clamp, a multi-epoch budget, an already-smaller step budget, the multiple-dataloader exemption and a non-positive epoch count.
* The five cases were verified against the helper in isolation, but the test module was not run under `pytest` in a full environment, so that box is left unchecked.
