### PR TITLE
feat(refit): add digest verification for vLLM IPC weight transfers

### DIFF
--- a/docs/guides/refit.md
+++ b/docs/guides/refit.md
@@ -105,12 +105,12 @@ policy:
 
 ## Verify a Transfer
 
-The colocated CUDA-IPC transport can verify, per parameter, that the bytes
-loaded by the vLLM workers are exactly the bytes the policy workers sent.
-Both sides hash their view of the transfer with a deterministic integer
-digest (no floating-point reduction, so the check itself cannot be skewed
-by the nondeterminism it is meant to catch), and the sender compares the
-two sets after the final acknowledgment.
+The colocated CUDA-IPC transport can verify, per parameter, that the tensor
+loaded by the vLLM workers has the same bytes, dtype, and shape as the tensor
+the policy workers sent. Both sides hash their view of the transfer with a
+deterministic integer digest (no floating-point reduction, so the check itself
+cannot be skewed by the nondeterminism it is meant to catch), and the sender
+compares the two sets after the final acknowledgment.
 
 ```yaml
 policy:
@@ -125,11 +125,11 @@ policy:
 - `"enforce"`: raise on mismatch so a corrupted transfer fails the refit
   instead of silently skewing rollout logprobs.
 
-A mismatch means the received bytes differ from the sent bytes: a corrupted
-transfer, or `prepare_refit_info` metadata that no longer matches what the
-exporter streams. Verification covers transfer integrity only; it does not
-compare against the weights vLLM materializes after loading (fusion, TP
-sharding, and online quantization legitimately transform them).
+A mismatch means the received bytes, dtype, or shape differ from what was sent:
+a corrupted transfer, or `prepare_refit_info` metadata that no longer matches
+what the exporter streams. Verification covers transfer integrity only; it
+does not compare against the weights vLLM materializes after loading (fusion,
+TP sharding, and online quantization legitimately transform them).
 
 ## Learn More
 

--- a/docs/guides/refit.md
+++ b/docs/guides/refit.md
@@ -103,6 +103,34 @@ policy:
         shard_expert_weights: false
 ```
 
+## Verify a Transfer
+
+The colocated CUDA-IPC transport can verify, per parameter, that the bytes
+loaded by the vLLM workers are exactly the bytes the policy workers sent.
+Both sides hash their view of the transfer with a deterministic integer
+digest (no floating-point reduction, so the check itself cannot be skewed
+by the nondeterminism it is meant to catch), and the sender compares the
+two sets after the final acknowledgment.
+
+```yaml
+policy:
+  generation:
+    refit_cfg:
+      verify:
+        mode: "off"   # "off" | "log" | "enforce" -- quote it; bare off is YAML false
+```
+
+- `"off"` (default): no hashing, zero overhead.
+- `"log"`: print a warning listing mismatched parameters.
+- `"enforce"`: raise on mismatch so a corrupted transfer fails the refit
+  instead of silently skewing rollout logprobs.
+
+A mismatch means the received bytes differ from the sent bytes: a corrupted
+transfer, or `prepare_refit_info` metadata that no longer matches what the
+exporter streams. Verification covers transfer integrity only; it does not
+compare against the weights vLLM materializes after loading (fusion, TP
+sharding, and online quantization legitimately transform them).
+
 ## Learn More
 
 - [NCCL Reshard Refit](../design-docs/nccl-reshard-refit.md) describes its

--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -223,6 +223,11 @@ policy: &POLICY_BASE
         val_top_k: ${.top_k}
         stop_token_ids: null
         stop_strings: null
+        refit_cfg:
+          # Byte-level digest verification of IPC refit transfers.
+          # Quote "off": bare off is YAML for boolean false.
+          verify:
+            mode: "off"
         vllm_cfg:
             async_engine: false
             precision: ${...precision}

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -393,6 +393,13 @@ policy:
     # colocated CUDA-IPC refit to avoid a GPU -> CPU -> GPU round trip.
     real_quant_export_cpu_offload: true
     refit_cfg:
+      # Byte-level digest verification of refit weight transfers (IPC/ZMQ
+      # transport). "off" (default) adds zero overhead; "log" hashes the sent
+      # and received bytes per parameter and warns on mismatch; "enforce"
+      # raises so a corrupted transfer fails the refit instead of silently
+      # skewing rollouts. Quote "off": bare off is YAML for boolean false.
+      verify:
+        mode: "off"
       nixl:
         update_weights_bucket_memory_ratio: 0.05
         device: cuda

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -279,6 +279,11 @@ policy:
       unified_memory_level: 0
       max_tokens: 16384
       logprobs_mode: processed_logprobs
+    refit_cfg:
+      # Byte-level digest verification of IPC refit transfers.
+      # Quote "off": bare off is YAML for boolean false.
+      verify:
+        mode: "off"
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -123,6 +123,7 @@ from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.config import (
     VLLM_SPARSE_REFIT_TRANSPORTS,
     normalize_vllm_refit_config,
+    resolve_refit_verify_config,
 )
 from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
