### PR TITLE
feat: add nccl-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ dependencies = [
   "pyzmq",
   "soundfile>=0.13.1",
   "nccl4py; sys_platform != 'darwin'",                                                                                       # for non-colocated refit
+  # Native M2N refit operations used by the nccl_reshard transport.
+  "nccl-extensions==0.1.0; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
   "cuda-bindings; sys_platform != 'darwin'",                                                                                 # for non-colocated refit
   # Worker venvs run a base sync before backend extras, so NIXL must be available here.
   "nixl==1.3.0; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",

--- a/uv.lock
+++ b/uv.lock
@@ -4044,6 +4044,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nccl-extensions"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-core" },
+    { name = "cuda-pathfinder" },
+    { name = "nccl4py" },
+    { name = "numpy" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/8b/0d98ca96c8625af88d834230b34115fac032ed69eb84c8bde7c38b956d16/nccl_extensions-0.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3678bce16864064a9f8774ec69f5c023cb2cbcd91db60a7f98e7c87fd4f18a50", size = 22265222, upload-time = "2026-09-02T15:39:12.533Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/66/0f0a3fe84ffdf6ddfb13c01a036ea370519204820cc8c53303f479c43a09/nccl_extensions-0.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3328dc1cfeed0ddf37caac00be8c49b3e4f727dce0e7980f8831696165619a4f", size = 22564580, upload-time = "2026-09-02T15:39:32.862Z" },
+]
+
+[[package]]
 name = "nccl4py"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4400,6 +4416,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mlflow" },
     { name = "mooncake-transfer-engine-cuda13" },
+    { name = "nccl-extensions" },
     { name = "nccl4py" },
     { name = "nemo-lens", extra = ["sdk"] },
     { name = "ninja" },
@@ -4609,6 +4626,7 @@ requires-dist = [
     { name = "mistral-common", marker = "extra == 'automodel'", specifier = ">=1.11.0" },
     { name = "mlflow", specifier = ">=3.13.0" },
     { name = "mooncake-transfer-engine-cuda13", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = "==0.3.11.post1" },
+    { name = "nccl-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = "==0.1.0" },
     { name = "nccl4py", marker = "sys_platform != 'darwin'" },
     { name = "nemo-automodel", extras = ["moe"], marker = "extra == 'automodel'", editable = "3rdparty/Automodel-workspace/Automodel" },
     { name = "nemo-gym", marker = "extra == 'nemo-gym'", editable = "3rdparty/Gym-workspace/Gym" },


### PR DESCRIPTION
# What does this PR do ?

Adds `nccl-extensions==0.1.0` as a Linux dependency for x86_64 and aarch64 systems, and updates `uv.lock` with the published wheels.

This makes the native `nccl.m2n.reshard` implementation available to the `nccl_reshard` refit transport without a separate package installation.

# Issues

N/A

# Usage

No usage change is required. Configure the existing transport as usual:

```yaml
policy:
  generation:
    refit_transport: nccl_reshard
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No new tests are required for this dependency-only change.
- [x] Ran `uv lock --check` with Python 3.13.14.
- [x] No documentation update is required because the existing `nccl_reshard` interface is unchanged.

# Additional Information

Validated manually with four GB200 GPUs using Python 3.13.14, Torch 2.11.0+cu130, CUDA 13.0, NCCL 2.30.7, `nccl4py==0.3.1`, and `nccl-extensions==0.1.0`.

The four-rank cross-dimension `nccl.m2n.reshard` benchmark completed successfully with validation enabled.
