### PR TITLE
fix(perf): Reduce Ray driver memory amplification in get_logprobs

### DIFF
--- a/nemo_rl/distributed/batched_data_dict.py
+++ b/nemo_rl/distributed/batched_data_dict.py
@@ -635,8 +635,12 @@ class BatchedDataDict(UserDict, Generic[DictT]):
                 all_chunk_bin_assignments.append(chunk_bin_assignments)
                 all_chunk_padded_seqlens.append(chunk_padded_seqlens_list)
 
-            # create shards with the packed bins
-            sharded_data: list[list[dict]] = [[] for _ in range(shards)]
+            # Build the packed-bin metadata first, then materialize each complete
+            # DP shard once.  Selecting every bin separately and feeding those
+            # tensors through ``from_batches`` copied globally padded rows once
+            # per bin and then copied them again while reassembling the shard.
+            # For long-context batches, those transient copies dominate driver
+            # host memory even though the final shards contain each row once.
             sharded_micro_indices: list = [[] for _ in range(shards)]
             sharded_micro_lengths: list = [[] for _ in range(shards)]
             sharded_elem_counts_per_gb: list = [[] for _ in range(shards)]
@@ -670,9 +674,6 @@ class BatchedDataDict(UserDict, Generic[DictT]):
 
                     for bin_indices in shard_bin_assignments:
                         global_bin_indices = [i + chunk_start for i in bin_indices]
-                        sharded_data[shard_idx].append(
-                            self.select_indices(global_bin_indices)
-                        )
                         global_indices_per_shard[shard_idx].extend(global_bin_indices)
                         bin_seqlen = sum(chunk_padded_seqlens[i] for i in bin_indices)
 
@@ -705,7 +706,8 @@ class BatchedDataDict(UserDict, Generic[DictT]):
 
             aggregated_shards = []
             for shard_idx in range(shards):
-                shard = SlicedDataDict.from_batches(sharded_data[shard_idx])
+                selected = self.select_indices(global_indices_per_shard[shard_idx])
+                shard = SlicedDataDict(selected.data)
                 shard.micro_batch_indices = sharded_micro_indices[shard_idx]
                 shard.micro_batch_lengths = sharded_micro_lengths[shard_idx]
                 shard.elem_counts_per_gb = sharded_elem_counts_per_gb[shard_idx]

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -45,7 +45,10 @@ class MultiWorkerFuture:
     called_workers: Optional[list[int]] = None
 
     def get_results(
-        self, worker_group: "RayWorkerGroup", return_generators_as_proxies: bool = False
+        self,
+        worker_group: "RayWorkerGroup",
+        return_generators_as_proxies: bool = False,
+        fetch_returned_only: bool = False,
     ) -> list[Any]:
         """Get results from the futures, optionally respecting tied workers.
 
@@ -58,6 +61,9 @@ class MultiWorkerFuture:
                 is required for the deduplication path.
             return_generators_as_proxies: If True, and a future is an ObjectRefGenerator,
                                           return the ObjectRefGenerator itself instead of consuming it.
+            fetch_returned_only: If True, fetch only the ObjectRefs selected by
+                                 ``return_from_workers``. This avoids materializing
+                                 large replicated worker outputs on the driver.
 
         Returns:
             List of results
@@ -101,13 +107,34 @@ class MultiWorkerFuture:
             else:
                 object_refs.append(fut)
 
-        # Retrieve the concrete results.
-        all_results = ray.get(object_refs)
-
         # If expanded generator was present we are in streaming mode.
         # Every ObjectRef now corresponds to a unique, ordered chunk of data
         if has_generator:
-            return all_results
+            return ray.get(object_refs)
+
+        if fetch_returned_only and self.return_from_workers is not None:
+            if self.called_workers is not None:
+                worker_to_ref_idx = {
+                    worker: idx for idx, worker in enumerate(self.called_workers)
+                }
+                valid_return_workers = [
+                    worker
+                    for worker in self.return_from_workers
+                    if worker in worker_to_ref_idx
+                ]
+                object_refs = [
+                    object_refs[worker_to_ref_idx[worker]]
+                    for worker in valid_return_workers
+                ]
+            else:
+                object_refs = [
+                    object_refs[worker] for worker in self.return_from_workers
+                ]
+            return ray.get(object_refs)
+
+        # Retrieve the concrete results. The default path intentionally fetches
+        # every worker result so failures from non-returned workers still surface.
+        all_results = ray.get(object_refs)
 
         if self.return_from_workers is not None:
             if self.called_workers is not None:
@@ -1045,6 +1072,7 @@ class RayWorkerGroup:
         self,
         future_bundle: MultiWorkerFuture,
         return_generators_as_proxies: bool = False,
+        fetch_returned_only: bool = False,
     ) -> list[Any]:
         """Get results from all workers, optionally filtering to get just one result per tied worker group.
 