@@ -2559,6 +2560,16 @@ def refit_policy_generation(
         # update weights
         update_success = False
         if colocated_inference:
+            generation_config = getattr(policy_generation, "cfg", None)
+            if generation_config is None:
+                raise RuntimeError(
+                    "Colocated IPC refit requires the generation config so the "
+                    "digest verification mode can be resolved."
+                )
+            verify_mode = resolve_refit_verify_config(
+                cast(VllmConfig, generation_config)
+            ).mode
+
             # get model param keys, which is grouped by size
             if _refit_buffer_size_gb is not None:
                 buffer_size_bytes = int(_refit_buffer_size_gb * (1024**3))
@@ -2577,8 +2588,11 @@ def refit_policy_generation(
             futures_train = policy.stream_weights_via_ipc_zmq(
                 buffer_size_bytes=buffer_size_bytes,
                 kv_scales=kv_scales,
+                verify_mode=verify_mode,
             )
-            futures_inference = policy_generation.update_weights_via_ipc_zmq()
+            futures_inference = policy_generation.update_weights_via_ipc_zmq(
+                verify_digests=verify_mode != "off"
+            )
             # wait for all futures to complete
             ray.get(futures_train)
             results = ray.get(futures_inference)

--- a/nemo_rl/models/generation/dynamo/dynamo_generation.py
+++ b/nemo_rl/models/generation/dynamo/dynamo_generation.py
@@ -629,7 +629,11 @@ class DynamoGeneration(GenerationInterface):
             raise RuntimeError("Dynamo refit channel is unavailable")
         channel.prepare(state_dict_info)
 
-    def update_weights_via_ipc_zmq(self) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> list[ray.ObjectRef]:
+        if verify_digests:
+            raise NotImplementedError(
+                "DynamoGeneration does not support IPC refit digest verification."
+            )
         raise NotImplementedError(
             "DynamoGeneration only supports NCCL weight transfer."
         )

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -493,7 +493,9 @@ class GenerationInterface(ABC):
         """Prepare the info for refit."""
         raise NotImplementedError
 
-    def update_weights_via_ipc_zmq(self) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(
+        self, verify_digests: bool = False
+    ) -> list[ray.ObjectRef]:
         """Update the model weights from the given IPC handles."""
         raise NotImplementedError
 

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -493,9 +493,7 @@ class GenerationInterface(ABC):
         """Prepare the info for refit."""
         raise NotImplementedError
 
-    def update_weights_via_ipc_zmq(
-        self, verify_digests: bool = False
-    ) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> list[ray.ObjectRef]:
         """Update the model weights from the given IPC handles."""
         raise NotImplementedError
 

--- a/nemo_rl/models/generation/sglang/sglang_generation.py
+++ b/nemo_rl/models/generation/sglang/sglang_generation.py
@@ -816,7 +816,11 @@ class SGLangGeneration(GenerationInterface):
     def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
         pass
 
-    def update_weights_via_ipc_zmq(self) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> list[ray.ObjectRef]:
+        if verify_digests:
+            raise NotImplementedError(
+                "SGLang does not support IPC refit digest verification."
+            )
         return []
 
     def update_weights_from_collective(

--- a/nemo_rl/models/generation/trtllm/trtllm_generation.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_generation.py
@@ -480,8 +480,12 @@ class TrtllmGeneration(GenerationInterface):
             recompute_kv=recompute_kv,
         )
 
-    def update_weights_via_ipc_zmq(self) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> list[ray.ObjectRef]:
         """Receive weights via CUDA-IPC + ZMQ (colocated mode)."""
+        if verify_digests:
+            raise NotImplementedError(
+                "TensorRT-LLM does not support IPC refit digest verification."
+            )
         if not self.worker_group or not self.worker_group.workers:
             raise RuntimeError("Worker group not initialised")
         return self.worker_group.run_all_workers_single_data(

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -165,7 +165,7 @@ class VllmCheckpointEnginePluginConfig(BaseModel, extra="allow"):
     release_after_refit: bool = False
 
 
-class VllmRefitVerifyConfig(BaseModel, extra="allow"):
+class VllmRefitVerifyConfig(BaseModel, extra="forbid"):
     """Tensor byte and metadata verification for refit weight transfers.
 
     mode:
@@ -285,8 +285,37 @@ def resolve_refit_verify_config(config: VllmConfig) -> VllmRefitVerifyConfig:
     refit_cfg = config.get("refit_cfg")
     if isinstance(refit_cfg, VllmRefitConfig):
         return refit_cfg.verify
-    raw_verify = (refit_cfg or {}).get("verify") or {}
+    if refit_cfg is None:
+        return VllmRefitVerifyConfig()
+    raw_verify = refit_cfg.get("verify")
+    if raw_verify is None:
+        return VllmRefitVerifyConfig()
+    # Anything explicitly provided (including invalid scalars like ``false``
+    # and unknown keys like ``mdoe``) must fail loudly in Pydantic rather
+    # than silently degrade to the "off" default.
     return VllmRefitVerifyConfig.model_validate(raw_verify)
+
+
+def enforce_refit_verify_supported(config: VllmConfig) -> None:
+    """Setup-boundary check shared by every vLLM deployment path.
+
+    Refit digest verification is implemented only for the colocated CUDA-IPC
+    transport. Synchronizers for other topologies/transports are sometimes
+    constructed directly (bypassing the weight-sync factory), so this is
+    validated where every algorithm must pass: VllmGeneration construction.
+    """
+    if resolve_refit_verify_config(config).mode == "off":
+        return
+    colocated = config["colocated"]["enabled"]
+    transport = config.get("refit_transport")
+    if not colocated or transport is not None:
+        raise NotImplementedError(
+            "policy.generation.refit_cfg.verify is currently supported only "
+            "for colocated CUDA-IPC weight synchronization "
+            "(policy.generation.colocated.enabled=true and "
+            "refit_transport=null). Set verify.mode='off' or switch to the "
+            "supported topology."
+        )
 
 
 def normalize_vllm_refit_config(config: VllmConfig) -> VllmRefitConfig | None:

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -166,12 +166,12 @@ class VllmCheckpointEnginePluginConfig(BaseModel, extra="allow"):
 
 
 class VllmRefitVerifyConfig(BaseModel, extra="allow"):
-    """Byte-level verification of refit weight transfers.
+    """Tensor byte and metadata verification for refit weight transfers.
 
     mode:
         - "off": no verification (default; zero overhead).
-        - "log": hash sent and received bytes per parameter, print a warning
-          listing mismatched parameters.
+        - "log": hash sent and received bytes, dtype, and shape per parameter;
+          print a warning listing mismatched parameters.
         - "enforce": like "log", but raise instead of warning so a corrupted
           transfer fails the refit rather than silently skewing rollouts.
     """

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -283,17 +283,16 @@ def resolve_refit_verify_config(config: VllmConfig) -> VllmRefitVerifyConfig:
     here independently.
     """
     refit_cfg = config.get("refit_cfg")
-    if isinstance(refit_cfg, VllmRefitConfig):
-        return refit_cfg.verify
     if refit_cfg is None:
         return VllmRefitVerifyConfig()
-    if "verify" not in refit_cfg:
-        return VllmRefitVerifyConfig()
-    # Only a truly absent field defaults. Anything explicitly provided --
-    # including ``verify: null``, ``verify: false``, and unknown inner keys
-    # like ``mdoe`` -- must fail loudly in Pydantic rather than silently
-    # degrade to the "off" default.
-    return VllmRefitVerifyConfig.model_validate(refit_cfg["verify"])
+    if not isinstance(refit_cfg, VllmRefitConfig):
+        # Any explicit non-null value -- including non-mappings like ``[]``
+        # or ``""``, ``verify: null``, and invalid inner keys -- goes to
+        # Pydantic as-is and fails loudly rather than silently degrading to
+        # the "off" default. Only a truly absent refit_cfg (or absent
+        # verify field, which Pydantic defaults) turns verification off.
+        refit_cfg = VllmRefitConfig.model_validate(refit_cfg)
+    return refit_cfg.verify
 
 
 _REFIT_CFG_KNOWN_KEYS = frozenset({"sparse", "nixl", "verify"})
@@ -308,17 +307,27 @@ def _validate_refit_cfg_keys(config: VllmConfig) -> None:
     would otherwise silently disable what the user thought they enabled.
     """
     refit_cfg = config.get("refit_cfg")
-    if refit_cfg is None or isinstance(refit_cfg, VllmRefitConfig):
+    if refit_cfg is None:
         return
-    allowed = set(_REFIT_CFG_KNOWN_KEYS)
+    if isinstance(refit_cfg, VllmRefitConfig):
+        # normalize_vllm_refit_config validates and writes the model back for
+        # non-default transports before VllmGeneration is constructed; a typo
+        # like "verfiy" then lives in model_extra and must still be caught.
+        present = set((refit_cfg.model_extra or {}).keys())
+    elif isinstance(refit_cfg, dict):
+        present = set(refit_cfg) - _REFIT_CFG_KNOWN_KEYS
+    else:
+        # Non-mapping values fail loudly in resolve_refit_verify_config.
+        return
     transport = config.get("refit_transport")
+    allowed = set()
     if isinstance(transport, str) and ":" in transport:
         allowed.add(transport)
-    unknown = set(refit_cfg) - allowed
+    unknown = present - allowed
     if unknown:
         raise ValueError(
             f"Unknown policy.generation.refit_cfg keys: {sorted(unknown)}. "
-            f"Known keys: {sorted(allowed)}."
+            f"Known keys: {sorted(_REFIT_CFG_KNOWN_KEYS | allowed)}."
         )
 
 
@@ -379,7 +388,12 @@ def normalize_vllm_refit_config(config: VllmConfig) -> VllmRefitConfig | None:
             "embeddings would silently survive weight updates. Supported "
             "transports: null (collective/IPC) and 'nccl_reshard'."
         )
-    refit_config = VllmRefitConfig.model_validate(config.get("refit_cfg") or {})
+    raw_refit_cfg = config.get("refit_cfg")
+    # Explicit falsy non-mappings ([] / "" / false) must fail in Pydantic,
+    # not be coerced into an empty (and therefore default) config.
+    refit_config = VllmRefitConfig.model_validate(
+        {} if raw_refit_cfg is None else raw_refit_cfg
+    )
     if ":" in transport:
         plugin_config = (refit_config.model_extra or {}).get(transport)
         if plugin_config is None:

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -165,9 +165,24 @@ class VllmCheckpointEnginePluginConfig(BaseModel, extra="allow"):
     release_after_refit: bool = False
 
 
+class VllmRefitVerifyConfig(BaseModel, extra="allow"):
+    """Byte-level verification of refit weight transfers.
+
+    mode:
+        - "off": no verification (default; zero overhead).
+        - "log": hash sent and received bytes per parameter, print a warning
+          listing mismatched parameters.
+        - "enforce": like "log", but raise instead of warning so a corrupted
+          transfer fails the refit rather than silently skewing rollouts.
+    """
+
+    mode: Literal["off", "log", "enforce"] = "off"
+
+
 class VllmRefitConfig(BaseModel, extra="allow"):
     sparse: VllmSparseRefitConfig = Field(default_factory=VllmSparseRefitConfig)
     nixl: VllmNixlRefitConfig = Field(default_factory=VllmNixlRefitConfig)
+    verify: VllmRefitVerifyConfig = Field(default_factory=VllmRefitVerifyConfig)
 
 
 class VllmConfig(GenerationConfig):
@@ -257,6 +272,21 @@ def materialize_vllm_video_config(
     # VideoMediaIO otherwise defaults to 32 independently of the policy-side
     # frame count. Materializing the value here makes a mismatch impossible.
     video_media_io_kwargs["num_frames"] = video_config.num_frames
+
+
+def resolve_refit_verify_config(config: VllmConfig) -> VllmRefitVerifyConfig:
+    """Resolve the refit verification scope regardless of transport.
+
+    ``normalize_vllm_refit_config`` returns early for the default transports
+    (null -> IPC/collective, "nccl_reshard") without validating ``refit_cfg``,
+    but verification is orthogonal to transport selection, so it is resolved
+    here independently.
+    """
+    refit_cfg = config.get("refit_cfg")
+    if isinstance(refit_cfg, VllmRefitConfig):
+        return refit_cfg.verify
+    raw_verify = (refit_cfg or {}).get("verify") or {}
+    return VllmRefitVerifyConfig.model_validate(raw_verify)
 
 
 def normalize_vllm_refit_config(config: VllmConfig) -> VllmRefitConfig | None:

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -287,13 +287,39 @@ def resolve_refit_verify_config(config: VllmConfig) -> VllmRefitVerifyConfig:
         return refit_cfg.verify
     if refit_cfg is None:
         return VllmRefitVerifyConfig()
-    raw_verify = refit_cfg.get("verify")
-    if raw_verify is None:
+    if "verify" not in refit_cfg:
         return VllmRefitVerifyConfig()
-    # Anything explicitly provided (including invalid scalars like ``false``
-    # and unknown keys like ``mdoe``) must fail loudly in Pydantic rather
-    # than silently degrade to the "off" default.
-    return VllmRefitVerifyConfig.model_validate(raw_verify)
+    # Only a truly absent field defaults. Anything explicitly provided --
+    # including ``verify: null``, ``verify: false``, and unknown inner keys
+    # like ``mdoe`` -- must fail loudly in Pydantic rather than silently
+    # degrade to the "off" default.
+    return VllmRefitVerifyConfig.model_validate(refit_cfg["verify"])
+
+
+_REFIT_CFG_KNOWN_KEYS = frozenset({"sparse", "nixl", "verify"})
+
+
+def _validate_refit_cfg_keys(config: VllmConfig) -> None:
+    """Reject unknown top-level refit_cfg keys (scoped to the transport).
+
+    ``VllmRefitConfig`` is ``extra="allow"`` so custom checkpoint-engine
+    plugins can scope their options under their own ``module:ClassName``
+    selector key; every other unknown key is a typo (e.g. ``verfiy``) that
+    would otherwise silently disable what the user thought they enabled.
+    """
+    refit_cfg = config.get("refit_cfg")
+    if refit_cfg is None or isinstance(refit_cfg, VllmRefitConfig):
+        return
+    allowed = set(_REFIT_CFG_KNOWN_KEYS)
+    transport = config.get("refit_transport")
+    if isinstance(transport, str) and ":" in transport:
+        allowed.add(transport)
+    unknown = set(refit_cfg) - allowed
+    if unknown:
+        raise ValueError(
+            f"Unknown policy.generation.refit_cfg keys: {sorted(unknown)}. "
+            f"Known keys: {sorted(allowed)}."
+        )
 
 
 def enforce_refit_verify_supported(config: VllmConfig) -> None:
@@ -304,6 +330,7 @@ def enforce_refit_verify_supported(config: VllmConfig) -> None:
     constructed directly (bypassing the weight-sync factory), so this is
     validated where every algorithm must pass: VllmGeneration construction.
     """
+    _validate_refit_cfg_keys(config)
     if resolve_refit_verify_config(config).mode == "off":
         return
     colocated = config["colocated"]["enabled"]

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -34,6 +34,7 @@ from nemo_rl.models.policy.utils import (
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.packed_tensor import packed_broadcast_consumer
+from nemo_rl.weight_sync.digest import digests_to_ints, tensor_digest
 from nemo_rl.weight_sync.nccl_reshard_utils import (
     _STR_TO_DTYPE,
     HFToLocalParamMap,
@@ -916,8 +917,15 @@ class VllmInternalWorkerExtension:
         torch.cuda.current_stream().synchronize()
 
     @wrap_with_nvtx_name("vllm_internal_worker_extension/update_weights_via_ipc_zmq")
-    def update_weights_via_ipc_zmq(self) -> bool:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool = False) -> bool:
         """Receive and update model weights via ZMQ IPC socket.
+
+        Args:
+            verify_digests: When True, hash every received parameter's bytes
+                and return the digests to the sender with the final ACK (as a
+                pyobj instead of the plain byte ACK). The sender compares them
+                against its own hashes of the sent bytes. Must match the
+                sender's refit verify configuration.
 
         Returns:
             bool: True if weights were successfully updated.
@@ -925,6 +933,7 @@ class VllmInternalWorkerExtension:
         buffer = None
         weight = None
         weights = None
+        received_digests: dict[str, torch.Tensor] = {}
 
         try:
             self.maybe_init_zmq()
@@ -941,7 +950,18 @@ class VllmInternalWorkerExtension:
                             manifest.require_complete()
                             finalize()
                         finally:
-                            self.zmq_socket.send(IPCProtocol.ACK.value.encode())
+                            if verify_digests:
+                                # Every hashed batch was synchronized before its
+                                # ACK, so materializing the digests here cannot
+                                # observe unfinished kernels.
+                                self.zmq_socket.send_pyobj(
+                                    {
+                                        "ack": IPCProtocol.ACK.value,
+                                        "digests": digests_to_ints(received_digests),
+                                    }
+                                )
+                            else:
+                                self.zmq_socket.send(IPCProtocol.ACK.value.encode())
                         break
 
                     batch_keys = None
@@ -976,6 +996,12 @@ class VllmInternalWorkerExtension:
                             "inaccurate info like keys or cached dtype in "
                             "state_dict_info"
                         )
+                        if verify_digests:
+                            # Hash the received views before loading mutates
+                            # anything downstream; the kernels are ordered on
+                            # the current stream ahead of this batch's fence.
+                            for key, received_weight in weights:
+                                received_digests[key] = tensor_digest(received_weight)
                         self._load_weights(weights)
                     except Exception as error:
                         batch_error = error

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -917,15 +917,15 @@ class VllmInternalWorkerExtension:
         torch.cuda.current_stream().synchronize()
 
     @wrap_with_nvtx_name("vllm_internal_worker_extension/update_weights_via_ipc_zmq")
-    def update_weights_via_ipc_zmq(self, verify_digests: bool = False) -> bool:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> bool:
         """Receive and update model weights via ZMQ IPC socket.
 
         Args:
-            verify_digests: When True, hash every received parameter's bytes
-                and return the digests to the sender with the final ACK (as a
-                pyobj instead of the plain byte ACK). The sender compares them
-                against its own hashes of the sent bytes. Must match the
-                sender's refit verify configuration.
+            verify_digests: When True, hash every received parameter's bytes,
+                dtype, and shape and return the digests to the sender with the
+                final ACK (as a pyobj instead of the plain byte ACK). The sender
+                compares them against its own hashes of the sent tensors. Must
+                match the sender's refit verify configuration.
 
         Returns:
             bool: True if weights were successfully updated.

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -1189,7 +1189,9 @@ class VllmGeneration(GenerationInterface):
         # Wait for all futures to complete
         ray.get(futures)
 
-    def update_weights_via_ipc_zmq(self) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(
+        self, verify_digests: bool = False
+    ) -> list[ray.ObjectRef]:
         """Update weights of the policy using IPC handles via ZMQ socket."""
         if not self.worker_group or not self.worker_group.workers:
             raise RuntimeError("Worker group is not initialized")
@@ -1201,9 +1203,9 @@ class VllmGeneration(GenerationInterface):
             else "update_weights_via_ipc_zmq"
         )
 
-        # Use run_all_workers_single_data since no data needs to be passed
         futures = self.worker_group.run_all_workers_single_data(
             method_name,
+            verify_digests=verify_digests,
             run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
         )
 

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -150,6 +150,14 @@ class VllmGeneration(GenerationInterface):
             defer_model_load: If True, defer model loading for overlapped init
         """
         # Store config
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        # Fail at construction (every algorithm and transport passes here)
+        # rather than let unsupported topologies silently skip verification.
+        enforce_refit_verify_supported(config)
+
         self.cfg = config
         self._defer_model_load = defer_model_load
         self.weight_synchronizer: WeightSynchronizer | None = None

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -1189,9 +1189,7 @@ class VllmGeneration(GenerationInterface):
         # Wait for all futures to complete
         ray.get(futures)
 
-    def update_weights_via_ipc_zmq(
-        self, verify_digests: bool = False
-    ) -> list[ray.ObjectRef]:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> list[ray.ObjectRef]:
         """Update weights of the policy using IPC handles via ZMQ socket."""
         if not self.worker_group or not self.worker_group.workers:
             raise RuntimeError("Worker group is not initialized")

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -1271,7 +1271,7 @@ class VllmGenerationWorkerImpl(VllmCheckpointEngineRpcMixin, BaseVllmGenerationW
         self.llm.collective_rpc("prepare_refit_info", args=(state_dict_info,))
 
     @wrap_with_nvtx_name("vllm_genertion_worker/update_weights_via_ipc_zmq")
-    def update_weights_via_ipc_zmq(self) -> bool:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool = False) -> bool:
         """Update weights from IPC handles via ZMQ socket."""
         try:
             assert self.llm is not None, (
@@ -1285,7 +1285,7 @@ class VllmGenerationWorkerImpl(VllmCheckpointEngineRpcMixin, BaseVllmGenerationW
 
             result_or_coro = self.llm.collective_rpc(
                 "update_weights_via_ipc_zmq",
-                args=tuple(),
+                args=(verify_digests,),
             )
             worker_results = cast(list[bool], result_or_coro)
 

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -1271,7 +1271,7 @@ class VllmGenerationWorkerImpl(VllmCheckpointEngineRpcMixin, BaseVllmGenerationW
         self.llm.collective_rpc("prepare_refit_info", args=(state_dict_info,))
 
     @wrap_with_nvtx_name("vllm_genertion_worker/update_weights_via_ipc_zmq")
-    def update_weights_via_ipc_zmq(self, verify_digests: bool = False) -> bool:
+    def update_weights_via_ipc_zmq(self, verify_digests: bool) -> bool:
         """Update weights from IPC handles via ZMQ socket."""
         try:
             assert self.llm is not None, (

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1422,7 +1422,7 @@ class VllmAsyncGenerationWorkerImpl(
 
     async def update_weights_via_ipc_zmq_async(
         self,
-        verify_digests: bool = False,
+        verify_digests: bool,
     ) -> bool:
         """Async version of update_weights_via_ipc_zmq."""
         try:

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1422,6 +1422,7 @@ class VllmAsyncGenerationWorkerImpl(
 
     async def update_weights_via_ipc_zmq_async(
         self,
+        verify_digests: bool = False,
     ) -> bool:
         """Async version of update_weights_via_ipc_zmq."""
         try:
@@ -1436,7 +1437,7 @@ class VllmAsyncGenerationWorkerImpl(
 
             # TODO: switch to update_weights_from_local_ipc_handles for better performance once collectively report_device_id is supported in asyncLLM initialization
             result_or_coro = await self.llm.collective_rpc(
-                "update_weights_via_ipc_zmq", args=tuple()
+                "update_weights_via_ipc_zmq", args=(verify_digests,)
             )
 
             if asyncio.iscoroutine(result_or_coro):

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -196,6 +196,7 @@ class ColocatablePolicyInterface(PolicyInterface):
         self,
         buffer_size_bytes: int,
         kv_scales: Optional[dict[str, float]] = None,
+        verify_mode: str = "off",
     ) -> list[ray.ObjectRef]:
         pass
 

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -196,7 +196,8 @@ class ColocatablePolicyInterface(PolicyInterface):
         self,
         buffer_size_bytes: int,
         kv_scales: Optional[dict[str, float]] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ) -> list[ray.ObjectRef]:
         pass
 

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -1089,7 +1089,8 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         self,
         buffer_size_bytes: int,
         kv_scales: Optional[dict[str, float]] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ) -> list[ray.ObjectRef]:
         """Send the weights for IPC handles via ZMQ socket."""
         futures = self.worker_group.run_all_workers_single_data(

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -1086,13 +1086,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         return free_memory_bytes
 
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int,
+        kv_scales: Optional[dict[str, float]] = None,
+        verify_mode: str = "off",
     ) -> list[ray.ObjectRef]:
         """Send the weights for IPC handles via ZMQ socket."""
         futures = self.worker_group.run_all_workers_single_data(
             "stream_weights_via_ipc_zmq",
             buffer_size_bytes=buffer_size_bytes,
             kv_scales=kv_scales,
+            verify_mode=verify_mode,
         )
         return futures
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -398,9 +398,9 @@ def _check_refit_digests(
     message = (
         f"{worker_name} (rank {rank}): refit digest mismatch for "
         f"{len(mismatched)}/{len(local_digests)} parameters: {shown}. "
-        "The bytes received by the generation worker differ from the bytes "
-        "sent by the policy worker (corrupted transfer or stale/desynced "
-        "refit metadata)."
+        "The tensor bytes, dtype, or shape received by the generation worker "
+        "differ from what the policy worker sent (corrupted transfer or "
+        "stale/desynced refit metadata)."
     )
     if verify_mode == "enforce":
         raise RuntimeError(message)
@@ -413,7 +413,8 @@ def stream_weights_via_ipc_zmq_impl(
     zmq_socket,
     rank: int,
     worker_name: str,
-    verify_mode: str = "off",
+    *,
+    verify_mode: str,
 ) -> None:
     """Shared implementation for streaming weights via IPC ZMQ with improved memory management.
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -359,8 +359,61 @@ def calculate_aligned_size(size_bytes: int, alignment: int = 512) -> int:
     return int(((size_bytes + alignment - 1) // alignment) * alignment)
 
 
+def _check_refit_digests(
+    local_digests: dict[str, "torch.Tensor"],
+    final_ack: object,
+    verify_mode: str,
+    rank: int,
+    worker_name: str,
+) -> None:
+    """Compare sender-side digests against the receiver's final-ACK digests.
+
+    Raises RuntimeError on mismatch in "enforce" mode; prints a warning in
+    "log" mode. A final ACK without digests means the two sides disagree on
+    the verification protocol, which is always an error.
+    """
+    from nemo_rl.weight_sync.digest import compare_digests, digests_to_ints
+
+    remote_digests = final_ack.get("digests") if isinstance(final_ack, dict) else None
+    if remote_digests is None:
+        raise RuntimeError(
+            f"{worker_name} (rank {rank}): refit verification is enabled on the "
+            "sender but the receiver's final ACK carried no digests. Both sides "
+            "must run with the same refit verify configuration."
+        )
+
+    mismatched = compare_digests(digests_to_ints(local_digests), remote_digests)
+    if not mismatched:
+        if rank == 0:
+            print(
+                f"{worker_name}: refit digest verification passed for "
+                f"{len(local_digests)} parameters",
+                flush=True,
+            )
+        return
+
+    shown = ", ".join(mismatched[:20])
+    if len(mismatched) > 20:
+        shown += f", ... ({len(mismatched) - 20} more)"
+    message = (
+        f"{worker_name} (rank {rank}): refit digest mismatch for "
+        f"{len(mismatched)}/{len(local_digests)} parameters: {shown}. "
+        "The bytes received by the generation worker differ from the bytes "
+        "sent by the policy worker (corrupted transfer or stale/desynced "
+        "refit metadata)."
+    )
+    if verify_mode == "enforce":
+        raise RuntimeError(message)
+    print(f"WARNING: {message}", flush=True)
+
+
 def stream_weights_via_ipc_zmq_impl(
-    params_generator, buffer_size_bytes: int, zmq_socket, rank: int, worker_name: str
+    params_generator,
+    buffer_size_bytes: int,
+    zmq_socket,
+    rank: int,
+    worker_name: str,
+    verify_mode: str = "off",
 ) -> None:
     """Shared implementation for streaming weights via IPC ZMQ with improved memory management.
 
@@ -373,7 +426,17 @@ def stream_weights_via_ipc_zmq_impl(
         zmq_socket: ZMQ socket for communication
         rank: Worker rank for logging
         worker_name: Name of the worker for logging
+        verify_mode: "off", "log", or "enforce" (see ``VllmRefitVerifyConfig``).
+            When not "off", every streamed tensor is hashed, the receiver
+            returns its own per-parameter hashes with the final ACK, and
+            mismatches are reported ("log") or raised ("enforce"). The
+            receiver must be invoked with ``verify_digests=True`` so both
+            sides agree on the final-ACK wire format.
     """
+    from nemo_rl.weight_sync.digest import tensor_digest
+
+    verify = verify_mode != "off"
+    local_digests: dict[str, torch.Tensor] = {}
     # Divide total buffer size by 2 because we use two individual buffers (ping-pong) for overlapping communication.
     buffer_size_bytes = buffer_size_bytes // 2
 
@@ -434,6 +497,11 @@ def stream_weights_via_ipc_zmq_impl(
 
     try:
         for name, tensor in params_generator:
+            if verify:
+                # Hash before packing so the oversized-parameter branch is
+                # covered too. The digest kernel runs on the current stream,
+                # ordered with the pack copy below.
+                local_digests[name] = tensor_digest(tensor)
             # Initialize device and buffers on first tensor
             if buffer_a is None:
                 buffer_device = tensor.device
@@ -521,7 +589,16 @@ def stream_weights_via_ipc_zmq_impl(
         torch.cuda.current_stream().synchronize()
         release_staging_buffers()
         zmq_socket.send_pyobj(IPCProtocol.COMPLETE)
-        zmq_socket.recv()
+        if verify:
+            # With verification on, the receiver replies to COMPLETE with a
+            # pyobj ACK carrying its per-parameter digests of the received
+            # bytes (instead of the plain byte ACK).
+            final_ack = zmq_socket.recv_pyobj()
+            _check_refit_digests(
+                local_digests, final_ack, verify_mode, rank, worker_name
+            )
+        else:
+            zmq_socket.recv()
 
         if rank == 0:
             print(

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1875,6 +1875,7 @@ class DTensorPolicyWorkerImpl(
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        verify_mode: str = "off",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -1896,6 +1897,7 @@ class DTensorPolicyWorkerImpl(
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            verify_mode=verify_mode,
         )
 
     def _checkpoint_engine_params(

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1875,7 +1875,8 @@ class DTensorPolicyWorkerImpl(
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1081,6 +1081,7 @@ class DTensorPolicyWorkerV2Impl(
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        verify_mode: str = "off",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -1102,6 +1103,7 @@ class DTensorPolicyWorkerV2Impl(
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            verify_mode=verify_mode,
         )
 
     @torch.no_grad()

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1081,7 +1081,8 @@ class DTensorPolicyWorkerV2Impl(
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2687,7 +2687,8 @@ class MegatronPolicyWorkerImpl(
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         self.maybe_init_zmq()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2684,7 +2684,10 @@ class MegatronPolicyWorkerImpl(
     @torch.no_grad()
     @wrap_with_nvtx_name("megatron_policy_worker/stream_weights_via_ipc_zmq")
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int = 0, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int = 0,
+        kv_scales: Optional[dict[str, float]] = None,
+        verify_mode: str = "off",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         self.maybe_init_zmq()
@@ -2700,6 +2703,7 @@ class MegatronPolicyWorkerImpl(
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            verify_mode=verify_mode,
         )
 
     @torch.no_grad()

--- a/nemo_rl/weight_sync/digest.py
+++ b/nemo_rl/weight_sync/digest.py
@@ -14,12 +14,17 @@
 
 """Deterministic per-tensor digests for refit weight-transfer verification.
 
-Each int64 lane is combined with its position and passed through a nonlinear
-64-bit mixer before reduction. Integer addition and multiplication use
-hardware wraparound (i.e. mod 2**64), so the result is bit-identical
-regardless of reduction order, chunking, or device. The tensor's dtype and
-shape are folded into the result as well as its bytes so stale refit metadata
-cannot reinterpret an otherwise identical byte stream undetected.
+Each int64 lane is bound to its position through a nonlinear mix and reduced
+with wraparound addition on two independently-parameterized 64-bit channels
+(128 bits of state total). Wraparound addition is associative and
+commutative, so the result is bit-identical regardless of reduction order,
+chunking, or device. A single such channel is not enough: for any bijective
+per-lane transform, a corruption that permutes the transformed lane values
+leaves a commutative sum unchanged and can be constructed in closed form.
+With two channels the same corrupted lanes must simultaneously preserve both
+nonlinearly-coupled sums, for which no closed-form construction exists. The
+tensor's dtype and shape seed both channels so equal-size metadata drift is
+also detected.
 """
 
 import hashlib
@@ -27,12 +32,17 @@ import hashlib
 import torch
 
 _U64 = 1 << 64
-# SplitMix64 constants. Position-salting before the bijective finalizer avoids
-# the deterministic cancellation that a linear polynomial has for paired
-# high-bit flips in separate int64 lanes.
-_POSITION_SALT = 0x9E3779B97F4A7C15
+# SplitMix64 finalizer constants.
 _MIX_MULTIPLIER_1 = 0xBF58476D1CE4E5B9
 _MIX_MULTIPLIER_2 = 0x94D049BB133111EB
+# Independent per-channel position salts and the second channel's lane offset.
+# A *linear* position salt (lane + pos * salt) is absorbable: corrupted lanes
+# can soak up the salt difference between two positions and permute the salted
+# values, which a commutative sum cannot see. Positions are therefore injected
+# through the nonlinear mixer (lane ^ _mix64(pos * salt)).
+_CHANNEL_1_POSITION_SALT = 0x9E3779B97F4A7C15
+_CHANNEL_2_POSITION_SALT = 0xC2B2AE3D27D4EB4F
+_CHANNEL_2_LANE_OFFSET = 0x452821E638D01377
 # 1 Mi int64 lanes (8 MiB) hashed per chunk.
 _CHUNK_LANES = 1 << 20
 
@@ -55,9 +65,9 @@ def _mix64(value: torch.Tensor) -> torch.Tensor:
     return value ^ _logical_right_shift(value, 31)
 
 
-def _metadata_seed(tensor: torch.Tensor) -> int:
-    """Stable 64-bit seed covering the tensor's dtype, shape, and byte length."""
-    metadata = hashlib.blake2b(digest_size=8, person=b"NeMoRLrefit-v2")
+def _metadata_seeds(tensor: torch.Tensor) -> tuple[int, int]:
+    """Stable per-channel 64-bit seeds covering dtype, shape, and byte length."""
+    metadata = hashlib.blake2b(digest_size=16, person=b"NeMoRLrefit-v3")
     dtype_name = str(tensor.dtype).encode("ascii")
     metadata.update(len(dtype_name).to_bytes(2, byteorder="little"))
     metadata.update(dtype_name)
@@ -65,14 +75,18 @@ def _metadata_seed(tensor: torch.Tensor) -> int:
     for dimension in tensor.shape:
         metadata.update(dimension.to_bytes(8, byteorder="little"))
     metadata.update(tensor.nbytes.to_bytes(8, byteorder="little"))
-    return int.from_bytes(metadata.digest(), byteorder="little")
+    raw = metadata.digest()
+    return (
+        int.from_bytes(raw[:8], byteorder="little"),
+        int.from_bytes(raw[8:], byteorder="little"),
+    )
 
 
 def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
-    """Digest a tensor's logical byte stream into a 0-dim int64 tensor.
+    """Digest a tensor's logical byte stream into a 2-element int64 tensor.
 
-    The hash covers the tensor's dtype and shape followed by exactly
-    ``tensor.nbytes`` bytes in flattened logical element order.
+    The 128-bit digest covers the tensor's dtype and shape followed by
+    exactly ``tensor.nbytes`` bytes in flattened logical element order.
 
     The result stays on ``tensor.device`` so callers can batch hashing on
     the active CUDA stream without a device sync per tensor; convert with
@@ -92,9 +106,9 @@ def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
         raw = padded
     lanes = raw.view(torch.int64)
 
-    digest = torch.full(
-        (), _as_i64(_metadata_seed(tensor)), dtype=torch.int64, device=lanes.device
-    )
+    seed_1, seed_2 = _metadata_seeds(tensor)
+    channel_1 = torch.full((), _as_i64(seed_1), dtype=torch.int64, device=lanes.device)
+    channel_2 = torch.full((), _as_i64(seed_2), dtype=torch.int64, device=lanes.device)
     lane_offset = 0
     for chunk in lanes.split(_CHUNK_LANES):
         lanes_in_chunk = chunk.numel()
@@ -104,14 +118,18 @@ def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
             dtype=torch.int64,
             device=lanes.device,
         )
-        salted = chunk + positions * _as_i64(_POSITION_SALT)
-        digest = digest + _mix64(salted).sum(dtype=torch.int64)
+        position_mix_1 = _mix64(positions * _as_i64(_CHANNEL_1_POSITION_SALT))
+        position_mix_2 = _mix64(positions * _as_i64(_CHANNEL_2_POSITION_SALT))
+        channel_1 = channel_1 + _mix64(chunk ^ position_mix_1).sum(dtype=torch.int64)
+        channel_2 = channel_2 + _mix64(
+            (chunk + _as_i64(_CHANNEL_2_LANE_OFFSET)) ^ position_mix_2
+        ).sum(dtype=torch.int64)
         lane_offset += lanes_in_chunk
-    return _mix64(digest)
+    return torch.stack([_mix64(channel_1), _mix64(channel_2)])
 
 
-def digests_to_ints(digests: dict[str, torch.Tensor]) -> dict[str, int]:
-    """Normalize digest tensors to unsigned Python ints (forces a device sync)."""
+def digests_to_ints(digests: dict[str, torch.Tensor]) -> dict[str, str]:
+    """Normalize digest tensors to 32-hex strings (forces a device sync)."""
     if not digests:
         return {}
 
@@ -119,15 +137,17 @@ def digests_to_ints(digests: dict[str, torch.Tensor]) -> dict[str, int]:
     for name, digest in digests.items():
         device_batches.setdefault(digest.device, []).append((name, digest))
 
-    normalized: dict[str, int] = {}
+    normalized: dict[str, str] = {}
     for batch in device_batches.values():
         stacked = torch.stack([digest for _, digest in batch]).cpu()
-        for (name, _), value in zip(batch, stacked.tolist()):
-            normalized[name] = int(value) & (_U64 - 1)
+        for (name, _), (first, second) in zip(batch, stacked.tolist()):
+            normalized[name] = (
+                f"{int(first) & (_U64 - 1):016x}{int(second) & (_U64 - 1):016x}"
+            )
     return {name: normalized[name] for name in digests}
 
 
-def compare_digests(sender: dict[str, int], receiver: dict[str, int]) -> list[str]:
+def compare_digests(sender: dict[str, str], receiver: dict[str, str]) -> list[str]:
     """Parameter names whose digests disagree or are missing on either side."""
     return sorted(
         name

--- a/nemo_rl/weight_sync/digest.py
+++ b/nemo_rl/weight_sync/digest.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic per-tensor digests for refit weight-transfer verification.
+
+The digest is a polynomial rolling hash over a tensor's flattened byte
+stream, computed in int64 with hardware wraparound (i.e. mod 2**64).
+Integer modular addition and multiplication are associative and
+commutative, so the result is bit-identical regardless of reduction
+order, chunking, or device -- unlike any floating-point checksum, which
+would itself be subject to the nondeterminism this module is meant to
+detect. Both ends of a transfer can therefore hash "the bytes they
+sent" and "the bytes they received" independently and compare exact
+integers.
+"""
+
+import torch
+
+_FNV_PRIME = 0x100000001B3
+_FNV_OFFSET_BASIS = 0xCBF29CE484222325
+_U64 = 1 << 64
+# 1 Mi int64 lanes (8 MiB) hashed per chunk; bounds the cached power table.
+_CHUNK_LANES = 1 << 20
+
+_POW_CACHE: dict[str, torch.Tensor] = {}
+
+
+def _as_i64(value: int) -> int:
+    """Map an unsigned 64-bit value onto the torch.int64 two's-complement range."""
+    value &= _U64 - 1
+    return value - _U64 if value >= (1 << 63) else value
+
+
+def _descending_powers(device: torch.device) -> torch.Tensor:
+    """[R^(_CHUNK_LANES-1), ..., R^1, R^0] as int64, mod 2**64."""
+    key = str(device)
+    cached = _POW_CACHE.get(key)
+    if cached is None:
+        base = torch.full(
+            (_CHUNK_LANES,), _as_i64(_FNV_PRIME), dtype=torch.int64, device=device
+        )
+        base[0] = 1
+        cached = torch.cumprod(base, dim=0).flip(0)
+        _POW_CACHE[key] = cached
+    return cached
+
+
+def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
+    """Digest a tensor's logical byte stream into a 0-dim int64 tensor.
+
+    The hash covers exactly ``tensor.nbytes`` bytes in flattened logical
+    element order, with the byte length folded in at the end, so tensors
+    of different lengths (or trailing zero padding) cannot collide with
+    each other's prefixes.
+
+    The result stays on ``tensor.device`` so callers can batch hashing on
+    the active CUDA stream without a device sync per tensor; convert with
+    :func:`digest_to_int` only after the producing stream is synchronized.
+    """
+    data = tensor.detach().reshape(-1)
+    if not data.is_contiguous():
+        data = data.contiguous()
+    raw = data.view(torch.uint8)
+    num_bytes = raw.numel()
+    pad = (-num_bytes) % 8
+    if pad or (raw.storage_offset() % 8):
+        # int64 lanes need 8-byte-aligned storage and a multiple-of-8 length;
+        # a bf16 slice at an odd element offset satisfies neither.
+        padded = raw.new_zeros(num_bytes + pad)
+        padded[:num_bytes] = raw
+        raw = padded
+    lanes = raw.view(torch.int64)
+
+    digest = torch.full(
+        (), _as_i64(_FNV_OFFSET_BASIS), dtype=torch.int64, device=lanes.device
+    )
+    powers = _descending_powers(lanes.device)
+    for chunk in lanes.split(_CHUNK_LANES):
+        lanes_in_chunk = chunk.numel()
+        # H(prefix + chunk) = H(prefix) * R^len(chunk) + H(chunk), mod 2**64.
+        digest = digest * _as_i64(pow(_FNV_PRIME, lanes_in_chunk, _U64)) + (
+            chunk * powers[-lanes_in_chunk:]
+        ).sum(dtype=torch.int64)
+    return digest * _as_i64(_FNV_PRIME) + num_bytes
+
+
+def digests_to_ints(digests: dict[str, torch.Tensor]) -> dict[str, int]:
+    """Normalize digest tensors to unsigned Python ints (forces a device sync)."""
+    if not digests:
+        return {}
+    stacked = torch.stack(list(digests.values())).cpu()
+    return {
+        name: int(value) & (_U64 - 1)
+        for name, value in zip(digests.keys(), stacked.tolist())
+    }
+
+
+def compare_digests(sender: dict[str, int], receiver: dict[str, int]) -> list[str]:
+    """Parameter names whose digests disagree or are missing on either side."""
+    return sorted(
+        name
+        for name in set(sender) | set(receiver)
+        if sender.get(name) != receiver.get(name)
+    )

--- a/nemo_rl/weight_sync/digest.py
+++ b/nemo_rl/weight_sync/digest.py
@@ -14,26 +14,27 @@
 
 """Deterministic per-tensor digests for refit weight-transfer verification.
 
-The digest is a polynomial rolling hash over a tensor's flattened byte
-stream, computed in int64 with hardware wraparound (i.e. mod 2**64).
-Integer modular addition and multiplication are associative and
-commutative, so the result is bit-identical regardless of reduction
-order, chunking, or device -- unlike any floating-point checksum, which
-would itself be subject to the nondeterminism this module is meant to
-detect. Both ends of a transfer can therefore hash "the bytes they
-sent" and "the bytes they received" independently and compare exact
-integers.
+Each int64 lane is combined with its position and passed through a nonlinear
+64-bit mixer before reduction. Integer addition and multiplication use
+hardware wraparound (i.e. mod 2**64), so the result is bit-identical
+regardless of reduction order, chunking, or device. The tensor's dtype and
+shape are folded into the result as well as its bytes so stale refit metadata
+cannot reinterpret an otherwise identical byte stream undetected.
 """
+
+import hashlib
 
 import torch
 
-_FNV_PRIME = 0x100000001B3
-_FNV_OFFSET_BASIS = 0xCBF29CE484222325
 _U64 = 1 << 64
-# 1 Mi int64 lanes (8 MiB) hashed per chunk; bounds the cached power table.
+# SplitMix64 constants. Position-salting before the bijective finalizer avoids
+# the deterministic cancellation that a linear polynomial has for paired
+# high-bit flips in separate int64 lanes.
+_POSITION_SALT = 0x9E3779B97F4A7C15
+_MIX_MULTIPLIER_1 = 0xBF58476D1CE4E5B9
+_MIX_MULTIPLIER_2 = 0x94D049BB133111EB
+# 1 Mi int64 lanes (8 MiB) hashed per chunk.
 _CHUNK_LANES = 1 << 20
-
-_POW_CACHE: dict[str, torch.Tensor] = {}
 
 
 def _as_i64(value: int) -> int:
@@ -42,31 +43,40 @@ def _as_i64(value: int) -> int:
     return value - _U64 if value >= (1 << 63) else value
 
 
-def _descending_powers(device: torch.device) -> torch.Tensor:
-    """[R^(_CHUNK_LANES-1), ..., R^1, R^0] as int64, mod 2**64."""
-    key = str(device)
-    cached = _POW_CACHE.get(key)
-    if cached is None:
-        base = torch.full(
-            (_CHUNK_LANES,), _as_i64(_FNV_PRIME), dtype=torch.int64, device=device
-        )
-        base[0] = 1
-        cached = torch.cumprod(base, dim=0).flip(0)
-        _POW_CACHE[key] = cached
-    return cached
+def _logical_right_shift(value: torch.Tensor, bits: int) -> torch.Tensor:
+    """Shift an int64 tensor right as unsigned values."""
+    return (value >> bits) & ((1 << (64 - bits)) - 1)
+
+
+def _mix64(value: torch.Tensor) -> torch.Tensor:
+    """Apply the SplitMix64 finalizer with int64 wraparound arithmetic."""
+    value = (value ^ _logical_right_shift(value, 30)) * _as_i64(_MIX_MULTIPLIER_1)
+    value = (value ^ _logical_right_shift(value, 27)) * _as_i64(_MIX_MULTIPLIER_2)
+    return value ^ _logical_right_shift(value, 31)
+
+
+def _metadata_seed(tensor: torch.Tensor) -> int:
+    """Stable 64-bit seed covering the tensor's dtype, shape, and byte length."""
+    metadata = hashlib.blake2b(digest_size=8, person=b"NeMoRLrefit-v2")
+    dtype_name = str(tensor.dtype).encode("ascii")
+    metadata.update(len(dtype_name).to_bytes(2, byteorder="little"))
+    metadata.update(dtype_name)
+    metadata.update(tensor.ndim.to_bytes(8, byteorder="little"))
+    for dimension in tensor.shape:
+        metadata.update(dimension.to_bytes(8, byteorder="little"))
+    metadata.update(tensor.nbytes.to_bytes(8, byteorder="little"))
+    return int.from_bytes(metadata.digest(), byteorder="little")
 
 
 def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
     """Digest a tensor's logical byte stream into a 0-dim int64 tensor.
 
-    The hash covers exactly ``tensor.nbytes`` bytes in flattened logical
-    element order, with the byte length folded in at the end, so tensors
-    of different lengths (or trailing zero padding) cannot collide with
-    each other's prefixes.
+    The hash covers the tensor's dtype and shape followed by exactly
+    ``tensor.nbytes`` bytes in flattened logical element order.
 
     The result stays on ``tensor.device`` so callers can batch hashing on
     the active CUDA stream without a device sync per tensor; convert with
-    :func:`digest_to_int` only after the producing stream is synchronized.
+    :func:`digests_to_ints` only after the producing stream is synchronized.
     """
     data = tensor.detach().reshape(-1)
     if not data.is_contiguous():
@@ -83,27 +93,38 @@ def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
     lanes = raw.view(torch.int64)
 
     digest = torch.full(
-        (), _as_i64(_FNV_OFFSET_BASIS), dtype=torch.int64, device=lanes.device
+        (), _as_i64(_metadata_seed(tensor)), dtype=torch.int64, device=lanes.device
     )
-    powers = _descending_powers(lanes.device)
+    lane_offset = 0
     for chunk in lanes.split(_CHUNK_LANES):
         lanes_in_chunk = chunk.numel()
-        # H(prefix + chunk) = H(prefix) * R^len(chunk) + H(chunk), mod 2**64.
-        digest = digest * _as_i64(pow(_FNV_PRIME, lanes_in_chunk, _U64)) + (
-            chunk * powers[-lanes_in_chunk:]
-        ).sum(dtype=torch.int64)
-    return digest * _as_i64(_FNV_PRIME) + num_bytes
+        positions = torch.arange(
+            lane_offset + 1,
+            lane_offset + lanes_in_chunk + 1,
+            dtype=torch.int64,
+            device=lanes.device,
+        )
+        salted = chunk + positions * _as_i64(_POSITION_SALT)
+        digest = digest + _mix64(salted).sum(dtype=torch.int64)
+        lane_offset += lanes_in_chunk
+    return _mix64(digest)
 
 
 def digests_to_ints(digests: dict[str, torch.Tensor]) -> dict[str, int]:
     """Normalize digest tensors to unsigned Python ints (forces a device sync)."""
     if not digests:
         return {}
-    stacked = torch.stack(list(digests.values())).cpu()
-    return {
-        name: int(value) & (_U64 - 1)
-        for name, value in zip(digests.keys(), stacked.tolist())
-    }
+
+    device_batches: dict[torch.device, list[tuple[str, torch.Tensor]]] = {}
+    for name, digest in digests.items():
+        device_batches.setdefault(digest.device, []).append((name, digest))
+
+    normalized: dict[str, int] = {}
+    for batch in device_batches.values():
+        stacked = torch.stack([digest for _, digest in batch]).cpu()
+        for (name, _), value in zip(batch, stacked.tolist()):
+            normalized[name] = int(value) & (_U64 - 1)
+    return {name: normalized[name] for name in digests}
 
 
 def compare_digests(sender: dict[str, int], receiver: dict[str, int]) -> list[str]:

--- a/nemo_rl/weight_sync/digest.py
+++ b/nemo_rl/weight_sync/digest.py
@@ -14,17 +14,20 @@
 
 """Deterministic per-tensor digests for refit weight-transfer verification.
 
-Each int64 lane is bound to its position through a nonlinear mix and reduced
-with wraparound addition on two independently-parameterized 64-bit channels
-(128 bits of state total). Wraparound addition is associative and
-commutative, so the result is bit-identical regardless of reduction order,
-chunking, or device. A single such channel is not enough: for any bijective
-per-lane transform, a corruption that permutes the transformed lane values
-leaves a commutative sum unchanged and can be constructed in closed form.
-With two channels the same corrupted lanes must simultaneously preserve both
-nonlinearly-coupled sums, for which no closed-form construction exists. The
-tensor's dtype and shape seed both channels so equal-size metadata drift is
-also detected.
+Int64 lanes are folded through an ordered binary tree whose pairwise merge
+is non-commutative (left and right children enter through different odd
+multipliers before a nonlinear mix), on two independently-parameterized
+64-bit channels. Every reduction step is elementwise over disjoint pairs, so
+the fold parallelizes on GPU and is bit-identical across devices; a lane's
+position is bound to its path through the tree rather than to its value.
+
+Commutative reductions are structurally unsafe here no matter how many
+channels they use: k channels impose k multiset constraints while n lanes
+provide n degrees of freedom, so lane permutations satisfying all channels
+simultaneously exist and have been constructed for one- and two-channel
+variants of this module. An ordered tree has no such permutation freedom.
+The tensor's dtype and shape seed both channels so equal-size metadata
+drift is also detected.
 """
 
 import hashlib
@@ -35,15 +38,23 @@ _U64 = 1 << 64
 # SplitMix64 finalizer constants.
 _MIX_MULTIPLIER_1 = 0xBF58476D1CE4E5B9
 _MIX_MULTIPLIER_2 = 0x94D049BB133111EB
-# Independent per-channel position salts and the second channel's lane offset.
-# A *linear* position salt (lane + pos * salt) is absorbable: corrupted lanes
-# can soak up the salt difference between two positions and permute the salted
-# values, which a commutative sum cannot see. Positions are therefore injected
-# through the nonlinear mixer (lane ^ _mix64(pos * salt)).
-_CHANNEL_1_POSITION_SALT = 0x9E3779B97F4A7C15
-_CHANNEL_2_POSITION_SALT = 0xC2B2AE3D27D4EB4F
-_CHANNEL_2_LANE_OFFSET = 0x452821E638D01377
-# 1 Mi int64 lanes (8 MiB) hashed per chunk.
+# Per-channel (left tweak, right tweak, multiplier) of the tree merge.
+# Both children pass through the mixer (with distinct tweaks) before the
+# linear combination: a bare linear combination leaves a structural channel
+# open, because two odd multipliers sum to an even number and
+# 2^63 * even == 0 mod 2^64, so flipping the top bit of both children
+# cancels. Distinct tweaks keep the merge non-commutative and remove the
+# all-zero fixed point of the mixer.
+_CHANNEL_1_LEFT_TWEAK = 0x9E3779B97F4A7C15
+_CHANNEL_1_RIGHT_TWEAK = 0xC2B2AE3D27D4EB4F
+_CHANNEL_1_MULTIPLIER = 0xFF51AFD7ED558CCD
+_CHANNEL_2_LEFT_TWEAK = 0x452821E638D01377
+_CHANNEL_2_RIGHT_TWEAK = 0xD1B54A32D192ED03
+_CHANNEL_2_MULTIPLIER = 0xC4CEB9FE1A85EC53
+# Chunk-chain multiplier binding the order of per-chunk tree roots.
+_CHAIN_MULTIPLIER = 0x2545F4914F6CDD1D
+# Lanes folded per tree (an algorithm constant, not a tuning knob: changing
+# it changes chunk boundaries and therefore the digest).
 _CHUNK_LANES = 1 << 20
 
 
@@ -63,6 +74,26 @@ def _mix64(value: torch.Tensor) -> torch.Tensor:
     value = (value ^ _logical_right_shift(value, 30)) * _as_i64(_MIX_MULTIPLIER_1)
     value = (value ^ _logical_right_shift(value, 27)) * _as_i64(_MIX_MULTIPLIER_2)
     return value ^ _logical_right_shift(value, 31)
+
+
+def _tree_fold(
+    lanes: torch.Tensor, left_tweak: int, right_tweak: int, multiplier: int
+) -> torch.Tensor:
+    """Fold a power-of-two lane vector through an ordered binary tree.
+
+    Each level merges disjoint (left, right) pairs elementwise as
+    ``mix64(mix64(left ^ lt) + mix64(right ^ rt) * mult)``. Mixing both
+    children before the combination closes the linear cancellation channel;
+    distinct tweaks make the merge order-sensitive, so a lane's position is
+    encoded by its path through the tree. Returns a 0-dim int64 tensor.
+    """
+    value = lanes
+    lt = _as_i64(left_tweak)
+    rt = _as_i64(right_tweak)
+    mult = _as_i64(multiplier)
+    while value.numel() > 1:
+        value = _mix64(_mix64(value[0::2] ^ lt) + _mix64(value[1::2] ^ rt) * mult)
+    return value.reshape(())
 
 
 def _metadata_seeds(tensor: torch.Tensor) -> tuple[int, int]:
@@ -109,22 +140,23 @@ def tensor_digest(tensor: torch.Tensor) -> torch.Tensor:
     seed_1, seed_2 = _metadata_seeds(tensor)
     channel_1 = torch.full((), _as_i64(seed_1), dtype=torch.int64, device=lanes.device)
     channel_2 = torch.full((), _as_i64(seed_2), dtype=torch.int64, device=lanes.device)
-    lane_offset = 0
+    chain = _as_i64(_CHAIN_MULTIPLIER)
     for chunk in lanes.split(_CHUNK_LANES):
         lanes_in_chunk = chunk.numel()
-        positions = torch.arange(
-            lane_offset + 1,
-            lane_offset + lanes_in_chunk + 1,
-            dtype=torch.int64,
-            device=lanes.device,
+        tree_width = 1 << max(1, (lanes_in_chunk - 1).bit_length())
+        if tree_width != lanes_in_chunk:
+            padded_chunk = chunk.new_zeros(tree_width)
+            padded_chunk[:lanes_in_chunk] = chunk
+            chunk = padded_chunk
+        root_1 = _tree_fold(
+            chunk, _CHANNEL_1_LEFT_TWEAK, _CHANNEL_1_RIGHT_TWEAK, _CHANNEL_1_MULTIPLIER
         )
-        position_mix_1 = _mix64(positions * _as_i64(_CHANNEL_1_POSITION_SALT))
-        position_mix_2 = _mix64(positions * _as_i64(_CHANNEL_2_POSITION_SALT))
-        channel_1 = channel_1 + _mix64(chunk ^ position_mix_1).sum(dtype=torch.int64)
-        channel_2 = channel_2 + _mix64(
-            (chunk + _as_i64(_CHANNEL_2_LANE_OFFSET)) ^ position_mix_2
-        ).sum(dtype=torch.int64)
-        lane_offset += lanes_in_chunk
+        root_2 = _tree_fold(
+            chunk, _CHANNEL_2_LEFT_TWEAK, _CHANNEL_2_RIGHT_TWEAK, _CHANNEL_2_MULTIPLIER
+        )
+        # Chunk roots are chained in order, so chunk position is bound too.
+        channel_1 = _mix64(channel_1 * chain + root_1)
+        channel_2 = _mix64(channel_2 * chain + root_2)
     return torch.stack([_mix64(channel_1), _mix64(channel_2)])
 
 

--- a/nemo_rl/weight_sync/factory.py
+++ b/nemo_rl/weight_sync/factory.py
@@ -84,6 +84,21 @@ def create_weight_synchronizer(
             f"Supported backends: {sorted(_SUPPORTED_BACKENDS)}"
         )
 
+    verify_mode = "off"
+    if generation_backend == VLLM_BACKEND:
+        from nemo_rl.models.generation.vllm.config import (
+            resolve_refit_verify_config,
+        )
+
+        verify_mode = resolve_refit_verify_config(generation.cfg).mode
+        if not colocated and verify_mode != "off":
+            raise NotImplementedError(
+                "Refit verification is currently supported only for colocated "
+                "vLLM IPC weight synchronization. Set "
+                "policy.generation.refit_cfg.verify.mode='off' or enable "
+                "policy.generation.colocated."
+            )
+
     checkpoint_engine_config = checkpoint_engine_refit_config(generation.cfg)
     if checkpoint_engine_config is not None:
         if colocated:
@@ -191,14 +206,6 @@ def create_weight_synchronizer(
     from nemo_rl.weight_sync.ipc_weight_synchronizer import (
         IPCWeightSynchronizer,
     )
-
-    verify_mode = "off"
-    if generation_backend == VLLM_BACKEND:
-        from nemo_rl.models.generation.vllm.config import (
-            resolve_refit_verify_config,
-        )
-
-        verify_mode = resolve_refit_verify_config(generation.cfg).mode
 
     return IPCWeightSynchronizer(
         policy=policy,

--- a/nemo_rl/weight_sync/factory.py
+++ b/nemo_rl/weight_sync/factory.py
@@ -192,8 +192,17 @@ def create_weight_synchronizer(
         IPCWeightSynchronizer,
     )
 
+    verify_mode = "off"
+    if generation_backend == VLLM_BACKEND:
+        from nemo_rl.models.generation.vllm.config import (
+            resolve_refit_verify_config,
+        )
+
+        verify_mode = resolve_refit_verify_config(generation.cfg).mode
+
     return IPCWeightSynchronizer(
         policy=policy,
         generation=generation,
         refit_buffer_size_gb=refit_buffer_size_gb,
+        verify_mode=verify_mode,
     )

--- a/nemo_rl/weight_sync/ipc_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/ipc_weight_synchronizer.py
@@ -50,6 +50,10 @@ class IPCWeightSynchronizer(WeightSynchronizer):
             (concretely a VllmGeneration instance).
         refit_buffer_size_gb: Fixed buffer size in GB for weight staging.
             If None, buffer size is computed dynamically from free GPU memory.
+        verify_mode: Byte-level transfer verification mode ("off", "log",
+            or "enforce"), resolved from
+            ``policy.generation.refit_cfg.verify.mode``. Passed through to
+            both the sending policy workers and the receiving vLLM workers.
     """
 
     def __init__(
@@ -57,10 +61,12 @@ class IPCWeightSynchronizer(WeightSynchronizer):
         policy: Any,
         generation: Any,
         refit_buffer_size_gb: Optional[float | int] = None,
+        verify_mode: str = "off",
     ):
         self._policy = policy
         self._generation = generation
         self._refit_buffer_size_gb = refit_buffer_size_gb
+        self._verify_mode = verify_mode
         self._stale = True
 
     def sync_weights(
@@ -85,8 +91,11 @@ class IPCWeightSynchronizer(WeightSynchronizer):
                 futures_train = self._policy.stream_weights_via_ipc_zmq(
                     buffer_size_bytes=buffer_size_bytes,
                     kv_scales=kv_scales,
+                    verify_mode=self._verify_mode,
                 )
-                futures_inference = self._generation.update_weights_via_ipc_zmq()
+                futures_inference = self._generation.update_weights_via_ipc_zmq(
+                    verify_digests=self._verify_mode != "off"
+                )
 
                 ray.get(futures_train)
                 results = ray.get(futures_inference)

--- a/nemo_rl/weight_sync/ipc_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/ipc_weight_synchronizer.py
@@ -50,7 +50,7 @@ class IPCWeightSynchronizer(WeightSynchronizer):
             (concretely a VllmGeneration instance).
         refit_buffer_size_gb: Fixed buffer size in GB for weight staging.
             If None, buffer size is computed dynamically from free GPU memory.
-        verify_mode: Byte-level transfer verification mode ("off", "log",
+        verify_mode: Tensor byte and metadata verification mode ("off", "log",
             or "enforce"), resolved from
             ``policy.generation.refit_cfg.verify.mode``. Passed through to
             both the sending policy workers and the receiving vLLM workers.
@@ -61,7 +61,8 @@ class IPCWeightSynchronizer(WeightSynchronizer):
         policy: Any,
         generation: Any,
         refit_buffer_size_gb: Optional[float | int] = None,
-        verify_mode: str = "off",
+        *,
+        verify_mode: str,
     ):
         self._policy = policy
         self._generation = generation

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -269,6 +269,7 @@ project-includes = [
   "nemo_rl/weight_sync/checkpoint_engine_config.py",
   "nemo_rl/weight_sync/checkpoint_engine_weight_synchronizer.py",
   "nemo_rl/weight_sync/collective_weight_synchronizer.py",
+  "nemo_rl/weight_sync/digest.py",
   "nemo_rl/weight_sync/factory.py",
   "nemo_rl/weight_sync/interfaces.py",
   "nemo_rl/weight_sync/ipc_weight_synchronizer.py",

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -192,8 +192,14 @@ def test_restore_async_replay_buffer_checkpoint_missing_file(tmp_path):
 
 
 @patch("nemo_rl.algorithms.grpo.ray")
-def test_refit_policy_generation_forwards_kv_scales_on_colocated_ipc(
+@pytest.mark.parametrize(
+    ("verify_mode", "verify_digests"),
+    [("off", False), ("enforce", True)],
+)
+def test_refit_policy_generation_forwards_resolved_ipc_config(
     mock_ray: MagicMock,
+    verify_mode: str,
+    verify_digests: bool,
 ) -> None:
     mock_ray.get.return_value = [True]
     policy = MagicMock()
@@ -202,6 +208,7 @@ def test_refit_policy_generation_forwards_kv_scales_on_colocated_ipc(
     # weight_synchronizer and refit_policy_generation would delegate to it instead
     # of taking the colocated IPC path under test.
     policy_generation.weight_synchronizer = None
+    policy_generation.cfg = {"refit_cfg": {"verify": {"mode": verify_mode}}}
     kv_scales = {"layer.0": 0.5}
 
     refit_policy_generation(
@@ -215,6 +222,10 @@ def test_refit_policy_generation_forwards_kv_scales_on_colocated_ipc(
     policy.stream_weights_via_ipc_zmq.assert_called_once_with(
         buffer_size_bytes=1024**3,
         kv_scales=kv_scales,
+        verify_mode=verify_mode,
+    )
+    policy_generation.update_weights_via_ipc_zmq.assert_called_once_with(
+        verify_digests=verify_digests
     )
 
 

--- a/tests/unit/models/generation/sglang/test_sglang_generation.py
+++ b/tests/unit/models/generation/sglang/test_sglang_generation.py
@@ -211,6 +211,18 @@ class _ImmediateAsyncLoop:
         pass
 
 
+def test_ipc_refit_rejects_digest_verification() -> None:
+    generation = SGLangGeneration.__new__(SGLangGeneration)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="SGLang does not support IPC refit digest verification",
+    ):
+        generation.update_weights_via_ipc_zmq(verify_digests=True)
+
+    assert generation.update_weights_via_ipc_zmq(verify_digests=False) == []
+
+
 def _make_minimal_sglang_gen_for_clamp_test(
     *, context_length: int, max_new_tokens: int
 ):

--- a/tests/unit/models/generation/test_dynamo_generation.py
+++ b/tests/unit/models/generation/test_dynamo_generation.py
@@ -95,6 +95,16 @@ def _config(*, tp: int = 1, expose_http_server: bool = False) -> dict[str, Any]:
     }
 
 
+def test_ipc_refit_rejects_digest_verification() -> None:
+    generation = DynamoGeneration.__new__(DynamoGeneration)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="DynamoGeneration does not support IPC refit digest verification",
+    ):
+        generation.update_weights_via_ipc_zmq(verify_digests=True)
+
+
 def _patch_runtime(
     monkeypatch: pytest.MonkeyPatch,
     workers: list[dict[str, Any]] | None = None,

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -1267,3 +1267,116 @@ def test_maybe_process_mtp_drafter_after_loading_noop_when_disk_loaded(monkeypat
     ext._maybe_process_mtp_drafter_after_loading()
 
     process_weights.assert_not_called()
+
+
+class _FakeRefitZmqSocket:
+    """Replays a scripted IPC payload sequence and records the replies."""
+
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.byte_acks = []
+        self.pyobj_acks = []
+
+    def recv_pyobj(self):
+        return self._payloads.pop(0)
+
+    def send(self, data):
+        self.byte_acks.append(data)
+
+    def send_pyobj(self, obj):
+        self.pyobj_acks.append(obj)
+
+
+def _make_ipc_update_extension(backend, state_dict_info, payloads):
+    ext = backend.VllmInternalWorkerExtension.__new__(
+        backend.VllmInternalWorkerExtension
+    )
+    ext.state_dict_info = state_dict_info
+    ext.device = SimpleNamespace(index=0)
+    ext.zmq_socket = _FakeRefitZmqSocket(payloads)
+    ext.maybe_init_zmq = lambda: None
+    ext.loaded_weights = []
+    ext._load_weights = ext.loaded_weights.extend
+    ext._synchronize_before_ipc_data_ack = lambda: None
+    ext._weight_update_errors_are_fatal = lambda: True
+
+    @contextlib.contextmanager
+    def _lifecycle(_transport):
+        yield lambda: None
+
+    ext._weight_update_lifecycle = _lifecycle
+    return ext
+
+
+def _pack_ipc_group(params):
+    """Stage tensors into one 512-byte-aligned buffer, sender-style."""
+    from nemo_rl.models.policy.utils import calculate_aligned_size
+
+    total = sum(calculate_aligned_size(t.nbytes) for _, t in params)
+    buffer = torch.zeros(total, dtype=torch.uint8)
+    offset = 0
+    for _, tensor in params:
+        raw = tensor.reshape(-1).view(torch.uint8)
+        buffer[offset : offset + tensor.nbytes] = raw
+        offset += calculate_aligned_size(tensor.nbytes)
+    return buffer, offset
+
+
+@pytest.mark.vllm
+def test_ipc_update_returns_received_digests_with_final_ack(monkeypatch):
+    """With verify on, the COMPLETE ACK is a pyobj carrying per-param digests."""
+    from nemo_rl.models.generation.vllm import vllm_backend
+    from nemo_rl.models.policy.utils import IPCProtocol
+    from nemo_rl.weight_sync.digest import digests_to_ints, tensor_digest
+
+    params = [
+        ("a.weight", torch.arange(4, dtype=torch.float32)),
+        ("b.weight", torch.arange(6, dtype=torch.float32).reshape(2, 3)),
+    ]
+    buffer, used_bytes = _pack_ipc_group(params)
+    state_dict_info = {name: (t.shape, t.dtype) for name, t in params}
+
+    ext = _make_ipc_update_extension(
+        vllm_backend,
+        state_dict_info,
+        payloads=[
+            (buffer, [name for name, _ in params], used_bytes),
+            IPCProtocol.COMPLETE,
+        ],
+    )
+    monkeypatch.setattr(
+        vllm_backend, "rebuild_cuda_tensor_from_ipc", lambda handle, _index: handle
+    )
+
+    assert ext.update_weights_via_ipc_zmq(verify_digests=True) is True
+
+    assert [name for name, _ in ext.loaded_weights] == ["a.weight", "b.weight"]
+    # Data batches keep the plain byte ACK; only COMPLETE is answered as pyobj.
+    assert len(ext.zmq_socket.byte_acks) == 1
+    assert len(ext.zmq_socket.pyobj_acks) == 1
+    ack = ext.zmq_socket.pyobj_acks[0]
+    expected = digests_to_ints({name: tensor_digest(tensor) for name, tensor in params})
+    assert ack["digests"] == expected
+
+
+@pytest.mark.vllm
+def test_ipc_update_default_keeps_plain_byte_acks(monkeypatch):
+    """verify off must keep the wire format byte-for-byte as before."""
+    from nemo_rl.models.generation.vllm import vllm_backend
+    from nemo_rl.models.policy.utils import IPCProtocol
+
+    params = [("a.weight", torch.arange(4, dtype=torch.float32))]
+    buffer, used_bytes = _pack_ipc_group(params)
+
+    ext = _make_ipc_update_extension(
+        vllm_backend,
+        {name: (t.shape, t.dtype) for name, t in params},
+        payloads=[(buffer, ["a.weight"], used_bytes), IPCProtocol.COMPLETE],
+    )
+    monkeypatch.setattr(
+        vllm_backend, "rebuild_cuda_tensor_from_ipc", lambda handle, _index: handle
+    )
+
+    assert ext.update_weights_via_ipc_zmq() is True
+    assert len(ext.zmq_socket.byte_acks) == 2
+    assert ext.zmq_socket.pyobj_acks == []

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -982,7 +982,7 @@ def test_update_weights_via_ipc_acks_manifest_error_and_returns_false(monkeypatc
 
     ext._weight_update_lifecycle = lifecycle
 
-    assert ext.update_weights_via_ipc_zmq() is False
+    assert ext.update_weights_via_ipc_zmq(verify_digests=False) is False
     assert ext.zmq_socket.sent == [IPCProtocol.ACK.value.encode()]
 
 
@@ -1360,7 +1360,7 @@ def test_ipc_update_returns_received_digests_with_final_ack(monkeypatch):
 
 
 @pytest.mark.vllm
-def test_ipc_update_default_keeps_plain_byte_acks(monkeypatch):
+def test_ipc_update_verify_off_keeps_plain_byte_acks(monkeypatch):
     """verify off must keep the wire format byte-for-byte as before."""
     from nemo_rl.models.generation.vllm import vllm_backend
     from nemo_rl.models.policy.utils import IPCProtocol
@@ -1377,6 +1377,6 @@ def test_ipc_update_default_keeps_plain_byte_acks(monkeypatch):
         vllm_backend, "rebuild_cuda_tensor_from_ipc", lambda handle, _index: handle
     )
 
-    assert ext.update_weights_via_ipc_zmq() is True
+    assert ext.update_weights_via_ipc_zmq(verify_digests=False) is True
     assert len(ext.zmq_socket.byte_acks) == 2
     assert ext.zmq_socket.pyobj_acks == []

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2329,8 +2329,11 @@ def test_vllm_weight_update_and_prefix_cache_reset(
         print("Updating vLLM weights from HF policy...")
 
         buffer_size_bytes = int(lm_policy.get_free_memory_bytes() * 0.3)
-        lm_policy.stream_weights_via_ipc_zmq(buffer_size_bytes=buffer_size_bytes)
-        update_success = vllm_policy.update_weights_via_ipc_zmq()
+        lm_policy.stream_weights_via_ipc_zmq(
+            buffer_size_bytes=buffer_size_bytes,
+            verify_mode="off",
+        )
+        update_success = vllm_policy.update_weights_via_ipc_zmq(verify_digests=False)
         assert update_success, "Weight update should succeed"
         print("vLLM weights successfully updated.")
 

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -1883,7 +1883,7 @@ def test_real_quant_ipc_complete_finalizes_vllm_layerwise_reload_and_acks(
         backend.torch.cuda, "empty_cache", lambda: calls.append("empty")
     )
 
-    assert extension.update_weights_via_ipc_zmq() is True
+    assert extension.update_weights_via_ipc_zmq(verify_digests=False) is True
     assert calls == [
         ("initialize", model),
         ("finalize", model, model_config),
@@ -1931,7 +1931,7 @@ def test_real_quant_ipc_finalize_failure_acks_complete(monkeypatch):
     with pytest.raises(
         RuntimeError, match="ModelOpt real-quant refit post-processing failed"
     ):
-        extension.update_weights_via_ipc_zmq()
+        extension.update_weights_via_ipc_zmq(verify_digests=False)
     assert socket.sent == [IPCProtocol.ACK.value.encode()]
 
 
@@ -2024,7 +2024,7 @@ def test_real_quant_ipc_rejects_invalid_key_manifest(
     monkeypatch.setattr(backend.torch.accelerator, "synchronize", lambda: None)
 
     with pytest.raises(RuntimeError, match=error):
-        extension.update_weights_via_ipc_zmq()
+        extension.update_weights_via_ipc_zmq(verify_digests=False)
     assert extension.zmq_socket.sent == [IPCProtocol.ACK.value.encode()] * len(payloads)
 
 
@@ -2122,7 +2122,7 @@ def test_real_quant_ipc_payload_loads_weights_and_handles_gpt_oss(monkeypatch):
     )
     monkeypatch.setattr(base_backend.gc, "collect", lambda: calls.append("gc"))
 
-    assert extension.update_weights_via_ipc_zmq() is True
+    assert extension.update_weights_via_ipc_zmq(verify_digests=False) is True
 
     assert extension.zmq_socket.sent == [
         IPCProtocol.ACK.value.encode(),
@@ -2157,10 +2157,10 @@ def test_non_real_quant_ipc_delegates(monkeypatch):
     monkeypatch.setattr(
         backend.VllmInternalWorkerExtension,
         "update_weights_via_ipc_zmq",
-        lambda self: "delegated",
+        lambda self, verify_digests: "delegated",
     )
 
-    assert extension.update_weights_via_ipc_zmq() == "delegated"
+    assert extension.update_weights_via_ipc_zmq(verify_digests=False) == "delegated"
 
 
 def test_weight_snapshot_returns_cpu_clone_and_missing_name_raises(monkeypatch):

--- a/tests/unit/models/generation/trtllm/test_trtllm_generation.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_generation.py
@@ -326,7 +326,7 @@ def test_ipc_refit_and_missing_worker_group():
     expected = [SimpleNamespace()]
     generation.worker_group.run_all_workers_single_data.return_value = expected
 
-    assert generation.update_weights_via_ipc_zmq() is expected
+    assert generation.update_weights_via_ipc_zmq(verify_digests=False) is expected
     generation.worker_group.run_all_workers_single_data.assert_called_once_with(
         "update_weights_via_ipc_zmq_async",
         run_rank_0_only_axes=["tensor_parallel"],
@@ -335,4 +335,16 @@ def test_ipc_refit_and_missing_worker_group():
     broken = _bare_generation(colocated=True)
     broken.worker_group.workers = []
     with pytest.raises(RuntimeError, match="Worker group not initialised"):
-        broken.update_weights_via_ipc_zmq()
+        broken.update_weights_via_ipc_zmq(verify_digests=False)
+
+
+def test_ipc_refit_rejects_digest_verification():
+    generation = _bare_generation(colocated=True)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="TensorRT-LLM does not support IPC refit digest verification",
+    ):
+        generation.update_weights_via_ipc_zmq(verify_digests=True)
+
+    generation.worker_group.run_all_workers_single_data.assert_not_called()

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -521,7 +521,11 @@ def test_stream_weights_via_ipc_zmq_uses_real_quant_generator_without_move(
         fake_stream_weights_via_ipc_zmq_impl,
     )
 
-    worker.stream_weights_via_ipc_zmq(buffer_size_bytes=123, kv_scales={"scale": 1.0})
+    worker.stream_weights_via_ipc_zmq(
+        buffer_size_bytes=123,
+        kv_scales={"scale": 1.0},
+        verify_mode="off",
+    )
 
     assert calls[0] == "init_zmq"
     assert calls[1]["buffer_size_bytes"] == 123
@@ -562,7 +566,11 @@ def test_stream_weights_via_ipc_zmq_does_not_move_without_real_quant(monkeypatch
         fake_stream_weights_via_ipc_zmq_impl,
     )
 
-    worker.stream_weights_via_ipc_zmq(buffer_size_bytes=123, kv_scales={"scale": 1.0})
+    worker.stream_weights_via_ipc_zmq(
+        buffer_size_bytes=123,
+        kv_scales={"scale": 1.0},
+        verify_mode="off",
+    )
 
     assert calls[0] == "init_zmq"
     assert calls[1]["buffer_size_bytes"] == 123

--- a/tests/unit/models/policy/test_refit_oversized_param.py
+++ b/tests/unit/models/policy/test_refit_oversized_param.py
@@ -84,6 +84,7 @@ def _stream(monkeypatch, params, buffer_size_bytes=BUFFER_BYTES):
         zmq_socket=socket,
         rank=0,
         worker_name="test-worker",
+        verify_mode="off",
     )
     return socket
 
@@ -312,7 +313,7 @@ def test_verify_rejects_protocol_desync(monkeypatch):
 
 
 def test_verify_off_keeps_plain_byte_protocol(monkeypatch):
-    """The default mode must not switch the final ACK to a pyobj."""
+    """The resolved off mode must not switch the final ACK to a pyobj."""
     socket = _stream(monkeypatch, [_param("layer.0.weight", 512)])
     # _stream runs with verify_mode="off" and FakeSocket has no recv_pyobj;
     # reaching COMPLETE with all ACKs consumed proves the old protocol held.

--- a/tests/unit/models/policy/test_refit_oversized_param.py
+++ b/tests/unit/models/policy/test_refit_oversized_param.py
@@ -25,9 +25,11 @@ These tests run on CPU tensors with a stub socket -- no GPU, no Ray -- because
 the packing/hand-off logic is plain Python around a byte buffer.
 """
 
+import pytest
 import torch
 
 from nemo_rl.models.policy import utils
+from nemo_rl.weight_sync.digest import digests_to_ints, tensor_digest
 
 # Small enough to keep the test instant; the arithmetic is scale-free.
 BUFFER_BYTES = 4096
@@ -167,3 +169,152 @@ def test_alignment_is_what_decides_oversized(monkeypatch):
 
     socket = _stream(monkeypatch, [_param("exact.weight", 2048)])
     assert socket.payloads == [(["exact.weight"], 2048)]
+
+
+# --- digest verification (refit_cfg.verify) -------------------------------
+#
+# The verifying socket mirrors the receiver's slicing exactly as
+# ``VllmInternalWorkerExtension.update_weights_via_ipc_zmq`` does it: walk the
+# staged buffer by aligned offsets, reinterpret each slice by the parameter's
+# dtype/shape, and hash it. Streaming end-to-end through a CPU byte buffer
+# proves the sender's digests describe the same bytes the receiver sees.
+
+
+class VerifyingFakeSocket(FakeSocket):
+    """FakeSocket that hashes received bytes and ACKs COMPLETE with digests."""
+
+    def __init__(self, state_dict_info, tamper=None):
+        super().__init__()
+        self.state_dict_info = state_dict_info
+        self.received_digests = {}
+        self.tamper = tamper or {}
+        self.plain_final_ack = False
+
+    def send_pyobj(self, payload):
+        if payload is utils.IPCProtocol.COMPLETE:
+            self.completed = True
+            self.pending_acks += 1
+            return
+        buffer, param_names, used_bytes = payload
+        offset = 0
+        for name in param_names:
+            shape, dtype = self.state_dict_info[name]
+            nbytes = dtype.itemsize * shape.numel()
+            weight = buffer[offset : offset + nbytes].view(dtype).view(shape)
+            self.received_digests[name] = tensor_digest(weight)
+            offset += utils.calculate_aligned_size(nbytes)
+        assert offset == used_bytes
+        self.payloads.append((list(param_names), used_bytes))
+        self.pending_acks += 1
+
+    def recv_pyobj(self):
+        assert self.completed, "final ACK requested before COMPLETE"
+        assert self.pending_acks > 0
+        self.pending_acks -= 1
+        if self.plain_final_ack:
+            return b""
+        digests = digests_to_ints(self.received_digests)
+        digests.update(self.tamper)
+        return {"ack": "ack", "digests": digests}
+
+
+def _stream_verified(monkeypatch, params, verify_mode, tamper=None, **socket_kwargs):
+    # The verifying receiver needs the staged bytes, not an opaque handle.
+    monkeypatch.setattr(
+        utils, "get_handle_from_tensor", lambda tensor: tensor.detach().clone()
+    )
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda *a, **k: _NullStream(), raising=False
+    )
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    state_dict_info = {name: (tensor.shape, tensor.dtype) for name, tensor in params}
+    socket = VerifyingFakeSocket(state_dict_info, tamper=tamper, **socket_kwargs)
+    utils.stream_weights_via_ipc_zmq_impl(
+        params_generator=iter(params),
+        buffer_size_bytes=BUFFER_BYTES,
+        zmq_socket=socket,
+        rank=0,
+        worker_name="test-worker",
+        verify_mode=verify_mode,
+    )
+    return socket
+
+
+def _random_param(name, nbytes, seed):
+    generator = torch.Generator().manual_seed(seed)
+    return name, torch.randint(
+        0, 256, (nbytes,), dtype=torch.uint8, generator=generator
+    )
+
+
+def test_verify_passes_on_clean_transfer(monkeypatch):
+    """Sender digests match receiver digests computed from the staged bytes."""
+    params = [
+        _random_param("layer.0.weight", 512, seed=0),
+        # Oversized parameters take the dedicated-buffer branch and must be
+        # hashed like any other.
+        _random_param("embed.weight", 3072, seed=1),
+        _random_param("layer.1.weight", 700, seed=2),
+    ]
+
+    socket = _stream_verified(monkeypatch, params, verify_mode="enforce")
+
+    assert socket.pending_acks == 0
+    assert set(socket.received_digests) == {name for name, _ in params}
+
+
+def test_verify_enforce_raises_on_mismatch(monkeypatch):
+    params = [_random_param("layer.0.weight", 512, seed=0)]
+
+    with pytest.raises(RuntimeError, match="layer.0.weight"):
+        _stream_verified(
+            monkeypatch, params, verify_mode="enforce", tamper={"layer.0.weight": 1}
+        )
+
+
+def test_verify_log_warns_but_does_not_raise(monkeypatch, capsys):
+    params = [_random_param("layer.0.weight", 512, seed=0)]
+
+    _stream_verified(
+        monkeypatch, params, verify_mode="log", tamper={"layer.0.weight": 1}
+    )
+
+    assert "refit digest mismatch" in capsys.readouterr().out
+
+
+def test_verify_rejects_protocol_desync(monkeypatch):
+    """A digest-less final ACK means the receiver ran without verification."""
+    params = [_random_param("layer.0.weight", 512, seed=0)]
+
+    with pytest.raises(RuntimeError, match="no digests"):
+        socket = VerifyingFakeSocket({name: (t.shape, t.dtype) for name, t in params})
+        socket.plain_final_ack = True
+        monkeypatch.setattr(
+            utils, "get_handle_from_tensor", lambda tensor: tensor.detach().clone()
+        )
+        monkeypatch.setattr(
+            torch.cuda, "current_stream", lambda *a, **k: _NullStream(), raising=False
+        )
+        monkeypatch.setattr(
+            torch.cuda, "empty_cache", lambda *a, **k: None, raising=False
+        )
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        utils.stream_weights_via_ipc_zmq_impl(
+            params_generator=iter(params),
+            buffer_size_bytes=BUFFER_BYTES,
+            zmq_socket=socket,
+            rank=0,
+            worker_name="test-worker",
+            verify_mode="enforce",
+        )
+
+
+def test_verify_off_keeps_plain_byte_protocol(monkeypatch):
+    """The default mode must not switch the final ACK to a pyobj."""
+    socket = _stream(monkeypatch, [_param("layer.0.weight", 512)])
+    # _stream runs with verify_mode="off" and FakeSocket has no recv_pyobj;
+    # reaching COMPLETE with all ACKs consumed proves the old protocol held.
+    assert socket.completed
+    assert socket.pending_acks == 0

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -188,6 +188,7 @@ def test_stream_weights_releases_buffers_before_complete_without_full_gc(
         zmq_socket=socket,
         rank=0,
         worker_name="test_worker",
+        verify_mode="off",
     )
 
     assert events == ["empty_cache"]
@@ -219,6 +220,7 @@ def test_stream_weights_via_ipc_zmq_uses_cuda_buffer_for_cpu_tensors(monkeypatch
         zmq_socket=socket,
         rank=0,
         worker_name="test_worker",
+        verify_mode="off",
     )
 
     assert captured["buffer_device"].type == "cuda"
@@ -257,6 +259,7 @@ def test_stream_weights_via_ipc_zmq_aligns_cpu_tensor_groups(monkeypatch):
         zmq_socket=socket,
         rank=0,
         worker_name="test_worker",
+        verify_mode="off",
     )
 
     assert captured["buffer_device"].type == "cuda"
@@ -302,6 +305,7 @@ def test_stream_weights_via_ipc_zmq_preserves_cpu_and_gpu_source_bytes(
             zmq_socket=socket,
             rank=0,
             worker_name="test_worker",
+            verify_mode="off",
         )
         _, names, used_bytes = socket.sent[0]
         offset = 0
@@ -349,6 +353,7 @@ def server_process(
             socket,
             rank=0,
             worker_name="test_server",
+            verify_mode="off",
         )
     except Exception as e:
         import sys

--- a/tests/unit/models/policy/test_worker_refit_signatures.py
+++ b/tests/unit/models/policy/test_worker_refit_signatures.py
@@ -57,6 +57,15 @@ FANOUT_METHODS = [
             "interfaces.py",
         ],
     ),
+    (
+        "stream_weights_via_ipc_zmq",
+        [
+            "workers/dtensor_policy_worker.py",
+            "workers/dtensor_policy_worker_v2.py",
+            "workers/megatron_policy_worker.py",
+            "interfaces.py",
+        ],
+    ),
 ]
 
 # The same contract on the generation side, and worse there: VllmGeneration picks the
@@ -85,7 +94,17 @@ GEN_FANOUT = [
     ),
     ("nccl_reshard_refit", "vllm_worker.py", "nccl_reshard_refit"),
     ("nccl_reshard_refit", "vllm_worker_async.py", "nccl_reshard_refit_async"),
+    ("update_weights_via_ipc_zmq", "vllm_worker.py", "update_weights_via_ipc_zmq"),
+    (
+        "update_weights_via_ipc_zmq",
+        "vllm_worker_async.py",
+        "update_weights_via_ipc_zmq_async",
+    ),
 ]
+
+# Worker-group control kwargs consumed by run_all_workers_*() itself, never
+# forwarded to the worker method.
+WORKER_GROUP_CONTROL_KWARGS = {"run_rank_0_only_axes"}
 
 # One level up again: CollectiveWeightSynchronizer holds a GenerationInterface and calls
 # update_weights_from_collective on it, so EVERY backend has to take what it sends --
@@ -172,13 +191,22 @@ def _forwarded_by_vllm_generation(method: str) -> set[str]:
         ):
             continue
         for call in ast.walk(node):
-            if (
-                isinstance(call, ast.Call)
-                and isinstance(call.func, ast.Attribute)
-                and call.func.attr == "remote"
+            if not (
+                isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
             ):
+                continue
+            if call.func.attr == "remote":
                 return {kw.arg for kw in call.keywords if kw.arg is not None}
-    raise AssertionError(f"VllmGeneration.{method}() has no .remote() fan-out")
+            # Same contract when the fan-out goes through the worker group:
+            # every kwarg except the group's own control kwargs reaches the
+            # worker method picked by config.
+            if call.func.attr.startswith("run_all_workers"):
+                return {
+                    kw.arg
+                    for kw in call.keywords
+                    if kw.arg is not None and kw.arg not in WORKER_GROUP_CONTROL_KWARGS
+                }
+    raise AssertionError(f"VllmGeneration.{method}() has no worker fan-out")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/policy/test_worker_refit_signatures.py
+++ b/tests/unit/models/policy/test_worker_refit_signatures.py
@@ -125,6 +125,17 @@ GENERATION_BACKENDS = [
     "sglang/sglang_generation.py",
 ]
 
+# Backends that override the IPC hook. Megatron inherits the base method because it
+# never uses IPC refit; every concrete override still has to accept the synchronizer's
+# verification keyword.
+GENERATION_IPC_BACKENDS = [
+    "interfaces.py",
+    "vllm/vllm_generation.py",
+    "dynamo/dynamo_generation.py",
+    "trtllm/trtllm_generation.py",
+    "sglang/sglang_generation.py",
+]
+
 
 def _kwargs_of(path: Path, method: str) -> set[str]:
     """Keyword names accepted by the outermost definition of ``method`` in ``path``."""
@@ -137,6 +148,31 @@ def _kwargs_of(path: Path, method: str) -> set[str]:
             return {
                 arg.arg
                 for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs)
+                if arg.arg != "self"
+            }
+    raise AssertionError(f"{path.name} does not define {method}()")
+
+
+def _defaulted_kwargs_of(path: Path, method: str) -> set[str]:
+    """Keyword-capable arguments with defaults on ``method`` in ``path``."""
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name == method
+        ):
+            args = node.args
+            positional = [*args.posonlyargs, *args.args]
+            positional_with_defaults = (
+                positional[-len(args.defaults) :] if args.defaults else []
+            )
+            keyword_only_with_defaults = [
+                arg
+                for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=True)
+                if default is not None
+            ]
+            return {
+                arg.arg
+                for arg in (*positional_with_defaults, *keyword_only_with_defaults)
                 if arg.arg != "self"
             }
     raise AssertionError(f"{path.name} does not define {method}()")
@@ -245,6 +281,22 @@ def _forwarded_by_collective_synchronizer() -> set[str]:
     )
 
 
+def _forwarded_by_ipc_synchronizer() -> set[str]:
+    """Keywords sent to ``generation.update_weights_via_ipc_zmq``."""
+    path = REPO_ROOT / "nemo_rl" / "weight_sync" / "ipc_weight_synchronizer.py"
+    tree = ast.parse(path.read_text())
+    for call in ast.walk(tree):
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "update_weights_via_ipc_zmq"
+        ):
+            return {kw.arg for kw in call.keywords if kw.arg is not None}
+    raise AssertionError(
+        "IPCWeightSynchronizer no longer calls update_weights_via_ipc_zmq"
+    )
+
+
 @pytest.mark.parametrize("backend", GENERATION_BACKENDS)
 def test_every_generation_backend_accepts_what_the_synchronizer_sends(backend):
     forwarded = _forwarded_by_collective_synchronizer()
@@ -259,9 +311,67 @@ def test_every_generation_backend_accepts_what_the_synchronizer_sends(backend):
     )
 
 
