### PR TITLE
feat(sc): stream PPO actor and critic minibatches

### DIFF
--- a/docs/guides/single-controller.md
+++ b/docs/guides/single-controller.md
@@ -280,7 +280,7 @@ The shipped exemplars cover three of the five modes:
 Field definitions:
 
 - `max_buffered_rollouts` — hard cap on unconsumed rollout groups buffered in the data plane. Validated at setup against the gated sampler's required capacity; a value too small deadlocks the rollout pump, so setup raises instead of silently blocking. Sized from the widest window the run ever uses, so `warmup_lookahead_versions` rather than `max_lookahead_versions` when it is set.
-- `min_groups_for_streaming_train` — minimum ready groups the trainer waits for before dispatching a batch. Set to `num_prompts_per_step` for sync/legacy semantics; lower for streaming. (PPO) Must equal `num_prompts_per_step` — the critic has no split train API, so each critic epoch calls the full-step `train_from_meta` once per chunk. Splitting an RL step across chunks would multiply both models' configured optimizer updates by the number of chunks.
+- `min_groups_for_streaming_train` — minimum ready groups the trainer waits for before dispatching a batch. Set to `num_prompts_per_step` for sync/legacy semantics; lower for streaming. PPO retains each prepared chunk in TQ until the step is complete, then accumulates all chunks into each actor and critic optimizer step. Lowering this value changes pipeline granularity without multiplying `ppo_epochs` or `critic_ppo_epochs`.
 - `sampler.warmup_lookahead_versions` (PPO) — lookahead used while `ppo.policy_training_start_step` critic warmup is in progress, shrinking back to `max_lookahead_versions` afterwards. The SC equivalent of `ppo.async_ppo.warmup_generation_lead_steps`.
 
 ## Implementation Structure
@@ -326,7 +326,7 @@ The SC path splits the async-GRPO loop across a rollout pump and a train pump th
 1. **Driver setup**: `setup_single_controller` builds the worker groups, virtual cluster, dp client, dataloader, `TQReplayBuffer`, `RolloutManager`, and weight synchronizer, and packs them into a `SingleControllerActorArgs` that the entrypoint cloudpickles into the actor.
 2. **Actor startup**: `SingleControllerActor` launches `_rollout_pump` and `_train_pump` concurrently as asyncio tasks; both share the same `TQReplayBuffer` and `StalenessSampler`.
 3. **Rollout pump loop**: `sampler.admit` gates dispatch against the current trainer version (returning a `target_step` for `in_order`); the pump then reserves a buffer slot, drives `RolloutManager.generate_and_push`, and commits with the observed `start_weight` / `end_weight`.
-4. **Train pump loop**: `sampler.evict` drops out-of-window groups and `sampler.select` picks the next batch. On PPO, `_value_stage` runs the critic forward, `_advantage_stage` computes advantages, and `_value_train_epochs` runs `ppo.critic_ppo_epochs` critic updates. The TQPolicy split API then runs one optimizer step per RL step on GRPO, or `ppo.ppo_epochs` policy updates on PPO.
+4. **Train pump loop**: `sampler.evict` drops out-of-window groups and `sampler.select` picks the next batch. On PPO, `_value_stage` runs the critic forward and `_advantage_stage` computes advantages as each chunk arrives. TQ keeps those prepared rows until the full step is assembled. `_value_train_epochs` then accumulates every chunk through the critic split API for each of `ppo.critic_ppo_epochs`; the TQPolicy split API does the same for each of `ppo.ppo_epochs`. On GRPO, the policy continues to train each chunk immediately and closes one optimizer step per RL step.
 5. **Weight sync**: after each optimizer step the pump bumps the trainer version, clears rollout permission, calls the weight synchronizer, and re-opens the rollout pump for the next version.
 
 ## Relation to Legacy Async GRPO
