### PR TITLE
fix(vllm): make threaded HTTP generation async-safe

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_sparse_refit.py
+++ b/nemo_rl/models/generation/vllm/vllm_sparse_refit.py
@@ -136,6 +136,9 @@ class VllmSparseRefitReceiver:
     def set_worker_hostnames(self, hostnames: list[str]) -> None:
         self._refit_workers_share_node = len(set(hostnames)) == 1
 
+    def set_async_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._refit_async_loop = loop
+
     def start_sync_server(self) -> None:
         llm = self._worker.llm
         if llm is None:
@@ -428,8 +431,6 @@ class VllmSparseRefitReceiver:
             raw_request: Request,
             action: Literal["prepare", "s3", "flush", "zmq_flush"],
         ) -> JSONResponse:
-            if cfg["vllm_cfg"]["async_engine"]:
-                self._refit_async_loop = asyncio.get_running_loop()
             supplied_token = raw_request.headers.get(G_VLLM_REFIT_API_KEY_HEADER)
             if token is not None and (
                 supplied_token is None or not hmac.compare_digest(token, supplied_token)

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -76,6 +76,7 @@ class _AsyncLLMHTTPClient:
         self.model_config = engine_client.model_config
         self.renderer = engine_client.renderer
         self.input_processor = engine_client.input_processor
+        self.vllm_config = engine_client.vllm_config
 
     async def _run_on_engine_loop(self, operation: Callable[[], Awaitable[Any]]) -> Any:
         if asyncio.get_running_loop() is self._engine_loop:
@@ -131,6 +132,8 @@ class _AsyncLLMHTTPClient:
                 except Exception:
                     LOGGER.exception("Failed to abort vLLM request %s", request_id)
 
+    # These members only read engine status or immutable configuration. Running
+    # them on the engine loop added a cross-thread wait to each HTTP request.
     @property
     def errored(self) -> bool:
         return self._engine_client.errored

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -20,6 +20,7 @@ import threading
 import time
 import uuid
 import warnings
+from collections.abc import Awaitable, Callable
 from typing import Any, AsyncGenerator, Optional, cast
 
 import ray
@@ -62,6 +63,86 @@ LOGGER = logging.getLogger(__name__)
 from nemo_rl.distributed.refit_watchdog import RefitAborted, is_refit_abort
 
 
+class _AsyncLLMHTTPClient:
+    """Keep HTTP generation on the loop that owns AsyncLLM request state.
+
+    The engine-client surface is explicit. Do not add a ``__getattr__`` fallback.
+    Add each new member here and decide whether it must run on the engine loop.
+    """
+
+    def __init__(self, engine_client: Any, engine_loop: asyncio.AbstractEventLoop):
+        self._engine_client = engine_client
+        self._engine_loop = engine_loop
+        self.model_config = engine_client.model_config
+        self.renderer = engine_client.renderer
+        self.input_processor = engine_client.input_processor
+
+    async def _run_on_engine_loop(self, operation: Callable[[], Awaitable[Any]]) -> Any:
+        if asyncio.get_running_loop() is self._engine_loop:
+            return await operation()
+
+        future = asyncio.run_coroutine_threadsafe(operation(), self._engine_loop)
+        try:
+            return await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
+
+    def generate(
+        self,
+        prompt: Any,
+        sampling_params: Any,
+        request_id: str,
+        **kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        return self._generate(prompt, sampling_params, request_id, kwargs)
+
+    async def _generate(
+        self,
+        prompt: Any,
+        sampling_params: Any,
+        request_id: str,
+        kwargs: dict[str, Any],
+    ) -> AsyncGenerator[Any, None]:
+        iterator = None
+        completed = False
+
+        async def next_output() -> Any:
+            nonlocal iterator
+            if iterator is None:
+                iterator = self._engine_client.generate(
+                    prompt, sampling_params, request_id, **kwargs
+                )
+            return await anext(iterator)
+
+        try:
+            while True:
+                try:
+                    yield await self._run_on_engine_loop(next_output)
+                except StopAsyncIteration:
+                    completed = True
+                    return
+        finally:
+            if not completed:
+                try:
+                    await self._run_on_engine_loop(
+                        lambda: self._engine_client.abort(request_id)
+                    )
+                except Exception:
+                    LOGGER.exception("Failed to abort vLLM request %s", request_id)
+
+    @property
+    def errored(self) -> bool:
+        return self._engine_client.errored
+
+    @property
+    def dead_error(self) -> BaseException:
+        return self._engine_client.dead_error
+
+    async def is_tracing_enabled(self) -> bool:
+        return await self._engine_client.is_tracing_enabled()
+
+
 class VllmAsyncGenerationWorkerImpl(
     VllmAsyncCheckpointEngineRpcMixin, BaseVllmGenerationWorker
 ):
@@ -98,11 +179,12 @@ class VllmAsyncGenerationWorkerImpl(
         self._deferred_bundle_indices = None
         self._deferred_seed = None
 
-        # Defaults for HTTP server state; overwritten by _create_engine()
-        # when the worker is a model owner and the model is actually loaded.
+        # Defaults for HTTP server state; populated after the actor loop starts.
         self.server_thread = None
         self.base_url = None
         self.http_server = None
+        self._engine_loop = None
+        self._http_engine_client = None
 
         super().__init__(
             config,
@@ -203,37 +285,11 @@ class VllmAsyncGenerationWorkerImpl(
             self.llm_async_engine_args, stat_loggers=self.stat_loggers
         )
 
-        if self.cfg["vllm_cfg"].get("expose_http_server"):
-            # Must run after AsyncLLM.from_engine_args and before
-            # _setup_vllm_server spawns the uvicorn thread.
-            self._install_engine_input_socket_lock()
-            self.server_thread, self.base_url, self.http_server = (
-                self._setup_vllm_server()
-            )
-
         # vLLM Metrics Logger
         # Metrics logger only enabled for per-actor, model-owner only
         self._vllm_metrics_lock = threading.Lock()
         if self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
             self._start_vllm_metrics_logger()
-
-    def _install_engine_input_socket_lock(self) -> None:
-        """Serialise sends on AsyncMPClient.input_socket across OS threads
-        to prevent race conditions that block the vLLM engine (e.g. during
-        in flight weight updates in async grpo).
-        """
-        shadow_sock = self.llm.engine_core.input_socket._shadow_sock
-
-        lock = threading.Lock()
-        original_send_multipart = shadow_sock.send_multipart
-
-        def locked_send_multipart(*args: Any, **kwargs: Any) -> Any:
-            with lock:
-                return original_send_multipart(*args, **kwargs)
-
-        # Replace the bound method on this socket instance only; other zmq
-        # sockets in the process are unaffected.
-        shadow_sock.send_multipart = locked_send_multipart  # type: ignore[assignment]
 
     def _start_vllm_metrics_logger(self) -> None:
         """Start a background thread that periodically collects vLLM logger metrics.
@@ -342,6 +398,11 @@ class VllmAsyncGenerationWorkerImpl(
         if self._sparse_refit_receiver is not None:
             hostnames = await self.llm.collective_rpc("report_node_hostname", args=())
             self._sparse_refit_receiver.set_worker_hostnames(hostnames)
+        if self.llm is not None and self.cfg["vllm_cfg"].get("expose_http_server"):
+            self._http_engine_client = _AsyncLLMHTTPClient(self.llm, self._engine_loop)
+            self.server_thread, self.base_url, self.http_server = (
+                self._setup_vllm_server()
+            )
 
     async def get_reserved_url(self) -> Optional[str]:
         """Return the URL from the reserved socket, available before model loading."""
@@ -398,7 +459,9 @@ class VllmAsyncGenerationWorkerImpl(
                 maybe_reasoning_parser_plugin
             )
 
-        engine_client = self.llm
+        engine_client = self._http_engine_client
+        if engine_client is None:
+            raise RuntimeError("The HTTP engine client is not initialized.")
         model_config = self.llm_async_engine_args.create_model_config()
         base_model_paths = [
             BaseModelPath(
@@ -970,9 +1033,7 @@ class VllmAsyncGenerationWorkerImpl(
         if reserved_sock is not None:
             # Hand the pre-bound listening socket directly to uvicorn's asyncio
             # server via server.serve(sockets=). No close-and-rebind needed.
-            import asyncio
-
-            def _run_with_socket():
+            def _run_with_socket() -> None:
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
                 loop.run_until_complete(server.serve(sockets=[reserved_sock]))
@@ -1679,6 +1740,11 @@ class VllmAsyncGenerationWorkerImpl(
     async def shutdown(self) -> bool:
         """Clean up vLLM resources."""
         try:
+            if self.server_thread is not None:
+                self.http_server.should_exit = True
+                await asyncio.to_thread(self.server_thread.join)
+                self.server_thread = None
+
             if self._sparse_refit_receiver is not None:
                 await asyncio.to_thread(self._sparse_refit_receiver.shutdown)
 
@@ -1699,17 +1765,6 @@ class VllmAsyncGenerationWorkerImpl(
             # Force garbage collection
             gc.collect()
             torch.cuda.empty_cache()
-
-            if self.server_thread is not None:
-                from threading import Thread
-
-                from uvicorn import Server
-
-                self.http_server: Server
-                self.server_thread: Thread
-
-                self.http_server.should_exit = True
-                self.server_thread.join()
 
             return True
         except Exception as e:

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -329,6 +329,9 @@ class VllmAsyncGenerationWorkerImpl(
             self.generation_tokens = []
 
     async def post_init_async(self):
+        self._engine_loop = asyncio.get_running_loop()
+        if self._sparse_refit_receiver is not None:
+            self._sparse_refit_receiver.set_async_loop(self._engine_loop)
         if self.llm is not None:
             await self.llm.collective_rpc("bind_numa", args=tuple())
         self.vllm_device_ids = await self.report_device_id_async()

--- a/tests/unit/models/generation/test_vllm_chat_template_wiring.py
+++ b/tests/unit/models/generation/test_vllm_chat_template_wiring.py
@@ -172,12 +172,16 @@ def _build_server(monkeypatch, serving_chat_kwargs):
         "vllm_cfg": {"http_server_serving_chat_kwargs": serving_chat_kwargs},
     }
     worker.llm = MagicMock(model_config="model-config", renderer="renderer")
+    worker._http_engine_client = MagicMock(
+        model_config="http-model-config", renderer="http-renderer"
+    )
     worker.llm_async_engine_args = MagicMock()
     worker.llm_async_engine_args.create_model_config.return_value = MagicMock(
         served_model_name="served-model", model="model-path"
     )
 
     worker._setup_vllm_openai_api_server(_FakeApp())
+    assert _BUILT["chat"][0].kwargs["engine_client"] is worker._http_engine_client
     return _BUILT["renderer"], _BUILT["chat"], _BUILT["tokenize"]
 
 

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import importlib.util
 import json
 import os
 import sys
+import threading
 import types
 from copy import deepcopy
 from pathlib import Path
@@ -44,6 +46,7 @@ from nemo_rl.models.generation.vllm.vllm_worker import (
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
+    _AsyncLLMHTTPClient,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
 from nemo_rl.models.policy.lm_policy import Policy
@@ -182,6 +185,128 @@ async def test_async_vllm_worker_uses_native_keep_pause_and_resume() -> None:
 
     worker.llm.pause_generation.assert_awaited_once_with(mode="keep", clear_cache=False)
     worker.llm.resume_generation.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_vllm_http_client_runs_generation_on_owner_loop() -> None:
+    engine_loop = asyncio.get_running_loop()
+    engine_thread = threading.get_ident()
+    calls = []
+
+    class FakeEngine:
+        model_config = "model-config"
+        renderer = "renderer"
+        input_processor = "input-processor"
+
+        @property
+        def errored(self):
+            calls.append(("errored", asyncio.get_running_loop(), threading.get_ident()))
+            return False
+
+        @property
+        def dead_error(self):
+            return RuntimeError("engine dead")
+
+        async def is_tracing_enabled(self):
+            calls.append(
+                (
+                    "is_tracing_enabled",
+                    asyncio.get_running_loop(),
+                    threading.get_ident(),
+                )
+            )
+            return False
+
+        async def generate(self, *args, **kwargs):
+            calls.append(
+                ("generate", asyncio.get_running_loop(), threading.get_ident())
+            )
+            yield "first"
+            yield "second"
+
+        async def abort(self, _request_id: str) -> None:
+            calls.append(("abort", asyncio.get_running_loop(), threading.get_ident()))
+
+    client = _AsyncLLMHTTPClient(FakeEngine(), engine_loop)
+
+    def use_client_from_http_thread():
+        async def use_client():
+            tracing_enabled = await client.is_tracing_enabled()
+            outputs = [
+                output async for output in client.generate(None, None, "request")
+            ]
+            errored = client.errored
+            return (
+                tracing_enabled,
+                outputs,
+                errored,
+                asyncio.get_running_loop(),
+                threading.get_ident(),
+            )
+
+        return asyncio.run(use_client())
+
+    tracing_enabled, outputs, errored, http_loop, http_thread = await asyncio.to_thread(
+        use_client_from_http_thread
+    )
+
+    assert tracing_enabled is False
+    assert outputs == ["first", "second"]
+    assert errored is False
+    assert client.model_config == "model-config"
+    assert client.renderer == "renderer"
+    assert client.input_processor == "input-processor"
+    assert not hasattr(client, "check_health")
+    assert http_loop is not engine_loop
+    assert http_thread != engine_thread
+    assert [call[0] for call in calls] == [
+        "is_tracing_enabled",
+        "generate",
+        "errored",
+    ]
+    assert calls[0][1:] == (http_loop, http_thread)
+    assert calls[1][1:] == (engine_loop, engine_thread)
+    assert calls[2][1:] == (http_loop, http_thread)
+
+
+@pytest.mark.asyncio
+async def test_async_vllm_http_client_aborts_cancelled_generation() -> None:
+    engine_loop = asyncio.get_running_loop()
+    started = threading.Event()
+    aborts = []
+
+    class FakeEngine:
+        model_config = None
+        renderer = None
+        input_processor = None
+
+        async def generate(self, *args, **kwargs):
+            started.set()
+            await asyncio.Event().wait()
+            yield None
+
+        async def abort(self, request_id):
+            aborts.append((request_id, asyncio.get_running_loop()))
+
+    client = _AsyncLLMHTTPClient(FakeEngine(), engine_loop)
+
+    def cancel_from_http_thread():
+        async def cancel():
+            async def consume():
+                async for _ in client.generate(None, None, "cancelled-request"):
+                    pass
+
+            task = asyncio.create_task(consume())
+            await asyncio.to_thread(started.wait)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(cancel())
+
+    await asyncio.to_thread(cancel_from_http_thread)
+
+    assert aborts == [("cancelled-request", engine_loop)]
 
 
 def test_vllm_generation_broadcasts_native_refit_pause_and_resume(
@@ -448,6 +573,7 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
         },
     }
     worker.llm = MagicMock(model_config="model-config", renderer="renderer")
+    worker._http_engine_client = worker.llm
     model_config = MagicMock(served_model_name="served-model", model="model-path")
     worker.llm_async_engine_args = MagicMock()
     worker.llm_async_engine_args.create_model_config.return_value = model_config

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -197,6 +197,7 @@ async def test_async_vllm_http_client_runs_generation_on_owner_loop() -> None:
         model_config = "model-config"
         renderer = "renderer"
         input_processor = "input-processor"
+        vllm_config = "vllm-config"
 
         @property
         def errored(self):
@@ -228,6 +229,12 @@ async def test_async_vllm_http_client_runs_generation_on_owner_loop() -> None:
             calls.append(("abort", asyncio.get_running_loop(), threading.get_ident()))
 
     client = _AsyncLLMHTTPClient(FakeEngine(), engine_loop)
+    assert (
+        await client._run_on_engine_loop(
+            lambda: asyncio.sleep(0, result="same-loop-result")
+        )
+        == "same-loop-result"
+    )
 
     def use_client_from_http_thread():
         async def use_client():
@@ -256,6 +263,8 @@ async def test_async_vllm_http_client_runs_generation_on_owner_loop() -> None:
     assert client.model_config == "model-config"
     assert client.renderer == "renderer"
     assert client.input_processor == "input-processor"
+    assert client.vllm_config == "vllm-config"
+    assert str(client.dead_error) == "engine dead"
     assert not hasattr(client, "check_health")
     assert http_loop is not engine_loop
     assert http_thread != engine_thread
@@ -269,8 +278,16 @@ async def test_async_vllm_http_client_runs_generation_on_owner_loop() -> None:
     assert calls[2][1:] == (http_loop, http_thread)
 
 
+@pytest.mark.parametrize(
+    "abort_error",
+    [None, RuntimeError("abort failed")],
+    ids=["success", "failure"],
+)
 @pytest.mark.asyncio
-async def test_async_vllm_http_client_aborts_cancelled_generation() -> None:
+async def test_async_vllm_http_client_aborts_cancelled_generation(
+    abort_error: RuntimeError | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     engine_loop = asyncio.get_running_loop()
     started = threading.Event()
     aborts = []
@@ -279,6 +296,7 @@ async def test_async_vllm_http_client_aborts_cancelled_generation() -> None:
         model_config = None
         renderer = None
         input_processor = None
+        vllm_config = None
 
         async def generate(self, *args, **kwargs):
             started.set()
@@ -287,6 +305,8 @@ async def test_async_vllm_http_client_aborts_cancelled_generation() -> None:
 
         async def abort(self, request_id):
             aborts.append((request_id, asyncio.get_running_loop()))
+            if abort_error is not None:
+                raise abort_error
 
     client = _AsyncLLMHTTPClient(FakeEngine(), engine_loop)
 
@@ -307,6 +327,54 @@ async def test_async_vllm_http_client_aborts_cancelled_generation() -> None:
     await asyncio.to_thread(cancel_from_http_thread)
 
     assert aborts == [("cancelled-request", engine_loop)]
+    if abort_error is not None:
+        assert "Failed to abort vLLM request cancelled-request" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_vllm_worker_stops_http_server_before_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    class ServerThread:
+        def join(self) -> None:
+            calls.append("server")
+
+    class SparseRefitReceiver:
+        def shutdown(self) -> None:
+            calls.append("sparse-refit")
+
+    class Engine:
+        async def collective_rpc(self, *args, **kwargs) -> None:
+            calls.append("engine-cleanup")
+
+        def shutdown(self) -> None:
+            calls.append("engine-shutdown")
+
+    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
+    worker.server_thread = ServerThread()
+    worker.http_server = MagicMock()
+    worker._sparse_refit_receiver = SparseRefitReceiver()
+    worker.llm = Engine()
+    worker.tokenizer = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_worker_async.shutdown_telemetry",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_worker_async.gc.collect", lambda: None
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_worker_async.torch.cuda.empty_cache",
+        lambda: None,
+    )
+
+    assert await worker.shutdown()
+    assert calls == ["server", "sparse-refit", "engine-cleanup", "engine-shutdown"]
+    assert worker.http_server.should_exit is True
+    assert worker.server_thread is None
+    assert worker.llm is None
 
 
 def test_vllm_generation_broadcasts_native_refit_pause_and_resume(

--- a/tests/unit/models/generation/test_vllm_sparse_refit.py
+++ b/tests/unit/models/generation/test_vllm_sparse_refit.py
@@ -453,6 +453,8 @@ def test_sparse_refit_api_auth_dispatch_and_error_mapping(monkeypatch) -> None:
             return_value={"ok": True, "payloads": 3}
         )
         receiver._refit_collective_rpc = MagicMock(return_value=[])
+        engine_loop = MagicMock()
+        receiver.set_async_loop(engine_loop)
         app = FastAPI()
         receiver.setup_api_server(app)
         headers = {G_VLLM_REFIT_API_KEY_HEADER: "secret"}
@@ -480,7 +482,7 @@ def test_sparse_refit_api_auth_dispatch_and_error_mapping(monkeypatch) -> None:
         assert flush_response.status_code == 200
         assert zmq_flush_response.status_code == 200
         assert prepare_response.status_code == 200
-        assert receiver._refit_async_loop is not None
+        assert receiver._refit_async_loop is engine_loop
         receiver._apply_s3_manifest_payload.assert_awaited_once_with({"key": "key"})
         receiver._flush_queued_sparse_payloads.assert_called_once_with()
         receiver.flush_zmq_sparse_refit_relay.assert_called_once_with("transfer", 0)
@@ -564,6 +566,9 @@ async def test_async_sparse_refit_post_init_records_worker_locality() -> None:
     assert worker.vllm_device_ids == ["0"]
     worker._sparse_refit_receiver.set_worker_hostnames.assert_called_once_with(
         ["node-0", "node-0"]
+    )
+    worker._sparse_refit_receiver.set_async_loop.assert_called_once_with(
+        asyncio.get_running_loop()
     )
     assert worker.llm.collective_rpc.await_args_list == [
         call("bind_numa", args=()),

--- a/tests/unit/models/generation/test_vllm_sparse_refit.py
+++ b/tests/unit/models/generation/test_vllm_sparse_refit.py
@@ -556,6 +556,7 @@ def test_sync_sparse_refit_server_shutdown_cleans_transport_resources(
 async def test_async_sparse_refit_post_init_records_worker_locality() -> None:
     worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
     worker._sparse_refit_receiver = MagicMock()
+    worker.cfg = {"vllm_cfg": {"expose_http_server": False}}
     worker._mtp_load_from_disk = False
     worker.report_device_id_async = AsyncMock(return_value=["0"])
     worker.llm = MagicMock()


### PR DESCRIPTION
# What does this PR do ?

Prevents the embedded vLLM HTTP server from sharing `AsyncLLM` request state across two event loops.

## Bug

NeMo-RL creates `AsyncLLM` on the Ray worker loop, then passes the same object to Uvicorn on another thread and event loop. An HTTP `generate()` call waits on a vLLM `RequestOutputCollector` event from Uvicorn's loop. vLLM's output handler sets that event from the Ray worker loop.

`asyncio.Event` is not thread-safe. The two threads can mutate its waiter deque at the same time. This kills the vLLM output handler and fails every request waiting on that engine replica.

```text
AsyncLLM output_handler failed.
Traceback (most recent call last):
  File ".../vllm/v1/engine/async_llm.py", line 695, in output_handler
    processed_outputs = output_processor.process_outputs(
  File ".../vllm/v1/engine/output_processor.py", line 681, in process_outputs
    req_state.queue.put(request_output)
  File ".../vllm/v1/engine/output_processor.py", line 66, in put
    self.ready.set()
  File "/usr/lib/python3.12/asyncio/locks.py", line 189, in set
    for fut in self._waiters:
RuntimeError: deque mutated during iteration
```

## Fix

Uvicorn remains on its own thread. Generation and cancellation run on the event loop that owns `AsyncLLM`. Stable setup data stays on the HTTP thread. Sparse refit records the owner loop during worker initialization. The old input-socket lock is no longer needed.

# Issues

Closes: #1857

# Usage

No user-facing changes.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Testing completed:

- pre-commit checks passed: Ruff, formatting, Pyrefly, and file checks.
- Nine focused unit tests passed on Python 3.13. A broader run passed 27 tests before reaching a GPU-only test in the CPU VM.
- An amplified A/B reproduced `deque mutated during iteration` in the old code after 114 requests. The fix completed 128 requests, five training steps, and five refits.
- An unamplified stress run completed 128 requests, five steps, and five refits without an error.
- The performance A/B completed 95,713 requests with no failures. Request rate changed by -0.17%. Median and p95 improved. Middle-run p99 rose from 1.54 seconds to 2.08 seconds.

Timing probes placed the added tail latency before vLLM admitted each request. The longest wait for `generate()` to begin on the Ray worker loop was 1.70--1.72 seconds, which matched HTTP p99. Submitting the cross-thread callback was cheap; the callback waited for the Ray worker loop to schedule it. After a refit, vLLM processed queued outputs on that loop before it admitted replacement HTTP requests. The old code admitted those requests on Uvicorn's loop, but that was the unsafe cross-loop access that caused the crash.