+@pytest.mark.parametrize("backend", GENERATION_IPC_BACKENDS)
+def test_every_ipc_generation_override_accepts_verification_keyword(backend):
+    forwarded = _forwarded_by_ipc_synchronizer()
+    accepted = _kwargs_of(GENERATION / backend, "update_weights_via_ipc_zmq")
+    missing = forwarded - accepted
+    assert not missing, (
+        f"IPCWeightSynchronizer sends {sorted(missing)} to "
+        f"generation.update_weights_via_ipc_zmq(), but {backend} does not accept "
+        f"{'it' if len(missing) == 1 else 'them'}. A GenerationInterface call then "
+        "fails with TypeError before the backend can reject unsupported verification."
+    )
+
+
+def test_ipc_verification_is_required_through_both_fanouts():
+    """Only the config model owns the off default; consumers require its result."""
+    required_args = [
+        (
+            REPO_ROOT / "nemo_rl" / "weight_sync" / "ipc_weight_synchronizer.py",
+            "__init__",
+            "verify_mode",
+        ),
+        (POLICY / "interfaces.py", "stream_weights_via_ipc_zmq", "verify_mode"),
+        (POLICY / "lm_policy.py", "stream_weights_via_ipc_zmq", "verify_mode"),
+        (POLICY / "utils.py", "stream_weights_via_ipc_zmq_impl", "verify_mode"),
+        *[
+            (POLICY / worker, "stream_weights_via_ipc_zmq", "verify_mode")
+            for worker in (
+                "workers/dtensor_policy_worker.py",
+                "workers/dtensor_policy_worker_v2.py",
+                "workers/megatron_policy_worker.py",
+            )
+        ],
+        *[
+            (GENERATION / backend, "update_weights_via_ipc_zmq", "verify_digests")
+            for backend in GENERATION_IPC_BACKENDS
+        ],
+        (GEN / "vllm_worker.py", "update_weights_via_ipc_zmq", "verify_digests"),
+        (
+            GEN / "vllm_worker_async.py",
+            "update_weights_via_ipc_zmq_async",
+            "verify_digests",
+        ),
+        (GEN / "vllm_backend.py", "update_weights_via_ipc_zmq", "verify_digests"),
+    ]
+
+    for path, method, argument in required_args:
+        assert argument in _kwargs_of(path, method)
+        assert argument not in _defaulted_kwargs_of(path, method), (
+            f"{path.relative_to(REPO_ROOT)}::{method}() defaults {argument}; callers "
+            "can bypass VllmRefitVerifyConfig resolution by omitting it."
+        )
+
+
 def test_the_refit_deadline_is_one_of_those_kwargs():
     """Guards the guard: if the deadline stops being forwarded, the test above goes vacuous."""
     assert "refit_timeout_s" in _forwarded_by_policy("broadcast_weights_for_collective")