@@ -356,7 +356,7 @@ Do not carry `max_num_epochs: -1` across either. [ppo.md](./ppo.md#asynchronous-
 | `warmup_generation_lead_steps` (PPO) | `sampler.warmup_lookahead_versions` — the lookahead to use while critic warmup is in progress |
 | `recompute_kv_cache_after_weight_updates` | `recompute_kv_cache_after_weight_updates` (same) |
 | `in_flight_weight_updates` | Always effectively true; `false`-equivalent behavior is not yet supported (drain-gate tracked in [issue #2625](https://github.com/NVIDIA-NeMo/RL/issues/2625)) |
-| *(no legacy equivalent — matches legacy full-batch train semantics)* | `min_groups_for_streaming_train: ${grpo.num_prompts_per_step}`, or `${ppo.num_prompts_per_step}` on a PPO run |
+| *(no legacy equivalent — matches legacy full-batch dispatch semantics)* | `min_groups_for_streaming_train: ${grpo.num_prompts_per_step}`, or `${ppo.num_prompts_per_step}` on a PPO run; lower either value to dispatch smaller streaming chunks while preserving one full-batch optimizer step |
 | *(no legacy equivalent — matches legacy `max_trajectory_age + 1` batches in flight)* | `max_inflight_prompts: num_prompts_per_step × (max_lookahead_versions + 1)` |
 | *(no legacy equivalent — legacy sizes its buffer to `num_prompts_per_step × max_trajectory_age_steps × 2`)* | `max_buffered_rollouts: num_prompts_per_step × (max_lookahead_versions + 1)` (tight; see the [Config → behavior map](#config--behavior-map) for per-sampler values) |
 
@@ -373,7 +373,7 @@ The SC path is still under active development. Feature gaps are tracked in [issu
 - Train backend: only Megatron is supported and validated; the AutoModel training path has not been tested on SC.
 - Generation backend: vLLM and Megatron generation are supported (Megatron in both non-colocated and colocated modes); SGLang and TRT-LLM have not been tested on SC.
 - Validation is not yet supported (setup raises on `val_period > 0`, `val_at_start`, or `val_at_end`); checkpointing is.
-- (PPO) Rollout drop budgets — `async_rl.rollout_failure.max_skipped_prompts` and `max_consecutive_dropped_prompts` must both be `0`. A drop shortens the step, and the critic shards it against the configured `value.train_global_batch_size` rather than its actual size, so setup rejects a non-zero budget. The resiliency layer stays available on GRPO.
+- (PPO) Rollout drop budgets — `async_rl.rollout_failure.max_skipped_prompts` and `max_consecutive_dropped_prompts` must both be `0`. Split actor/critic steps normalize from the rows they receive, but a shortened step is not yet padded for critic data-parallel sharding and may be indivisible by the DP size. The resiliency layer stays available on GRPO.
 - Reward shaping and sample filtering — `reward_shaping`, `reward_scaling`, and `use_dynamic_sampling` are implemented on neither algorithm block, so setup rejects them rather than silently skipping the shaping. Environment-flagged sample masking and `overlong_filtering` are supported; truncated completions are excluded from the loss through `sample_mask`, and a step in which every completion is filtered is rejected rather than skipped.
 - The `windowed` sampler has no `over_sampling_ratio` cap — over-produced groups aged past the window are evicted, wasting rollout compute.
 - The drain gate in refit is not yet supported.

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -69,10 +69,8 @@ async_rl:
     # INDEPENDENT counters, so one prompt can consume up to their sum minus one.
     max_skipped_prompts: 0
     # CONSECUTIVE prompts allowed to exhaust their infra budget and be dropped; any
-    # committed rollout resets the count. Must stay 0 on a PPO run: a drop shortens the
-    # step, and the critic shards it against the configured value.train_global_batch_size
-    # rather than its actual size, so _validate_algo_settings rejects a non-zero budget.
-    # (On GRPO you may raise it on a large fleet where losing the odd shard is expected.)
+    # committed rollout resets the count. Must stay 0 on PPO until shortened
+    # batches support uneven/padded sharding across critic DP ranks.
     max_consecutive_dropped_prompts: 0
     # Smallest batch a step may train on, as a fraction of num_prompts_per_step.
     # The budgets above are run-scoped and cannot bound how short one step gets, so

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -1827,6 +1827,17 @@ class MseValueLossFn(LossFunction):
         self.scale = cfg.scale
         self.cliprange = cfg.cliprange
         self.loss_type = LossType.TOKEN_LEVEL
+        self.metric_normalizations: dict[str, MetricNormalizer] = {
+            "loss": MetricNormalizer.TOKENS,
+            "vf_clipfrac": MetricNormalizer.TOKENS,
+            "returns_mean": MetricNormalizer.TOKENS,
+            "values_mean": MetricNormalizer.TOKENS,
+            "values_min": MetricNormalizer.NONE,
+            "values_max": MetricNormalizer.NONE,
+            "returns_sq_mean": MetricNormalizer.TOKENS,
+            "residual_sq_mean": MetricNormalizer.TOKENS,
+            "num_valid_samples": MetricNormalizer.NONE,
+        }
 
     def __call__(
         self,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -2800,11 +2800,9 @@ class SingleControllerActor:
                         # PPO retains every selected row and training claim through
                         # all actor/critic epochs. Release them even when filtering
                         # or model training fails so teardown cannot deadlock.
-                        async with (
-                            self._data_plane_checkpoint_barrier.mutation(
-                                "sample_clears"
-                            ) as cut
-                        ):
+                        async with self._data_plane_checkpoint_barrier.mutation(
+                            "sample_clears"
+                        ) as cut:
                             await self._cleanup_consumed_metas_unlocked(
                                 cut, consumed_metas
                             )

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -2426,24 +2426,15 @@ class SingleControllerActor:
                 b. Value model forward (PPO only), with the policy parked on CPU
                     so the critic never shares the training GPUs with it.
                 c. _advantage_stage.
-            3. Train on the chunk.
-                a. Value model (PPO only): train_from_meta, which is a whole
-                    optimizer step. That is why a PPO step is pinned to a single
-                    chunk -- the value workers have no split train API yet (#2625).
-                b. Policy model: train_microbatches_from_meta, which only
-                    accumulates gradients.
-                c. PPO only: all critic updates run before all policy updates.
-                    Their counts are ppo.critic_ppo_epochs and ppo.ppo_epochs,
-                    respectively. Each policy optimizer step closes here rather
-                    than in 5 -- a PPO step is one chunk, so there is nothing to
-                    accumulate across chunks.
-            4. Close the chunk. Refresh min_sample_version and the dispatch tally. The
-                consumed rows stay in TQ: staged capture deltas are read by the policy
-                workers during 3, so nothing is cleared until the step closes.
-            5. Train the policy model (GRPO) -- finish_train_step all_reduces the
-                accumulated gradients, rescales, and runs optimizer.step. Then
-                _cleanup_consumed_metas clears every consumed canonical row and its
-                staged capture deltas.
+            3. Train on the chunk (GRPO only). PPO retains each prepared metadata
+                slice in TQ until the complete RL step is assembled.
+            4. Close the chunk. Refresh min_sample_version and the dispatch tally,
+                and record finalizer metrics. The consumed rows stay in TQ until
+                the full step closes.
+            5. Close model updates. GRPO finishes its one policy step. PPO replays
+                every prepared metadata slice for each critic epoch, then each actor
+                epoch; both split APIs step only after the full RL batch. Cleanup then
+                clears every canonical row, staged capture delta, and training claim.
             6. Refit the model. Sync the new policy weights to generation.
 
         PPO critic warmup (ppo.policy_training_start_step > 0) changes which of those
@@ -2465,8 +2456,8 @@ class SingleControllerActor:
             chunks_dispatched = 0
             calibration_batches: list[BatchedDataDict[Any]] = []
             selected_rollout_metrics: list[dict[str, Any]] = []
-            # One chunk per step on the PPO path, so these are the step's own
-            # model updates -- the last epoch's, when there is more than one.
+            ppo_chunks: list[tuple[KVBatchMeta, bool]] = []
+            # These are the step's final actor/critic epoch results.
             policy_result: Optional[dict[str, Any]] = None
             value_result: Optional[dict[str, Any]] = None
             # Always True off the PPO path: the start step is pinned to 0 there.
@@ -2667,49 +2658,14 @@ class SingleControllerActor:
                             has_valid_training_tokens,
                         ) = await self._advantage_stage(train_meta)
 
-                    # A PPO step is this one chunk, so a chunk with nothing left
-                    # after filtering is a step that trains neither model.
-                    if self._is_ppo and not has_valid_training_tokens:
-                        raise RuntimeError(
-                            "SingleController has no valid response tokens after "
-                            "filtering. Check seq_logprob_error_threshold, "
-                            "overlong_filtering, and environment mask_sample flags "
-                            "to avoid an optimizer step with an empty batch."
-                        )
-
                     # ---- 3. Train the model -- train_microbatches_from_meta ----
                     # Filtering can leave a GRPO streaming chunk with no training
                     # tokens. Consume that chunk without F/B, then continue the same
                     # optimizer step with the next chunk.
 
-                    # GRPO runs one iteration: F/B only, its optimizer step is in 5.
-                    # For PPO, each actor epoch and critic epoch is a full optimizer
-                    # step. Group each model's epochs under one residency cycle so
-                    # the colocated models do not move between CPU and GPU per epoch.
-                    # TODO(#2625): value_result, policy_result only record the last epoch's metrics.
-                    # That matches ppo.py for the losses; total_flops is additive and undercounted.
-                    if self._is_ppo:
-                        # A critic optimizer update is already irreversible. Keep
-                        # periodic snapshots out until this whole training step is
-                        # published as consumed below.
-                        self._optimizer_commit_in_progress = True
-                        with self._timer.time("value_training"):
-                            value_result = await self._value_train_epochs(
-                                train_meta,
-                                num_epochs=self._critic_ppo_epochs,
-                            )
-
-                    if is_policy_training_step:
-                        if (
-                            self._is_ppo
-                            and self._train_steps == policy_training_start_step
-                            and policy_training_start_step > 0
-                        ):
-                            print(
-                                f"  ✓ Critic warmup complete ({policy_training_start_step} "
-                                "steps). Starting policy training.",
-                                flush=True,
-                            )
+                    # PPO trains after the chunk loop so every epoch sees all
+                    # prepared chunks. GRPO continues accumulating immediately.
+                    if is_policy_training_step and not self._is_ppo:
                         # Always restore training mode because log-prob inference may have
                         # switched the model to inference mode. Keep it resident
                         # across every PPO actor epoch.
@@ -2717,26 +2673,18 @@ class SingleControllerActor:
                             await asyncio.to_thread(self._trainer.prepare_for_training)
 
                         if has_valid_training_tokens:
-                            for _ in range(self._ppo_epochs):
-                                with self._timer.time("policy_training"):
-                                    if not step_open:
-                                        await asyncio.to_thread(
-                                            self._trainer.begin_train_step,
-                                            self._loss_fn,
-                                        )
-                                        step_open = True
+                            with self._timer.time("policy_training"):
+                                if not step_open:
                                     await asyncio.to_thread(
-                                        self._trainer.train_microbatches_from_meta,
-                                        train_meta,
-                                        train_fields=self._train_fields,
+                                        self._trainer.begin_train_step,
+                                        self._loss_fn,
                                     )
-                                    # A PPO step is one chunk: nothing to
-                                    # accumulate, so close every epoch here.
-                                    if self._is_ppo:
-                                        policy_result = await asyncio.to_thread(
-                                            self._trainer.finish_train_step
-                                        )
-                                        step_open = False
+                                    step_open = True
+                                await asyncio.to_thread(
+                                    self._trainer.train_microbatches_from_meta,
+                                    train_meta,
+                                    train_fields=self._train_fields,
+                                )
 
                     if train_meta.sequence_lengths:
                         self._step_log_dict["sequence_lengths"].extend(
@@ -2775,6 +2723,8 @@ class SingleControllerActor:
                     else:
                         min_sample_version = curr_min_sample_version
 
+                    if self._is_ppo:
+                        ppo_chunks.append((train_meta, has_valid_training_tokens))
                     groups_dispatched += num_groups
                     chunks_dispatched += 1
                     # How many chunks a step is split into decides how many times
@@ -2805,8 +2755,66 @@ class SingleControllerActor:
                     groups_dispatched,
                 )
 
-                # Only the streaming path has anything left open: a PPO step is one
-                # chunk, so each epoch already closed its own optimizer step above.
+                if self._is_ppo:
+                    try:
+                        valid_ppo_metas = [
+                            meta for meta, is_valid in ppo_chunks if is_valid
+                        ]
+                        if not valid_ppo_metas:
+                            raise RuntimeError(
+                                "SingleController has no valid response tokens after "
+                                "filtering. Check seq_logprob_error_threshold, "
+                                "overlong_filtering, and environment mask_sample flags "
+                                "to avoid an optimizer step with an empty batch."
+                            )
+
+                        # A critic optimizer update is irreversible. Block periodic
+                        # snapshots until the complete PPO step is published below.
+                        self._optimizer_commit_in_progress = True
+                        with self._timer.time("value_training"):
+                            value_result = await self._value_train_epochs(
+                                valid_ppo_metas,
+                                num_epochs=self._critic_ppo_epochs,
+                            )
+
+                        if is_policy_training_step:
+                            if (
+                                self._train_steps == policy_training_start_step
+                                and policy_training_start_step > 0
+                            ):
+                                print(
+                                    "  ✓ Critic warmup complete "
+                                    f"({policy_training_start_step} steps). "
+                                    "Starting policy training.",
+                                    flush=True,
+                                )
+                            with self._timer.time("training_prep"):
+                                await asyncio.to_thread(
+                                    self._trainer.prepare_for_training
+                                )
+                            policy_result = await self._policy_train_epochs(
+                                valid_ppo_metas,
+                                num_epochs=self._ppo_epochs,
+                            )
+                    finally:
+                        # PPO retains every selected row and training claim through
+                        # all actor/critic epochs. Release them even when filtering
+                        # or model training fails so teardown cannot deadlock.
+                        async with (
+                            self._data_plane_checkpoint_barrier.mutation(
+                                "sample_clears"
+                            ) as cut
+                        ):
+                            await self._cleanup_consumed_metas_unlocked(
+                                cut, consumed_metas
+                            )
+                            self._buffer.release_training_claims(
+                                consumed_training_claim_ids
+                            )
+                        for _ in range(consumed_group_count):
+                            self._buffer_capacity.release()
+
+                # GRPO kept one policy optimizer step open across its chunks.
                 if not self._is_ppo:
                     if not step_open:
                         raise RuntimeError(
@@ -2828,13 +2836,16 @@ class SingleControllerActor:
                     step_metrics.update(aggregate_step_metrics(policy_result))
                 if value_result is not None:
                     step_metrics.update(_compute_critic_metrics(value_result))
-                async with self._data_plane_checkpoint_barrier.mutation(
-                    "sample_clears"
-                ) as cut:
-                    await self._cleanup_consumed_metas_unlocked(cut, consumed_metas)
-                    self._buffer.release_training_claims(consumed_training_claim_ids)
-                for _ in range(consumed_group_count):
-                    self._buffer_capacity.release()
+                if not self._is_ppo:
+                    async with self._data_plane_checkpoint_barrier.mutation(
+                        "sample_clears"
+                    ) as cut:
+                        await self._cleanup_consumed_metas_unlocked(cut, consumed_metas)
+                        self._buffer.release_training_claims(
+                            consumed_training_claim_ids
+                        )
+                    for _ in range(consumed_group_count):
+                        self._buffer_capacity.release()
                 step_metrics.update(
                     {
                         name: statistics.fmean(values)
@@ -4659,23 +4670,59 @@ class SingleControllerActor:
         return meta.with_fields([self._advantage_cfg.values_field])
 
     async def _value_train_epochs(
-        self, meta: KVBatchMeta, *, num_epochs: int
+        self, metas: list[KVBatchMeta], *, num_epochs: int
     ) -> dict[str, Any]:
-        """Run consecutive critic epochs under one model onload/offload cycle.
+        """Train each critic epoch across all prepared PPO chunks.
 
         Returns:
-            The final epoch's ``train_from_meta`` output; earlier epochs'
-            results are discarded.
+            The final epoch's split-step output; earlier epochs are discarded.
         """
+        assert self._value is not None
         await asyncio.to_thread(self._value.prepare_for_training)
         result: dict[str, Any] | None = None
+        try:
+            for _ in range(num_epochs):
+                try:
+                    await asyncio.to_thread(
+                        self._value.begin_train_step,
+                        self._value_loss_fn,  # pyrefly: ignore
+                    )
+                    for meta in metas:
+                        await asyncio.to_thread(
+                            self._value.train_microbatches_from_meta,
+                            meta,
+                        )
+                    result = await asyncio.to_thread(self._value.finish_train_step)
+                except BaseException:
+                    await asyncio.to_thread(self._value.abort_train_step)
+                    raise
+        finally:
+            await asyncio.to_thread(self._value.finish_training)
+        assert result is not None
+        return result
+
+    async def _policy_train_epochs(
+        self, metas: list[KVBatchMeta], *, num_epochs: int
+    ) -> dict[str, Any]:
+        """Train each PPO actor epoch across all prepared chunks."""
+        result: dict[str, Any] | None = None
         for _ in range(num_epochs):
-            result = await asyncio.to_thread(
-                self._value.train_from_meta,
-                meta,
-                self._value_loss_fn,  # pyrefly: ignore
-            )
-        await asyncio.to_thread(self._value.finish_training)
+            with self._timer.time("policy_training"):
+                try:
+                    await asyncio.to_thread(
+                        self._trainer.begin_train_step,
+                        self._loss_fn,
+                    )
+                    for meta in metas:
+                        await asyncio.to_thread(
+                            self._trainer.train_microbatches_from_meta,
+                            meta,
+                            train_fields=self._train_fields,
+                        )
+                    result = await asyncio.to_thread(self._trainer.finish_train_step)
+                except BaseException:
+                    await asyncio.to_thread(self._trainer.abort_train_step)
+                    raise
         assert result is not None
         return result
 

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -1180,21 +1180,10 @@ def _validate_algo_settings(master_config: MasterConfig) -> None:
             "carry TQWorkerMixin, so it has no data-plane setup to call (#2625)."
         )
 
-    # Each PPO epoch must consume the complete RL batch. Without this guard, every
-    # chunk would independently run the configured actor and critic optimizer steps.
-    if async_config.min_groups_for_streaming_train != algo_cfg.num_prompts_per_step:
-        raise ValueError(
-            "PPO on the SingleController path requires "
-            "async_rl.min_groups_for_streaming_train "
-            f"({async_config.min_groups_for_streaming_train}) == "
-            f"num_prompts_per_step ({algo_cfg.num_prompts_per_step}) so that each RL "
-            "step is assembled from a single chunk. Otherwise each chunk would "
-            "run ppo.critic_ppo_epochs critic optimizer steps and ppo.ppo_epochs "
-            "policy optimizer steps on only part of the RL batch. Streaming PPO "
-            "needs a split train API on the value workers, which they do not have "
-            "yet (#2625)."
-        )
-
+    # Split training removes the one-chunk restriction, but a dropped prompt
+    # can still make the shortened step indivisible by critic DP. Keep the
+    # existing conservative contract until uneven/padded critic sharding is
+    # implemented explicitly.
     failure_config = async_config.rollout_failure
     drop_budget = (
         failure_config.max_skipped_prompts
@@ -1205,10 +1194,8 @@ def _validate_algo_settings(master_config: MasterConfig) -> None:
             "PPO on the SingleController path requires "
             "async_rl.rollout_failure.max_skipped_prompts=0 and "
             "max_consecutive_dropped_prompts=0, but they sum to "
-            f"{drop_budget}. A drop shortens the step, and the critic shards that "
-            "step against the configured value.train_global_batch_size rather than "
-            "its actual size, so the first short step fails a divisibility assert "
-            "inside the value workers (#2625)."
+            f"{drop_budget}. A shortened step is not guaranteed to divide "
+            "evenly across the critic data-parallel ranks."
         )
 
     policy_megatron_cfg = master_config.policy.get("megatron_cfg", {})  # type: ignore

--- a/nemo_rl/models/value/tq_value.py
+++ b/nemo_rl/models/value/tq_value.py
@@ -53,9 +53,8 @@ class TQValue(TQDriverMixin, Value):
     built alongside this critic already did that. Partition lifecycle stays
     with the caller.
 
-    TODO(#2625): the value workers have no split begin/microbatch/finish train
-    API yet, so one train_from_meta call is one optimizer step and the
-    SingleController requires a PPO step to be a single streaming chunk.
+    The split begin/microbatch/finish API lets SingleController accumulate one
+    PPO critic optimizer step across several rollout chunks.
     """
 
     def __init__(
@@ -202,3 +201,72 @@ class TQValue(TQDriverMixin, Value):
         return _aggregate_train_results(
             self.worker_group.get_all_worker_results(futures)
         )
+
+    # ── split-API fanout (SC async PPO path) ──────────────────────────────
+
+    def begin_train_step(
+        self,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        """Open one logical critic optimizer step on every worker."""
+        batch_size = gbs or self.cfg["train_global_batch_size"]
+        micro_batch_size = mbs or self.cfg["train_micro_batch_size"]
+        futures = self.worker_group.run_all_workers_single_data(
+            "begin_train_step_presharded",
+            loss_fn=loss_fn,
+            gbs=batch_size,
+            mbs=micro_batch_size,
+        )
+        ray.get(futures)
+
+    def train_microbatches_from_meta(
+        self,
+        meta: KVBatchMeta,
+        timer: Optional[Timer] = None,
+    ) -> None:
+        """Accumulate one TQ metadata slice into the open critic step."""
+        spa, dba = self._packing_args("train_mb_tokens")
+        train_meta = self._isolated_meta(
+            meta,
+            fields=list(DP_VALUE_TRAIN_FIELDS),
+            task_name="value_train",
+        )
+        with timer.time("value_training/shard_meta") if timer else nullcontext():
+            dp_metas, _ = shard_meta_for_dp(
+                train_meta,
+                dp_world=self.sharding_annotations.get_axis_size("data_parallel"),
+                batch_size=None,
+                sequence_packing_args=spa,
+                dynamic_batching_args=dba,
+            )
+        with (
+            timer.time("value_training/submit_microbatch_futures")
+            if timer
+            else nullcontext()
+        ):
+            futures = self.worker_group.run_all_workers_sharded_data(
+                "train_microbatch_presharded",
+                meta=dp_metas,
+                in_sharded_axes=["data_parallel"],
+                replicate_on_axes=_REPLICATED_AXES,
+                output_is_replicated=_REPLICATED_AXES,
+            )
+        self.worker_group.get_all_worker_results(futures)
+
+    def finish_train_step(self) -> dict[str, Any]:
+        """Finish and aggregate one logical critic optimizer step."""
+        futures = self.worker_group.run_all_workers_single_data(
+            "finish_train_step_presharded"
+        )
+        results = ray.get(futures)
+        leader_results = [r for r in results if r.get("is_replica_leader", True)]
+        return _aggregate_train_results(leader_results)
+
+    def abort_train_step(self) -> None:
+        """Drop a partially accumulated critic step without updating weights."""
+        futures = self.worker_group.run_all_workers_single_data(
+            "abort_train_step_presharded"
+        )
+        ray.get(futures)

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import logging
 import os
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
@@ -51,7 +52,11 @@ from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from transformers import PreTrainedTokenizerBase
 
-from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.loss.interfaces import (
+    LossFunction,
+    LossType,
+    MetricNormalizer,
+)
 from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import allgather_cp_sharded_tensor
@@ -65,6 +70,9 @@ from nemo_rl.models.megatron.data import (
     get_microbatch_iterator,
     process_global_batch,
 )
+from nemo_rl.models.megatron.pipeline_parallel import (
+    broadcast_loss_metrics_from_last_stage,
+)
 from nemo_rl.models.megatron.setup import (
     finalize_megatron_setup,
     handle_model_import,
@@ -77,6 +85,7 @@ from nemo_rl.models.megatron.setup import (
 )
 from nemo_rl.models.megatron.train import (
     LossPostProcessor,
+    aggregate_training_statistics,
     megatron_forward_backward,
     suspend_activation_offload_for_forward_only,
 )
@@ -89,6 +98,7 @@ from nemo_rl.telemetry.setup import init_telemetry_worker
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
+log = logging.getLogger(__name__)
 
 
 def _install_value_head_load_skip(chunk: GPTModel) -> None:
@@ -360,6 +370,7 @@ class MegatronValueWorkerImpl(TQWorkerMixin, AbstractPolicyWorker):
         init_telemetry_worker()
 
         self.cfg = config
+        self._train_step_state: Optional[dict[str, Any]] = None
         self.rank = get_rank_safe()
 
         # Step 1: Setup distributed
@@ -476,6 +487,294 @@ class MegatronValueWorkerImpl(TQWorkerMixin, AbstractPolicyWorker):
     def disable_forward_pre_hook(self, param_sync=True):
         if isinstance(self.model, DistributedDataParallel):
             self.model.disable_forward_pre_hook(param_sync=param_sync)
+
+    # ── split train-step state (SingleController PPO) ──────────────────
+
+    def _new_train_step_state(
+        self,
+        loss_fn: LossFunction,
+        gbs: Optional[int],
+        mbs: Optional[int],
+    ) -> dict[str, Any]:
+        metric_normalizations = getattr(loss_fn, "metric_normalizations", None)
+        if not isinstance(metric_normalizations, dict):
+            metric_normalizations = {}
+        return {
+            "loss_fn": loss_fn,
+            "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
+            "metric_normalizations": metric_normalizations,
+            "gbs": gbs or self.cfg["train_global_batch_size"],
+            "mbs": mbs or self.cfg["train_micro_batch_size"],
+            "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "local_valid_toks": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "all_mb_metrics": [],
+            "mb_losses": [],
+            "total_num_microbatches": 0,
+            "num_chunks": 0,
+            "saved_grad_sync_func": None,
+            "saved_no_sync_func": None,
+            "saved_finalize_model_grads_func": None,
+        }
+
+    def _assert_train_step_open(self) -> dict[str, Any]:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            raise RuntimeError(
+                "no critic train step open; begin_train_step must be called first"
+            )
+        return state
+
+    def _restore_train_step_hooks(self, state: dict[str, Any]) -> None:
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            model_config.grad_sync_func = state.get("saved_grad_sync_func")
+            model_config.no_sync_func = state.get("saved_no_sync_func")
+            model_config.finalize_model_grads_func = state.get(
+                "saved_finalize_model_grads_func"
+            )
+
+    @wrap_with_nvtx_name("megatron_value_worker/begin_train_step")
+    def begin_train_step(
+        self,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        if getattr(self, "_train_step_state", None) is not None:
+            raise RuntimeError(
+                "a critic train step is already open; finish or abort it first"
+            )
+        if hasattr(self.model, "inference_params"):
+            self.model.inference_params = None
+        self.model.train()
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+
+        state = self._new_train_step_state(loss_fn, gbs, mbs)
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            state["saved_grad_sync_func"] = getattr(
+                model_config, "grad_sync_func", None
+            )
+            state["saved_no_sync_func"] = getattr(model_config, "no_sync_func", None)
+            state["saved_finalize_model_grads_func"] = getattr(
+                model_config, "finalize_model_grads_func", None
+            )
+            model_config.grad_sync_func = None
+            model_config.no_sync_func = nullcontext
+            model_config.finalize_model_grads_func = None
+        self._train_step_state = state
+
+    @wrap_with_nvtx_name("megatron_value_worker/train_microbatch")
+    def train_microbatch(self, data: BatchedDataDict[Any]) -> None:
+        state = self._assert_train_step_open()
+        try:
+            self._train_microbatch_body(state, data)
+        except Exception:
+            self._restore_train_step_hooks(state)
+            raise
+
+    def _train_microbatch_body(
+        self, state: dict[str, Any], data: BatchedDataDict[Any]
+    ) -> None:
+        state["num_chunks"] += 1
+        sample_mask = data["sample_mask"]
+        local_valid_seqs = torch.sum(sample_mask).to(torch.float64)
+        local_valid_toks = torch.sum(
+            data["token_mask"][:, 1:] * sample_mask.unsqueeze(-1)
+        ).to(torch.float64)
+        state["local_valid_seqs"] += local_valid_seqs
+        state["local_valid_toks"] += local_valid_toks
+
+        (
+            data_iterator,
+            num_microbatches,
+            micro_batch_size,
+            _,
+            padded_seq_length,
+        ) = get_microbatch_iterator(
+            data,
+            self._policy_like_cfg,
+            state["mbs"],
+            straggler_timer=self.mcore_state.straggler_timer,
+        )
+        state["total_num_microbatches"] += int(num_microbatches)
+        loss_post_processor = LossPostProcessor(
+            loss_fn=state["loss_fn"],
+            cfg=self._policy_like_cfg,
+            num_microbatches=num_microbatches,
+            prepare_fn=_value_loss_prepare_fn,
+        )
+        placeholder_n = torch.tensor(1.0, device="cuda")
+        with self.model.no_sync():
+            rerun_state_machine = get_rerun_state_machine()
+            while rerun_state_machine.should_run_forward_backward(data_iterator):
+                losses_reduced = megatron_forward_backward(
+                    model=self.model,
+                    data_iterator=data_iterator,
+                    num_microbatches=num_microbatches,
+                    seq_length=padded_seq_length,
+                    mbs=micro_batch_size,
+                    post_processing_fn=loss_post_processor,
+                    forward_only=False,
+                    defer_fp32_logits=self.defer_fp32_logits,
+                    global_valid_seqs=placeholder_n,
+                    global_valid_toks=placeholder_n,
+                )
+
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
+            torch.cuda.empty_cache()
+
+        if is_pipeline_last_stage(ignore_virtual=True):
+            metrics = [dict(item) for item in losses_reduced]
+        else:
+            metrics = None
+        metrics = broadcast_loss_metrics_from_last_stage(metrics)
+        for item in metrics:
+            state["all_mb_metrics"].append(item)
+            if "loss" in item:
+                state["mb_losses"].append(item["loss"])
+
+    @wrap_with_nvtx_name("megatron_value_worker/finish_train_step")
+    def finish_train_step(self) -> dict[str, Any]:
+        state = self._assert_train_step_open()
+        try:
+            return self._finish_train_step_body(state)
+        except Exception:
+            self._restore_train_step_hooks(state)
+            raise
+
+    def _finish_train_step_body(self, state: dict[str, Any]) -> dict[str, Any]:
+        if state["num_chunks"] == 0:
+            raise RuntimeError("cannot finish a critic train step with no chunks")
+
+        valid_counts = torch.stack(
+            [state["local_valid_seqs"], state["local_valid_toks"]]
+        )
+        torch.distributed.all_reduce(
+            valid_counts, group=parallel_state.get_data_parallel_group()
+        )
+        global_valid_seqs, global_valid_toks = valid_counts
+        normalizer = (
+            global_valid_toks
+            if state["loss_type"] == LossType.TOKEN_LEVEL
+            else global_valid_seqs
+        )
+        normalizer = normalizer.clamp(min=1)
+        inv_normalizer = float((1.0 / normalizer).item())
+        self.model.scale_gradients(inv_normalizer)
+
+        finalize_model_grads_func = state["saved_finalize_model_grads_func"]
+        assert finalize_model_grads_func is not None, (
+            "finalize_model_grads_func is required for a split critic train step"
+        )
+        ddp_config = self.cfg["megatron_cfg"].get(
+            "distributed_data_parallel_config", {}
+        )
+        if ddp_config.get("overlap_grad_reduce", False):
+            self.model.start_grad_sync()
+        finalize_model_grads_func([self.model], None)
+        torch.cuda.synchronize()
+
+        update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()
+        pg_collection = get_pg_collection(self.model)
+        update_successful = logical_and_across_model_parallel_group(
+            update_successful, mp_group=pg_collection.mp
+        )
+        grad_norm = reduce_max_stat_across_model_parallel_group(
+            grad_norm, mp_group=pg_collection.mp
+        )
+        reduce_max_stat_across_model_parallel_group(
+            num_zeros_in_grad, mp_group=pg_collection.mp
+        )
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 2:
+            torch.cuda.empty_cache()
+
+        self._restore_train_step_hooks(state)
+        current_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
+        current_wd = self.scheduler.get_wd()
+        self.scheduler.step(increment=state["gbs"])
+
+        inv_toks = float((1.0 / global_valid_toks.clamp(min=1)).item())
+        inv_seqs = float((1.0 / global_valid_seqs.clamp(min=1)).item())
+        metric_normalizations = state["metric_normalizations"]
+
+        def scale_metric(name: str, value: Any) -> Any:
+            kind = metric_normalizations.get(name)
+            if kind is MetricNormalizer.NONE:
+                return value
+            scale = (
+                inv_toks
+                if kind is MetricNormalizer.TOKENS
+                else inv_seqs
+                if kind is MetricNormalizer.SEQUENCES
+                else inv_normalizer
+            )
+            return (
+                value.detach() * scale
+                if isinstance(value, torch.Tensor)
+                else value * scale
+            )
+
+        scaled_metrics = []
+        for item in state["all_mb_metrics"]:
+            output = {
+                name: value
+                if name.endswith(("_min", "_max"))
+                else scale_metric(name, value)
+                for name, value in item.items()
+            }
+            output.update(
+                lr=current_lr,
+                wd=current_wd,
+                global_valid_seqs=float(global_valid_seqs.item()),
+                global_valid_toks=float(global_valid_toks.item()),
+            )
+            scaled_metrics.append(output)
+
+        mb_metrics, global_loss = aggregate_training_statistics(
+            all_mb_metrics=scaled_metrics,
+            losses=[
+                torch.tensor([loss * inv_normalizer for loss in state["mb_losses"]])
+                .sum()
+                .item()
+            ],
+            data_parallel_group=parallel_state.get_data_parallel_group(),
+        )
+        result = {
+            "global_loss": global_loss.cpu(),
+            "rank": torch.distributed.get_rank(),
+            "all_mb_metrics": mb_metrics,
+            "grad_norm": torch.tensor([grad_norm]),
+        }
+
+        model_config = getattr(self.model, "config", None)
+        num_moe_experts = getattr(model_config, "num_moe_experts", None)
+        if num_moe_experts is not None and num_moe_experts > 1:
+            moe_metrics = get_moe_metrics(
+                loss_scale=1.0 / max(1, state["total_num_microbatches"]),
+                per_layer_logging=bool(
+                    self.cfg["megatron_cfg"].get("moe_per_layer_logging", False)
+                ),
+                num_layers=getattr(model_config, "num_layers", None),
+                mtp_num_layers=getattr(model_config, "mtp_num_layers", None),
+                track_names=get_aux_loss_track_names(model_config),
+            )
+            if moe_metrics:
+                result["moe_metrics"] = moe_metrics
+
+        self._train_step_state = None
+        return result
+
+    @wrap_with_nvtx_name("megatron_value_worker/abort_train_step")
+    def abort_train_step(self) -> None:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            return
+        self._restore_train_step_hooks(state)
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+        self._train_step_state = None
 
     @wrap_with_nvtx_name("megatron_value_worker/train")
     def train(

--- a/tests/functional/ppo_async_single_controller.sh
+++ b/tests/functional/ppo_async_single_controller.sh
@@ -54,7 +54,9 @@ TRAIN_CMD=(
     async_rl.sampler.name=in_order
     async_rl.sampler.max_lookahead_versions=1
     async_rl.sampler.warmup_lookahead_versions=2
-    async_rl.min_groups_for_streaming_train=2
+    # Force two one-group chunks so every actor/critic epoch exercises the
+    # split accumulation path instead of receiving the full step at once.
+    async_rl.min_groups_for_streaming_train=1
     async_rl.max_inflight_prompts=6
     async_rl.max_buffered_rollouts=6
     cluster.gpus_per_node=2

--- a/tests/unit/algorithms/test_ppo.py
+++ b/tests/unit/algorithms/test_ppo.py
@@ -29,6 +29,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     MseValueLossConfig,
     MseValueLossFn,
 )
+from nemo_rl.algorithms.loss.interfaces import MetricNormalizer
 from nemo_rl.algorithms.ppo import PPOConfig
 from nemo_rl.algorithms.reward_functions import RewardShapingConfig
 from nemo_rl.data import DataConfig
@@ -556,6 +557,17 @@ def test_mse_value_loss_metrics():
         "vf_clipfrac",
     }
     assert expected_keys.issubset(set(metrics.keys()))
+    assert loss_fn.metric_normalizations == {
+        "loss": MetricNormalizer.TOKENS,
+        "vf_clipfrac": MetricNormalizer.TOKENS,
+        "returns_mean": MetricNormalizer.TOKENS,
+        "values_mean": MetricNormalizer.TOKENS,
+        "values_min": MetricNormalizer.NONE,
+        "values_max": MetricNormalizer.NONE,
+        "returns_sq_mean": MetricNormalizer.TOKENS,
+        "residual_sq_mean": MetricNormalizer.TOKENS,
+        "num_valid_samples": MetricNormalizer.NONE,
+    }
 
 
 def test_mse_value_loss_squeeze_trailing_dim():

--- a/tests/unit/models/value/test_megatron_value_split_parity.py
+++ b/tests/unit/models/value/test_megatron_value_split_parity.py
@@ -14,8 +14,6 @@
 
 """GPU A/B for a synchronous critic step vs two split-API chunks."""
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 import ray
@@ -39,7 +37,7 @@ NUM_GPUS = 2
 SEQ_LEN = 64
 
 
-def _make_value(model_name: str, cluster_name: str, **checkpoint_paths):
+def _make_value(model_name: str, cluster_name: str):
     cluster = RayVirtualCluster(
         name=cluster_name,
         bundle_ct_per_node_list=[NUM_GPUS],
@@ -53,7 +51,6 @@ def _make_value(model_name: str, cluster_name: str, **checkpoint_paths):
         cluster=cluster,
         config=config,
         tokenizer=tokenizer,
-        **checkpoint_paths,
     )
     return value, cluster, config
 
@@ -87,9 +84,9 @@ def _run_split(value: Value, data: BatchedDataDict, loss_fn, gbs: int, mbs: int)
     )
     for start in (0, gbs // 2):
         chunk = data.slice(start, start + gbs // 2)
-        sharded, _ = chunk.shard_by_batch_size(
+        sharded = chunk.shard_by_batch_size(
             value.sharding_annotations.get_axis_size("data_parallel"),
-            batch_size=None,
+            batch_size=gbs // 2,
         )
         wg.get_all_worker_results(
             wg.run_all_workers_sharded_data(
@@ -108,9 +105,7 @@ def _run_split(value: Value, data: BatchedDataDict, loss_fn, gbs: int, mbs: int)
                 ],
             )
         )
-    finished = ray.get(
-        wg.run_all_workers_single_data("finish_train_step_presharded")
-    )
+    finished = ray.get(wg.run_all_workers_single_data("finish_train_step_presharded"))
     value.finish_training()
     return _aggregate_train_results(
         [result for result in finished if result.get("is_replica_leader", True)]
@@ -129,9 +124,7 @@ def _reduce_metric(key: str, values: list) -> float:
 
 @pytest.mark.hf_gated
 @pytest.mark.timeout(600)
-def test_two_split_critic_chunks_match_one_sync_step(
-    tiny_qwen2_model_path, tmp_path
-):
+def test_two_split_critic_chunks_match_one_sync_step(tiny_qwen2_model_path):
     loss_fn = MseValueLossFn(MseValueLossConfig(scale=1.0, cliprange=0.5))
     sync_value, sync_cluster, config = _make_value(
         tiny_qwen2_model_path, "critic-parity-sync"
@@ -139,12 +132,7 @@ def test_two_split_critic_chunks_match_one_sync_step(
     gbs = config["train_global_batch_size"]
     mbs = config["train_micro_batch_size"]
     data = _make_batch(gbs)
-    weights_path = Path(tmp_path) / "initial" / "weights"
-    optimizer_path = Path(tmp_path) / "initial" / "optimizer"
     try:
-        sync_value.save_checkpoint(
-            weights_path=str(weights_path), optimizer_path=str(optimizer_path)
-        )
         sync_value.prepare_for_training()
         sync_result = sync_value.train(data, loss_fn)
         sync_value.finish_training()
@@ -152,11 +140,11 @@ def test_two_split_critic_chunks_match_one_sync_step(
         sync_value.shutdown()
         sync_cluster.shutdown()
 
+    # Fresh workers load the same tiny checkpoint and deterministic seed, so both
+    # paths start with identical model and optimizer state. Saving a distributed
+    # optimizer before its first step is unsupported by Megatron Core.
     split_value, split_cluster, _ = _make_value(
-        tiny_qwen2_model_path,
-        "critic-parity-split",
-        weights_path=weights_path,
-        optimizer_path=optimizer_path,
+        tiny_qwen2_model_path, "critic-parity-split"
     )
     try:
         split_result = _run_split(split_value, data, loss_fn, gbs, mbs)
@@ -173,9 +161,7 @@ def test_two_split_critic_chunks_match_one_sync_step(
         rtol=1e-3,
         atol=1e-5,
     )
-    assert set(split_result["all_mb_metrics"]) == set(
-        sync_result["all_mb_metrics"]
-    )
+    assert set(split_result["all_mb_metrics"]) == set(sync_result["all_mb_metrics"])
     for key in sorted(sync_result["all_mb_metrics"]):
         assert _reduce_metric(
             key, split_result["all_mb_metrics"][key]

--- a/tests/unit/models/value/test_megatron_value_split_parity.py
+++ b/tests/unit/models/value/test_megatron_value_split_parity.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU A/B for a synchronous critic step vs two split-API chunks."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import ray
+import torch
+
+pytest.importorskip("megatron.bridge")
+
+from nemo_rl.algorithms.loss import MseValueLossConfig, MseValueLossFn
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.value.lm_value import Value
+from nemo_rl.models.value.tq_value import _aggregate_train_results
+from tests.unit.models.value.test_megatron_value_worker import (
+    _create_value_test_config,
+)
+
+pytestmark = pytest.mark.mcore
+
+NUM_GPUS = 2
+SEQ_LEN = 64
+
+
+def _make_value(model_name: str, cluster_name: str, **checkpoint_paths):
+    cluster = RayVirtualCluster(
+        name=cluster_name,
+        bundle_ct_per_node_list=[NUM_GPUS],
+        use_gpus=True,
+        num_gpus_per_node=NUM_GPUS,
+        max_colocated_worker_groups=1,
+    )
+    config = _create_value_test_config(model_name=model_name)
+    tokenizer = get_tokenizer(config["tokenizer"])
+    value = Value(
+        cluster=cluster,
+        config=config,
+        tokenizer=tokenizer,
+        **checkpoint_paths,
+    )
+    return value, cluster, config
+
+
+def _make_batch(batch_size: int) -> BatchedDataDict:
+    torch.manual_seed(42)
+    attention_mask = torch.ones(batch_size, SEQ_LEN)
+    token_mask = attention_mask.clone()
+    token_mask[:, :8] = 0
+    token_mask[0, -4:] = 0
+    return BatchedDataDict(
+        {
+            "input_ids": torch.randint(0, 151000, (batch_size, SEQ_LEN)),
+            "input_lengths": attention_mask.sum(dim=1).to(torch.int32),
+            "attention_mask": attention_mask,
+            "returns": torch.randn(batch_size, SEQ_LEN) * 0.1,
+            "values": torch.randn(batch_size, SEQ_LEN) * 0.1,
+            "token_mask": token_mask,
+            "sample_mask": torch.ones(batch_size),
+        }
+    )
+
+
+def _run_split(value: Value, data: BatchedDataDict, loss_fn, gbs: int, mbs: int):
+    value.prepare_for_training()
+    wg = value.worker_group
+    ray.get(
+        wg.run_all_workers_single_data(
+            "begin_train_step_presharded", loss_fn=loss_fn, gbs=gbs, mbs=mbs
+        )
+    )
+    for start in (0, gbs // 2):
+        chunk = data.slice(start, start + gbs // 2)
+        sharded, _ = chunk.shard_by_batch_size(
+            value.sharding_annotations.get_axis_size("data_parallel"),
+            batch_size=None,
+        )
+        wg.get_all_worker_results(
+            wg.run_all_workers_sharded_data(
+                "train_microbatch",
+                data=sharded,
+                in_sharded_axes=["data_parallel"],
+                replicate_on_axes=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                output_is_replicated=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+            )
+        )
+    finished = ray.get(
+        wg.run_all_workers_single_data("finish_train_step_presharded")
+    )
+    value.finish_training()
+    return _aggregate_train_results(
+        [result for result in finished if result.get("is_replica_leader", True)]
+    )
+
+
+def _reduce_metric(key: str, values: list) -> float:
+    if key.endswith("_min"):
+        return float(np.min(values))
+    if key.endswith("_max"):
+        return float(np.max(values))
+    if key in ("lr", "wd", "global_valid_seqs", "global_valid_toks"):
+        return float(np.mean(values))
+    return float(np.sum(values))
+
+
+@pytest.mark.hf_gated
+@pytest.mark.timeout(600)
+def test_two_split_critic_chunks_match_one_sync_step(
+    tiny_qwen2_model_path, tmp_path
+):
+    loss_fn = MseValueLossFn(MseValueLossConfig(scale=1.0, cliprange=0.5))
+    sync_value, sync_cluster, config = _make_value(
+        tiny_qwen2_model_path, "critic-parity-sync"
+    )
+    gbs = config["train_global_batch_size"]
+    mbs = config["train_micro_batch_size"]
+    data = _make_batch(gbs)
+    weights_path = Path(tmp_path) / "initial" / "weights"
+    optimizer_path = Path(tmp_path) / "initial" / "optimizer"
+    try:
+        sync_value.save_checkpoint(
+            weights_path=str(weights_path), optimizer_path=str(optimizer_path)
+        )
+        sync_value.prepare_for_training()
+        sync_result = sync_value.train(data, loss_fn)
+        sync_value.finish_training()
+    finally:
+        sync_value.shutdown()
+        sync_cluster.shutdown()
+
+    split_value, split_cluster, _ = _make_value(
+        tiny_qwen2_model_path,
+        "critic-parity-split",
+        weights_path=weights_path,
+        optimizer_path=optimizer_path,
+    )
+    try:
+        split_result = _run_split(split_value, data, loss_fn, gbs, mbs)
+    finally:
+        split_value.shutdown()
+        split_cluster.shutdown()
+
+    torch.testing.assert_close(
+        split_result["loss"], sync_result["loss"], rtol=1e-3, atol=1e-5
+    )
+    torch.testing.assert_close(
+        split_result["grad_norm"].float(),
+        sync_result["grad_norm"].float(),
+        rtol=1e-3,
+        atol=1e-5,
+    )
+    assert set(split_result["all_mb_metrics"]) == set(
+        sync_result["all_mb_metrics"]
+    )
+    for key in sorted(sync_result["all_mb_metrics"]):
+        assert _reduce_metric(
+            key, split_result["all_mb_metrics"][key]
+        ) == pytest.approx(
+            _reduce_metric(key, sync_result["all_mb_metrics"][key]),
+            rel=1e-3,
+            abs=1e-5,
+        )

--- a/tests/unit/models/value/test_tq_value.py
+++ b/tests/unit/models/value/test_tq_value.py
@@ -204,6 +204,79 @@ class TestTQValueFanout:
         assert out["all_mb_metrics"]["loss"] == [0.1, 0.2]
 
 
+class TestTQValueSplitFanout:
+    def test_begin_consumes_single_data_futures_with_ray_get(self):
+        v, wg = _make_tq_value()
+        wg.run_all_workers_single_data.return_value = ["f0", "f1"]
+
+        with patch("nemo_rl.models.value.tq_value.ray") as mock_ray:
+            v.begin_train_step(loss_fn="LF")
+
+        wg.run_all_workers_single_data.assert_called_once_with(
+            "begin_train_step_presharded", loss_fn="LF", gbs=8, mbs=2
+        )
+        mock_ray.get.assert_called_once_with(["f0", "f1"])
+
+    def test_microbatch_dispatches_only_value_train_columns(self):
+        v, wg = _make_tq_value()
+        meta = _meta()
+        with (
+            patch.object(TQValue, "_stamp_pad_seqlen"),
+            patch.object(TQValue, "_packing_args", return_value=(None, None)),
+            patch(
+                "nemo_rl.models.value.tq_value.shard_meta_for_dp",
+                return_value=([meta, meta], None),
+            ) as mock_shard,
+        ):
+            out = v.train_microbatches_from_meta(meta)
+
+        assert out is None
+        train_meta = mock_shard.call_args.args[0]
+        assert train_meta.fields == list(DP_VALUE_TRAIN_FIELDS)
+        assert train_meta.task_name == "value_train"
+        assert (
+            wg.run_all_workers_sharded_data.call_args.args[0]
+            == "train_microbatch_presharded"
+        )
+        wg.get_all_worker_results.assert_called_once()
+
+    def test_finish_deduplicates_replica_twins_before_aggregation(self):
+        v, wg = _make_tq_value()
+        wg.run_all_workers_single_data.return_value = ["f0", "f1"]
+
+        def _result(loss: float, *, leader: bool) -> dict:
+            return {
+                "global_loss": 1.0,
+                "grad_norm": 0.5,
+                "all_mb_metrics": {"loss": [loss]},
+                "is_replica_leader": leader,
+            }
+
+        with patch("nemo_rl.models.value.tq_value.ray") as mock_ray:
+            mock_ray.get.return_value = [
+                _result(0.1, leader=True),
+                _result(99.0, leader=False),
+            ]
+            out = v.finish_train_step()
+
+        wg.run_all_workers_single_data.assert_called_once_with(
+            "finish_train_step_presharded"
+        )
+        assert out["all_mb_metrics"]["loss"] == [0.1]
+
+    def test_abort_consumes_single_data_futures(self):
+        v, wg = _make_tq_value()
+        wg.run_all_workers_single_data.return_value = ["f0", "f1"]
+
+        with patch("nemo_rl.models.value.tq_value.ray") as mock_ray:
+            v.abort_train_step()
+
+        wg.run_all_workers_single_data.assert_called_once_with(
+            "abort_train_step_presharded"
+        )
+        mock_ray.get.assert_called_once_with(["f0", "f1"])
+
+
 class TestPadTargetIsolation:
     """Each dispatch mints its own pad target, in both directions: the critic
     goes first within a step, and with ppo_epochs > 1 the policy has already

--- a/tests/unit/single_controller/test_ppo_setup.py
+++ b/tests/unit/single_controller/test_ppo_setup.py
@@ -285,16 +285,10 @@ class TestPPOValidation:
         with pytest.raises(ValueError, match="the `ppo` block is absent"):
             validate_single_controller_config(mc)
 
-    def test_rejects_multi_chunk_streaming(self):
-        """PPO cannot spread one full-batch optimizer epoch across chunks."""
+    def test_accepts_multi_chunk_streaming(self):
+        """The split APIs accumulate one full PPO step across rollout chunks."""
         mc = _ppo_master_config(min_groups_for_streaming_train=1)
-
-        with pytest.raises(
-            ValueError,
-            match=r"min_groups_for_streaming_train \(1\) == "
-            rf"num_prompts_per_step \({_NUM_PROMPTS_PER_STEP}\)",
-        ):
-            validate_single_controller_config(mc)
+        validate_single_controller_config(mc)
 
     def test_rejects_value_global_batch_size_mismatch(self):
         mc = _ppo_master_config(value=_value_config(train_global_batch_size=4))
@@ -388,7 +382,7 @@ class TestPPOValidation:
         "field", ["max_skipped_prompts", "max_consecutive_dropped_prompts"]
     )
     def test_rejects_a_drop_budget_under_ppo(self, field):
-        """A drop shortens the step; the critic shards against the configured size."""
+        """A shortened step is not guaranteed to divide across critic DP."""
         mc = _ppo_master_config()
         setattr(mc.async_rl.rollout_failure, field, 1)
 

--- a/tests/unit/single_controller/test_single_controller_actor.py
+++ b/tests/unit/single_controller/test_single_controller_actor.py
@@ -1200,6 +1200,9 @@ class _NoOpTrainer:
     def finish_train_step(self) -> dict:
         return {}
 
+    def abort_train_step(self) -> None:
+        pass
+
     def offload_to_cpu(self) -> None:
         pass
 
@@ -1338,8 +1341,11 @@ class _StepMetricRecordingGeneration:
 
 
 class _NoOpDataPlane:
+    def __init__(self) -> None:
+        self.clear_calls: list[list[str]] = []
+
     def clear_samples(self, **kwargs) -> None:
-        del kwargs
+        self.clear_calls.append(list(kwargs["sample_ids"]))
 
 
 def _train_pump_controller(*, sampler) -> object:
@@ -1959,14 +1965,24 @@ class _NoOpValue:
     def prepare_for_training(self) -> None:
         self._record("prepare_for_training")
 
-    def train_from_meta(self, meta: KVBatchMeta, loss_fn) -> dict:
-        del meta, loss_fn
-        self._record("train_from_meta")
+    def begin_train_step(self, loss_fn) -> None:
+        del loss_fn
+        self._record("begin_train_step")
+
+    def train_microbatches_from_meta(self, meta: KVBatchMeta) -> None:
+        del meta
+        self._record("train_microbatches_from_meta")
+
+    def finish_train_step(self) -> dict:
+        self._record("finish_train_step")
         return {
             "loss": torch.tensor([0.25]),
             "grad_norm": torch.tensor([1.5]),
             "all_mb_metrics": {"vf_clipfrac": [0.0], "values_min": [-1.0]},
         }
+
+    def abort_train_step(self) -> None:
+        self._record("abort_train_step")
 
     def finish_training(self) -> None:
         self._record("finish_training")
@@ -1979,6 +1995,7 @@ def _ppo_train_pump_controller(
     value: _NoOpValue | None = None,
     ppo_epochs: int = 1,
     critic_ppo_epochs: int | None = None,
+    num_prompts_per_step: int = 1,
 ) -> tuple[object, _NoOpValue]:
     ctrl = _train_pump_controller(sampler=sampler)
     value = _NoOpValue() if value is None else value
@@ -1991,7 +2008,7 @@ def _ppo_train_pump_controller(
     ctrl._value_loss_fn = MagicMock(name="value_loss_fn")
     ctrl._master_config.grpo = None
     ctrl._master_config.ppo = PPOConfig.model_construct(
-        num_prompts_per_step=1,
+        num_prompts_per_step=num_prompts_per_step,
         max_num_steps=1,
         policy_training_start_step=policy_training_start_step,
         seq_logprob_error_threshold=None,
@@ -2044,7 +2061,9 @@ def test_train_pump_parks_the_policy_on_cpu_across_the_critic_stages(
         "critic.get_values_from_meta",
         "critic.finish_inference",
         "critic.prepare_for_training",
-        "critic.train_from_meta",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
         "critic.finish_training",
         "policy.prepare_for_training",
     ]
@@ -2117,9 +2136,51 @@ def test_train_pump_skips_the_critic_on_an_empty_chunk(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="no valid response tokens after filtering"):
         asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
 
-    assert "train_from_meta" not in value.calls
+    assert "train_microbatches_from_meta" not in value.calls
     # The forward still ran -- it is what the advantage stage consumes.
     assert "get_values_from_meta" in value.calls
+    assert ctrl._dp_client.clear_calls == [["sample-0"]]
+
+
+def test_train_pump_aborts_a_failed_split_critic_step_and_clears_tq(
+    monkeypatch,
+) -> None:
+    meta = _single_group_meta()
+    value = _NoOpValue()
+    value.train_microbatches_from_meta = MagicMock(
+        side_effect=RuntimeError("critic failed")
+    )
+    value.abort_train_step = MagicMock()
+    ctrl, _ = _ppo_train_pump_controller(
+        sampler=_OneThenEmptySampler(meta), value=value
+    )
+    ctrl._advantage_stage = AsyncMock(return_value=(meta, True))
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    with pytest.raises(RuntimeError, match="critic failed"):
+        asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    value.abort_train_step.assert_called_once_with()
+    assert value.calls.count("finish_training") == 1
+    assert ctrl._dp_client.clear_calls == [["sample-0"]]
+
+
+def test_train_pump_aborts_a_failed_split_policy_step_and_clears_tq(
+    monkeypatch,
+) -> None:
+    meta = _single_group_meta()
+    ctrl, _ = _ppo_train_pump_controller(sampler=_OneThenEmptySampler(meta))
+    trainer = MagicMock(spec=_NoOpTrainer)
+    trainer.train_microbatches_from_meta.side_effect = RuntimeError("actor failed")
+    ctrl._trainer = trainer
+    ctrl._advantage_stage = AsyncMock(return_value=(meta, True))
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    with pytest.raises(RuntimeError, match="actor failed"):
+        asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    trainer.abort_train_step.assert_called_once_with()
+    assert ctrl._dp_client.clear_calls == [["sample-0"]]
 
 
 @pytest.mark.parametrize("ppo_epochs", [1, 2])
@@ -2164,7 +2225,7 @@ def test_train_pump_freezes_the_policy_during_critic_warmup(
 
     asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
 
-    assert value.calls.count("train_from_meta") == critic_ppo_epochs
+    assert value.calls.count("finish_train_step") == critic_ppo_epochs
     trainer.prepare_for_training.assert_not_called()
     trainer.begin_train_step.assert_not_called()
     trainer.finish_train_step.assert_not_called()
@@ -2235,8 +2296,12 @@ def test_train_pump_groups_ppo_epochs_by_model(monkeypatch) -> None:
         "critic.get_values_from_meta",
         "critic.finish_inference",
         "critic.prepare_for_training",
-        "critic.train_from_meta",
-        "critic.train_from_meta",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
         "critic.finish_training",
         "policy.prepare_for_training",
         "policy.begin_train_step",
@@ -2275,9 +2340,15 @@ def test_train_pump_runs_all_critic_epochs_before_actor_epochs(monkeypatch) -> N
         "critic.get_values_from_meta",
         "critic.finish_inference",
         "critic.prepare_for_training",
-        "critic.train_from_meta",
-        "critic.train_from_meta",
-        "critic.train_from_meta",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
+        "critic.begin_train_step",
+        "critic.train_microbatches_from_meta",
+        "critic.finish_train_step",
         "critic.finish_training",
         "policy.prepare_for_training",
         "policy.begin_train_step",
@@ -2285,6 +2356,36 @@ def test_train_pump_runs_all_critic_epochs_before_actor_epochs(monkeypatch) -> N
         "policy.finish_train_step",
     ]
     ctrl._sync_weights.assert_awaited_once_with(calibration_data=None)
+
+
+def test_train_pump_accumulates_every_ppo_chunk_into_each_optimizer_step(
+    monkeypatch,
+) -> None:
+    """A PPO epoch spans the full step even when the sampler yields it in chunks."""
+    meta = _single_group_meta()
+    calls: list[str] = []
+    ctrl, _ = _ppo_train_pump_controller(
+        sampler=_ChunkedSampler(meta, chunks=2),
+        value=_NoOpValue(calls=calls, prefix="critic."),
+        ppo_epochs=2,
+        critic_ppo_epochs=2,
+        num_prompts_per_step=2,
+    )
+    ctrl._trainer = _EpochRecordingTrainer(calls)
+    ctrl._advantage_stage = AsyncMock(return_value=(meta, True))
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    assert calls.count("critic.begin_train_step") == 2
+    assert calls.count("critic.train_microbatches_from_meta") == 4
+    assert calls.count("critic.finish_train_step") == 2
+    assert calls.count("policy.begin_train_step") == 2
+    assert calls.count("policy.train_microbatches_from_meta") == 4
+    assert calls.count("policy.finish_train_step") == 2
+    assert calls.index("critic.finish_training") < calls.index(
+        "policy.prepare_for_training"
+    )
 
 
 def test_advantage_stage_writes_gae_returns_alongside_advantages() -> None:


### PR DESCRIPTION
# What does this PR do?

Lets Single Controller PPO stream actor and Megatron critic minibatches from native TQ replay instead of materializing one merged training payload.

The critic now has an explicit begin/train-chunk/finish/abort lifecycle. Chunks accumulate gradients and correctly normalized diagnostics, then take one optimizer step at the end of each critic epoch. The controller retains replay rows across critic and actor epochs, cleans up partial failures, skips invalid chunks, and rejects drop budgets that cannot preserve data-parallel batch divisibility.

Relates to #2625.

## Validation

Current head `1253e0264a5a7665440fcff6607f63cd450164bc`, rebased on upstream `main` at `d633032b2a8017c69ddfff9183deb42cab6b36f4`.

| Check | Result |
| --- | --- |
| Current-head PPO/value/setup/SC actor suite on macOS arm64 (Python 3.12.2, pytest 7.4.4, torch 2.8.0 CPU, Ray 2.51.1; NVTX push/pop replaced with test-process no-ops) | 233 passed, 8 skipped (7 GPU-gated; 1 missing optional `megatron.bridge`) |
| Ruff check, format check, diff check, and DCO | passed |
| Split critic parity on 2×H100 NVL, Megatron value model (`2a9b108a` pre-refresh head) | loss, grad norm, and every diagnostic metric matched |
| SC PPO functional + resume on 2×H100 NVL, Qwen2.5-0.5B, async vLLM, Megatron policy/value (same pre-refresh head) | steps 0–2 and resume 2–4 passed |
| Checkpoint and TensorBoard assertions (same H100 run) | checkpoints complete at steps 1–4; 10/10 assertions passed |

The main refresh composes the intervening MOPD, NeMo Gym, refit, token-capture, training-claim, finalizer-metric, and rollout-checkpoint changes with PPO's multi-epoch row retention. The #3925 reconciliation uses the new `sample_clears` checkpoint-barrier mutation category for both PPO and non-PPO cleanup, while retaining the PPO-specific early cleanup on failure.

The 2-GPU Megatron split-parity and functional runs have not been rerun at the current head, so current-head GPU confirmation remains pending.

Functional entry point:

```bash
uv run --locked bash tests/functional/ppo_async_single_controller.sh
```

## Before your PR is ready for review

- [x] Read and followed the contributor guidelines
- [x] Added the necessary tests
- [x] Ran unit and functional tests
- [x] Updated the Single Controller guide and example config
