### PR TITLE
fix: merge LoRA into refit weights under activation checkpointing

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -33,6 +33,9 @@ from nemo_automodel.components.distributed.tensor_utils import (
 )
 from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
 from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    _CHECKPOINT_PREFIX,
+)
 from torch.distributed.tensor import DTensor
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
@@ -113,7 +116,8 @@ def dtensor_params_generator(
         Tuples of (fully_qualified_name, tensor) where tensors are converted to
         the refit dtype and made contiguous.
     """
-    module_map = dict(model.named_modules())
+    module_map = _state_dict_keyed_module_map(model)
+    _assert_lora_modules_reachable(module_map, model.state_dict())
     for name, tensor in model.state_dict().items():
         if name.endswith(".lora_A.weight") or name.endswith(".lora_B.weight"):
             continue
@@ -131,6 +135,47 @@ def dtensor_params_generator(
         del adapted_fqn_tensors
         del merged_tensor
         del full_tensor
+
+
+def _state_dict_keyed_module_map(model: nn.Module) -> dict[str, nn.Module]:
+    """Map modules by the FQN ``state_dict()`` uses for their parameters.
+
+    ``checkpoint_wrapper`` installs a state_dict hook that strips
+    ``_CHECKPOINT_PREFIX`` from parameter keys but leaves it in ``named_modules()``.
+    Keying the map on the raw module name therefore misses every LoRA module whenever
+    activation checkpointing is on, and ``_maybe_merge_lora_weight`` silently returns
+    the *unmerged* base weight -- so the adapter never reaches the inference engine and
+    generation runs on the base model for the whole job.
+    """
+    return {
+        name.replace(_CHECKPOINT_PREFIX, ""): module
+        for name, module in model.named_modules()
+    }
+
+
+def _assert_lora_modules_reachable(
+    module_map: dict[str, nn.Module],
+    state_dict: dict[str, Any],
+) -> None:
+    """Fail loudly if any LoRA module's weight is not addressable in ``state_dict``.
+
+    A missed lookup is otherwise invisible: the refit streams base weights, generation
+    silently diverges from the trained policy, and the only symptom is a slowly climbing
+    ``token_mult_prob_error`` many steps later.
+    """
+    unreachable = sorted(
+        name
+        for name, module in module_map.items()
+        if isinstance(module, LinearLoRA) and f"{name}.weight" not in state_dict
+    )
+    if unreachable:
+        raise RuntimeError(
+            f"{len(unreachable)} LoRA module(s) could not be matched to a state_dict "
+            f"entry, so their adapters would not be merged into the weights sent to the "
+            f"inference engine. First few: {unreachable[:5]}. This usually means a module "
+            f"wrapper is rewriting parameter names in a way _state_dict_keyed_module_map "
+            f"does not undo."
+        )
 
 
 @torch.no_grad()
@@ -158,8 +203,11 @@ def _maybe_merge_lora_weight(
         if isinstance(module.lora_B.weight, DTensor)
         else module.lora_B.weight
     )
-    lora_a = lora_a.to(device=tensor.device, dtype=tensor.dtype)
-    lora_b = lora_b.to(device=tensor.device, dtype=tensor.dtype)
+    # Accumulate in fp32: at rank 128 with alpha/rank scaling, a bf16 matmul of the
+    # low-rank product carries enough relative error to show up as train/generation
+    # logprob drift, which is exactly what this merge exists to prevent.
+    lora_a = lora_a.to(device=tensor.device, dtype=torch.float32)
+    lora_b = lora_b.to(device=tensor.device, dtype=torch.float32)
     scale = getattr(module, "scale", None)
 
     if scale is None and hasattr(module, "alpha") and hasattr(module, "dim"):
@@ -167,7 +215,8 @@ def _maybe_merge_lora_weight(
     if scale is None:
         scale = 1.0
 
-    return tensor + torch.matmul(lora_b, lora_a) * scale
+    delta = torch.matmul(lora_b, lora_a) * scale
+    return (tensor.to(torch.float32) + delta).to(tensor.dtype)
 
 
 def _maybe_adapt_tensor_to_hf(

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -1212,3 +1212,76 @@ def test_dtensor_v2_fresh_run_with_reference_model_does_not_defer(monkeypatch):
     assert setup_mock.call_args.kwargs["weights_path"] is None
     load_mock.assert_not_called()
     assert worker.reference_model_state_dict == {"ref": "state"}
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+class TestLoraMergeUnderActivationCheckpointing:
+    """LoRA must reach the inference engine when activation checkpointing is on.
+
+    checkpoint_wrapper strips _CHECKPOINT_PREFIX from state_dict keys but leaves it in
+    named_modules(). Keying the module map on the raw name made every LoRA lookup miss,
+    so the refit streamed base weights while the trainer moved away from them -- visible
+    only as a slowly climbing train/token_mult_prob_error many steps later.
+    """
+
+    @staticmethod
+    def _lora_model(wrap: bool):
+        from nemo_automodel.components._peft.lora import LinearLoRA
+        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+            checkpoint_wrapper,
+        )
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.up_proj = LinearLoRA(
+                    orig_linear=nn.Linear(8, 8, bias=False), dim=4, alpha=8
+                )
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([Block()])
+
+        model = Model()
+        with torch.no_grad():
+            model.layers[0].up_proj.lora_A.weight.fill_(0.1)
+            model.layers[0].up_proj.lora_B.weight.fill_(0.1)
+        if wrap:
+            model.layers[0] = checkpoint_wrapper(model.layers[0])
+        return model
+
+    @pytest.mark.parametrize("activation_checkpointing", [False, True])
+    def test_lora_delta_reaches_refit_stream(self, activation_checkpointing):
+        model = self._lora_model(wrap=activation_checkpointing)
+        base = dict(model.state_dict())["layers.0.up_proj.weight"].clone()
+
+        streamed = dict(dtensor_params_generator(model, torch.float32))
+        merged = streamed["layers.0.up_proj.weight"]
+
+        # lora_B @ lora_A * (alpha/dim), both filled at 0.1, dim=4, alpha=8
+        expected_delta = 4 * (0.1 * 0.1) * (8 / 4)
+        assert not torch.allclose(merged, base), (
+            "LoRA delta was not merged into the streamed weight; the inference engine "
+            "would generate from the base model."
+        )
+        torch.testing.assert_close(
+            merged - base,
+            torch.full_like(base, expected_delta),
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+    def test_unreachable_lora_module_raises(self):
+        from nemo_rl.models.policy.workers.dtensor_policy_worker_v2 import (
+            _assert_lora_modules_reachable,
+        )
+
+        model = self._lora_model(wrap=True)
+        # Simulate a wrapper this helper does not know how to undo.
+        bad_map = {
+            "mangled.up_proj": model.layers[0]._checkpoint_wrapped_module.up_proj
+        }
+        with pytest.raises(RuntimeError, match="could not be matched to a state_dict"):
+            _assert_lora_modules_reachable(bad_map, model.state_dict())


### PR DESCRIPTION
# What does this PR do ?

**Explained in very simple terms:**

**Context:**
There are two copies of the model during training:

- the student — the copy that's learning
- the writer — the copy that actually writes the math answers (vLLM)

After every training step, the student's improvements get copied over to the writer, so the next batch of answers comes from a slightly better model. That copy step is called a refit.

LoRA means we don't change the original model at all. We freeze it and attach small adjustments on top. The real model = original + small adjustments.

So the refit has to do a bit of assembly: for each layer, find that layer's adjustments, add them onto the original weights, and send the sum to the writer. It finds those adjustments by the layer's name.

**Bug:**

Activation checkpointing is a memory-saving trick, it throws away intermediate results and recomputes them later. To do that it wraps each layer in a box. And that box changes the layer's name: `layers.0.up_proj` becomes `layers.0._checkpoint_wrapped_module.up_proj`

But only in one of the two places the code looks. The list of weights still used the short name; the list of layers now used the long name. So the code searched for `layers.0.up_proj`, found nothing and just shipped the original weights, with no adjustments.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