+
+
+def test_the_digest_flag_is_one_of_the_ipc_kwargs():
+    """Guards the guard: backend compatibility is vacuous if no flag is sent."""
+    assert "verify_digests" in _forwarded_by_ipc_synchronizer()
 
 
 # Refit entrypoints on the Ray-actor side of a vLLM collective_rpc. Everything these call

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -202,6 +202,11 @@ policy: &POLICY_BASE
         val_top_k: ${.top_k}
         stop_token_ids: null
         stop_strings: null
+        refit_cfg:
+          # Byte-level digest verification of IPC refit transfers.
+          # Quote "off": bare off is YAML for boolean false.
+          verify:
+            mode: "off"
         vllm_cfg:
             async_engine: false
             precision: ${...precision}

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -375,6 +375,8 @@ policy:
     # colocated CUDA-IPC refit to avoid a GPU -> CPU -> GPU round trip.
     real_quant_export_cpu_offload: true
     refit_cfg:
+      verify:
+        mode: "off"
       nixl:
         update_weights_bucket_memory_ratio: 0.05
         device: cuda

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -256,6 +256,11 @@ policy:
       unified_memory_level: 0
       max_tokens: 16384
       logprobs_mode: processed_logprobs
+    refit_cfg:
+      # Byte-level digest verification of IPC refit transfers.
+      # Quote "off": bare off is YAML for boolean false.
+      verify:
+        mode: "off"
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}