@@ -1052,12 +1080,16 @@ class RayWorkerGroup:
             future_bundle: MultiWorkerFuture containing futures and worker information.
             return_generators_as_proxies: If True, and a future in the bundle is an ObjectRefGenerator,
                                           return the ObjectRefGenerator itself instead of consuming it.
+            fetch_returned_only: If True, fetch only results selected by the
+                                 future bundle's ``return_from_workers``.
 
         Returns:
             List of results, deduplicated as specified in the future_bundle
         """
         return future_bundle.get_results(
-            self, return_generators_as_proxies=return_generators_as_proxies
+            self,
+            return_generators_as_proxies=return_generators_as_proxies,
+            fetch_returned_only=fetch_returned_only,
         )
 
     def shutdown(

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -588,7 +588,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 ],
             )
         logprobs: BatchedDataDict[LogprobOutputSpec] = BatchedDataDict.from_batches(
-            self.worker_group.get_all_worker_results(futures)
+            self.worker_group.get_all_worker_results(futures, fetch_returned_only=True)
         )
 
         # dynamic batching sorts the inputs by sequence length to improve load balancing,
@@ -641,7 +641,9 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             )
         logprobs: BatchedDataDict[ReferenceLogprobOutputSpec] = (
             BatchedDataDict.from_batches(
-                self.worker_group.get_all_worker_results(futures)
+                self.worker_group.get_all_worker_results(
+                    futures, fetch_returned_only=True
+                )
             )
         )
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1758,6 +1758,58 @@ def test_initial_refit_completes_before_async_collection_starts(
     assert events[:3] == ["refit", "set_weight_version", "start_collection"]
 
 
+def test_async_initial_buffer_wait_is_included_in_first_step_timing(
+    mock_grpo_components,
+) -> None:
+    """The startup rollout wait is part of step 1, not initialization."""
+    timing_sample_counts = []
+
+    class InspectingTimer(Timer):
+        def get_timing_metrics(self, reduction_op="mean"):
+            timing_sample_counts.append(
+                {label: len(samples) for label, samples in self._timers.items()}
+            )
+            return super().get_timing_metrics(reduction_op)
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.env["should_log_nemo_gym_responses"] = True
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+
+    with (
+        mock_async_grpo_infrastructure(
+            mock_batch,
+            {"mean_gen_tokens_per_sample": 2.0},
+        ),
+        patch("nemo_rl.algorithms.grpo.Timer", InspectingTimer),
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    first_step_counts = timing_sample_counts[0]
+    # One startup-wait sample plus the regular optimizer-step context.
+    assert first_step_counts["total_step_time"] == 2
+    # Startup wait + replay sample coordination + pre-refit collector wait.
+    assert first_step_counts["exposed_generation"] == 3
+
+
 def test_async_grpo_awaits_resume_after_refit_failure(mock_grpo_components) -> None:
     master_config = mock_grpo_components["master_config"]
     master_config.policy["generation"]["backend"] = "dynamo"
@@ -3533,8 +3585,8 @@ def test_async_grpo_colocated_save_defers_wake_until_after_checkpoint(
     policy_generation.finish_generation.side_effect = lambda *a, **k: events.append(
         ("finish_generation", k.get("release_gpu", True))
     )
-    policy_generation.prepare_for_generation.side_effect = (
-        lambda *a, **k: events.append("wake_engine")
+    policy_generation.prepare_for_generation.side_effect = lambda *a, **k: (
+        events.append("wake_engine")
     )
     policy.offload_before_refit.side_effect = lambda *a, **k: events.append(
         "offload_before_refit"

--- a/tests/unit/distributed/test_batched_data_dict.py
+++ b/tests/unit/distributed/test_batched_data_dict.py
@@ -349,6 +349,50 @@ def test_sequence_packing_basic():
         assert len(problem_ids_seen) == batch_size
 
 
+def test_sequence_packing_materializes_each_shard_once(monkeypatch):
+    """Packed bins should not be copied individually before shard assembly."""
+    sequence_lengths = torch.full((8,), 6)
+    batch_data = BatchedDataDict(
+        {
+            "input_ids": torch.arange(64).reshape(8, 8),
+            "sequence_lengths": sequence_lengths,
+            "problem_ids": torch.arange(8),
+        }
+    )
+    sequence_packing_args = SequencePackingArgs(
+        max_tokens_per_microbatch=10,
+        input_key="input_ids",
+        input_lengths_key="sequence_lengths",
+        algorithm="modified_first_fit_decreasing",
+        sequence_length_pad_multiple=1,
+    )
+
+    selected_indices = []
+    original_select_indices = BatchedDataDict.select_indices
+
+    def tracked_select_indices(self, indices):
+        selected_indices.append(list(indices))
+        return original_select_indices(self, indices)
+
+    monkeypatch.setattr(BatchedDataDict, "select_indices", tracked_select_indices)
+
+    sharded_batches, sorted_indices = batch_data.shard_by_batch_size(
+        shards=2,
+        sequence_packing_args=sequence_packing_args,
+    )
+
+    assert len(selected_indices) == len(sharded_batches) == 2
+    assert all(len(indices) == 4 for indices in selected_indices)
+    assert sorted(index for indices in selected_indices for index in indices) == list(
+        range(8)
+    )
+
+    reconstructed = BatchedDataDict.from_batches(sharded_batches)
+    reconstructed.reorder_data(sorted_indices)
+    assert torch.equal(reconstructed["input_ids"], batch_data["input_ids"])
+    assert torch.equal(reconstructed["problem_ids"], batch_data["problem_ids"])
+
+
 def test_sequence_packing_executes_bins_largest_first():
     """Each shard keeps its assigned bins but executes them largest-first."""
     sequence_lengths = torch.tensor([46, 24, 55, 88, 11, 14, 73, 17])

--- a/tests/unit/distributed/test_worker_groups.py
+++ b/tests/unit/distributed/test_worker_groups.py
@@ -25,7 +25,11 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
     PY_EXECUTABLES,
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
-from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+from nemo_rl.distributed.worker_groups import (
+    MultiWorkerFuture,
+    RayWorkerBuilder,
+    RayWorkerGroup,
+)
 
 
 @ray.remote
@@ -943,6 +947,41 @@ def test_run_all_workers_sharded_data_2d_output_replicated(worker_group_2d_shard
     # Assuming MultiWorkerFuture.get_results returns in order of return_from_workers
     assert "my_rank: 0" in results[0]  # from worker 0
     assert "my_rank: 2" in results[1]  # from worker 2
+
+
+def test_fetch_returned_only_selects_object_refs_before_ray_get(monkeypatch):
+    refs = [ray.ObjectRef.from_random() for _ in range(3)]
+    result_by_ref = {
+        refs[0]: "worker-10",
+        refs[1]: "worker-12",
+        refs[2]: "worker-15",
+    }
+    fetched_refs = []
+
+    def fake_get(object_refs):
+        fetched_refs.append(list(object_refs))
+        return [result_by_ref[ref] for ref in object_refs]
+
+    monkeypatch.setattr(ray, "get", fake_get)
+    future_bundle = MultiWorkerFuture(
+        futures=refs,
+        called_workers=[10, 12, 15],
+        return_from_workers=[15, 10],
+    )
+    worker_group = object.__new__(RayWorkerGroup)
+
+    selected_results = worker_group.get_all_worker_results(
+        future_bundle, fetch_returned_only=True
+    )
+
+    assert fetched_refs == [[refs[2], refs[0]]]
+    assert selected_results == ["worker-15", "worker-10"]
+
+    fetched_refs.clear()
+    default_results = worker_group.get_all_worker_results(future_bundle)
+
+    assert fetched_refs == [refs]
+    assert default_results == ["worker-15", "worker-10"]
 
 
 def test_nsight_configuration_forwarding(register_test_actor, virtual_cluster):


### PR DESCRIPTION
Reduce Ray driver memory amplification when collecting megatron worker logprob computation results.

Previously, every CP/TP/PP worker returned a replicated logprob batch. Although only one result per model-parallel group was ultimately used, `MultiWorkerFuture.get_results()` called `ray.get()` on every worker result before filtering. This materialized up to CP * TP * PP copies per data-parallel shard on the driver, which is large enough to cause an OOM on the driver node.