### PR TITLE
fix(megatron): make linear CE fusion work through VLM wrappers

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -2520,6 +2520,13 @@ def _gpt_forward_with_linear_ce_fusion(
     )
     from megatron.core.utils import deprecate_inference_params, get_pg_size
 
+    # A VLM wrapper in front of this GPTModel cannot forward the kwarg (its own
+    # forward() does not declare it), so nemo_rl.models.megatron.train arms this
+    # instance for the duration of the call instead. See
+    # _armed_linear_ce_fusion().
+    if getattr(self, "_linear_ce_fusion_armed", False):
+        return_logprobs_for_linear_ce_fusion = True
+
     if not return_logprobs_for_linear_ce_fusion:
         passthrough_kwargs: dict[str, Any] = {}
         # is_spec_decode was added to GPTModel.forward in newer Megatron-LM. Only

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1766,6 +1766,64 @@ def build_inference_model(
     return inference_model
 
 
+def _assert_linear_ce_fusion_reaches_gpt_model(model: Any) -> None:
+    """Fail fast when linear CE fusion cannot safely use the patched GPTModel.
+
+    ``patch_gpt_model_forward_for_linear_ce_fusion()`` rebinds
+    ``GPTModel.forward``, so fusion only happens if a ``GPTModel`` is actually
+    reached. Two layouts work: the caller-facing module *is* the ``GPTModel``
+    (after ``Float16Module``/DDP-style ``.module`` unwrapping), or it is a VLM
+    wrapper holding one as ``.language_model`` -- ``model_forward()`` arms the
+    inner instance for those.
+
+    Anything else would reach the first forward pass and fail there with an
+    opaque ``TypeError``, i.e. after the full allocation and model load, so
+    surface it here instead, next to where the patch is applied.
+
+    Reaching GPTModel is not sufficient for models with logit softcapping:
+    fusion uses the output weight directly and bypasses output_layer.forward,
+    including its softcapping transform. Reject that configuration rather than
+    silently computing logprobs and gradients for a different distribution.
+    """
+    from megatron.core.models.gpt import GPTModel
+
+    from nemo_rl.models.megatron.train import find_linear_ce_fusion_target
+
+    chunks = model if isinstance(model, (list, tuple)) else [model]
+    for chunk in chunks:
+        module = chunk
+        while not isinstance(module, GPTModel) and hasattr(module, "module"):
+            module = module.module
+        # Either the invoked module is the patched GPTModel, or model_forward()
+        # can reach one behind a wrapper and arm it.
+        target = (
+            module
+            if isinstance(module, GPTModel)
+            else find_linear_ce_fusion_target(chunk)
+        )
+        if target is None:
+            raise NotImplementedError(
+                "policy.megatron_cfg.use_fused_linear_logprobs=true is not supported "
+                f"for {type(module).__name__}: linear CE fusion patches "
+                "GPTModel.forward, but no GPTModel is reachable on this module "
+                "(neither directly nor as '.language_model'), so the fused forward "
+                "would never run. Set "
+                "policy.megatron_cfg.use_fused_linear_logprobs=false."
+            )
+
+        # This optional provider field is absent on ordinary GPT configurations.
+        # Check every pipeline chunk, even those without a local output layer.
+        softcap = getattr(target.config, "final_logit_softcapping", None)
+        if softcap:
+            raise NotImplementedError(
+                "policy.megatron_cfg.use_fused_linear_logprobs=true is not supported "
+                f"for {type(module).__name__} with final_logit_softcapping={softcap}: "
+                "linear CE fusion bypasses output_layer.forward and its logit "
+                "softcapping, producing incorrect logprobs and gradients. Set "
+                "policy.megatron_cfg.use_fused_linear_logprobs=false."
+            )
+
+
 def setup_model_and_optimizer(
     policy_cfg: PolicyConfig,
     megatron_cfg: ConfigContainer,
@@ -2017,6 +2075,9 @@ def setup_model_and_optimizer(
         pg_collection=pg_collection,
         wrap_with_ddp=load_optimizer,
     )
+
+    if policy_cfg["megatron_cfg"].get("use_fused_linear_logprobs", False):
+        _assert_linear_ce_fusion_reaches_gpt_model(model)
 
     if load_optimizer:
         optimizer, scheduler = setup_optimizer(

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -116,6 +116,64 @@ def suspend_activation_offload_for_forward_only(
                 model_config.fine_grained_activation_offloading = original_value
 
 
+def find_linear_ce_fusion_target(model: Any, max_depth: int = 8) -> Optional[GPTModel]:
+    """Return the inner ``GPTModel`` when a wrapper hides it from the caller.
+
+    Linear CE fusion works by rebinding ``GPTModel.forward``, and only that
+    patched forward understands ``return_logprobs_for_linear_ce_fusion``. A VLM
+    checkpoint puts a wrapper in front of it -- Gemma-4 loads as
+    ``Gemma4ForConditionalGeneration``, so the invoked module is
+    ``Gemma4VLModel`` and the ``GPTModel`` is its ``.language_model``. The
+    wrapper's own ``forward()`` does not declare that kwarg, so passing it
+    raises ``TypeError``.
+
+    Returns ``None`` when the invoked module *is* the ``GPTModel`` (after
+    ``Float16Module``/DDP-style ``.module`` unwrapping), i.e. the kwarg can be
+    passed normally, and also when no ``GPTModel`` is reachable at all -- callers
+    then keep their existing behaviour instead of silently skipping fusion.
+
+    ``max_depth`` bounds the walk. Real stacks nest only a few levels, and an
+    unbounded loop would spin on objects that answer every attribute.
+    """
+    module = model
+    for _ in range(max_depth):
+        if isinstance(module, GPTModel):
+            # The invoked forward is the patched one; no arming needed.
+            return None
+        # Check before descending: a wrapper may expose both .language_model
+        # and a .module of its own.
+        inner = getattr(module, "language_model", None)
+        if isinstance(inner, GPTModel):
+            return inner
+        if not hasattr(module, "module"):
+            return None
+        module = module.module
+    return None
+
+
+@contextmanager
+def _armed_linear_ce_fusion(target: Optional[GPTModel]) -> Iterator[None]:
+    """Make ``target``'s patched forward return fused logprobs for this call.
+
+    Used when the kwarg cannot be threaded through an intervening wrapper. The
+    flag is set per-instance (not on the class) and always restored, so
+    concurrent models and the non-fused path are unaffected.
+    """
+    if target is None:
+        yield
+        return
+    sentinel = object()
+    previous = getattr(target, "_linear_ce_fusion_armed", sentinel)
+    target._linear_ce_fusion_armed = True
+    try:
+        yield
+    finally:
+        if previous is sentinel:
+            del target._linear_ce_fusion_armed
+        else:
+            target._linear_ce_fusion_armed = previous
+
+
 def model_forward(
     model: GPTModel,
     data_dict: BatchedDataDict[Any],
@@ -173,20 +231,31 @@ def model_forward(
 
     if defer_fp32_logits:
         additional_kwargs["fp32_output"] = False
+
+    # The fusion patch rebinds GPTModel.forward, and the kwarg below is only
+    # understood by that patched forward. When the top-level module is a VLM
+    # wrapper (e.g. Gemma-4 loads as Gemma4ForConditionalGeneration, so the
+    # module is Gemma4VLModel and GPTModel is only its .language_model), the
+    # wrapper's own forward does not accept it. In that case arm the inner
+    # GPTModel for the duration of the call instead of passing the kwarg.
+    fusion_target = None
     if use_fused_linear_logprobs:
         additional_kwargs["labels"] = input_ids_cp_sharded
-        # Only pass this kwarg when linear CE fusion is enabled. Older Megatron-LM
-        # GPTModel.forward signatures do not accept it.
-        additional_kwargs["return_logprobs_for_linear_ce_fusion"] = True
+        fusion_target = find_linear_ce_fusion_target(model)
+        if fusion_target is None:
+            # Only pass this kwarg when linear CE fusion is enabled. Older Megatron-LM
+            # GPTModel.forward signatures do not accept it.
+            additional_kwargs["return_logprobs_for_linear_ce_fusion"] = True
 
     with straggler_timer() if straggler_timer is not None else nullcontext():
-        output_tensor = model(
-            input_ids=input_ids_cp_sharded,
-            position_ids=position_ids,
-            attention_mask=attention_mask,
-            **additional_kwargs,
-            **multimodal_data,
-        )
+        with _armed_linear_ce_fusion(fusion_target):
+            output_tensor = model(
+                input_ids=input_ids_cp_sharded,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                **additional_kwargs,
+                **multimodal_data,
+            )
 
     # A model that slices context parallelism itself returns (output,
     # sliced_loss_mask) when it was handed a full-sequence loss_mask, so the

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -4040,3 +4040,146 @@ class TestForceSyncOptimizerFp32FromModel:
                 f"DistributedOptimizer no longer references {name!r}; "
                 "_force_sync_optimizer_fp32_from_model's level-1 sync is now a silent no-op."
             )
+
+
+@pytest.mark.mcore
+class TestAssertLinearCeFusionReachesGptModel:
+    """Linear CE fusion must reach the GPTModel whose forward was patched."""
+
+    @staticmethod
+    def _make_gpt_model():
+        from megatron.core.models.gpt import GPTModel
+
+        model = MagicMock(spec=GPTModel)
+        model.config = SimpleNamespace()
+        return model
+
+    @staticmethod
+    def _wrap_model(model: Any, layout: str) -> Any:
+        if layout == "bare":
+            return model
+        if layout == "module":
+            return SimpleNamespace(module=model)
+        wrapper = SimpleNamespace(language_model=model)
+        if layout == "vlm":
+            return wrapper
+        if layout == "wrapped_vlm":
+            return SimpleNamespace(module=SimpleNamespace(module=wrapper))
+        raise ValueError(f"Unknown model layout: {layout}")
+
+    @pytest.mark.parametrize("layout", ["bare", "module", "vlm", "wrapped_vlm"])
+    @pytest.mark.parametrize("softcap", [None, 0.0, 30.0])
+    def test_validates_logit_softcapping(
+        self, layout: str, softcap: float | None
+    ) -> None:
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        model = self._make_gpt_model()
+        model.config.final_logit_softcapping = softcap
+        wrapped = self._wrap_model(model, layout)
+
+        if softcap:
+            with pytest.raises(
+                NotImplementedError, match="final_logit_softcapping=30.0"
+            ) as exc_info:
+                _assert_linear_ce_fusion_reaches_gpt_model(wrapped)
+            assert "output_layer.forward" in str(exc_info.value)
+            assert "policy.megatron_cfg.use_fused_linear_logprobs=false" in str(
+                exc_info.value
+            )
+        else:
+            _assert_linear_ce_fusion_reaches_gpt_model(wrapped)
+
+        # Disabling model softcapping would change the checkpoint's distribution.
+        assert model.config.final_logit_softcapping == softcap
+
+    @pytest.mark.parametrize("layout", ["bare", "module", "vlm", "wrapped_vlm"])
+    def test_accepts_model_without_softcapping_config(self, layout: str) -> None:
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        _assert_linear_ce_fusion_reaches_gpt_model(
+            self._wrap_model(self._make_gpt_model(), layout)
+        )
+
+    @pytest.mark.parametrize("container", [list, tuple])
+    def test_checks_softcapping_on_later_pipeline_chunks(self, container: type) -> None:
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        supported = self._make_gpt_model()
+        unsupported = self._make_gpt_model()
+        unsupported.config.final_logit_softcapping = 30.0
+        chunks = container([supported, self._wrap_model(unsupported, "wrapped_vlm")])
+
+        with pytest.raises(NotImplementedError, match="final_logit_softcapping"):
+            _assert_linear_ce_fusion_reaches_gpt_model(chunks)
+
+    def test_accepts_bare_gpt_model(self):
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        _assert_linear_ce_fusion_reaches_gpt_model(self._make_gpt_model())
+
+    def test_accepts_wrapped_gpt_model(self):
+        """Float16Module/DDP wrappers expose the inner model as `.module`."""
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        wrapped = SimpleNamespace(module=self._make_gpt_model())
+        _assert_linear_ce_fusion_reaches_gpt_model(wrapped)
+
+    def test_accepts_list_of_chunks(self):
+        """get_model() returns a list of chunks (virtual pipeline stages)."""
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        _assert_linear_ce_fusion_reaches_gpt_model(
+            [self._make_gpt_model(), self._make_gpt_model()]
+        )
+
+    def test_accepts_vlm_wrapper_holding_gpt_model(self):
+        """A VLM wrapper holds GPTModel under `.language_model`, not `.module`.
+
+        model_forward() arms that inner instance, so this layout is supported.
+        """
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        class Gemma4VLModel:
+            def __init__(self, language_model):
+                self.language_model = language_model
+
+        _assert_linear_ce_fusion_reaches_gpt_model(
+            Gemma4VLModel(self._make_gpt_model())
+        )
+
+    def test_rejects_module_with_no_reachable_gpt_model(self):
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        class SomeOtherModel:
+            pass
+
+        with pytest.raises(NotImplementedError, match="use_fused_linear_logprobs"):
+            _assert_linear_ce_fusion_reaches_gpt_model(SomeOtherModel())
+
+    def test_error_names_the_offending_type(self):
+        from nemo_rl.models.megatron.setup import (
+            _assert_linear_ce_fusion_reaches_gpt_model,
+        )
+
+        class SomeOtherModel:
+            pass
+
+        with pytest.raises(NotImplementedError, match="SomeOtherModel"):
+            _assert_linear_ce_fusion_reaches_gpt_model(SomeOtherModel())

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -167,6 +167,110 @@ class TestModelForward:
         assert call_kwargs["position_ids"] is None
 
 
+class TestLinearCeFusionThroughVlmWrapper:
+    """Linear CE fusion must reach the GPTModel the patch rebound."""
+
+    @staticmethod
+    def _gpt_model():
+        from megatron.core.models.gpt import GPTModel
+
+        return MagicMock(spec=GPTModel)
+
+    def _run(self, model):
+        from nemo_rl.models.megatron.train import model_forward
+
+        data_dict = MagicMock()
+        data_dict.get_multimodal_dict.return_value = {}
+        model_forward(
+            model=model,
+            data_dict=data_dict,
+            input_ids_cp_sharded=torch.tensor([[1, 2, 3]]),
+            position_ids=torch.tensor([[0, 1, 2]]),
+            attention_mask=torch.ones(1, 3),
+            use_fused_linear_logprobs=True,
+        )
+
+    def test_plain_gpt_model_still_receives_the_kwarg(self):
+        """Unwrapped models keep the existing behaviour."""
+        model = self._gpt_model()
+        model.return_value = torch.randn(1, 3)
+
+        self._run(model)
+
+        kwargs = model.call_args[1]
+        assert kwargs["return_logprobs_for_linear_ce_fusion"] is True
+        assert "labels" in kwargs
+
+    def test_vlm_wrapper_is_not_handed_the_kwarg(self):
+        """The wrapper's forward() would raise TypeError on it."""
+        inner = self._gpt_model()
+
+        class Gemma4VLModel(MagicMock):
+            pass
+
+        wrapper = Gemma4VLModel()
+        wrapper.language_model = inner
+        wrapper.return_value = torch.randn(1, 3)
+
+        self._run(wrapper)
+
+        kwargs = wrapper.call_args[1]
+        assert "return_logprobs_for_linear_ce_fusion" not in kwargs
+        # labels are still required by the fused forward.
+        assert "labels" in kwargs
+
+    def test_vlm_wrapper_arms_the_inner_gpt_model(self):
+        """Fusion is requested via the inner instance instead."""
+        inner = self._gpt_model()
+        seen = {}
+
+        class Gemma4VLModel(MagicMock):
+            pass
+
+        wrapper = Gemma4VLModel()
+        wrapper.language_model = inner
+
+        def _capture(*args, **kwargs):
+            seen["armed"] = getattr(inner, "_linear_ce_fusion_armed", False)
+            return torch.randn(1, 3)
+
+        wrapper.side_effect = _capture
+
+        self._run(wrapper)
+
+        assert seen["armed"] is True, "inner GPTModel was not armed during forward"
+
+    def test_arming_is_reverted_after_the_call(self):
+        """The flag must not leak into later non-fused forwards."""
+        inner = self._gpt_model()
+
+        class Gemma4VLModel(MagicMock):
+            pass
+
+        wrapper = Gemma4VLModel()
+        wrapper.language_model = inner
+        wrapper.return_value = torch.randn(1, 3)
+
+        self._run(wrapper)
+
+        assert not getattr(inner, "_linear_ce_fusion_armed", False)
+
+    def test_arming_is_reverted_when_forward_raises(self):
+        inner = self._gpt_model()
+
+        class Gemma4VLModel(MagicMock):
+            pass
+
+        wrapper = Gemma4VLModel()
+        wrapper.language_model = inner
+        wrapper.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            self._run(wrapper)
+
+        assert not getattr(inner, "_linear_ce_fusion_armed", False)
+
+
 class TestApplyTemperatureScaling:
     """Tests for apply_temperature_scaling function."""
 


### PR DESCRIPTION
# What does this PR do ?

Makes linear CE fusion usable for checkpoints whose top-level module wraps the `GPTModel` (VLM wrappers), instead of failing in the first forward pass with an opaque `TypeError`.

# Changelog

- `nemo_rl/models/megatron/train.py`
  - Add `find_linear_ce_fusion_target()`: returns the inner `GPTModel` when a wrapper hides it, and `None` when the invoked module already *is* the patched `GPTModel` (after `Float16Module`/DDP-style `.module` unwrapping) or when no `GPTModel` is reachable. The walk checks `.language_model` at each level before descending, and is depth-bounded.
  - Add `_armed_linear_ce_fusion()`: sets a **per-instance** flag on that inner model for the duration of the call and always restores it in a `finally`, so it cannot leak into later non-fused forwards.
  - `model_forward()` now passes the kwarg as before for unwrapped models, and arms the inner model instead when a wrapper is in the way.
- `nemo_rl/distributed/model_utils.py`: the patched forward honors the per-instance flag.
- `nemo_rl/models/megatron/setup.py`: keep a startup guard, but only reject models where **no** `GPTModel` is reachable at all -- those would silently never run the fused path.
- Tests for both the traversal and the arming lifecycle, including restoration when the forward raises.

## Background

`patch_gpt_model_forward_for_linear_ce_fusion()` rebinds `GPTModel.forward`, and `model_forward()` passes `return_logprobs_for_linear_ce_fusion` to the module it invokes. When a checkpoint loads as a VLM wrapper, that module is not the patched `GPTModel`:

```
TypeError: Gemma4VLModel.forward() got an unexpected keyword argument
           'return_logprobs_for_linear_ce_fusion'
```

Gemma-4 is one such case: the HF checkpoint is `Gemma4ForConditionalGeneration`, so the invoked module is `Gemma4VLModel` and `GPTModel` is only its `.language_model`. Fused logprobs were therefore unusable there -- including for **text-only** runs, where the wrapper is otherwise inert. That matters at scale, since the fused path exists specifically to avoid materializing the `[B, S, vocab]` fp32 logits tensor.

## Why arming rather than forwarding the kwarg

The wrapper already forwards everything the fused path needs (`labels`, `decoder_input`, `packed_seq_params`) to the inner model -- only the *request* could not get through. `return_logprobs_for_linear_ce_fusion` is introduced by this repo's monkey-patch, not part of the upstream `GPTModel` API, so teaching every wrapper to declare it would push that coupling into models NeMo-RL does not own. Arming the instance keeps it here.

Unwrapped models are unaffected: they keep receiving the kwarg directly.

# GitHub Actions CI

A NVIDIA developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) - No