--- a/tests/unit/weight_sync/test_reconcile_communicator.py
+++ b/tests/unit/weight_sync/test_reconcile_communicator.py
@@ -116,19 +116,14 @@ def _rebuildable(dp_size=4, workers_per_shard=1, dead_shards=(), train_world_siz
     generation.set_refit_membership = lambda membership: setattr(
         generation, "_refit_membership", membership
     )
-    generation.rebuild_collective = (
-        lambda membership, ip, port: vllm_generation.VllmGeneration.rebuild_collective(
+    generation.rebuild_collective = lambda membership, ip, port: (
+        vllm_generation.VllmGeneration.rebuild_collective(
             generation, membership, ip, port
         )
     )
     policy_calls = []
     policy = SimpleNamespace(
-        init_collective=lambda ip,
-        port,
-        world_size,
-        *,
-        train_world_size,
-        nccl_peer=None: (
+        init_collective=lambda ip, port, world_size, *, train_world_size, nccl_peer=None: (
             policy_calls.append(
                 {
                     "ip": ip,
@@ -346,10 +341,9 @@ class TestControllerCallSite:
         _condemn(monitor, 1)
         calls = []
         synchronizer = SimpleNamespace(
-            reconcile_communicator=lambda absent, force=False: calls.append(
-                list(absent)
+            reconcile_communicator=lambda absent, force=False: (
+                calls.append(list(absent)) or False
             )
-            or False
         )
         ctrl = self._controller(monitor, synchronizer)
 

--- a/tests/unit/weight_sync/test_reconcile_communicator.py
+++ b/tests/unit/weight_sync/test_reconcile_communicator.py
@@ -123,7 +123,12 @@ def _rebuildable(dp_size=4, workers_per_shard=1, dead_shards=(), train_world_siz
     )
     policy_calls = []
     policy = SimpleNamespace(
-        init_collective=lambda ip, port, world_size, *, train_world_size, nccl_peer=None: (
+        init_collective=lambda ip,
+        port,
+        world_size,
+        *,
+        train_world_size,
+        nccl_peer=None: (
             policy_calls.append(
                 {
                     "ip": ip,

--- a/tests/unit/weight_sync/test_reshard_rebuild.py
+++ b/tests/unit/weight_sync/test_reshard_rebuild.py
@@ -94,8 +94,10 @@ def _reshard(dp_size=4, workers_per_shard=1, dead_shards=(), train_world_size=8)
             gen,
             name,
             (
-                lambda n: lambda *a, **k: getattr(vllm_generation.VllmGeneration, n)(
-                    gen, *a, **k
+                lambda n: (
+                    lambda *a, **k: getattr(vllm_generation.VllmGeneration, n)(
+                        gen, *a, **k
+                    )
                 )
             )(name),
         )
@@ -257,8 +259,8 @@ class TestRefitDispatchExcludesTheDeadShard:
         from nemo_rl.models.generation.vllm import vllm_generation
 
         sync, gen, workers, _, kill = _reshard(dp_size=4, dead_shards=(1,))
-        gen.update_weights_from_collective = (
-            lambda: vllm_generation.VllmGeneration.update_weights_from_collective(gen)
+        gen.update_weights_from_collective = lambda: (
+            vllm_generation.VllmGeneration.update_weights_from_collective(gen)
         )
         gen.set_refit_membership(
             plan_refit_membership(

--- a/tests/unit/weight_sync/test_weight_digest.py
+++ b/tests/unit/weight_sync/test_weight_digest.py
@@ -1,0 +1,90 @@
+"""Properties of the deterministic refit transfer digest.
+
+The digest must be a pure function of a tensor's logical byte stream: stable
+across calls, sensitive to value, position, and length changes, and identical
+for any dtype reinterpretation, memory layout, or hashing chunk size that
+preserves those bytes. All tests run on CPU tensors; the arithmetic is pure
+integer math with wraparound, so device changes cannot alter results.
+"""
+
+import torch
+
+from nemo_rl.weight_sync import digest as digest_mod
+from nemo_rl.weight_sync.digest import (
+    compare_digests,
+    digests_to_ints,
+    tensor_digest,
+)
+
+
+def _value(tensor):
+    return digests_to_ints({"x": tensor_digest(tensor)})["x"]
+
+
+def test_digest_is_deterministic():
+    t = torch.arange(1000, dtype=torch.int32)
+    assert _value(t) == _value(t.clone())
+
+
+def test_digest_changes_with_any_value():
+    t = torch.arange(1000, dtype=torch.int32)
+    tampered = t.clone()
+    tampered[500] += 1
+    assert _value(t) != _value(tampered)
+
+
+def test_digest_is_position_sensitive():
+    t = torch.tensor([1, 2], dtype=torch.int64)
+    swapped = torch.tensor([2, 1], dtype=torch.int64)
+    assert _value(t) != _value(swapped)
+
+
+def test_digest_folds_in_length():
+    # Trailing zero bytes extend the stream but leave every lane sum equal,
+    # so only the length fold distinguishes these.
+    assert _value(torch.zeros(8, dtype=torch.uint8)) != _value(
+        torch.zeros(16, dtype=torch.uint8)
+    )
+
+
+def test_digest_matches_byte_reinterpretation():
+    t = torch.randn(64, dtype=torch.bfloat16)
+    assert _value(t) == _value(t.view(torch.uint8))
+
+
+def test_digest_uses_logical_element_order():
+    t = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+    transposed = t.t()
+    assert _value(transposed) == _value(transposed.contiguous())
+    assert _value(transposed) != _value(t)
+
+
+def test_digest_handles_odd_storage_offset():
+    # A bf16 slice at an odd element offset has 8-byte-misaligned storage,
+    # which the int64 lane view must not trip over.
+    base = torch.randn(65, dtype=torch.bfloat16)
+    sliced = base[1:]
+    assert _value(sliced) == _value(sliced.clone())
+
+
+def test_digest_is_chunking_invariant(monkeypatch):
+    t = torch.arange(999, dtype=torch.uint8)
+    reference = _value(t)
+    monkeypatch.setattr(digest_mod, "_CHUNK_LANES", 4)
+    monkeypatch.setattr(digest_mod, "_POW_CACHE", {})
+    assert _value(t) == reference
+
+
+def test_digests_to_ints_roundtrip_and_empty():
+    assert digests_to_ints({}) == {}
+    tensors = {"a": torch.ones(3), "b": torch.zeros(5)}
+    ints = digests_to_ints({k: tensor_digest(v) for k, v in tensors.items()})
+    assert set(ints) == {"a", "b"}
+    assert all(0 <= v < (1 << 64) for v in ints.values())
+
+
+def test_compare_digests_reports_mismatch_and_missing():
+    assert compare_digests({"a": 1, "b": 2}, {"a": 1, "b": 2}) == []
+    assert compare_digests({"a": 1, "b": 2}, {"a": 1, "b": 3}) == ["b"]
+    assert compare_digests({"a": 1, "b": 2}, {"a": 1}) == ["b"]
+    assert compare_digests({"a": 1}, {"a": 1, "c": 9}) == ["c"]

--- a/tests/unit/weight_sync/test_weight_digest.py
+++ b/tests/unit/weight_sync/test_weight_digest.py
@@ -48,13 +48,51 @@ def test_digest_rejects_salted_lane_permutation():
     With lanes [0, 0] and a linear position salt S, the salted lanes are
     [S, 2S]; corrupted lanes [S, -S] (as signed int64) salt to [2S, S] -- a
     permutation that any single per-lane-bijection + commutative-sum digest
-    cannot see. The dual-channel digest must reject it.
+    cannot see. Position must be structural (tree path), not an input.
     """
     original = torch.zeros(2, dtype=torch.int64)
     corrupted = torch.tensor(
         [-7046029254386353131, 7046029254386353131], dtype=torch.int64
     )
     assert _value(original) != _value(corrupted)
+
+
+_DUAL_CHANNEL_COLLISION_X = [
+    1463740549975506996,
+    7247435662023658159,
+    -6925967542218718874,
+    8546351873743446617,
+    -8135354941262485898,
+    -1523163779216173669,
+]
+_DUAL_CHANNEL_COLLISION_Y = [
+    -1671919555023232268,
+    -7491608144376453009,
+    -7861950440807229534,
+    4727800188207773341,
+    -9070301026299793230,
+    -2460484802935340705,
+]
+
+
+def test_digest_rejects_dual_channel_permutation_collision():
+    """The 6-lane pair that collided both commutative channels at once.
+
+    k commutative channels impose only k multiset constraints while n lanes
+    provide n degrees of freedom, so simultaneous permutations exist for any
+    fixed k; these lanes permuted channel 1 by (1,0,4,5,2,3) and channel 2 by
+    (2,3,1,0,5,4). An ordered tree fold has no permutation freedom to exploit.
+    """
+    x = torch.tensor(_DUAL_CHANNEL_COLLISION_X, dtype=torch.int64)
+    y = torch.tensor(_DUAL_CHANNEL_COLLISION_Y, dtype=torch.int64)
+    assert _value(x) != _value(y)
+
+
+def test_digest_rejects_dual_channel_collision_as_bf16():
+    """The same 48 bytes reinterpreted as bf16 must not collide either."""
+    x = torch.tensor(_DUAL_CHANNEL_COLLISION_X, dtype=torch.int64).view(torch.bfloat16)
+    y = torch.tensor(_DUAL_CHANNEL_COLLISION_Y, dtype=torch.int64).view(torch.bfloat16)
+    assert _value(x) != _value(y)
 
 
 def test_digest_is_position_sensitive():
@@ -95,11 +133,13 @@ def test_digest_handles_odd_storage_offset():
     assert _value(sliced) == _value(sliced.clone())
 
 
-def test_digest_is_chunking_invariant(monkeypatch):
-    t = torch.arange(999, dtype=torch.uint8)
-    reference = _value(t)
-    monkeypatch.setattr(digest_mod, "_CHUNK_LANES", 4)
-    assert _value(t) == reference
+def test_digest_is_stable_across_chunk_boundaries():
+    # _CHUNK_LANES is an algorithm constant (chunk boundaries are part of the
+    # tree structure), so the guarantee is determinism for inputs of any
+    # length relative to the chunk size -- including non-power-of-two tails.
+    for lanes in (1, 2, 3, digest_mod._CHUNK_LANES + 3):
+        t = torch.arange(lanes * 8, dtype=torch.uint8)
+        assert _value(t) == _value(t.clone())
 
 
 def test_digests_to_ints_roundtrip_and_empty():

--- a/tests/unit/weight_sync/test_weight_digest.py
+++ b/tests/unit/weight_sync/test_weight_digest.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Properties of the deterministic refit transfer digest.
 
 The digest must be stable across calls; sensitive to value, position, dtype,

--- a/tests/unit/weight_sync/test_weight_digest.py
+++ b/tests/unit/weight_sync/test_weight_digest.py
@@ -42,6 +42,21 @@ def test_digest_rejects_paired_high_bit_flips():
     assert _value(original) != _value(corrupted)
 
 
+def test_digest_rejects_salted_lane_permutation():
+    """Closed-form permutation attack on a single commutative channel.
+
+    With lanes [0, 0] and a linear position salt S, the salted lanes are
+    [S, 2S]; corrupted lanes [S, -S] (as signed int64) salt to [2S, S] -- a
+    permutation that any single per-lane-bijection + commutative-sum digest
+    cannot see. The dual-channel digest must reject it.
+    """
+    original = torch.zeros(2, dtype=torch.int64)
+    corrupted = torch.tensor(
+        [-7046029254386353131, 7046029254386353131], dtype=torch.int64
+    )
+    assert _value(original) != _value(corrupted)
+
+
 def test_digest_is_position_sensitive():
     t = torch.tensor([1, 2], dtype=torch.int64)
     swapped = torch.tensor([2, 1], dtype=torch.int64)
@@ -92,7 +107,9 @@ def test_digests_to_ints_roundtrip_and_empty():
     tensors = {"a": torch.ones(3), "b": torch.zeros(5)}
     ints = digests_to_ints({k: tensor_digest(v) for k, v in tensors.items()})
     assert set(ints) == {"a", "b"}
-    assert all(0 <= v < (1 << 64) for v in ints.values())
+    assert all(
+        isinstance(v, str) and len(v) == 32 and int(v, 16) >= 0 for v in ints.values()
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")

--- a/tests/unit/weight_sync/test_weight_digest.py
+++ b/tests/unit/weight_sync/test_weight_digest.py
@@ -1,12 +1,13 @@
 """Properties of the deterministic refit transfer digest.
 
-The digest must be a pure function of a tensor's logical byte stream: stable
-across calls, sensitive to value, position, and length changes, and identical
-for any dtype reinterpretation, memory layout, or hashing chunk size that
-preserves those bytes. All tests run on CPU tensors; the arithmetic is pure
-integer math with wraparound, so device changes cannot alter results.
+The digest must be stable across calls; sensitive to value, position, dtype,
+shape, and length changes; and independent of memory layout and hashing chunk
+size. Except for the mixed-device regression, tests run on CPU tensors; the
+arithmetic is pure integer math with wraparound, so devices produce the same
+result.
 """
 
+import pytest
 import torch
 
 from nemo_rl.weight_sync import digest as digest_mod
@@ -33,6 +34,14 @@ def test_digest_changes_with_any_value():
     assert _value(t) != _value(tampered)
 
 
+def test_digest_rejects_paired_high_bit_flips():
+    original = torch.zeros(16, dtype=torch.uint8)
+    corrupted = original.clone()
+    corrupted[7] = 0x80
+    corrupted[15] = 0x80
+    assert _value(original) != _value(corrupted)
+
+
 def test_digest_is_position_sensitive():
     t = torch.tensor([1, 2], dtype=torch.int64)
     swapped = torch.tensor([2, 1], dtype=torch.int64)
@@ -40,16 +49,20 @@ def test_digest_is_position_sensitive():
 
 
 def test_digest_folds_in_length():
-    # Trailing zero bytes extend the stream but leave every lane sum equal,
-    # so only the length fold distinguishes these.
+    # An all-zero extension must still change the metadata-covered stream.
     assert _value(torch.zeros(8, dtype=torch.uint8)) != _value(
         torch.zeros(16, dtype=torch.uint8)
     )
 
 
-def test_digest_matches_byte_reinterpretation():
-    t = torch.randn(64, dtype=torch.bfloat16)
-    assert _value(t) == _value(t.view(torch.uint8))
+def test_digest_covers_equal_size_dtype_metadata():
+    raw = torch.arange(64, dtype=torch.int16)
+    assert _value(raw.view(torch.bfloat16)) != _value(raw.view(torch.float16))
+
+
+def test_digest_covers_equal_size_shape_metadata():
+    tensor = torch.arange(12, dtype=torch.float32)
+    assert _value(tensor.reshape(3, 4)) != _value(tensor.reshape(2, 6))
 
 
 def test_digest_uses_logical_element_order():
@@ -71,7 +84,6 @@ def test_digest_is_chunking_invariant(monkeypatch):
     t = torch.arange(999, dtype=torch.uint8)
     reference = _value(t)
     monkeypatch.setattr(digest_mod, "_CHUNK_LANES", 4)
-    monkeypatch.setattr(digest_mod, "_POW_CACHE", {})
     assert _value(t) == reference
 
 
@@ -81,6 +93,17 @@ def test_digests_to_ints_roundtrip_and_empty():
     ints = digests_to_ints({k: tensor_digest(v) for k, v in tensors.items()})
     assert set(ints) == {"a", "b"}
     assert all(0 <= v < (1 << 64) for v in ints.values())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_digests_to_ints_handles_mixed_devices():
+    tensors = {
+        "cpu": torch.arange(8, dtype=torch.float32),
+        "cuda": torch.arange(8, dtype=torch.float32, device="cuda"),
+    }
+    ints = digests_to_ints({name: tensor_digest(t) for name, t in tensors.items()})
+    assert set(ints) == {"cpu", "cuda"}
+    assert ints["cpu"] == ints["cuda"]
 
 
 def test_compare_digests_reports_mismatch_and_missing():

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -150,6 +150,37 @@ class TestIPCWeightSynchronizer:
         assert call_kwargs.kwargs["kv_scales"] == kv_scales
 
     @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
+    def test_sync_weights_threads_verify_mode_to_both_sides(self, mock_ray):
+        mock_ray.get.return_value = [True]
+        policy = _mock_policy()
+        gen = _mock_generation()
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="enforce")
+
+        sync.sync_weights()
+
+        assert (
+            policy.stream_weights_via_ipc_zmq.call_args.kwargs["verify_mode"]
+            == "enforce"
+        )
+        assert gen.update_weights_via_ipc_zmq.call_args.kwargs["verify_digests"] is True
+
+    @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
+    def test_sync_weights_default_leaves_verification_off(self, mock_ray):
+        mock_ray.get.return_value = [True]
+        policy = _mock_policy()
+        gen = _mock_generation()
+        sync = IPCWeightSynchronizer(policy, gen)
+
+        sync.sync_weights()
+
+        assert (
+            policy.stream_weights_via_ipc_zmq.call_args.kwargs["verify_mode"] == "off"
+        )
+        assert (
+            gen.update_weights_via_ipc_zmq.call_args.kwargs["verify_digests"] is False
+        )
+
+    @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
     def test_sync_weights_raises_on_failure(self, mock_ray):
         mock_ray.get.side_effect = [
             None,  # futures_train

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -1072,3 +1072,33 @@ class TestRefitVerifyConfigValidation:
         )
 
         enforce_refit_verify_supported({"colocated": {"enabled": False}})
+
+    def test_explicit_null_verify_is_rejected(self):
+        from nemo_rl.models.generation.vllm.config import resolve_refit_verify_config
+
+        with pytest.raises(Exception):
+            resolve_refit_verify_config({"refit_cfg": {"verify": None}})
+
+    def test_misspelled_outer_verify_key_is_rejected(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        config = {
+            "refit_cfg": {"verfiy": {"mode": "enforce"}},
+            "colocated": {"enabled": True},
+        }
+        with pytest.raises(ValueError, match="verfiy"):
+            enforce_refit_verify_supported(config)
+
+    def test_plugin_selector_key_is_allowed(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        config = {
+            "refit_cfg": {"my.mod:Engine": {}},
+            "refit_transport": "my.mod:Engine",
+            "colocated": {"enabled": True},
+        }
+        enforce_refit_verify_supported(config)

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -1014,3 +1014,61 @@ class TestFactory:
                 colocated=True,
                 refit_buffer_size_gb=0,
             )
+
+
+# ---------------------------------------------------------------------------
+# Refit verify config: fail loud, not silently off
+# ---------------------------------------------------------------------------
+
+
+class TestRefitVerifyConfigValidation:
+    def test_misspelled_mode_key_is_rejected(self):
+        from nemo_rl.models.generation.vllm.config import resolve_refit_verify_config
+
+        with pytest.raises(Exception, match="mdoe"):
+            resolve_refit_verify_config({"refit_cfg": {"verify": {"mdoe": "enforce"}}})
+
+    def test_non_mapping_verify_is_rejected(self):
+        from nemo_rl.models.generation.vllm.config import resolve_refit_verify_config
+
+        with pytest.raises(Exception):
+            resolve_refit_verify_config({"refit_cfg": {"verify": False}})
+
+    def test_absent_verify_defaults_off(self):
+        from nemo_rl.models.generation.vllm.config import resolve_refit_verify_config
+
+        assert resolve_refit_verify_config({}).mode == "off"
+        assert resolve_refit_verify_config({"refit_cfg": None}).mode == "off"
+        assert resolve_refit_verify_config({"refit_cfg": {}}).mode == "off"
+
+    def test_enforce_rejected_on_non_colocated_topology(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        config = {
+            "refit_cfg": {"verify": {"mode": "enforce"}},
+            "colocated": {"enabled": False},
+        }
+        with pytest.raises(NotImplementedError, match="colocated"):
+            enforce_refit_verify_supported(config)
+
+    def test_enforce_rejected_on_non_default_transport(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        config = {
+            "refit_cfg": {"verify": {"mode": "enforce"}},
+            "colocated": {"enabled": True},
+            "refit_transport": "vllm_zmq_sparse",
+        }
+        with pytest.raises(NotImplementedError, match="colocated"):
+            enforce_refit_verify_supported(config)
+
+    def test_off_is_supported_everywhere(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+        )
+
+        enforce_refit_verify_supported({"colocated": {"enabled": False}})

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -123,7 +123,7 @@ class TestIPCWeightSynchronizer:
         mock_ray.get.return_value = [True]
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         assert sync.is_stale
         sync.sync_weights()
@@ -141,7 +141,7 @@ class TestIPCWeightSynchronizer:
         mock_ray.get.return_value = [True]
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
         kv_scales = {"layer.0": 0.5}
 
         sync.sync_weights(kv_scales=kv_scales)
@@ -165,11 +165,11 @@ class TestIPCWeightSynchronizer:
         assert gen.update_weights_via_ipc_zmq.call_args.kwargs["verify_digests"] is True
 
     @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
-    def test_sync_weights_default_leaves_verification_off(self, mock_ray):
+    def test_sync_weights_resolved_off_disables_verification(self, mock_ray):
         mock_ray.get.return_value = [True]
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         sync.sync_weights()
 
@@ -188,7 +188,7 @@ class TestIPCWeightSynchronizer:
         ]
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         with pytest.raises(RuntimeError, match="Weight transfer failed"):
             sync.sync_weights()
@@ -198,7 +198,12 @@ class TestIPCWeightSynchronizer:
         mock_ray.get.return_value = [True]
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen, refit_buffer_size_gb=2)
+        sync = IPCWeightSynchronizer(
+            policy,
+            gen,
+            refit_buffer_size_gb=2,
+            verify_mode="off",
+        )
 
         sync.sync_weights()
         call_kwargs = policy.stream_weights_via_ipc_zmq.call_args
@@ -211,7 +216,7 @@ class TestIPCWeightSynchronizer:
         policy = _mock_policy()
         policy.get_free_memory_bytes.return_value = 10 * (1024**3)
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         sync.sync_weights()
         call_kwargs = policy.stream_weights_via_ipc_zmq.call_args
@@ -221,7 +226,7 @@ class TestIPCWeightSynchronizer:
     def test_init_communicator(self):
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         sync.init_communicator()
         policy.prepare_refit_info.assert_called_once()
@@ -233,7 +238,7 @@ class TestIPCWeightSynchronizer:
         mock_ray.get.side_effect = RuntimeError("IPC transfer exploded")
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
 
         with pytest.raises(RuntimeError, match="IPC transfer exploded"):
             sync.sync_weights()
@@ -245,7 +250,12 @@ class TestIPCWeightSynchronizer:
     def test_negative_buffer_size_raises(self):
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen, refit_buffer_size_gb=-1)
+        sync = IPCWeightSynchronizer(
+            policy,
+            gen,
+            refit_buffer_size_gb=-1,
+            verify_mode="off",
+        )
         with pytest.raises(ValueError, match="refit_buffer_size_gb must be > 0"):
             sync._compute_buffer_size()
 
@@ -254,7 +264,7 @@ class TestIPCWeightSynchronizer:
         monkeypatch.setenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "not_a_number")
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
         with pytest.raises(ValueError, match="must be a valid float"):
             sync._compute_buffer_size()
 
@@ -263,7 +273,7 @@ class TestIPCWeightSynchronizer:
         monkeypatch.setenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0")
         policy = _mock_policy()
         gen = _mock_generation()
-        sync = IPCWeightSynchronizer(policy, gen)
+        sync = IPCWeightSynchronizer(policy, gen, verify_mode="off")
         with pytest.raises(ValueError, match="must be > 0"):
             sync._compute_buffer_size()
 
@@ -899,6 +909,31 @@ class TestFactory:
             inference_cluster=_mock_cluster(),
         )
         assert isinstance(sync, CollectiveWeightSynchronizer)
+
+    @pytest.mark.parametrize("verify_mode", ["log", "enforce"])
+    @pytest.mark.parametrize("refit_transport", [None, "nccl_reshard"])
+    def test_non_colocated_vllm_rejects_refit_verification(
+        self, verify_mode: str, refit_transport: str | None
+    ) -> None:
+        gen = _mock_generation(
+            cfg={
+                "refit_transport": refit_transport,
+                "refit_cfg": {"verify": {"mode": verify_mode}},
+            }
+        )
+
+        with pytest.raises(
+            NotImplementedError,
+            match="supported only for colocated vLLM IPC weight synchronization",
+        ):
+            create_weight_synchronizer(
+                policy=_mock_policy(),
+                generation=gen,
+                generation_backend=VLLM_BACKEND,
+                colocated=False,
+                train_cluster=_mock_cluster(),
+                inference_cluster=_mock_cluster(),
+            )
 
     def test_non_colocated_dynamo_returns_collective(self):
         sync = create_weight_synchronizer(

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -1102,3 +1102,43 @@ class TestRefitVerifyConfigValidation:
             "colocated": {"enabled": True},
         }
         enforce_refit_verify_supported(config)
+
+    def test_non_mapping_refit_cfg_is_rejected(self):
+        from nemo_rl.models.generation.vllm.config import resolve_refit_verify_config
+
+        for bad in ([], "", False):
+            with pytest.raises(Exception):
+                resolve_refit_verify_config({"refit_cfg": bad})
+
+    def test_normalized_model_extra_typo_still_rejected(self):
+        """normalize -> VllmGeneration is the real GRPO order for non-default
+        transports; the typo lands in model_extra and must still be caught."""
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+            normalize_vllm_refit_config,
+        )
+
+        config = {
+            "refit_transport": "vllm_zmq_sparse",
+            "refit_cfg": {"verfiy": {"mode": "enforce"}},
+            "colocated": {"enabled": True},
+            "vllm_cfg": {},
+        }
+        normalize_vllm_refit_config(config)
+        with pytest.raises(ValueError, match="verfiy"):
+            enforce_refit_verify_supported(config)
+
+    def test_normalized_plugin_selector_still_allowed(self):
+        from nemo_rl.models.generation.vllm.config import (
+            enforce_refit_verify_supported,
+            normalize_vllm_refit_config,
+        )
+
+        config = {
+            "refit_transport": "my.mod:Engine",
+            "refit_cfg": {"my.mod:Engine": {}},
+            "colocated": {"enabled": True},
+            "vllm_cfg": {},
+        }
+        normalize_vllm_refit_config(config)
+        enforce_refit_verify_supported(config)


### PR DESCRIPTION
# What does this PR do ?

Adds opt-in sender/receiver digest verification for colocated vLLM CUDA-IPC weight refits.

Policy and vLLM workers independently digest each transferred parameter's bytes, dtype, and shape. The receiver returns its digests with the final acknowledgment, and the sender either logs mismatches or fails the refit. The digest is a deterministic, ordered two-channel tree fold that runs on the tensor's device and remains stable across CPU/CUDA devices and chunk boundaries.

This PR also validates verification configuration at setup, rejects unsupported transports and generation backends instead of silently ignoring the setting, preserves the existing IPC wire format when verification is disabled, and updates the refit guide and example configurations.

# Issues

N/A — this is a proactive feature and is not linked to an existing issue.

# Usage

```yaml
policy:
  generation:
    backend: "vllm"
    colocated:
      enabled: true
    refit_transport: null
    refit_cfg:
      verify:
        mode: "enforce"  # "off" | "log" | "enforce"
```

- `"off"` is the default: no digest computation and no IPC wire-format change.
- `"log"` reports mismatched parameters and continues.
- `"enforce"` raises on a mismatch.

Verification is currently supported only for colocated vLLM CUDA-IPC refits (`colocated.enabled=true` and `refit_transport=null`). Enabling it for collective, NCCL reshard, sparse/NIXL/plugin transports, or another generation backend fails during setup.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

Focused unit tests were run locally; GPU functional coverage is left to CI.

# Additional Information

Validation performed:

- Focused digest/config/refit regression suite: 25 passed.
- Worker/refit signature-contract suite: 50 passed.
- Repository-pinned Ruff 0.9.9 lint and format checks passed.
- Changed example/reference YAML files parse successfully, and `git diff --check` passes.

Risk and scope:

- Verification is disabled by default, so existing refits retain the current byte-ACK protocol and do not run hashing kernels.
- Enabled modes add per-parameter device-side hashing and one final digest materialization/acknowledgment step.
- The digest targets accidental transfer corruption and software or metadata desynchronization; it is not a cryptographic integrity mechanism for malicious inputs.
- Verification covers the transferred tensor view before vLLM loads it. Post-load fusion, TP sharding, and quantization transformations are intentionally outside scope.
