### PR TITLE
feat(mopd): add full-vocabulary on-policy distillation to SingleController

### DIFF
--- a/docs/about/algorithms/mopd.md
+++ b/docs/about/algorithms/mopd.md
@@ -184,11 +184,22 @@ Rejected at construction rather than silently ignored:
   `policy.megatron_cfg.pipeline_model_parallel_size: 1` and
   `policy.generation.temperature: 1.0`. The `logits` path has neither
   restriction.
+- `teacher_payload: hidden_states` also requires a teacher whose logits are
+  exactly `output_layer(h)`. Models that transform the logits after that linear
+  — Gemma2 and Gemma4 (`final_logit_softcapping`), MuseGlimmer
+  (`output_multiplier`), and any MuP model (`use_mup`) — are rejected on the
+  teacher worker, because the student's reconstruction cannot reproduce the
+  post-transform and would silently distill toward a distribution the teacher
+  never emits. Use `teacher_payload: logits`, which is exact for these models.
 - `policy.megatron_cfg.use_fused_linear_logprobs: false` and
   `policy.sequence_packing.fuse_loss: false`.
-- The policy-gradient knobs have no code path under this objective and are
-  rejected: ratio clipping, CISPO, importance-sampling correction, truncated
-  importance sampling, and `positive_example_nll_weight`.
+- The policy-gradient and reward-side KL knobs have no code path under this
+  objective and are rejected: `disable_ppo_ratio: false`, `ratio_clip_c`,
+  `use_cispo`, `force_on_policy_ratio`, `sequence_level_importance_ratios`,
+  `use_importance_sampling_correction`, `truncated_importance_sampling_type`,
+  `positive_example_nll_weight`, `use_kl_in_reward`, and
+  `use_on_policy_kl_approximation` (the base MOPD recipe sets this one to
+  `true`, so a derived full-vocabulary recipe must override it to `false`).
 
 ## Running MOPD
 

--- a/docs/about/algorithms/mopd.md
+++ b/docs/about/algorithms/mopd.md
@@ -26,9 +26,10 @@ teacher-minus-student log-probability gap:
 `log π_student` is the policy's `prev_logprobs` and `log π_teacher` is computed
 by the teacher worker group at collection time. Maximizing this advantage is
 reverse-KL minimization — it pushes the student toward the teacher's token
-distribution — but, unlike forward-KL logit distillation, it needs only the
-teacher's log-probability for the *sampled* token rather than the full
-vocabulary distribution.
+distribution — but, in this default (top-k) form, it needs only the teacher's
+log-probability for the *sampled* token rather than the full vocabulary
+distribution. See [Full-vocabulary MOPD](#full-vocabulary-mopd) for the exact
+K=V variant, which trades that property for an unbiased objective.
 
 The advantage is applied only to trained (assistant) tokens via the loss mask;
 tool / environment tokens contribute zero. Because the advantage subtracts a
@@ -123,6 +124,72 @@ trainable) + 1 node vLLM generation (frozen) + 1 node teacher (frozen). Ten
 distinct teachers at 1 node each would instead add 10 nodes on top of the
 policy and generation nodes.
 
+## Full-vocabulary MOPD
+
+`on_policy_distillation.full` replaces the sampled-token log-probability gap
+with the exact reverse KL over the whole vocabulary:
+
+```
+L_t = Σ_v p_student(v) · [ log p_student(v) − log p_teacher(v) ]
+```
+
+This is the K=V limit of the top-k estimator: with the support spanning the
+whole vocabulary the score-function tail term vanishes, so the objective is
+exact, deterministic, and free of that estimator's off-policy bias. It replaces
+the policy-gradient objective entirely — the OPD advantage estimator still runs
+(`advantages` is a required training column and its stage supplies the
+teacher/student gap diagnostic), but this loss ignores its output.
+
+```yaml
+on_policy_distillation:
+  full:
+    enabled: true
+    teacher_payload: hidden_states  # or: logits
+    divergence: reverse_kl
+    payload_dtype: bfloat16
+    teacher_lm_head_lifecycle: offload  # none | offload | evict
+    chunk_size: 1024
+    validate_decomposition: false
+```
+
+`teacher_payload` selects what crosses the teacher/student boundary:
+
+| | width | notes |
+|---|---|---|
+| `hidden_states` (default) | `hidden_size` | Teacher ships pre-LM-head hidden states; the student projects them with an output-layer shard loaded from the teacher checkpoint. Teacher and student parallelism stay decoupled. |
+| `logits` | `vocab_size` | Teacher ships full-vocabulary logits; no student-side teacher LM head. Roughly 74× larger for a 2k-hidden / 152k-vocab model — a numerical reference and fallback, not a production configuration. |
+
+`chunk_size` bounds the live fp32 vocabulary working set in the divergence
+kernels; unchunked, one 8K-token row materializes several GB of fp32
+log-softmax. `teacher_lm_head_lifecycle` controls whether the teacher LM-head
+shard stays resident on GPU, is parked on CPU between steps, or is freed and
+reloaded each step.
+
+`validate_decomposition` additionally reports the reverse KL against its
+entropy / cross-entropy decomposition. Note that this residual is an algebraic
+identity — all three kernels read the same logits, so a corrupted teacher
+cancels out of it. It pins the kernels' own arithmetic and nothing upstream of
+them, at the cost of a second full-vocabulary log-softmax, so it is off by
+default. The assertion that actually catches a broken payload, gather, LM-head
+shard, or token shift is the divergence itself staying near zero under
+self-distillation.
+
+### Current restrictions
+
+Rejected at construction rather than silently ignored:
+
+- Megatron backend and the Single-Controller runtime only.
+- Exactly one teacher checkpoint.
+- `teacher_payload: hidden_states` additionally requires student
+  `policy.megatron_cfg.pipeline_model_parallel_size: 1` and
+  `policy.generation.temperature: 1.0`. The `logits` path has neither
+  restriction.
+- `policy.megatron_cfg.use_fused_linear_logprobs: false` and
+  `policy.sequence_packing.fuse_loss: false`.
+- The policy-gradient knobs have no code path under this objective and are
+  rejected: ratio clipping, CISPO, importance-sampling correction, truncated
+  importance sampling, and `positive_example_nll_weight`.
+
 ## Running MOPD
 
 MOPD collects rollouts through NeMo Gym and supports both the legacy async GRPO
@@ -143,6 +210,11 @@ uv run examples/run_grpo_single_controller.py \
 
 See [Train with Single-Controller](../../guides/single-controller.md) for the
 runtime's configuration and architecture.
+
+The full-vocabulary variants of that recipe are
+`mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.yaml` (H100) and
+`mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.yaml` (GB200),
+run the same way.
 
 ### Legacy async GRPO path
 

--- a/examples/configs/recipes/llm/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.yaml
+++ b/examples/configs/recipes/llm/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.yaml
@@ -1,0 +1,26 @@
+defaults: ./mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.yaml
+
+# GB200 variant of the H100 3n8g recipe. GB200 nodes have 4 GPUs, so every
+# gpus_per_node knob is halved; tensor_model_parallel_size=2 still divides 4.
+policy:
+  generation:
+    colocated:
+      resources:
+        gpus_per_node: 4
+
+checkpointing:
+  checkpoint_dir: results/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab
+
+logger:
+  wandb:
+    name: mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab
+  mlflow:
+    run_name: mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab
+
+cluster:
+  gpus_per_node: 4
+
+on_policy_distillation:
+  non_colocated_teachers:
+    default_teacher_cfg:
+      gpus_per_node: 4

--- a/examples/configs/recipes/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.yaml
+++ b/examples/configs/recipes/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.yaml
@@ -1,0 +1,53 @@
+defaults: ./mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller.yaml
+
+# Full-vocabulary MOPD: the exact reverse KL over the whole vocabulary,
+#
+#   L_t = sum_v p_student(v) * (log p_student(v) - log p_teacher(v))
+#
+# i.e. the K=V limit of the top-k estimator, with no score-function tail term.
+# Student and teacher are the same Qwen3-1.7B checkpoint, so any nonzero
+# divergence means a broken payload, gather, LM-head shard, or token shift.
+on_policy_distillation:
+  full:
+    enabled: true
+    # Teacher ships pre-LM-head hidden states (hidden_size wide), so teacher and
+    # student parallelism stay decoupled. 'logits' is vocab_size wide (~74x
+    # larger here) and is a numerical reference, not a production setting.
+    teacher_payload: hidden_states
+    divergence: reverse_kl
+    payload_dtype: bfloat16
+    teacher_lm_head_lifecycle: offload
+    # Bounds the live fp32 vocabulary working set: unchunked, one 8K row would
+    # materialize ~5 GB of fp32 log-softmax.
+    chunk_size: 1024
+    # Off: the residual is an algebraic identity, not a correctness signal. All
+    # three kernels consume the same logits, and exp(s)(s-t) == exp(s)s +
+    # exp(s)(-t) holds per element before the linear all-reduce, so a corrupted
+    # teacher cancels out. Measured over seven corruptions (zeroed payload, wrong
+    # LM head, mis-sharded head, token misalignment, temperature mismatch, bad
+    # gather) the residual stays under 1e-6 while opd_full_reverse_kl moves to
+    # 0.6-1.7. It costs a second full-vocabulary log-softmax; leave it to
+    # debugging runs.
+    validate_decomposition: false
+
+loss_fn:
+  # opd_full replaces the policy-gradient objective, so the base recipe's ratio
+  # and importance-sampling knobs have no code path and are rejected at loss
+  # construction (see _validate_opd_full_loss_config in loss_functions.py).
+  use_importance_sampling_correction: false
+  truncated_importance_sampling_type: null
+  use_on_policy_kl_approximation: false
+
+policy:
+  # The payload is per-token, so the base recipe's 32K window would move ~4 GB
+  # per enrichment batch. 8K keeps this inside the top-k sibling's budget.
+  max_total_sequence_length: 8192
+
+checkpointing:
+  checkpoint_dir: results/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab
+
+logger:
+  wandb:
+    name: mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab
+  mlflow:
+    run_name: mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -625,6 +625,19 @@ def setup(
         "grpo.val_num_generations_per_prompt > 1"
     )
 
+    # opd_full is implemented only on the SingleController runtime, which has its
+    # own setup(). This entry point never reads on_policy_distillation.full, so
+    # accepting it would silently train the sampled-token top-k objective while
+    # the user believes they configured the full-vocabulary reverse KL.
+    if opd_module.get_opd_full_config(master_config) is not None:
+        raise ValueError(
+            "on_policy_distillation.full is only implemented on the "
+            "SingleController runtime (examples/run_grpo_single_controller.py). "
+            "This entry point never reads it, so leaving it enabled here would "
+            "silently train the sampled-token top-k objective instead of the "
+            "full-vocabulary reverse KL."
+        )
+
     # Set seed for all random number generators
     set_seed(grpo_config.seed)
 

--- a/nemo_rl/algorithms/loss/interfaces.py
+++ b/nemo_rl/algorithms/loss/interfaces.py
@@ -52,6 +52,7 @@ class MetricNormalizer(enum.Enum):
 class LossInputType(enum.Enum):
     LOGIT = "logit"
     LOGPROB = "logprob"
+    OPD_FULL = "opd_full"
     DISTILLATION = "distillation"
     DISTILLATION_CROSS_TOKENIZER = "distillation_cross_tokenizer"
     DRAFT = "draft"
@@ -97,6 +98,8 @@ class LossFunction(Protocol):
             **kwargs: Loss function input, which varies by input_type:
                 - For LossInputType.LOGPROB: next_token_logprobs (torch.Tensor)
                 - For LossInputType.LOGIT: logits (torch.Tensor)
+                - For LossInputType.OPD_FULL: opd_full_divergence, and optionally
+                  opd_full_entropy / opd_full_cross_entropy (torch.Tensor)
                 - For LossInputType.DISTILLATION: student_topk_logprobs, teacher_topk_logprobs, H_all (torch.Tensor)
                 - For LossInputType.DISTILLATION_CROSS_TOKENIZER: logits (torch.Tensor), teacher_full_logits_by_idx (dict[int, torch.Tensor])
                 - For LossInputType.DRAFT: teacher_logits, student_logits, mask (torch.Tensor)

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -418,7 +418,25 @@ class ClippedPGLossFn(LossFunction):
         opd_full_entropy: Optional[Tensor] = None,
         opd_full_cross_entropy: Optional[Tensor] = None,
     ) -> tuple[torch.Tensor, dict]:
-        """Clipped Policy Gradient RL loss function."""
+        """Clipped Policy Gradient RL loss, or the full-vocabulary MOPD reverse KL.
+
+        Which objective runs is fixed at construction by ``opd_full``.
+
+        Args:
+            next_token_logprobs: Sampled-token log-probabilities ``[B, S - 1]``.
+                Required on the policy-gradient branch; on the ``opd_full``
+                branch only when ``reference_policy_kl_penalty`` is non-zero.
+            data: Microbatch with masks, advantages, and prior log-probabilities.
+            global_valid_seqs: Global valid-sequence count for normalization.
+            global_valid_toks: Global valid-token count for normalization.
+            opd_full_divergence: Per-token reverse KL ``[B, S - 1]``, required on
+                the ``opd_full`` branch.
+            opd_full_entropy: Optional ``sum_v p_s log p_s`` diagnostic.
+            opd_full_cross_entropy: Optional ``-sum_v p_s log p_t`` diagnostic.
+
+        Returns:
+            Tuple of the scalar loss and its metric dict.
+        """
         assert data is not None, "ClippedPGLossFn requires data"
         assert global_valid_seqs is not None, (
             "ClippedPGLossFn requires global_valid_seqs"
@@ -920,12 +938,23 @@ class ClippedPGLossFn(LossFunction):
                     "next_token_logprobs from prepare_loss_input: the penalty must "
                     "be differentiable through the current policy."
                 )
+            # Unlike the exact divergence above, this penalty is sampled, so its
+            # gradient needs the score-function term through the sampling
+            # probability, as in the policy-gradient branch.
+            # exp(x - x.detach()) is 1 in the forward pass and supplies it.
+            kl_importance_weights = torch.nan_to_num(
+                torch.exp(next_token_logprobs - next_token_logprobs.detach()),
+                nan=0.0,
+                posinf=0.0,
+                neginf=0.0,
+            )
             kl = self.reference_policy_kl_penalty * calculate_kl(
                 logprobs=next_token_logprobs,
                 logprobs_reference=data["reference_policy_logprobs"][:, 1:],
                 kl_type=self.reference_policy_kl_type,
                 input_clamp_value=self.kl_input_clamp_value,
                 output_clamp_value=self.kl_output_clamp_value,
+                importance_sampling_weights=kl_importance_weights,
             )
             kl = reduce_like_loss(kl)
 

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, NotRequired, Optional, TypedDict, TypeVar
+import warnings
+from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, TypeVar
 
 import torch
 from pydantic import BaseModel, Field
@@ -48,6 +49,11 @@ from nemo_rl.distributed.model_utils import (
     vocab_parallel_log_softmax,
 )
 from nemo_rl.models.dtensor.parallelize import to_local_if_dtensor
+
+if TYPE_CHECKING:
+    # Import-time only: nemo_rl.algorithms.opd imports the data plane, which
+    # would pull a heavy dependency chain into every loss-function consumer.
+    from nemo_rl.algorithms.opd import OnPolicyDistillationFullConfig
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
@@ -227,13 +233,24 @@ class ClippedPGLossFn(LossFunction):
     input_type = LossInputType.LOGPROB
 
     def __init__(
-        self, cfg: ClippedPGLossConfig, use_fused_linear_logprobs: bool = False
+        self,
+        cfg: ClippedPGLossConfig,
+        use_fused_linear_logprobs: bool = False,
+        opd_full: Optional["OnPolicyDistillationFullConfig"] = None,
     ):
         # When True, the model forward is patched to return precomputed next-token
         # logprobs (via chunked linear CE fusion) instead of full logits. This is
         # consumed by prepare_loss_input, which short-circuits the logits->logprobs
         # conversion. See nemo_rl/distributed/model_utils.py for the fused forward.
         self.use_fused_linear_logprobs = use_fused_linear_logprobs
+        self.opd_full = opd_full if opd_full is not None and opd_full.enabled else None
+        self.input_type = (
+            LossInputType.OPD_FULL
+            if self.opd_full is not None
+            else LossInputType.LOGPROB
+        )
+        if self.opd_full is not None:
+            _validate_opd_full_loss_config(cfg, use_fused_linear_logprobs)
         self.disable_ppo_ratio = cfg.disable_ppo_ratio
         self.ratio_clip_min = cfg.ratio_clip_min
         self.ratio_clip_max = cfg.ratio_clip_max
@@ -371,15 +388,57 @@ class ClippedPGLossFn(LossFunction):
                 if self.truncated_importance_sampling_type == "seq-mask-tis"
                 else MetricNormalizer.TOKENS
             )
+        if self.opd_full is not None:
+            # opd_full returns its own metric set from _opd_full_call; the
+            # policy-gradient diagnostics above are never produced there.
+            self.metric_normalizations = {
+                "loss": grad_normalizer,
+                "kl_penalty": grad_normalizer,
+                "num_valid_samples": MetricNormalizer.NONE,
+                "opd_full_reverse_kl": MetricNormalizer.TOKENS,
+                "opd_full_reverse_kl_min": MetricNormalizer.NONE,
+                "opd_full_reverse_kl_max": MetricNormalizer.NONE,
+            }
+            if self.opd_full.validate_decomposition:
+                self.metric_normalizations.update(
+                    {
+                        "opd_full_entropy": MetricNormalizer.TOKENS,
+                        "opd_full_cross_entropy": MetricNormalizer.TOKENS,
+                        "opd_full_decomposition_error": MetricNormalizer.NONE,
+                    }
+                )
 
     def __call__(
         self,
-        next_token_logprobs: Tensor,
-        data: BatchedDataDict[ClippedPGLossDataDict],
-        global_valid_seqs: torch.Tensor,
-        global_valid_toks: torch.Tensor,
+        next_token_logprobs: Optional[Tensor] = None,
+        data: Optional[BatchedDataDict[ClippedPGLossDataDict]] = None,
+        global_valid_seqs: Optional[torch.Tensor] = None,
+        global_valid_toks: Optional[torch.Tensor] = None,
+        opd_full_divergence: Optional[Tensor] = None,
+        opd_full_entropy: Optional[Tensor] = None,
+        opd_full_cross_entropy: Optional[Tensor] = None,
     ) -> tuple[torch.Tensor, dict]:
         """Clipped Policy Gradient RL loss function."""
+        assert data is not None, "ClippedPGLossFn requires data"
+        assert global_valid_seqs is not None, (
+            "ClippedPGLossFn requires global_valid_seqs"
+        )
+        assert global_valid_toks is not None, (
+            "ClippedPGLossFn requires global_valid_toks"
+        )
+        if self.opd_full is not None:
+            return self._opd_full_call(
+                data=data,
+                global_valid_seqs=global_valid_seqs,
+                global_valid_toks=global_valid_toks,
+                next_token_logprobs=next_token_logprobs,
+                opd_full_divergence=opd_full_divergence,
+                opd_full_entropy=opd_full_entropy,
+                opd_full_cross_entropy=opd_full_cross_entropy,
+            )
+        assert next_token_logprobs is not None, (
+            "ClippedPGLossFn requires next_token_logprobs"
+        )
         curr_logprobs = next_token_logprobs
         token_mask = data["token_mask"][:, 1:]
         sample_mask = data["sample_mask"]
@@ -786,6 +845,234 @@ class ClippedPGLossFn(LossFunction):
                 **_is_filter_metrics,
                 "positive_nll_loss": nll_loss.item(),
             },
+        )
+
+    def _opd_full_call(
+        self,
+        *,
+        data: BatchedDataDict[ClippedPGLossDataDict],
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+        next_token_logprobs: Optional[Tensor],
+        opd_full_divergence: Optional[Tensor],
+        opd_full_entropy: Optional[Tensor],
+        opd_full_cross_entropy: Optional[Tensor],
+    ) -> tuple[torch.Tensor, dict]:
+        """Full-vocabulary MOPD objective: the exact reverse KL is the whole loss.
+
+        ``prepare_loss_input`` reconstructs the teacher distribution and runs the
+        distributed divergence kernel, so this only masks and normalizes. No
+        policy-gradient ratio, advantage, or importance-sampling term applies:
+        the reverse KL is an exact expectation over the student distribution and
+        does not depend on which token was sampled.
+
+        Args:
+            data: Microbatch with ``token_mask`` and ``sample_mask``.
+            global_valid_seqs: Global valid-sequence count for normalization.
+            global_valid_toks: Global valid-token count for normalization.
+            next_token_logprobs: Current-policy sampled-token log-probabilities,
+                only needed when ``reference_policy_kl_penalty`` is non-zero.
+            opd_full_divergence: Per-token reverse KL ``[B, S - 1]``.
+            opd_full_entropy: Optional ``sum_v p_s log p_s`` diagnostic.
+            opd_full_cross_entropy: Optional ``-sum_v p_s log p_t`` diagnostic.
+
+        Returns:
+            Tuple of the scalar loss and its metric dict.
+
+        Raises:
+            ValueError: If the divergence tensor is missing.
+        """
+        if opd_full_divergence is None:
+            raise ValueError(
+                "opd_full requires opd_full_divergence from prepare_loss_input."
+            )
+        token_mask = data["token_mask"][:, 1:]
+        sample_mask = data["sample_mask"]
+        mask = token_mask * sample_mask.unsqueeze(-1)
+
+        def reduce_like_loss(per_token_values: Tensor) -> torch.Tensor:
+            """Reduce a per-token tensor the way the gradient is normalized.
+
+            SEQUENCE_LEVEL averages within each sequence first, so every sequence
+            contributes equally regardless of length; a flat masked_mean against
+            ``global_valid_seqs`` would instead divide a token sum by a sequence
+            count and scale the loss by the mean sequence length.
+            """
+            if self.loss_type == LossType.TOKEN_LEVEL:
+                return masked_mean(
+                    per_token_values,
+                    mask,
+                    global_normalization_factor=global_valid_toks,
+                )
+            return masked_mean(
+                masked_mean(per_token_values, token_mask, dim=-1),
+                sample_mask,
+                global_normalization_factor=global_valid_seqs,
+            )
+
+        actor_loss = reduce_like_loss(opd_full_divergence)
+
+        kl = torch.tensor(0.0, device=actor_loss.device)
+        if self.reference_policy_kl_penalty != 0:
+            if next_token_logprobs is None:
+                raise ValueError(
+                    "opd_full with reference_policy_kl_penalty != 0 requires "
+                    "next_token_logprobs from prepare_loss_input: the penalty must "
+                    "be differentiable through the current policy."
+                )
+            kl = self.reference_policy_kl_penalty * calculate_kl(
+                logprobs=next_token_logprobs,
+                logprobs_reference=data["reference_policy_logprobs"][:, 1:],
+                kl_type=self.reference_policy_kl_type,
+                input_clamp_value=self.kl_input_clamp_value,
+                output_clamp_value=self.kl_output_clamp_value,
+            )
+            kl = reduce_like_loss(kl)
+
+        loss = actor_loss + kl
+
+        with torch.no_grad():
+            masked_divergence = opd_full_divergence.detach()[mask.bool()]
+            # Token-normalized diagnostics use global_valid_toks regardless of
+            # loss_type, matching their declared MetricNormalizer.TOKENS.
+            reverse_kl_metric = masked_mean(
+                opd_full_divergence.detach(),
+                mask,
+                global_normalization_factor=global_valid_toks,
+            )
+            metrics: dict[str, Any] = {
+                "loss": loss.item(),
+                # Report the raw KL, undoing the coefficient. Guard on the
+                # coefficient: `kl` is 0-dim, so its `numel()` is always 1 and
+                # cannot stand in for "the penalty is active".
+                "kl_penalty": (
+                    kl.item() / self.reference_policy_kl_penalty
+                    if self.reference_policy_kl_penalty
+                    else 0
+                ),
+                "num_valid_samples": sample_mask.sum().item(),
+                "opd_full_reverse_kl": reverse_kl_metric.item(),
+                "opd_full_reverse_kl_min": (
+                    masked_divergence.min().item()
+                    if masked_divergence.numel() > 0
+                    else float("inf")
+                ),
+                "opd_full_reverse_kl_max": (
+                    masked_divergence.max().item()
+                    if masked_divergence.numel() > 0
+                    else float("-inf")
+                ),
+            }
+            if (
+                opd_full_entropy is not None
+                and opd_full_cross_entropy is not None
+                and self.opd_full is not None
+                and self.opd_full.validate_decomposition
+            ):
+                # reverse_kl == sum_v p_s log p_s + (-sum_v p_s log p_t)
+                decomposition = (
+                    opd_full_entropy.detach() + opd_full_cross_entropy.detach()
+                )
+                metrics["opd_full_entropy"] = masked_mean(
+                    -opd_full_entropy.detach(),
+                    mask,
+                    global_normalization_factor=global_valid_toks,
+                ).item()
+                metrics["opd_full_cross_entropy"] = masked_mean(
+                    opd_full_cross_entropy.detach(),
+                    mask,
+                    global_normalization_factor=global_valid_toks,
+                ).item()
+                metrics["opd_full_decomposition_error"] = (
+                    (decomposition - opd_full_divergence.detach())
+                    .abs()
+                    .mul(mask)
+                    .max()
+                    .item()
+                )
+
+        return loss, metrics
+
+
+def _validate_opd_full_loss_config(
+    cfg: ClippedPGLossConfig, use_fused_linear_logprobs: bool
+) -> None:
+    """Reject loss knobs that have no code path under the full-vocabulary objective.
+
+    ``opd_full`` replaces the whole policy-gradient objective with an exact
+    reverse KL, so the ratio, CISPO, and importance-sampling machinery is dead
+    code on that branch. Erroring out beats silently ignoring user config.
+
+    Args:
+        cfg: The clipped-PG loss config supplied by the user.
+        use_fused_linear_logprobs: Whether the fused linear-CE forward is on.
+
+    Raises:
+        ValueError: If any incompatible option is set.
+    """
+    if use_fused_linear_logprobs:
+        raise ValueError(
+            "opd_full is incompatible with use_fused_linear_logprobs: the fused "
+            "forward returns precomputed logprobs, but the full-vocabulary "
+            "reverse KL needs the raw vocabulary-parallel logits."
+        )
+
+    # Policy-gradient ratio machinery: no ratio exists under opd_full.
+    if not cfg.disable_ppo_ratio:
+        raise ValueError("opd_full requires loss_fn.disable_ppo_ratio=true.")
+    if cfg.ratio_clip_c is not None:
+        raise ValueError("opd_full is incompatible with dual PPO clipping.")
+    if cfg.use_cispo:
+        raise ValueError("opd_full is incompatible with CISPO.")
+    if cfg.force_on_policy_ratio:
+        raise ValueError("opd_full is incompatible with force_on_policy_ratio.")
+    if cfg.use_on_policy_kl_approximation:
+        raise ValueError(
+            "opd_full is incompatible with use_on_policy_kl_approximation: it "
+            "reweights the reference-KL term by a generation-to-current ratio "
+            "that only the policy-gradient branch computes. The opd_full branch "
+            "never reads it, so leaving it on would be silently ignored."
+        )
+    if cfg.sequence_level_importance_ratios:
+        raise ValueError(
+            "opd_full is incompatible with sequence_level_importance_ratios."
+        )
+
+    # Importance-sampling machinery: the reverse KL is an exact expectation over
+    # the student distribution, so no sampling-distribution correction applies.
+    if cfg.use_importance_sampling_correction:
+        raise ValueError(
+            "opd_full is incompatible with use_importance_sampling_correction: the "
+            "full-vocabulary reverse KL is an exact expectation and carries no "
+            "sampled-token score-function term to correct."
+        )
+    if cfg.truncated_importance_sampling_type is not None:
+        raise ValueError(
+            "opd_full is incompatible with truncated_importance_sampling_type."
+        )
+
+    # Advantage/reward-shaped terms: opd_full never reads advantages or rewards.
+    if cfg.positive_example_nll_weight != 0:
+        raise ValueError(
+            "opd_full is incompatible with a non-zero positive_example_nll_weight."
+        )
+
+    if cfg.use_kl_in_reward:
+        raise ValueError(
+            "opd_full is incompatible with use_kl_in_reward: it routes the "
+            "reference KL through the reward, which reaches the objective only "
+            "via advantages, and opd_full ignores advantages entirely. It also "
+            "zeroes the loss-side reference_policy_kl_penalty, so the penalty "
+            "would be dropped on both paths. Set use_kl_in_reward=false; the "
+            "loss-side penalty is applied directly."
+        )
+
+    if cfg.reference_policy_kl_penalty != 0:
+        warnings.warn(
+            "opd_full is already a KL objective against the teacher; "
+            "reference_policy_kl_penalty adds a second KL against the frozen "
+            "reference policy on top of it.",
+            stacklevel=3,
         )
 
 

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -159,9 +159,10 @@ def reconstruct_opd_full_teacher_logits(
         ValueError: If the payload and student shard cannot be aligned, or if the
             hidden-state path is used without a teacher LM-head shard.
     """
-    payload = payload.to(device=student_logits.device)
     vocab_shard_size = int(student_logits.shape[-1])
 
+    # Every narrowing below happens before the device copy, and before the
+    # hidden-state path widens the payload to the vocabulary.
     if teacher_payload == "hidden_states":
         if teacher_output_layer_weight is None:
             raise ValueError(
@@ -174,10 +175,6 @@ def reconstruct_opd_full_teacher_logits(
                 f"payload width {payload.shape[-1]} vs LM-head input width "
                 f"{teacher_output_layer_weight.shape[1]}."
             )
-        teacher_logits = torch.matmul(
-            payload.to(dtype=teacher_output_layer_weight.dtype),
-            teacher_output_layer_weight.t(),
-        )
     else:
         assert vocab_parallel_rank is not None, (
             "vocab_parallel_rank is required to slice the opd_full logits payload"
@@ -190,32 +187,50 @@ def reconstruct_opd_full_teacher_logits(
                 f"window: payload width {payload.shape[-1]} vs required "
                 f"{vocab_end_index}."
             )
-        teacher_logits = payload[..., vocab_start_index:vocab_end_index]
+        payload = payload[..., vocab_start_index:vocab_end_index]
 
-    if int(teacher_logits.shape[-1]) != vocab_shard_size:
-        raise ValueError(
-            "Reconstructed teacher logits must match the student vocabulary shard "
-            f"width; got {teacher_logits.shape[-1]} vs {vocab_shard_size}."
-        )
-
+    # Narrow to this rank's sequence window *before* the payload is widened to
+    # the vocabulary. Projecting first would do cp_size times the matmul and
+    # allocate a full-sequence [B, S, V_local] tensor that the divergence
+    # kernel's chunking cannot bound.
     cp_size = (
         1
         if context_parallel_group is None
         else torch.distributed.get_world_size(context_parallel_group)
     )
     target_seq_len = int(student_logits.shape[1]) * cp_size
-    pad_len = target_seq_len - int(teacher_logits.shape[1])
+    pad_len = target_seq_len - int(payload.shape[1])
     if pad_len < 0:
         raise ValueError(
             "Teacher payload is longer than the student forward window: "
-            f"{teacher_logits.shape[1]} vs {target_seq_len}."
+            f"{payload.shape[1]} vs {target_seq_len}."
         )
     if pad_len > 0:
-        teacher_logits = torch.nn.functional.pad(teacher_logits, (0, 0, 0, pad_len))
+        # Zero-padding survives the projection (the LM head has no bias), so the
+        # padded positions carry the same uniform logits either way. They are
+        # masked out downstream regardless.
+        payload = torch.nn.functional.pad(payload, (0, 0, 0, pad_len))
     if cp_size > 1:
         cp_rank = torch.distributed.get_rank(context_parallel_group)
-        teacher_logits = _get_tokens_on_this_cp_rank(
-            teacher_logits, cp_rank, cp_size, seq_dim=1
+        payload = _get_tokens_on_this_cp_rank(payload, cp_rank, cp_size, seq_dim=1)
+
+    # contiguous() before the copy: the vocabulary slice above is a view, and the
+    # result is handed to save_for_backward. Without it the whole-vocabulary
+    # payload storage stays resident on the device until backward completes.
+    payload = payload.contiguous().to(device=student_logits.device)
+
+    if teacher_payload == "hidden_states":
+        teacher_logits = torch.matmul(
+            payload.to(dtype=teacher_output_layer_weight.dtype),  # type: ignore[union-attr]
+            teacher_output_layer_weight.t(),  # type: ignore[union-attr]
+        )
+    else:
+        teacher_logits = payload
+
+    if int(teacher_logits.shape[-1]) != vocab_shard_size:
+        raise ValueError(
+            "Reconstructed teacher logits must match the student vocabulary shard "
+            f"width; got {teacher_logits.shape[-1]} vs {vocab_shard_size}."
         )
     return teacher_logits
 

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -27,7 +27,11 @@ from nemo_rl.algorithms.x_token.loss_utils import (
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedCrossEntropyToFixedLogits,
+    ChunkedDistributedEntropy,
+    ChunkedDistributedReverseKLToFixedLogits,
     _get_tokens_on_this_cp_rank,
+    allgather_cp_sharded_tensor,
     from_parallel_logits_to_logprobs_packed_sequences,
     get_cp_sharded_next_token_logprobs,
     get_distillation_topk_logprobs_from_logits,
@@ -123,6 +127,234 @@ def pack_rolled_draft_token_mask(
     return roll_packed_seq_dim(packed, cu_seqlens_padded, seq_dim=1)
 
 
+def reconstruct_opd_full_teacher_logits(
+    payload: torch.Tensor,
+    *,
+    teacher_payload: str,
+    student_logits: torch.Tensor,
+    vocab_parallel_rank: Optional[int],
+    context_parallel_group: Optional[torch.distributed.ProcessGroup],
+    teacher_output_layer_weight: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Turn the transported teacher payload into this rank's teacher logit shard.
+
+    The payload is canonical ``[B, S, D]`` (already TP/CP-gathered on the teacher
+    side), so it is re-sharded onto the student's own CP window here, exactly as
+    ``from_parallel_logits_to_logprobs`` does for the student logits.
+
+    Args:
+        payload: Teacher payload ``[B, S, D]`` -- hidden states or full logits.
+        teacher_payload: ``"hidden_states"`` or ``"logits"``.
+        student_logits: Student logits ``[B, S_local, V_local]``, used for the
+            target device, dtype-independent shapes, and CP geometry.
+        vocab_parallel_rank: This rank's vocabulary-parallel rank.
+        context_parallel_group: Context-parallel process group, if any.
+        teacher_output_layer_weight: ``[V_local, H_teacher]`` teacher LM-head
+            shard; required for the hidden-state path.
+
+    Returns:
+        Teacher logits ``[B, S_local, V_local]`` aligned with ``student_logits``.
+
+    Raises:
+        ValueError: If the payload and student shard cannot be aligned, or if the
+            hidden-state path is used without a teacher LM-head shard.
+    """
+    payload = payload.to(device=student_logits.device)
+    vocab_shard_size = int(student_logits.shape[-1])
+
+    if teacher_payload == "hidden_states":
+        if teacher_output_layer_weight is None:
+            raise ValueError(
+                "opd_full hidden-state reconstruction requires a loaded teacher "
+                "output-layer weight shard on the training worker."
+            )
+        if int(payload.shape[-1]) != int(teacher_output_layer_weight.shape[1]):
+            raise ValueError(
+                "Teacher hidden states do not match the loaded teacher LM head: "
+                f"payload width {payload.shape[-1]} vs LM-head input width "
+                f"{teacher_output_layer_weight.shape[1]}."
+            )
+        teacher_logits = torch.matmul(
+            payload.to(dtype=teacher_output_layer_weight.dtype),
+            teacher_output_layer_weight.t(),
+        )
+    else:
+        assert vocab_parallel_rank is not None, (
+            "vocab_parallel_rank is required to slice the opd_full logits payload"
+        )
+        vocab_start_index = vocab_parallel_rank * vocab_shard_size
+        vocab_end_index = vocab_start_index + vocab_shard_size
+        if int(payload.shape[-1]) < vocab_end_index:
+            raise ValueError(
+                "Teacher logits payload is narrower than this rank's vocabulary "
+                f"window: payload width {payload.shape[-1]} vs required "
+                f"{vocab_end_index}."
+            )
+        teacher_logits = payload[..., vocab_start_index:vocab_end_index]
+
+    if int(teacher_logits.shape[-1]) != vocab_shard_size:
+        raise ValueError(
+            "Reconstructed teacher logits must match the student vocabulary shard "
+            f"width; got {teacher_logits.shape[-1]} vs {vocab_shard_size}."
+        )
+
+    cp_size = (
+        1
+        if context_parallel_group is None
+        else torch.distributed.get_world_size(context_parallel_group)
+    )
+    target_seq_len = int(student_logits.shape[1]) * cp_size
+    pad_len = target_seq_len - int(teacher_logits.shape[1])
+    if pad_len < 0:
+        raise ValueError(
+            "Teacher payload is longer than the student forward window: "
+            f"{teacher_logits.shape[1]} vs {target_seq_len}."
+        )
+    if pad_len > 0:
+        teacher_logits = torch.nn.functional.pad(teacher_logits, (0, 0, 0, pad_len))
+    if cp_size > 1:
+        cp_rank = torch.distributed.get_rank(context_parallel_group)
+        teacher_logits = _get_tokens_on_this_cp_rank(
+            teacher_logits, cp_rank, cp_size, seq_dim=1
+        )
+    return teacher_logits
+
+
+def prepare_opd_full_loss_input(
+    logits: torch.Tensor,
+    data: BatchedDataDict[Any],
+    loss_fn: LossFunction,
+    *,
+    vocab_parallel_rank: Optional[int],
+    vocab_parallel_group: Optional[torch.distributed.ProcessGroup],
+    context_parallel_group: Optional[torch.distributed.ProcessGroup],
+    sampling_params: Optional[TrainingSamplingParams],
+    chunk_size: Optional[int],
+    teacher_output_layer_weight: Optional[torch.Tensor],
+) -> dict[str, Any]:
+    """Build the full-vocabulary MOPD loss input from student logits + teacher payload.
+
+    Runs the distributed reverse-KL kernel here rather than inside the loss so the
+    loss stays free of process-group plumbing, mirroring the DISTILLATION branch.
+
+    Args:
+        logits: Student vocabulary-parallel logits ``[B, S_local, V_local]``.
+        data: Microbatch carrying the teacher payload column.
+        loss_fn: The ``opd_full``-configured loss function.
+        vocab_parallel_rank: Vocabulary-parallel rank.
+        vocab_parallel_group: Vocabulary-parallel process group.
+        context_parallel_group: Context-parallel process group.
+        sampling_params: Training sampling params for the sampled-token logprobs.
+        chunk_size: Sequence-dim chunk size for the sampled-token logprobs.
+        teacher_output_layer_weight: Teacher LM-head shard for the hidden path.
+
+    Returns:
+        Loss input dict with the per-token divergence and, when requested, the
+        entropy/cross-entropy decomposition.
+
+    Raises:
+        ValueError: If the teacher payload column is missing.
+        NotImplementedError: If no vocabulary-parallel group is available.
+    """
+    # Deferred: nemo_rl.algorithms.opd imports the data plane (tensordict), which
+    # should not be pulled into every loss-function consumer.
+    from nemo_rl.algorithms.opd import opd_full_payload_field
+
+    full_cfg = loss_fn.opd_full  # type: ignore[attr-defined]
+    if vocab_parallel_group is None:
+        raise NotImplementedError(
+            "opd_full currently requires the Megatron vocabulary-parallel path; "
+            "the DTensor-only logit path is not supported."
+        )
+
+    payload_field = opd_full_payload_field(full_cfg)
+    if payload_field not in data:
+        raise ValueError(
+            f"opd_full requires the teacher payload column {payload_field!r} in "
+            "the training microbatch."
+        )
+
+    teacher_logits = reconstruct_opd_full_teacher_logits(
+        data[payload_field],
+        teacher_payload=full_cfg.teacher_payload,
+        student_logits=logits,
+        vocab_parallel_rank=vocab_parallel_rank,
+        context_parallel_group=context_parallel_group,
+        teacher_output_layer_weight=teacher_output_layer_weight,
+    ).detach()
+
+    divergence_chunk_size = full_cfg.chunk_size or int(logits.shape[1])
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(  # type: ignore[misc]
+        logits,
+        teacher_logits,
+        divergence_chunk_size,
+        vocab_parallel_group,
+        False,
+    )
+    entropy = None
+    cross_entropy = None
+    if full_cfg.validate_decomposition:
+        # inference_only: both are read detached for metrics only, so there is no
+        # reason to save their inputs for a backward that never runs.
+        entropy = ChunkedDistributedEntropy.apply(  # type: ignore[misc]
+            logits,
+            divergence_chunk_size,
+            vocab_parallel_group,
+            True,
+        )
+        cross_entropy = ChunkedDistributedCrossEntropyToFixedLogits.apply(  # type: ignore[misc]
+            logits,
+            teacher_logits,
+            divergence_chunk_size,
+            vocab_parallel_group,
+            True,
+        )
+
+    if context_parallel_group is not None and (
+        torch.distributed.get_world_size(context_parallel_group) > 1
+    ):
+        reverse_kl = allgather_cp_sharded_tensor(
+            reverse_kl, context_parallel_group, seq_dim=1
+        )
+        if entropy is not None:
+            entropy = allgather_cp_sharded_tensor(
+                entropy, context_parallel_group, seq_dim=1
+            )
+        if cross_entropy is not None:
+            cross_entropy = allgather_cp_sharded_tensor(
+                cross_entropy, context_parallel_group, seq_dim=1
+            )
+
+    # Position t predicts token t+1 on both sides, so dropping the last position
+    # matches the LOGPROB convention that pairs with token_mask[:, 1:].
+    next_token_width = int(data["input_ids"].shape[1]) - 1
+    loss_input: dict[str, Any] = {
+        "opd_full_divergence": reverse_kl[:, :next_token_width],
+        "opd_full_entropy": None if entropy is None else entropy[:, :next_token_width],
+        "opd_full_cross_entropy": (
+            None if cross_entropy is None else cross_entropy[:, :next_token_width]
+        ),
+    }
+    if getattr(loss_fn, "reference_policy_kl_penalty", 0) != 0:
+        # Unfiltered: this is consumed only by the reference-KL term, and
+        # calculate_kl cannot take -inf. Under top-k/top-p a sampled token
+        # outside the kept set would give logprob -inf, hence logr +inf, hence
+        # a NaN k3 estimate that masked_mean then spreads over the whole step.
+        # The LOGPROB branch keeps a separate unfiltered copy for the same
+        # reason; opd_full has no filtered consumer, so it just asks for one.
+        loss_input["next_token_logprobs"] = get_next_token_logprobs_from_logits(
+            input_ids=data["input_ids"],
+            next_token_logits=logits,
+            seq_index=data.get("seq_index", None),
+            vocab_parallel_rank=vocab_parallel_rank,
+            vocab_parallel_group=vocab_parallel_group,
+            context_parallel_group=context_parallel_group,
+            sampling_params=None,
+            chunk_size=chunk_size,
+        )
+    return loss_input
+
+
 def prepare_loss_input(
     logits: torch.Tensor,
     data: BatchedDataDict[Any],
@@ -134,6 +366,7 @@ def prepare_loss_input(
     d2t: Optional[torch.Tensor] = None,
     chunk_size: Optional[int] = None,
     cp_sharder: Optional["ContextParallelSharder"] = None,
+    teacher_output_layer_weight: Optional[torch.Tensor] = None,
 ) -> tuple[dict[str, Any], BatchedDataDict[Any]]:
     """Prepare loss input for a loss function.
 
@@ -152,11 +385,15 @@ def prepare_loss_input(
         cp_sharder: Automodel ``ContextParallelSharder`` owning this forward's
             sequence layout (V2 automodel worker with cp_size > 1); ``logits``
             are then this rank's CP-local shard while ``data`` stays canonical.
+        teacher_output_layer_weight: This TP rank's ``[V_local, H_teacher]``
+            teacher LM-head shard, used by the ``opd_full`` hidden-state path to
+            project the teacher payload into teacher logits.
 
     Notes:
         vocab_parallel_rank, vocab_parallel_group, context_parallel_group are only used for megatron policy worker.
         sampling_params is only used for LossInputType.LOGPROB, and currently only supported for ClippedPGLossFn.
         d2t is only used for LossInputType.DRAFT.
+        teacher_output_layer_weight is only used for LossInputType.OPD_FULL.
 
     Returns:
         tuple(loss_input, maybe_updated_data)
@@ -213,6 +450,19 @@ def prepare_loss_input(
                 )
 
         loss_input = {"next_token_logprobs": logprobs}
+
+    elif loss_fn.input_type == LossInputType.OPD_FULL:
+        loss_input = prepare_opd_full_loss_input(
+            logits,
+            data,
+            loss_fn,
+            vocab_parallel_rank=vocab_parallel_rank,
+            vocab_parallel_group=vocab_parallel_group,
+            context_parallel_group=context_parallel_group,
+            sampling_params=sampling_params,
+            chunk_size=chunk_size,
+            teacher_output_layer_weight=teacher_output_layer_weight,
+        )
 
     elif loss_fn.input_type == LossInputType.DISTILLATION:
         calculate_entropy = loss_fn.zero_outside_topk and loss_fn.kl_type != "forward"

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -24,6 +24,25 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
+# Metrics combined across the sequences of one packed bin by extremum, not sum.
+# Keep in sync with _MB_METRIC_MIN / _MB_METRIC_MAX in
+# single_controller_utils/utils.py, grpo.py, grpo_sync.py and ppo.py.
+#
+# TODO: duplicated across seven sites. Omitting one silently sums extrema instead
+# of reducing them, reporting a "min" larger than any individual value. Hoist
+# into a single shared definition in loss/interfaces.py.
+_SEQ_METRIC_MIN: frozenset[str] = frozenset(
+    {"probs_ratio_min", "probs_ratio_clamped_min", "opd_full_reverse_kl_min"}
+)
+_SEQ_METRIC_MAX: frozenset[str] = frozenset(
+    {
+        "probs_ratio_max",
+        "probs_ratio_clamped_max",
+        "opd_full_reverse_kl_max",
+        "opd_full_decomposition_error",
+    }
+)
+
 
 class SequencePackingLossWrapper:
     def __init__(
@@ -144,9 +163,9 @@ class SequencePackingLossWrapper:
             loss_accum += loss
             for k, v in metrics.items():
                 if k not in metrics_accum:
-                    if k in {"probs_ratio_min", "probs_ratio_clamped_min"}:
+                    if k in _SEQ_METRIC_MIN:
                         metrics_accum[k] = float("inf")
-                    elif k in {"probs_ratio_max", "probs_ratio_clamped_max"}:
+                    elif k in _SEQ_METRIC_MAX:
                         metrics_accum[k] = float("-inf")
                     else:
                         metrics_accum[k] = 0
@@ -154,10 +173,10 @@ class SequencePackingLossWrapper:
                 val = v.item() if isinstance(v, torch.Tensor) and v.ndim == 0 else v
 
                 # Skip inf/-inf sentinel values (from sequences with no valid tokens)
-                if k in {"probs_ratio_min", "probs_ratio_clamped_min"}:
+                if k in _SEQ_METRIC_MIN:
                     if not math.isinf(val):
                         metrics_accum[k] = min(metrics_accum[k], val)
-                elif k in {"probs_ratio_max", "probs_ratio_clamped_max"}:
+                elif k in _SEQ_METRIC_MAX:
                     if not math.isinf(val):
                         metrics_accum[k] = max(metrics_accum[k], val)
                 else:

--- a/nemo_rl/algorithms/opd.py
+++ b/nemo_rl/algorithms/opd.py
@@ -24,15 +24,19 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import ray
 import torch
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from nemo_rl.data_plane.column_io import read_columns, write_columns
 from nemo_rl.data_plane.interfaces import DataPlaneClient, KVBatchMeta
-from nemo_rl.data_plane.schema import TEACHER_LP_FIELDS
+from nemo_rl.data_plane.schema import (
+    OPD_FULL_HIDDEN_STATES_FIELD,
+    OPD_FULL_LOGITS_FIELD,
+    TEACHER_LP_FIELDS,
+)
 from nemo_rl.distributed.virtual_cluster import (
     RayVirtualCluster,
     prepare_segment_topology,
@@ -72,6 +76,51 @@ class NonColocatedTeachersConfig(BaseModel, extra="allow"):
     teacher_overrides: dict[str, TeacherResourceConfig] = Field(default_factory=dict)
 
 
+class OnPolicyDistillationFullConfig(BaseModel, extra="allow"):
+    """Full-vocabulary MOPD (``opd_full``).
+
+    The student matches the teacher's entire next-token distribution through an
+    exact reverse KL instead of the sampled-token log-probability gap -- the
+    K=V limit of the top-k estimator, with no score-function tail term.
+
+    The policy-gradient knobs on ``ClippedPGLossConfig`` (ratio clipping, CISPO,
+    importance-sampling correction, truncated IS) have no code path here and are
+    rejected at construction. The OPD advantage estimator still runs: its output
+    is unused, but ``advantages`` is a required training column.
+    """
+
+    enabled: bool = False
+    # "hidden_states": teacher ships pre-LM-head hidden states, student projects
+    #   them with an LM-head shard from the teacher checkpoint. `hidden_size`
+    #   wide, so teacher/student parallelism stay decoupled. Production path.
+    # "logits": teacher ships full-vocabulary logits, no student-side LM head.
+    #   `vocab_size` wide (~74x larger at 2k hidden / 152k vocab), so this is a
+    #   numerical reference and fallback, not a production configuration.
+    teacher_payload: Literal["hidden_states", "logits"] = "hidden_states"
+    divergence: Literal["reverse_kl"] = "reverse_kl"
+    payload_dtype: Literal["bfloat16", "float16", "float32"] = "bfloat16"
+    # Sequence-dimension chunk for the distributed divergence kernels, bounding
+    # the live fp32 vocabulary working set. None processes the sequence at once.
+    chunk_size: Optional[int] = None
+    # Student-side cache policy for the teacher LM-head shard (hidden path only).
+    #   none    -- keep resident on GPU for the whole run
+    #   offload -- park on CPU between train steps, stage back in per step
+    #   evict   -- free after every train step and reload from the checkpoint
+    teacher_lm_head_lifecycle: Literal["none", "offload", "evict"] = "offload"
+    # Report the entropy/cross-entropy residual against the reverse KL. Roughly
+    # doubles the divergence cost; diagnostics only.
+    validate_decomposition: bool = False
+
+    @model_validator(mode="after")
+    def validate_positive_sizes(self) -> "OnPolicyDistillationFullConfig":
+        """Reject a chunk size that would make the divergence kernels useless."""
+        if self.chunk_size is not None and self.chunk_size < 1:
+            raise ValueError(
+                f"on_policy_distillation.full.chunk_size must be >= 1, got {self.chunk_size}."
+            )
+        return self
+
+
 class OnPolicyDistillationConfig(BaseModel, extra="allow"):
     """User-facing config for the top-level ``on_policy_distillation`` block."""
 
@@ -81,6 +130,7 @@ class OnPolicyDistillationConfig(BaseModel, extra="allow"):
     strict_agent_name_match: bool = False
     deduplicate_shared_teacher_checkpoints: bool = True
     non_colocated_teachers: Optional[NonColocatedTeachersConfig] = None
+    full: Optional[OnPolicyDistillationFullConfig] = None
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +168,34 @@ def is_non_colocated_teachers_enabled(master_config: Any) -> bool:
     return bool(
         _opd_cfg(master_config).get("non_colocated_teachers", {}).get("enabled", False)
     )
+
+
+def get_opd_full_config(master_config: Any) -> Optional[OnPolicyDistillationFullConfig]:
+    """Return the validated ``opd_full`` sub-config when the feature is enabled.
+
+    Args:
+        master_config: Full training configuration, a plain dict, or any object
+            without the field (non-OPD recipes).
+
+    Returns:
+        The full-vocabulary config when both OPD and ``full.enabled`` are on,
+        otherwise ``None``.
+    """
+    if not is_opd_enabled(master_config):
+        return None
+    full_cfg = _opd_cfg(master_config).get("full")
+    if full_cfg is None:
+        return None
+    if not isinstance(full_cfg, OnPolicyDistillationFullConfig):
+        full_cfg = OnPolicyDistillationFullConfig(**full_cfg)
+    return full_cfg if full_cfg.enabled else None
+
+
+def opd_full_payload_field(full_cfg: OnPolicyDistillationFullConfig) -> str:
+    """Return the data-plane column name carrying this run's teacher payload."""
+    if full_cfg.teacher_payload == "hidden_states":
+        return OPD_FULL_HIDDEN_STATES_FIELD
+    return OPD_FULL_LOGITS_FIELD
 
 
 def _skip_prev_logprobs(master_config: Any) -> bool:
@@ -239,6 +317,15 @@ class TQTeacherLogprobCoordinator:
         self._teacher_worker_groups = dict(teacher_worker_groups)
         self._alias_to_group_alias = dict(alias_to_group_alias)
         self._opd_cfg = dict(on_policy_distillation_cfg)
+        # Set when full-vocabulary MOPD is on: the teacher then writes a second,
+        # per-token payload column the training fetch must also see.
+        full_cfg = self._opd_cfg.get("full")
+        self._opd_full_field: Optional[str] = (
+            opd_full_payload_field(OnPolicyDistillationFullConfig(**full_cfg))
+            if full_cfg and full_cfg.get("enabled")
+            else None
+        )
+        self._teacher_full_payload_tokens = 0
         # Physical (deduplicated) groups own locks, not routing aliases. Two
         # aliases sharing one checkpoint therefore share one collective FIFO.
         self._teacher_locks = {
@@ -407,6 +494,10 @@ class TQTeacherLogprobCoordinator:
         self._teacher_logprob_time_s += total_time_s
         self._teacher_inference_time_s += inference_time_s
         self._teacher_lock_wait_time_s += lock_wait_s
+        if self._opd_full_field is not None:
+            self._teacher_full_payload_tokens += meta.size * max(
+                meta.sequence_lengths or [0]
+            )
         self._aliases_seen.add(alias)
         print(
             f"[teacher_logprob] group={group_alias} samples={meta.size} "
@@ -414,7 +505,10 @@ class TQTeacherLogprobCoordinator:
             f"total={total_time_s:.2f}s",
             flush=True,
         )
-        return meta.with_fields([self.teacher_logprobs_field])
+        enriched_fields = [self.teacher_logprobs_field]
+        if self._opd_full_field is not None:
+            enriched_fields.append(self._opd_full_field)
+        return meta.with_fields(enriched_fields)
 
     def drain_metrics(self) -> dict[str, float]:
         """Return and reset teacher activity accumulated since the last drain."""
@@ -425,6 +519,12 @@ class TQTeacherLogprobCoordinator:
             "on_policy_distillation/teacher_inference_time_s": self._teacher_inference_time_s,
             "on_policy_distillation/teacher_lock_wait_time_s": self._teacher_lock_wait_time_s,
         }
+        if self._opd_full_field is not None:
+            # Tokens, not bytes: the coordinator does not know the payload width.
+            # For bytes, multiply by hidden_size (or vocab_size) x dtype itemsize.
+            metrics["on_policy_distillation/teacher_full_payload_tokens"] = float(
+                self._teacher_full_payload_tokens
+            )
         if self._teacher_batches:
             # Cardinality describes what ran. On an idle step, zero reads as
             # "zero teacher models" rather than "no teacher activity."
@@ -439,6 +539,7 @@ class TQTeacherLogprobCoordinator:
         self._teacher_logprob_time_s = 0.0
         self._teacher_inference_time_s = 0.0
         self._teacher_lock_wait_time_s = 0.0
+        self._teacher_full_payload_tokens = 0
         self._aliases_seen.clear()
         return metrics
 

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -18,7 +18,7 @@ import math
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional, cast
 
 from pydantic import (
     BaseModel,
@@ -59,7 +59,7 @@ from nemo_rl.distributed.virtual_cluster import (
 )
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym
 from nemo_rl.experience.rollout_recovery import RecoveryGranularity
-from nemo_rl.models.policy import PolicyConfig
+from nemo_rl.models.policy import MegatronConfig, PolicyConfig
 from nemo_rl.models.value import ValueConfig
 from nemo_rl.utils.checkpoint import CheckpointingConfig
 
@@ -849,6 +849,111 @@ def validate_sampler_buffer_capacity(
         )
 
 
+def _validate_opd_full_config(
+    master_config: MasterConfig, opd_config: OnPolicyDistillationConfig
+) -> None:
+    """Validate the full-vocabulary MOPD block against the rest of the run.
+
+    Args:
+        master_config: Full SingleController config, already known to have OPD on.
+        opd_config: The resolved ``on_policy_distillation`` block.
+
+    Raises:
+        ValueError: If ``opd_full`` is enabled with an unsupported backend, an
+            incompatible logprob path, a fused packing path that never reaches
+            the opd_full branch, more than one teacher checkpoint, a student
+            pipeline-parallel size the teacher LM-head load cannot support, or a
+            sampling temperature the hidden-state payload cannot honor.
+    """
+    full_cfg = opd_module.get_opd_full_config(master_config)
+    if full_cfg is None:
+        return
+
+    policy_config = master_config.policy
+    if not policy_config.get("megatron_cfg", {}).get("enabled", False):
+        raise ValueError(
+            "on_policy_distillation.full requires the Megatron backend: the "
+            "teacher payload and the distributed reverse-KL kernels both run on "
+            "the vocabulary-parallel logit path."
+        )
+    # Narrowed by the check above: megatron_cfg.enabled true means this is a
+    # MegatronConfig, so its parallelism fields can be read directly.
+    megatron_cfg = cast(MegatronConfig, policy_config["megatron_cfg"])
+    if megatron_cfg.get("use_fused_linear_logprobs", False):
+        raise ValueError(
+            "on_policy_distillation.full is incompatible with "
+            "megatron_cfg.use_fused_linear_logprobs: the fused forward bypasses "
+            "output_layer, so the teacher hidden-state hook never fires and the "
+            "student never exposes full-vocabulary logits."
+        )
+
+    sequence_packing_config = policy_config.get("sequence_packing", {})
+    if sequence_packing_config.get("enabled", False) and sequence_packing_config.get(
+        "fuse_loss", False
+    ):
+        raise ValueError(
+            "on_policy_distillation.full is incompatible with "
+            "policy.sequence_packing.fuse_loss: the fused packing path routes "
+            "through prepare_packed_loss_input, which only supports "
+            "LossInputType.LOGPROB and never reaches the opd_full branch. "
+            "Without this check the run fails inside the first training forward, "
+            "after the whole cluster and every teacher have already come up. "
+            "Set sequence_packing.fuse_loss=false."
+        )
+
+    unique_teacher_checkpoints = sorted(
+        set(opd_config.teacher_model_by_agent_name.values())
+    )
+    if len(unique_teacher_checkpoints) != 1:
+        raise ValueError(
+            "on_policy_distillation.full currently supports exactly one unique "
+            f"teacher checkpoint, got {len(unique_teacher_checkpoints)}: "
+            f"{unique_teacher_checkpoints}. Multi-teacher full-vocabulary "
+            "distillation needs one LM head and one payload column per teacher."
+        )
+
+    if (
+        full_cfg.teacher_payload == "hidden_states"
+        and megatron_cfg["pipeline_model_parallel_size"] > 1
+    ):
+        raise ValueError(
+            "on_policy_distillation.full.teacher_payload='hidden_states' does not "
+            "support policy.megatron_cfg.pipeline_model_parallel_size > 1 yet. "
+            "Megatron builds output_layer only on the last pipeline stage, but the "
+            "teacher LM head is loaded through a collective that spans the whole "
+            "student world, so earlier stages would fail while the last stage hangs "
+            "in that collective. Use pipeline_model_parallel_size=1, or "
+            "teacher_payload='logits', which needs no teacher LM head."
+        )
+
+    generation_config = policy_config.get("generation")
+    temperature = (
+        1.0 if generation_config is None else generation_config.get("temperature", 1.0)
+    )
+    if full_cfg.teacher_payload == "hidden_states" and temperature != 1.0:
+        raise ValueError(
+            "on_policy_distillation.full.teacher_payload='hidden_states' does not "
+            f"support policy.generation.temperature != 1.0 (got {temperature}). "
+            "Temperature scaling divides the training logits in place, but the "
+            "capture hook reads output_layer's input, which is upstream of that "
+            "division -- so the student would be scaled while the teacher logits "
+            "reconstructed from its hidden states would not, silently optimizing a "
+            "mismatched objective. Use teacher_payload='logits', where both sides "
+            "come from the same scaled tensor."
+        )
+
+    if full_cfg.teacher_payload == "logits":
+        # The logits payload is vocab_size wide, so a production-scale run would
+        # move tens of GB per teacher batch. Advisory, not an error: a small
+        # vocabulary or a short-sequence cross-check is a legitimate use.
+        print(
+            "  ! on_policy_distillation.full.teacher_payload='logits' transports "
+            "the full vocabulary per token. This is a numerical-reference path; "
+            "prefer 'hidden_states' for production runs.",
+            flush=True,
+        )
+
+
 def _validate_failure_settings(
     async_config: AsyncRLConfig,
     num_prompts_per_step: int,
@@ -1370,6 +1475,7 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
                 "at least one teacher mapping."
             )
         opd_module.assert_prev_logprobs_available(master_config)
+        _validate_opd_full_config(master_config, opd_config)
 
     if (
         reference_policy_kl_penalty == 0

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -919,17 +919,16 @@ def _validate_opd_full_config(
         raise ValueError(
             "on_policy_distillation.full.teacher_payload='hidden_states' does not "
             "support policy.megatron_cfg.pipeline_model_parallel_size > 1 yet. "
-            "Megatron builds output_layer only on the last pipeline stage, but the "
-            "teacher LM head is loaded through a collective that spans the whole "
-            "student world, so earlier stages would fail while the last stage hangs "
-            "in that collective. Use pipeline_model_parallel_size=1, or "
+            "Megatron builds output_layer only on the last pipeline stage, but resolving "
+            "the teacher checkpoint iteration goes through Megatron-Bridge's "
+            "read_train_state, whose broadcast_object_list spans the whole student "
+            "world, so earlier stages would fail while the last stage hangs in that "
+            "broadcast. Use pipeline_model_parallel_size=1, or "
             "teacher_payload='logits', which needs no teacher LM head."
         )
 
     generation_config = policy_config.get("generation")
-    temperature = (
-        1.0 if generation_config is None else generation_config.get("temperature", 1.0)
-    )
+    temperature = 1.0 if generation_config is None else generation_config["temperature"]
     if full_cfg.teacher_payload == "hidden_states" and temperature != 1.0:
         raise ValueError(
             "on_policy_distillation.full.teacher_payload='hidden_states' does not "

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -127,6 +127,7 @@ from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
 )
+from nemo_rl.models.policy import OnPolicyDistillationFullTransport, PolicyConfig
 from nemo_rl.models.policy.tq_policy import TQPolicy
 from nemo_rl.models.value.tq_value import TQValue
 from nemo_rl.utils.checkpoint import (
@@ -892,6 +893,54 @@ def _build_retry_policy(master_config: MasterConfig) -> RolloutRetryPolicy:
     )
 
 
+def _load_opd_full_teacher_lm_heads(
+    trainer: Any,
+    teacher_worker_groups: dict[str, Any],
+) -> None:
+    """Load the teacher LM head onto every student worker for full-vocabulary MOPD.
+
+    Callers gate this on the ``hidden_states`` payload; the ``logits`` payload
+    ships the projected distribution and needs no teacher LM head.
+
+    Args:
+        trainer: The driver-side policy whose workers hold the student model.
+        teacher_worker_groups: Deduplicated teacher groups, keyed by primary alias.
+
+    Raises:
+        ValueError: If the run does not resolve to exactly one teacher checkpoint.
+    """
+    teacher_checkpoints = {
+        teacher.model_name for teacher in teacher_worker_groups.values()
+    }
+    if len(teacher_checkpoints) != 1:
+        raise ValueError(
+            "on_policy_distillation.full currently supports exactly one teacher "
+            f"checkpoint, got {sorted(teacher_checkpoints)}."
+        )
+
+    teacher = next(iter(teacher_worker_groups.values()))
+    # TeacherWorkerGroup deep-copies the student policy config and overrides only
+    # `model_name`, so a student `pretrained_checkpoint` rides along. Left in,
+    # validate_model_paths would hand back the *student's* checkpoint, silently
+    # distilling the student into itself. Clear it so resolution keys off the
+    # teacher's model name.
+    #
+    # Resolution happens on the student workers, not here: validate_model_paths
+    # imports megatron.bridge at module scope, and only the Megatron worker
+    # actors get the mcore extra.
+    teacher_path_config = {**teacher.cfg, "pretrained_checkpoint": None}
+    results = ray.get(
+        trainer.worker_group.run_all_workers_single_data(
+            "load_opd_full_teacher_lm_head",
+            teacher_path_config=cast(PolicyConfig, teacher_path_config),
+        )
+    )
+    print(
+        f"  ✓ Loaded opd_full teacher LM head from {results[0]}",
+        flush=True,
+    )
+
+
 def setup_single_controller(
     master_config: MasterConfig,
     tokenizer: PreTrainedTokenizerBase,
@@ -1086,6 +1135,23 @@ def setup_single_controller(
                     "gym_token_capture",
                 )
             )
+
+    # Resolved once here so the student workers and the teacher worker group
+    # (which deep-copies this config) read the same settings. Absent means the
+    # feature is off; workers must not re-derive a default.
+    opd_full_config = opd_module.get_opd_full_config(master_config)
+    if opd_full_config is not None:
+        # model_dump() is typed dict[str, Any], so the envelope is assembled here
+        # and cast: OnPolicyDistillationFullConfig stays the single source of the
+        # keys and their defaults, and OnPolicyDistillationFullTransport mirrors
+        # it for the workers that read it.
+        policy_config["on_policy_distillation_full"] = cast(
+            OnPolicyDistillationFullTransport,
+            {
+                **opd_full_config.model_dump(),
+                "payload_field": opd_module.opd_full_payload_field(opd_full_config),
+            },
+        )
 
     set_seed(algo_cfg.seed)
 
@@ -1578,6 +1644,13 @@ def setup_single_controller(
         )
         for teacher in teacher_worker_groups.values():
             teacher.setup_data_plane(dp_config)
+        # Only reachable now: create_teacher_worker_groups above materializes the
+        # teacher's Megatron checkpoint, so the LM head cannot be read earlier.
+        if (
+            opd_full_config is not None
+            and opd_full_config.teacher_payload == "hidden_states"
+        ):
+            _load_opd_full_teacher_lm_heads(trainer, teacher_worker_groups)
         setup_timing_metrics.teacher_model_init_time_s = time.perf_counter() - t0
         setup_timing_metrics.teacher_init_time_s = (
             setup_timing_metrics.teacher_reservation_time_s or 0.0
@@ -1694,7 +1767,10 @@ def setup_single_controller(
     # Setup Algorithm + Rollout Wiring
     # ==========================
     advantage_estimator = _build_advantage_estimator(master_config)
-    loss_fn: LossFunction = ClippedPGLossFn(master_config.loss_fn)
+    loss_fn: LossFunction = ClippedPGLossFn(
+        master_config.loss_fn,
+        opd_full=opd_module.get_opd_full_config(master_config),
+    )
     value_loss_fn: Optional[LossFunction] = (
         MseValueLossFn(master_config.value_loss_fn)  # type: ignore
         if is_ppo_run(master_config)

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -919,20 +919,13 @@ def _load_opd_full_teacher_lm_heads(
         )
 
     teacher = next(iter(teacher_worker_groups.values()))
-    # TeacherWorkerGroup deep-copies the student policy config and overrides only
-    # `model_name`, so a student `pretrained_checkpoint` rides along. Left in,
-    # validate_model_paths would hand back the *student's* checkpoint, silently
-    # distilling the student into itself. Clear it so resolution keys off the
-    # teacher's model name.
-    #
     # Resolution happens on the student workers, not here: validate_model_paths
     # imports megatron.bridge at module scope, and only the Megatron worker
     # actors get the mcore extra.
-    teacher_path_config = {**teacher.cfg, "pretrained_checkpoint": None}
     results = ray.get(
         trainer.worker_group.run_all_workers_single_data(
             "load_opd_full_teacher_lm_head",
-            teacher_path_config=cast(PolicyConfig, teacher_path_config),
+            teacher_path_config=cast(PolicyConfig, teacher.cfg),
         )
     )
     print(

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -26,10 +26,15 @@ from nemo_rl.data_plane import KVBatchMeta
 
 # Reduction rules for all_mb_metrics. Mirror grpo.py / grpo_sync.py.
 _MB_METRIC_MIN: frozenset[str] = frozenset(
-    {"probs_ratio_min", "probs_ratio_clamped_min"}
+    {"probs_ratio_min", "probs_ratio_clamped_min", "opd_full_reverse_kl_min"}
 )
 _MB_METRIC_MAX: frozenset[str] = frozenset(
-    {"probs_ratio_max", "probs_ratio_clamped_max"}
+    {
+        "probs_ratio_max",
+        "probs_ratio_clamped_max",
+        "opd_full_reverse_kl_max",
+        "opd_full_decomposition_error",
+    }
 )
 _MB_METRIC_MEAN: frozenset[str] = frozenset(
     {

--- a/nemo_rl/data_plane/column_io.py
+++ b/nemo_rl/data_plane/column_io.py
@@ -42,6 +42,7 @@ from nemo_rl.data_plane.schema import (
     GLOBAL_FORWARD_PAD_SEQLEN,
     INVALID_TOOL_CALL_MASK,
     MALFORMED_THINKING_MASK,
+    OPD_FULL_FIELDS,
     Layout,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -57,6 +58,7 @@ _TEXT_TOKEN_ALIGNED_FIELDS = frozenset(
         "prev_logprobs",
         "reference_policy_logprobs",
         "teacher_reference_logprobs",
+        *OPD_FULL_FIELDS,
         "advantages",
         "returns",
         "values",

--- a/nemo_rl/data_plane/schema.py
+++ b/nemo_rl/data_plane/schema.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Shared constants and type aliases for the data-plane meta contract."""
 
-from typing import Literal, Sequence
+from typing import Literal, Optional, Sequence
 
 # Materialization layout for `codec.materialize` / `read_columns` / worker fetch.
 Layout = Literal["padded", "jagged"]
@@ -56,6 +56,14 @@ DP_TRAIN_FIELDS = (
     "sample_mask",
 )
 
+# Full-vocabulary MOPD teacher payload columns; exactly one is written per run,
+# selected by ``on_policy_distillation.full.teacher_payload``. Both are jagged-
+# packed per-token ``[N, S, D]``, with ``D`` the hidden size or vocabulary size.
+OPD_FULL_HIDDEN_STATES_FIELD = "teacher_full_hidden_states"
+OPD_FULL_LOGITS_FIELD = "teacher_full_logits"
+OPD_FULL_FIELDS = (OPD_FULL_HIDDEN_STATES_FIELD, OPD_FULL_LOGITS_FIELD)
+
+
 # Full known tensor schema for SingleController's long-lived rollout partition.
 # The initial rollout put writes the first seven payload fields; later stages add
 # student/reference logprobs, advantages, PPO critic columns, and the MOPD teacher
@@ -70,6 +78,7 @@ SC_ROLLOUT_SCHEMA_FIELDS = (
     "values",
     "returns",
     "teacher_reference_logprobs",
+    *OPD_FULL_FIELDS,
     INVALID_TOOL_CALL_MASK,
     MALFORMED_THINKING_MASK,
 )
@@ -139,4 +148,27 @@ def fields_with_optional_routed_experts(
     out = list(fields)
     if enabled and ROUTED_EXPERTS_FIELD not in out:
         out.append(ROUTED_EXPERTS_FIELD)
+    return out
+
+
+def fields_with_optional_opd_full(
+    fields: Sequence[str],
+    *,
+    field: Optional[str],
+) -> list[str]:
+    """Return `fields` plus the full-vocabulary MOPD teacher payload column.
+
+    Added only when the run configures one: a GRPO run requesting a column
+    nobody wrote would error on read, hence not folded into ``DP_TRAIN_FIELDS``.
+
+    Args:
+        fields: Base field list.
+        field: Payload column name, or ``None`` when opd_full is off.
+
+    Returns:
+        The field list, with the payload column appended when applicable.
+    """
+    out = list(fields)
+    if field is not None and field not in out:
+        out.append(field)
     return out

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -767,6 +767,48 @@ class TQWorkerMixin:
 
         return NamedSharding.is_axis_zero(self._local_coords(), REPLICATED_AXES)
 
+    def _is_stage_local_writer(self) -> bool:
+        """True iff this rank is the TP/CP-zero rank of its own pipeline stage.
+
+        Unlike :meth:`_is_replica_leader` this does not pin the pipeline stage,
+        so it selects one rank per stage rather than one per DP rank. Callers
+        must therefore only write outputs that exist on a single stage; see
+        :meth:`_write_back_stage_local`.
+        """
+        from nemo_rl.distributed.named_sharding import NamedSharding
+
+        return NamedSharding.is_axis_zero(
+            self._local_coords(), ("tensor_parallel", "context_parallel")
+        )
+
+    def _write_back_stage_local(
+        self,
+        meta: "KVBatchMeta",
+        fields: dict[str, torch.Tensor],
+    ) -> None:
+        """Write fields produced on exactly one pipeline stage.
+
+        The ordinary :meth:`_write_back` writes from the replica leader, which
+        sits on stage 0. Outputs that only the last stage holds -- notably the
+        full-vocabulary MOPD teacher payload -- would then have to be broadcast
+        backwards just to be written, which for a per-token payload means moving
+        gigabytes across the pipeline group for nothing. This writes from the
+        stage that already owns the data instead.
+
+        Single-writer safety comes from the caller: it must pass fields that are
+        absent (``None``) on every other stage, so exactly one stage reaches this
+        and :meth:`_is_stage_local_writer` picks one rank within it.
+
+        Args:
+            meta: Per-rank ``KVBatchMeta`` for this slice.
+            fields: Map of field name to tensor to write back.
+        """
+        if not self._is_stage_local_writer() or not fields:
+            return
+        from nemo_rl.data_plane.column_io import write_columns
+
+        write_columns(self._require_dp_client(), meta, fields)
+
     def _write_back(
         self,
         meta: "KVBatchMeta",
@@ -910,8 +952,24 @@ class TQWorkerMixin:
         self,
         meta: "KVBatchMeta",
         micro_batch_size: Optional[int] = None,
+        opd_full_payload: Optional[str] = None,
+        opd_full_payload_dtype: Optional[str] = None,
+        opd_full_payload_field: Optional[str] = None,
     ) -> None:
-        """Per-rank frozen-teacher logprob entrypoint for SingleController MOPD."""
+        """Per-rank frozen-teacher logprob entrypoint for SingleController MOPD.
+
+        Args:
+            meta: Per-rank ``KVBatchMeta`` for this DP shard.
+            micro_batch_size: Overrides the configured logprob batch size.
+            opd_full_payload: When set (``"hidden_states"`` or ``"logits"``), also
+                emit the full-vocabulary teacher payload from the same forward.
+            opd_full_payload_dtype: Torch dtype name for that payload.
+            opd_full_payload_field: Data-plane column the payload is written to.
+
+        Raises:
+            ValueError: If a payload is requested without a target column.
+            RuntimeError: If batching metadata was not planned driver-side.
+        """
         data = self._fetch(meta)
         cfg = getattr(self, "cfg", {})
         batching_enabled = bool(
@@ -928,10 +986,37 @@ class TQWorkerMixin:
                 "can desynchronize data-parallel collectives."
             )
         data = self._attach_or_repack_pack_metadata(data, meta)
-        result: BatchedDataDict[Any] = self.get_logprobs(  # type: ignore[attr-defined]
-            data=data,
-            micro_batch_size=micro_batch_size,
-        )
+        if opd_full_payload is None:
+            result: BatchedDataDict[Any] = self.get_logprobs(  # type: ignore[attr-defined]
+                data=data,
+                micro_batch_size=micro_batch_size,
+            )
+        else:
+            if opd_full_payload_field is None:
+                raise ValueError(
+                    "opd_full_payload requires opd_full_payload_field naming the "
+                    "data-plane column to write the teacher payload to."
+                )
+            if opd_full_payload_dtype is None:
+                raise ValueError(
+                    "opd_full_payload requires opd_full_payload_dtype; it is "
+                    "resolved by the driver from OnPolicyDistillationFullConfig, "
+                    "which owns the default."
+                )
+            result = self.get_logprobs_with_full_payload(  # type: ignore[attr-defined]
+                data=data,
+                payload=opd_full_payload,
+                payload_dtype=opd_full_payload_dtype,
+                micro_batch_size=micro_batch_size,
+            )
+            # None off the last pipeline stage, which is what keeps this to a
+            # single writer: the payload never leaves the stage that produced it.
+            teacher_full_payload = result.get("teacher_full_payload")
+            if teacher_full_payload is not None:
+                self._write_back_stage_local(
+                    meta, {opd_full_payload_field: teacher_full_payload.detach().cpu()}
+                )
+            del teacher_full_payload
         self._write_back_result_field(
             meta,
             result,

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -2433,6 +2433,11 @@ def _chunked_distributed_student_teacher_reduction(
 ) -> torch.Tensor:
     """Reduce ``sum_v p_student(v) * weight_fn(v)`` across TP, chunked over sequence.
 
+    ``weight_fn`` must depend on the student logits only through ``log p_s`` with a
+    constant ``dw/dlog p_s``: the shared backward below assumes exactly that, so a
+    weight like the forward KL (an expectation under the teacher) needs its own
+    kernel rather than a fourth ``weight_fn``.
+
     Args:
         student_vocab_parallel_logits: Student logits ``[B, S, V_local]``.
         teacher_vocab_parallel_logits: Teacher logits ``[B, S, V_local]``, treated

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
@@ -2258,73 +2259,328 @@ class ChunkedDistributedEntropy(torch.autograd.Function):
         tp_group: torch.distributed.ProcessGroup,
         inference_only: bool = False,
     ) -> torch.Tensor:
-        B, S, _ = vocab_parallel_logits.shape
-        num_chunks = (int(S) + chunk_size - 1) // chunk_size
-        out_chunks: list[torch.Tensor] = []
-
-        for chunk_idx in range(num_chunks):
-            s0 = chunk_idx * chunk_size
-            s1 = min(int(S), (chunk_idx + 1) * chunk_size)
-
-            logits = vocab_parallel_logits[:, s0:s1, :].to(dtype=torch.float32)
-            log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
-            softmax_output = log_probs.exp()
-            H_local = (softmax_output * log_probs).sum(dim=-1)  # [B, Sc]
-            torch.distributed.all_reduce(
-                H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
-            out_chunks.append(H_local)
-
-        H_all = torch.cat(out_chunks, dim=1) if len(out_chunks) > 1 else out_chunks[0]
+        entropy = _chunked_distributed_student_teacher_reduction(
+            vocab_parallel_logits,
+            None,
+            chunk_size=chunk_size,
+            tp_group=tp_group,
+            weight_fn=_entropy_weight,
+        )
 
         if not inference_only:
             ctx.save_for_backward(vocab_parallel_logits)
             ctx.chunk_size = int(chunk_size)
             ctx.tp_group = tp_group
 
-        return H_all.contiguous()
+        return entropy
 
     @staticmethod
     def backward(
         ctx: Any, *grad_outputs: torch.Tensor
     ) -> tuple[torch.Tensor, None, None, None]:
-        grad_output = grad_outputs[0]  # [B, S]
         (vocab_parallel_logits,) = ctx.saved_tensors
-        chunk_size: int = ctx.chunk_size
-        tp_group = ctx.tp_group
+        grad_input = _chunked_distributed_student_teacher_backward(
+            vocab_parallel_logits,
+            None,
+            grad_output=grad_outputs[0],
+            chunk_size=ctx.chunk_size,
+            tp_group=ctx.tp_group,
+            weight_fn=_entropy_weight,
+        )
+        return grad_input, None, None, None
 
-        B, S, V_local = vocab_parallel_logits.shape
-        num_chunks = (int(S) + chunk_size - 1) // chunk_size
 
-        grad_input: torch.Tensor = torch.empty_like(
-            vocab_parallel_logits, dtype=torch.float32
+class ChunkedDistributedCrossEntropyToFixedLogits(torch.autograd.Function):
+    """Compute ``CE = -sum_v p_student(v) log p_teacher(v)`` across TP with chunking.
+
+    Forward returns a ``[B, S]`` tensor of per-token cross-entropy between the
+    current student distribution and a fixed (frozen-teacher) distribution.
+    Gradients flow only through the student logits; the teacher side is a
+    constant, so its log-softmax is recomputed under ``no_grad`` semantics.
+
+    Both log-softmaxes are recomputed in backward from the saved raw logits
+    rather than cached, mirroring :class:`ChunkedDistributedEntropy`. Caching the
+    fp32 teacher log-probs would hold an extra ``[B, S, V_local]`` tensor alive
+    for the whole microbatch.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        student_vocab_parallel_logits: torch.Tensor,  # [B, S, V_local]
+        teacher_vocab_parallel_logits: torch.Tensor,  # [B, S, V_local]
+        chunk_size: int,
+        tp_group: torch.distributed.ProcessGroup,
+        inference_only: bool = False,
+    ) -> torch.Tensor:
+        cross_entropy = _chunked_distributed_student_teacher_reduction(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            chunk_size=chunk_size,
+            tp_group=tp_group,
+            weight_fn=_cross_entropy_weight,
         )
 
-        for chunk_idx in range(num_chunks):
-            s0 = chunk_idx * chunk_size
-            s1 = min(int(S), (chunk_idx + 1) * chunk_size)
-
-            logits = vocab_parallel_logits[:, s0:s1, :].to(dtype=torch.float32)
-            log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
-            softmax_output = log_probs.exp()
-            H_local = (softmax_output * log_probs).sum(dim=-1)
-            torch.distributed.all_reduce(
-                H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
+        if not inference_only:
+            ctx.save_for_backward(
+                student_vocab_parallel_logits, teacher_vocab_parallel_logits
             )
+            ctx.chunk_size = int(chunk_size)
+            ctx.tp_group = tp_group
 
-            # Inplace index into the preallocated grad_input tensor
-            grad_input_chunk = grad_input[:, s0:s1, :]
+        return cross_entropy
 
-            # dH/dz = softmax * (log_probs - H_all)
-            grad_input_chunk.copy_(
-                softmax_output.mul_(log_probs - H_local.unsqueeze(-1))
-            )  # inplace copy
-            grad_input_chunk.mul_(grad_output[:, s0:s1].unsqueeze(-1))
+    @staticmethod
+    def backward(
+        ctx: Any, *grad_outputs: torch.Tensor
+    ) -> tuple[torch.Tensor, None, None, None, None]:
+        student_vocab_parallel_logits, teacher_vocab_parallel_logits = ctx.saved_tensors
+        grad_input = _chunked_distributed_student_teacher_backward(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            grad_output=grad_outputs[0],
+            chunk_size=ctx.chunk_size,
+            tp_group=ctx.tp_group,
+            weight_fn=_cross_entropy_weight,
+        )
+        return grad_input, None, None, None, None
 
-            # Explicitly free before next iteration allocates
-            del softmax_output, log_probs, logits, H_local
 
-        return grad_input, None, None, None
+class ChunkedDistributedReverseKLToFixedLogits(torch.autograd.Function):
+    """Compute ``KL = sum_v p_student(v) (log p_student(v) - log p_teacher(v))``.
+
+    Forward returns a ``[B, S]`` tensor of per-token reverse KL between the
+    current student distribution and a fixed (frozen-teacher) distribution.
+    Gradients flow only through the student logits.
+
+    This is the full-vocabulary limit of the top-k MOPD estimator: with the
+    support spanning the whole vocabulary, the sampled-token score-function tail
+    term vanishes and only this exact expectation remains.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        student_vocab_parallel_logits: torch.Tensor,  # [B, S, V_local]
+        teacher_vocab_parallel_logits: torch.Tensor,  # [B, S, V_local]
+        chunk_size: int,
+        tp_group: torch.distributed.ProcessGroup,
+        inference_only: bool = False,
+    ) -> torch.Tensor:
+        reverse_kl = _chunked_distributed_student_teacher_reduction(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            chunk_size=chunk_size,
+            tp_group=tp_group,
+            weight_fn=_reverse_kl_weight,
+        )
+
+        if not inference_only:
+            ctx.save_for_backward(
+                student_vocab_parallel_logits, teacher_vocab_parallel_logits
+            )
+            ctx.chunk_size = int(chunk_size)
+            ctx.tp_group = tp_group
+
+        return reverse_kl
+
+    @staticmethod
+    def backward(
+        ctx: Any, *grad_outputs: torch.Tensor
+    ) -> tuple[torch.Tensor, None, None, None, None]:
+        student_vocab_parallel_logits, teacher_vocab_parallel_logits = ctx.saved_tensors
+        grad_input = _chunked_distributed_student_teacher_backward(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            grad_output=grad_outputs[0],
+            chunk_size=ctx.chunk_size,
+            tp_group=ctx.tp_group,
+            weight_fn=_reverse_kl_weight,
+        )
+        return grad_input, None, None, None, None
+
+
+def _entropy_weight(
+    student_log_probs: torch.Tensor, teacher_log_probs: Optional[torch.Tensor]
+) -> torch.Tensor:
+    """Per-vocabulary weight whose student-probability expectation is sum_v p log p."""
+    return student_log_probs
+
+
+def _cross_entropy_weight(
+    student_log_probs: torch.Tensor, teacher_log_probs: Optional[torch.Tensor]
+) -> torch.Tensor:
+    """Per-vocabulary weight whose student-probability expectation is the CE."""
+    assert teacher_log_probs is not None
+    return -teacher_log_probs
+
+
+def _reverse_kl_weight(
+    student_log_probs: torch.Tensor, teacher_log_probs: Optional[torch.Tensor]
+) -> torch.Tensor:
+    """Per-vocabulary weight whose student-probability expectation is the KL."""
+    assert teacher_log_probs is not None
+    return student_log_probs - teacher_log_probs
+
+
+def _chunked_distributed_student_teacher_reduction(
+    student_vocab_parallel_logits: torch.Tensor,
+    teacher_vocab_parallel_logits: Optional[torch.Tensor],
+    *,
+    chunk_size: int,
+    tp_group: torch.distributed.ProcessGroup,
+    weight_fn: Callable[[torch.Tensor, Optional[torch.Tensor]], torch.Tensor],
+) -> torch.Tensor:
+    """Reduce ``sum_v p_student(v) * weight_fn(v)`` across TP, chunked over sequence.
+
+    Args:
+        student_vocab_parallel_logits: Student logits ``[B, S, V_local]``.
+        teacher_vocab_parallel_logits: Teacher logits ``[B, S, V_local]``, treated
+            as a constant. ``None`` for weights that read only the student
+            (the entropy).
+        chunk_size: Sequence-dimension chunk size bounding the live fp32 working set.
+        tp_group: Tensor-parallel process group the vocabulary is sharded over.
+        weight_fn: Maps ``(student_log_probs, teacher_log_probs)`` to the
+            per-vocabulary weight being averaged under the student distribution.
+
+    Returns:
+        Per-token reduction with shape ``[B, S]``.
+    """
+    _validate_student_teacher_logits(
+        student_vocab_parallel_logits, teacher_vocab_parallel_logits
+    )
+    seq_len = int(student_vocab_parallel_logits.shape[1])
+    num_chunks = (seq_len + chunk_size - 1) // chunk_size
+    out_chunks: list[torch.Tensor] = []
+
+    for chunk_idx in range(num_chunks):
+        s0 = chunk_idx * chunk_size
+        s1 = min(seq_len, (chunk_idx + 1) * chunk_size)
+
+        student_log_probs, teacher_log_probs = _student_teacher_log_softmax_chunk(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            s0=s0,
+            s1=s1,
+            tp_group=tp_group,
+        )
+        reduction_local = (
+            student_log_probs.exp() * weight_fn(student_log_probs, teacher_log_probs)
+        ).sum(dim=-1)
+        torch.distributed.all_reduce(
+            reduction_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
+        )
+        out_chunks.append(reduction_local)
+
+        del student_log_probs, teacher_log_probs
+
+    reduction = torch.cat(out_chunks, dim=1) if len(out_chunks) > 1 else out_chunks[0]
+    return reduction.contiguous()
+
+
+def _chunked_distributed_student_teacher_backward(
+    student_vocab_parallel_logits: torch.Tensor,
+    teacher_vocab_parallel_logits: Optional[torch.Tensor],
+    *,
+    grad_output: torch.Tensor,
+    chunk_size: int,
+    tp_group: torch.distributed.ProcessGroup,
+    weight_fn: Callable[[torch.Tensor, Optional[torch.Tensor]], torch.Tensor],
+) -> torch.Tensor:
+    """Backward for :func:`_chunked_distributed_student_teacher_reduction`.
+
+    For ``L = sum_v p_s(v) w(v)`` where ``w`` depends on the student logits only
+    through ``log p_s``, the gradient is ``dL/dz = p_s * (w + dw/dlogp_s - L)``.
+    Both supported weights have a constant ``dw/dlogp_s`` (``0`` for the cross
+    entropy, ``1`` for the reverse KL), and that constant cancels against the
+    ``sum_v p_s = 1`` normalization, leaving ``dL/dz = p_s * (w - L)``.
+
+    Args:
+        student_vocab_parallel_logits: Student logits ``[B, S, V_local]``.
+        teacher_vocab_parallel_logits: Teacher logits ``[B, S, V_local]``, or
+            ``None`` for student-only weights.
+        grad_output: Upstream gradient ``[B, S]``.
+        chunk_size: Sequence-dimension chunk size.
+        tp_group: Tensor-parallel process group.
+        weight_fn: Same weight used in the forward reduction.
+
+    Returns:
+        Gradient with respect to the student logits, shape ``[B, S, V_local]``.
+    """
+    seq_len = int(student_vocab_parallel_logits.shape[1])
+    num_chunks = (seq_len + chunk_size - 1) // chunk_size
+    grad_input: torch.Tensor = torch.empty_like(
+        student_vocab_parallel_logits, dtype=torch.float32
+    )
+
+    for chunk_idx in range(num_chunks):
+        s0 = chunk_idx * chunk_size
+        s1 = min(seq_len, (chunk_idx + 1) * chunk_size)
+
+        student_log_probs, teacher_log_probs = _student_teacher_log_softmax_chunk(
+            student_vocab_parallel_logits,
+            teacher_vocab_parallel_logits,
+            s0=s0,
+            s1=s1,
+            tp_group=tp_group,
+        )
+        weight = weight_fn(student_log_probs, teacher_log_probs)
+        student_probs = student_log_probs.exp()
+        reduction_local = (student_probs * weight).sum(dim=-1)
+        torch.distributed.all_reduce(
+            reduction_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
+        )
+
+        # Inplace index into the preallocated grad_input tensor
+        grad_input_chunk = grad_input[:, s0:s1, :]
+        grad_input_chunk.copy_(
+            student_probs.mul_(weight - reduction_local.unsqueeze(-1))
+        )
+        grad_input_chunk.mul_(grad_output[:, s0:s1].unsqueeze(-1))
+
+        # Explicitly free before next iteration allocates
+        del student_log_probs, teacher_log_probs, weight, student_probs, reduction_local
+
+    return grad_input
+
+
+def _student_teacher_log_softmax_chunk(
+    student_vocab_parallel_logits: torch.Tensor,
+    teacher_vocab_parallel_logits: Optional[torch.Tensor],
+    *,
+    s0: int,
+    s1: int,
+    tp_group: torch.distributed.ProcessGroup,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Return TP-normalized fp32 student and teacher log-probs for one chunk."""
+    student_logits = student_vocab_parallel_logits[:, s0:s1, :].to(dtype=torch.float32)
+    student_log_probs = _compute_distributed_log_softmax(student_logits, group=tp_group)
+    if teacher_vocab_parallel_logits is None:
+        return student_log_probs, None
+    teacher_logits = teacher_vocab_parallel_logits[:, s0:s1, :].to(dtype=torch.float32)
+    teacher_log_probs = _compute_distributed_log_softmax(teacher_logits, group=tp_group)
+    return student_log_probs, teacher_log_probs
+
+
+def _validate_student_teacher_logits(
+    student_vocab_parallel_logits: torch.Tensor,
+    teacher_vocab_parallel_logits: Optional[torch.Tensor],
+) -> None:
+    """Raise if the student and teacher vocabulary shards are not aligned."""
+    if student_vocab_parallel_logits.ndim != 3:
+        raise ValueError(
+            "Student logits must be rank 3 [B, S, V_local]; got "
+            f"{tuple(student_vocab_parallel_logits.shape)}."
+        )
+    if (
+        teacher_vocab_parallel_logits is not None
+        and student_vocab_parallel_logits.shape != teacher_vocab_parallel_logits.shape
+    ):
+        raise ValueError(
+            "Student and teacher logits must share the same [B, S, V_local] shape; "
+            f"got {tuple(student_vocab_parallel_logits.shape)} and "
+            f"{tuple(teacher_vocab_parallel_logits.shape)}."
+        )
 
 
 def from_parallel_hidden_states_to_logprobs(

--- a/nemo_rl/models/megatron/opd_full_capture.py
+++ b/nemo_rl/models/megatron/opd_full_capture.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capture the pre-LM-head hidden states of a frozen MOPD teacher.
+
+Full-vocabulary MOPD ships these to the student, which projects them with a
+teacher LM-head shard. Moving ``hidden_size`` floats per token instead of
+``vocab_size`` keeps teacher and student parallelism decoupled.
+
+The capture is a forward pre-hook on ``output_layer``: ``GPTModel.forward`` ends
+in ``logits, _ = self.output_layer(hidden_states, ...)``, so the hook's first
+argument is the post-``final_layernorm`` hidden state. Hooking ``decoder``
+instead would miss ``final_layernorm``, and ``decoder.final_layernorm`` is absent
+under some transformer specs.
+"""
+
+from contextlib import contextmanager, nullcontext
+from typing import Any, ContextManager, Iterator, Optional
+
+import torch
+from megatron.core import parallel_state
+from megatron.core.utils import unwrap_model
+from torch import Tensor, nn
+
+
+class OutputLayerInputCapture:
+    """Capture the tensor fed into a Megatron model's ``output_layer``.
+
+    The tensor is ``[S_local, B, H]`` (Megatron sequence-first). Sequence
+    parallelism shards ``S_local`` across the TP group, so
+    :meth:`get_hidden_states` gathers it back.
+    """
+
+    def __init__(self, model: nn.Module):
+        self.model = unwrap_model(model)
+        self._output_layer = getattr(self.model, "output_layer", None)
+        if self._output_layer is None:
+            language_model = getattr(self.model, "language_model", None)
+            if language_model is not None:
+                self._output_layer = getattr(language_model, "output_layer", None)
+        self._captured: Optional[Tensor] = None
+        self._hook_handle: Optional[torch.utils.hooks.RemovableHandle] = None
+
+    @property
+    def is_available(self) -> bool:
+        """Whether this rank owns an ``output_layer`` to hook (last PP stage)."""
+        return self._output_layer is not None
+
+    def _pre_hook(self, module: nn.Module, args: tuple[Any, ...]) -> None:
+        if args:
+            self._captured = args[0]
+
+    @contextmanager
+    def capture_context(self) -> Iterator[None]:
+        """Register the pre-hook for the duration of one forward pass."""
+        self._captured = None
+        if self._output_layer is None:
+            yield
+            return
+        self._hook_handle = self._output_layer.register_forward_pre_hook(self._pre_hook)
+        try:
+            yield
+        finally:
+            self._hook_handle.remove()
+            self._hook_handle = None
+
+    def get_hidden_states(self) -> Optional[Tensor]:
+        """Return the captured hidden states in full ``[S, B, H]`` layout.
+
+        Returns:
+            The detached hidden states with sequence parallelism undone, or
+            ``None`` when this rank ran no output layer (non-final pipeline
+            stage) or the forward never reached it.
+
+        Raises:
+            ValueError: If the captured tensor is not rank 3.
+        """
+        if self._captured is None:
+            return None
+        hidden_states = self._captured
+        if hidden_states.ndim != 3:
+            raise ValueError(
+                "Expected pre-LM-head hidden states of rank 3 [S, B, H]; got "
+                f"{tuple(hidden_states.shape)}."
+            )
+        if getattr(self._output_layer, "sequence_parallel", False):
+            # SP hands output_layer an [S/TP, B, H] shard and gathers internally,
+            # so the pre-hook sees the shard. Undo it here or every TP>1 run
+            # silently mismatches the sequence dimension.
+            from megatron.core.tensor_parallel import (
+                gather_from_sequence_parallel_region,
+            )
+
+            # Gather over the layer's own group, which is what it sharded with:
+            # GPTModel builds output_layer with tp_group=pg_collection.tp, and
+            # mcore's inference path undoes it with that same group. Identical to
+            # the mpu group whenever the model is built on mpu process groups.
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                group=getattr(
+                    self._output_layer,
+                    "tp_group",
+                    parallel_state.get_tensor_model_parallel_group(),
+                ),
+            )
+        return hidden_states.detach()
+
+
+def get_opd_full_capture_context(
+    model: nn.Module, enabled: bool
+) -> tuple[ContextManager[Any], Optional[OutputLayerInputCapture]]:
+    """Build the capture context for one teacher forward pass.
+
+    Args:
+        model: The (possibly wrapped) Megatron model about to run forward.
+        enabled: Whether full-vocabulary hidden-state capture is requested.
+
+    Returns:
+        Tuple of the context manager to wrap the forward in, and the capture
+        object to read afterwards (``None`` when disabled or unavailable).
+    """
+    if not enabled:
+        return nullcontext(), None
+    capture = OutputLayerInputCapture(model)
+    if not capture.is_available:
+        # Non-final pipeline stages have no output layer; the last stage writes
+        # the payload, so this rank has nothing to capture.
+        return nullcontext(), None
+    return capture.capture_context(), capture

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -2457,6 +2457,127 @@ def setup_reference_model_state(
     return reference_state_dict
 
 
+def load_teacher_output_layer_weight(
+    *,
+    teacher_pretrained_path: str,
+    local_vocab_size: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Load this rank's shard of a teacher checkpoint's LM-head weight.
+
+    Full-vocabulary MOPD ships the teacher's hidden states and projects them on
+    the student side, which needs the teacher's ``output_layer.weight``. Only
+    that one tensor is read: instantiating a second Megatron model just to reach
+    it is far more fragile, since provider and config objects accumulate
+    runtime-only distributed state during live training.
+
+    The request is built at the **student's** tensor-parallel rank and size.
+    Re-sharding a teacher saved at a different tensor-parallel width is
+    dist_checkpointing's ordinary by-offset load and needs no special flag.
+    ``allow_shape_mismatch=True`` covers a different case: a teacher whose
+    *padded* vocabulary differs from the student's. Megatron pads to a multiple
+    of ``make_vocab_size_divisible_by * tp_size``, so the two widths diverge
+    whenever the parallel sizes do. Under that flag mcore zero-initializes and
+    partially loads instead of raising, so rows above the narrower of the two
+    padded widths come back as zeros. Those are pad slots rather than real
+    vocabulary entries, so the objective is unaffected in practice -- but this
+    is a silent fallback, not a re-sharding mechanism.
+
+    Args:
+        teacher_pretrained_path: Megatron checkpoint root of the teacher.
+        local_vocab_size: This rank's vocabulary shard width.
+        dtype: Dtype to materialize the shard in.
+
+    Returns:
+        The ``[local_vocab_size, hidden_size]`` weight shard on CPU.
+
+    Raises:
+        FileNotFoundError: If the checkpoint root holds no readable iteration.
+        KeyError: If neither an output-layer nor a tied-embedding weight exists.
+        TypeError: If the loaded checkpoint entry is not a ``torch.Tensor``.
+        ValueError: If the checkpoint tensor is not a rank-2 matrix.
+    """
+    from megatron.bridge.training.utils.checkpoint_utils import (
+        TRACKER_PREFIX,
+        get_checkpoint_name,
+        get_checkpoint_train_state_filename,
+        is_checkpoint_iteration_directory,
+        read_train_state,
+    )
+    from megatron.core import dist_checkpointing
+    from megatron.core.utils import make_tp_sharded_tensor_for_checkpoint
+
+    if not checkpoint_exists(teacher_pretrained_path):
+        raise FileNotFoundError(
+            "opd_full needs the teacher LM head, but no Megatron checkpoint is "
+            f"readable at {teacher_pretrained_path!r}."
+        )
+    # validate_model_paths returns a checkpoint root on the HF-cache path but an
+    # already-resolved iteration directory for an explicit pretrained_checkpoint.
+    # Detect which, instead of assuming a root and failing on a missing tracker.
+    # Bridge owns this decision (four markers, MSC-aware) and checkpoint_exists
+    # above already delegates to it.
+    if is_checkpoint_iteration_directory(teacher_pretrained_path):
+        checkpoint_dir = teacher_pretrained_path
+    else:
+        # prefix is required: the default returns train_state.pt, not
+        # latest_train_state.pt.
+        train_state_filename = get_checkpoint_train_state_filename(
+            teacher_pretrained_path, prefix=TRACKER_PREFIX
+        )
+        train_state = read_train_state(train_state_filename)
+        checkpoint_dir = get_checkpoint_name(
+            teacher_pretrained_path, train_state.step, release=False
+        )
+
+    tensor_metadata = dist_checkpointing.load_tensors_metadata(checkpoint_dir)
+    if "output_layer.weight" in tensor_metadata:
+        checkpoint_key = "output_layer.weight"
+    elif "embedding.word_embeddings.weight" in tensor_metadata:
+        # Tied embedding/output checkpoints store the LM head under the
+        # embedding tensor's checkpoint key.
+        checkpoint_key = "embedding.word_embeddings.weight"
+    else:
+        available_keys = sorted(tensor_metadata)
+        raise KeyError(
+            "Could not find a teacher LM-head tensor in "
+            f"{checkpoint_dir!r}. Expected 'output_layer.weight' or "
+            "'embedding.word_embeddings.weight'; got "
+            f"{len(available_keys)} keys, first few: {available_keys[:8]}."
+        )
+
+    global_shape = tuple(tensor_metadata[checkpoint_key].global_shape)
+    if len(global_shape) != 2:
+        raise ValueError(
+            f"Teacher LM-head tensor {checkpoint_key!r} must be rank 2, got "
+            f"global shape {global_shape}."
+        )
+    teacher_hidden_size = int(global_shape[1])
+
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    weight_template = torch.empty(
+        (int(local_vocab_size), teacher_hidden_size), dtype=dtype, device="cpu"
+    )
+    sharded_template = make_tp_sharded_tensor_for_checkpoint(
+        weight_template,
+        key=checkpoint_key,
+        allow_shape_mismatch=True,
+        tp_group=pg_collection.tp,
+        dp_cp_group=pg_collection.dp_cp,
+    )
+    loaded = dist_checkpointing.load(
+        {checkpoint_key: sharded_template},
+        checkpoint_dir,
+        validate_access_integrity=False,
+    )[checkpoint_key]
+    if not isinstance(loaded, torch.Tensor):
+        raise TypeError(
+            f"Expected a Tensor for {checkpoint_key!r} from {checkpoint_dir!r}, "
+            f"got {type(loaded).__name__}."
+        )
+    return loaded.detach().to(device="cpu", dtype=dtype, copy=True)
+
+
 def finalize_megatron_setup(
     config: PolicyConfig,
     megatron_cfg: ConfigContainer,

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -64,6 +64,7 @@ from nemo_rl.models.megatron.data import ProcessedMicrobatch
 from nemo_rl.models.megatron.draft.hidden_capture import (
     get_capture_context,
 )
+from nemo_rl.models.megatron.opd_full_capture import get_opd_full_capture_context
 from nemo_rl.models.megatron.router_replay import (
     clear_router_replay,
     set_router_replay_backward,
@@ -75,6 +76,7 @@ from nemo_rl.models.policy import PolicyConfig
 PostProcessingFunction = Union[
     "LossPostProcessor",
     "LogprobsPostProcessor",
+    "TeacherFullPayloadPostProcessor",
     "TopkLogitsPostProcessor",
 ]
 
@@ -261,6 +263,7 @@ def forward_with_post_processing_fn(
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    enable_opd_full_capture: bool = False,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -282,6 +285,8 @@ def forward_with_post_processing_fn(
         straggler_timer: Straggler detector for profiling the forward pass
         draft_model: Draft model for online draft model training
         enable_hidden_capture: Whether to enable hidden state capture for draft model training
+        enable_opd_full_capture: Whether to capture pre-LM-head hidden states for
+            the full-vocabulary MOPD teacher payload
 
     Returns:
         tuple: (output_tensor, post_processing_fn_wrapped)
@@ -313,9 +318,19 @@ def forward_with_post_processing_fn(
         set_router_replay_forward(model, routed_experts_cp_sharded)
 
     # Insert hook to capture hidden states and embeddings for draft model training if draft_model is provided
+    #
+    # TODO: rename get_capture_context to get_draft_capture_context -- beside the
+    # opd_full capture below the unqualified name reads as the generic one. Not
+    # done here: it would pull draft/*.py and three @patch paths in
+    # test_train.py into an unrelated feature's review.
     capture_context, capture = get_capture_context(model, enable_hidden_capture)
+    # Independent of the draft capture above: grabs the pre-LM-head hidden states
+    # a frozen MOPD teacher ships for full-vocabulary distillation.
+    opd_full_capture_context, opd_full_capture = get_opd_full_capture_context(
+        model, bool(enable_opd_full_capture)
+    )
     try:
-        with capture_context:
+        with capture_context, opd_full_capture_context:
             output_tensor = model_forward(
                 model=model,
                 data_dict=data_dict,
@@ -383,7 +398,12 @@ def forward_with_post_processing_fn(
     # Loss computation should use unscaled logits.
     if isinstance(
         post_processing_fn,
-        (LossPostProcessor, LogprobsPostProcessor, TopkLogitsPostProcessor),
+        (
+            LossPostProcessor,
+            LogprobsPostProcessor,
+            TeacherFullPayloadPostProcessor,
+            TopkLogitsPostProcessor,
+        ),
     ):
         # Temperature scaling is element-wise, directly applying it here.
         # Other sampling parameters like top-k and top-p need the logits from whole vocabulary,
@@ -405,6 +425,19 @@ def forward_with_post_processing_fn(
             input_ids=input_ids,
             cu_seqlens_padded=cu_seqlens_padded,
             original_seq_length=original_seq_length,
+        )
+    elif isinstance(post_processing_fn, TeacherFullPayloadPostProcessor):
+        assert original_seq_length is not None
+        post_processing_fn_wrapped = post_processing_fn(
+            data_dict=data_dict,
+            input_ids=input_ids,
+            cu_seqlens_padded=cu_seqlens_padded,
+            original_seq_length=original_seq_length,
+            hidden_states=(
+                None
+                if opd_full_capture is None
+                else opd_full_capture.get_hidden_states()
+            ),
         )
     elif isinstance(post_processing_fn, TopkLogitsPostProcessor):
         assert original_seq_length is not None
@@ -436,6 +469,7 @@ def megatron_forward_backward(
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    enable_opd_full_capture: bool = False,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -461,6 +495,8 @@ def megatron_forward_backward(
         straggler_timer: Straggler detector for profiling the forward pass
         draft_model: Draft model for online draft model training
         enable_hidden_capture: Whether to enable hidden state capture for draft model training
+        enable_opd_full_capture: Whether to capture pre-LM-head hidden states for
+            the full-vocabulary MOPD teacher payload
 
     Returns:
         Results from the forward/backward execution
@@ -475,6 +511,7 @@ def megatron_forward_backward(
         straggler_timer=straggler_timer,
         draft_model=draft_model,
         enable_hidden_capture=enable_hidden_capture,
+        enable_opd_full_capture=enable_opd_full_capture,
         use_fused_linear_logprobs=use_fused_linear_logprobs,
         use_router_replay=use_router_replay,
         router_replay_train=router_replay_train,
@@ -509,6 +546,7 @@ class LossPostProcessor:
         sampling_params: Optional[TrainingSamplingParams] = None,
         draft_model: Optional[MegatronModule] = None,
         prepare_fn: Optional[Callable[..., Any]] = None,
+        teacher_output_layer_weight: Optional[torch.Tensor] = None,
     ):
         """Build a per-microbatch loss post-processor for the Megatron train loop.
 
@@ -525,6 +563,11 @@ class LossPostProcessor:
                 vocab_parallel_group, context_parallel_group)`` and return
                 ``(loss_input, data)``; value models pass one that right-shifts
                 and CP-all-gathers the scalar value-head output.
+            teacher_output_layer_weight: This rank's teacher LM-head shard, used
+                by the full-vocabulary MOPD loss to project the teacher payload.
+                It rides this argument rather than the data dict because the
+                sequence-packing wrapper batch-slices every data entry, and
+                rather than the loss object because that is pickled to workers.
         """
         self.loss_fn = loss_fn
         self.cfg = cfg
@@ -532,6 +575,7 @@ class LossPostProcessor:
         self.cp_normalize = cp_normalize
         self.sampling_params = sampling_params
         self.prepare_fn = prepare_fn
+        self.teacher_output_layer_weight = teacher_output_layer_weight
         if draft_model is not None and draft_model.eagle_module is not None:
             self.d2t = getattr(draft_model.eagle_module, "d2t", None)
         else:
@@ -569,6 +613,7 @@ class LossPostProcessor:
                 sampling_params=self.sampling_params,
                 d2t=self.d2t,
                 chunk_size=logprob_chunk_size,
+                teacher_output_layer_weight=self.teacher_output_layer_weight,
             )
 
         # wrap loss function with loss input preparation
@@ -761,6 +806,168 @@ class LogprobsPostProcessor:
 
             return torch.tensor(0.0, device=token_logprobs.device), {
                 "logprobs": token_logprobs
+            }
+
+        return processor_fn_inner
+
+
+class TeacherFullPayloadPostProcessor:
+    """Emit sampled-token logprobs plus the full-vocabulary teacher payload.
+
+    Full-vocabulary MOPD needs the teacher's whole next-token distribution, not
+    just the sampled token's log-probability. Both come out of the same forward
+    pass: this wraps :class:`LogprobsPostProcessor` for the scalar column and
+    adds the payload the student reconstructs the distribution from.
+
+    The payload is returned in canonical ``[B, S, D]`` layout with tensor,
+    context, and sequence parallelism already undone, so the student's own
+    parallelism can differ from the teacher's.
+    """
+
+    def __init__(
+        self,
+        cfg: PolicyConfig,
+        payload: str,
+        payload_dtype: torch.dtype,
+        sampling_params: Optional[TrainingSamplingParams] = None,
+    ):
+        if payload not in ("hidden_states", "logits"):
+            raise ValueError(
+                f"teacher payload must be 'hidden_states' or 'logits', got {payload!r}."
+            )
+        self.cfg = cfg
+        self.payload = payload
+        self.payload_dtype = payload_dtype
+        self.sampling_params = sampling_params
+        self._logprobs_post_processor = LogprobsPostProcessor(
+            cfg=cfg, sampling_params=sampling_params
+        )
+
+    def __call__(
+        self,
+        data_dict: BatchedDataDict[Any],
+        input_ids: torch.Tensor,
+        cu_seqlens_padded: torch.Tensor,
+        original_seq_length: int,
+        hidden_states: Optional[torch.Tensor] = None,
+    ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        """Create the post-processing function for a teacher full-payload forward.
+
+        Args:
+            data_dict: Batched data dictionary containing input sequences.
+            input_ids: Processed input token IDs.
+            cu_seqlens_padded: Cumulative sequence lengths for packed sequences.
+            original_seq_length: Sequence width before dense padding was applied.
+            hidden_states: Captured pre-LM-head hidden states ``[S, B, H]``,
+                required for the ``hidden_states`` payload.
+
+        Returns:
+            Callable mapping the model output to ``(dummy_loss, {"logprobs":
+            [B, S], "teacher_full_payload": [B, S, D]})``.
+        """
+        logprobs_fn = self._logprobs_post_processor(
+            data_dict=data_dict,
+            input_ids=input_ids,
+            cu_seqlens_padded=cu_seqlens_padded,
+            original_seq_length=original_seq_length,
+        )
+        pack = self.cfg["sequence_packing"]["enabled"]
+        cp_size = self.cfg["megatron_cfg"]["context_parallel_size"]
+        batch_size = data_dict["input_ids"].shape[0]
+        unpacked_seqlen = data_dict["input_ids"].shape[1]
+        seq_lengths = data_dict["input_lengths"]
+
+        def processor_fn_inner(output_tensor):
+            _, logprob_outputs = logprobs_fn(output_tensor)
+
+            if self.payload == "hidden_states":
+                if hidden_states is None:
+                    raise ValueError(
+                        "The hidden-state teacher payload requires captured "
+                        "pre-LM-head hidden states; none were provided."
+                    )
+                # Megatron hands hidden states sequence-first; logits arrive
+                # batch-first, so align the payload with the logit layout.
+                payload_local = hidden_states.transpose(0, 1).contiguous()
+            else:
+                # Vocabulary is TP-sharded; gather so the student can slice its
+                # own window regardless of the teacher's tensor parallelism.
+                from megatron.core.tensor_parallel import (
+                    gather_from_tensor_model_parallel_region,
+                )
+
+                payload_local = gather_from_tensor_model_parallel_region(
+                    output_tensor, get_tensor_model_parallel_group()
+                )
+
+            if payload_local.shape[1] != output_tensor.shape[1]:
+                raise ValueError(
+                    "Teacher payload and logits disagree on the local sequence "
+                    f"width: {payload_local.shape[1]} vs {output_tensor.shape[1]}. "
+                    "This usually means sequence-parallel gathering was skipped."
+                )
+
+            if cp_size > 1:
+                cp_grp = get_context_parallel_group()
+                if pack:
+                    # Per-sequence CP allgather. CP uses a load-balanced
+                    # (2 x CP interleaved) layout per sequence, so gathering the
+                    # packed buffer as one contiguous shard would misplace tokens
+                    # at every sequence boundary.
+                    total_packed_len = int(cu_seqlens_padded[-1].item())
+                    payload_full = torch.zeros(
+                        (1, total_packed_len, payload_local.shape[-1]),
+                        dtype=payload_local.dtype,
+                        device=payload_local.device,
+                    )
+                    for i in range(batch_size):
+                        start_idx = int(cu_seqlens_padded[i].item())
+                        end_idx = int(cu_seqlens_padded[i + 1].item())
+                        if end_idx > start_idx:
+                            local_slice = payload_local[
+                                :, start_idx // cp_size : end_idx // cp_size, :
+                            ]
+                            gathered = allgather_cp_sharded_tensor(
+                                local_slice, cp_grp, seq_dim=1
+                            )
+                            # Some kernels return [X, Y, D] with X*Y = the span;
+                            # flatten and reshape to [1, expected_len, D].
+                            expected_len = end_idx - start_idx
+                            if (
+                                gathered.dim() == 3
+                                and gathered.shape[1] != expected_len
+                            ):
+                                gathered = gathered.reshape(
+                                    1, expected_len, gathered.shape[-1]
+                                )
+                            payload_full[:, start_idx:end_idx, :] = gathered
+                else:
+                    # Sequence packing must be enabled when CP > 1
+                    raise RuntimeError(
+                        "Context Parallelism (CP>1) requires sequence packing to be enabled."
+                    )
+            else:
+                payload_full = payload_local
+
+            if pack:
+                unpacked_payload = torch.zeros(
+                    (batch_size, unpacked_seqlen, payload_full.shape[-1]),
+                    dtype=payload_full.dtype,
+                    device=payload_full.device,
+                )
+                for i in range(batch_size):
+                    seq_len = min(int(seq_lengths[i].item()), unpacked_seqlen)
+                    start_idx = int(cu_seqlens_padded[i].item())
+                    if seq_len > 0:
+                        unpacked_payload[i, :seq_len, :] = payload_full[
+                            0, start_idx : start_idx + seq_len, :
+                        ]
+                payload_full = unpacked_payload
+            payload_full = payload_full[:, :original_seq_length, :]
+
+            return output_tensor.new_zeros(()), {
+                "logprobs": logprob_outputs["logprobs"],
+                "teacher_full_payload": payload_full.to(dtype=self.payload_dtype),
             }
 
         return processor_fn_inner

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -967,7 +967,13 @@ class TeacherFullPayloadPostProcessor:
 
             return output_tensor.new_zeros(()), {
                 "logprobs": logprob_outputs["logprobs"],
-                "teacher_full_payload": payload_full.to(dtype=self.payload_dtype),
+                # Off the GPU here, inside the schedule: mcore retains every
+                # microbatch's output dict until the whole forward completes, so
+                # a device tensor would accumulate the entire data-parallel
+                # shard's payload rather than one microbatch's.
+                "teacher_full_payload": payload_full.to(
+                    device="cpu", dtype=self.payload_dtype
+                ),
             }
 
         return processor_fn_inner

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -599,7 +599,7 @@ class OnPolicyDistillationFullTransport(TypedDict):
     teacher_payload: Literal["hidden_states", "logits"]
     divergence: Literal["reverse_kl"]
     payload_dtype: Literal["bfloat16", "float16", "float32"]
-    chunk_size: NotRequired[int | None]
+    chunk_size: int | None
     teacher_lm_head_lifecycle: Literal["none", "offload", "evict"]
     validate_decomposition: bool
     payload_field: str

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -586,6 +586,25 @@ class RouterReplayConfig(TypedDict):
     enabled: Literal[True]
 
 
+class OnPolicyDistillationFullTransport(TypedDict):
+    """Resolved full-vocabulary MOPD settings carried to the policy workers.
+
+    A ``model_dump`` of ``OnPolicyDistillationFullConfig`` plus the resolved
+    ``payload_field``. That BaseModel remains the authoritative schema and the
+    only place defaults are declared, so readers must take these keys as
+    required rather than supplying their own fallbacks.
+    """
+
+    enabled: bool
+    teacher_payload: Literal["hidden_states", "logits"]
+    divergence: Literal["reverse_kl"]
+    payload_dtype: Literal["bfloat16", "float16", "float32"]
+    chunk_size: NotRequired[int | None]
+    teacher_lm_head_lifecycle: Literal["none", "offload", "evict"]
+    validate_decomposition: bool
+    payload_field: str
+
+
 class PolicyConfig(TypedDict):
     model_name: str
     tokenizer: TokenizerConfig
@@ -607,6 +626,9 @@ class PolicyConfig(TypedDict):
     megatron_cfg: NotRequired[MegatronConfig | MegatronConfigDisabled]
     draft: NotRequired[DraftConfig | DraftConfigDisabled]
     pretrained_checkpoint: NotRequired[PretrainedCheckpointConfig]
+    # Resolved once by the driver and carried to the student workers and (via
+    # deepcopy) to the teacher group. Absent means full-vocabulary MOPD is off.
+    on_policy_distillation_full: NotRequired[OnPolicyDistillationFullTransport]
     router_replay: NotRequired[RouterReplayConfig | RouterReplayConfigDisabled]
     hf_config_overrides: NotRequired[dict[str, Any]]
     dynamic_batching: DynamicBatchingConfig | DynamicBatchingConfigDisabled

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -48,6 +48,19 @@ class TopkLogitsOutputSpec(TypedDict):
     topk_indices: torch.Tensor
 
 
+class TeacherFullPayloadOutputSpec(TypedDict):
+    """Sampled-token logprobs plus the full-vocabulary MOPD teacher payload.
+
+    ``teacher_full_payload`` is ``[B, S, hidden_size]`` or ``[B, S, vocab_size]``
+    depending on ``on_policy_distillation.full.teacher_payload``. It is ``None``
+    off the last pipeline stage: the payload is far too large to broadcast, so
+    only the stage that produced it writes it back.
+    """
+
+    logprobs: torch.Tensor
+    teacher_full_payload: Optional[torch.Tensor]
+
+
 class PolicyInterface(ABC):
     """Abstract base class defining the interface for RL policies."""
 

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -54,7 +54,9 @@ class TeacherFullPayloadOutputSpec(TypedDict):
     ``teacher_full_payload`` is ``[B, S, hidden_size]`` or ``[B, S, vocab_size]``
     depending on ``on_policy_distillation.full.teacher_payload``. It is ``None``
     off the last pipeline stage: the payload is far too large to broadcast, so
-    only the stage that produced it writes it back.
+    only the stage that produced it writes it back. It comes back on CPU --
+    each microbatch is moved off the device inside the forward schedule, which
+    is what bounds the resident payload to one microbatch.
     """
 
     logprobs: torch.Tensor

--- a/nemo_rl/models/policy/teacher_worker_group.py
+++ b/nemo_rl/models/policy/teacher_worker_group.py
@@ -236,6 +236,19 @@ class TeacherWorkerGroup:
         self.cfg = cfg
         self._micro_batch_size = teacher_cfg.micro_batch_size
 
+        # Resolved by the driver in setup and carried on the deep-copied policy
+        # config; absent means full-vocabulary MOPD is off for this run.
+        opd_full_cfg = cfg.get("on_policy_distillation_full")
+        self._opd_full_payload: Optional[str] = (
+            opd_full_cfg["teacher_payload"] if opd_full_cfg else None
+        )
+        self._opd_full_payload_dtype: Optional[str] = (
+            opd_full_cfg["payload_dtype"] if opd_full_cfg else None
+        )
+        self._opd_full_payload_field: Optional[str] = (
+            opd_full_cfg["payload_field"] if opd_full_cfg else None
+        )
+
         # Set up sequence packing / dynamic batching (mirrors lm_policy.py)
         self.use_sequence_packing = cfg["sequence_packing"]["enabled"]
         self.use_dynamic_batches = cfg["dynamic_batching"]["enabled"]
@@ -332,7 +345,12 @@ class TeacherWorkerGroup:
                 "tensor_parallel",
                 "pipeline_parallel",
             ],
-            common_kwargs={"micro_batch_size": self._micro_batch_size},
+            common_kwargs={
+                "micro_batch_size": self._micro_batch_size,
+                "opd_full_payload": self._opd_full_payload,
+                "opd_full_payload_dtype": self._opd_full_payload_dtype,
+                "opd_full_payload_field": self._opd_full_payload_field,
+            },
         )
         self.worker_group.get_all_worker_results(futures)
 

--- a/nemo_rl/models/policy/teacher_worker_group.py
+++ b/nemo_rl/models/policy/teacher_worker_group.py
@@ -174,6 +174,11 @@ class TeacherWorkerGroup:
         # TQ fetch does not carry routed_experts, so replay must stay off.
         if "router_replay" in cfg:
             cfg["router_replay"]["enabled"] = False
+        # A student `pretrained_checkpoint` rides along on the copied config and
+        # would be loaded as the teacher's own weights. Resume keeps student
+        # weights out of the config for the same reason (`weights_path=None`
+        # below); this key has to be dropped explicitly.
+        cfg.pop("pretrained_checkpoint", None)
         # The teacher uses the plain Megatron worker, so a student-side quant_cfg
         # would be silently ignored. Drop it explicitly and warn instead.
         if cfg.get("quant_cfg") is not None:

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -50,6 +50,7 @@ from nemo_rl.data_plane.schema import (
     LP_SEED_FIELDS,
     ROUTE_PASSTHROUGH_FLAG,
     ROUTE_PLAN_TAG,
+    fields_with_optional_opd_full,
     fields_with_optional_routed_experts,
 )
 from nemo_rl.models.policy.lm_policy import Policy
@@ -136,6 +137,12 @@ class TQPolicy(TQDriverMixin, Policy):
         self._router_replay_enabled = bool(
             (self.cfg.get("router_replay") or {}).get("enabled", False)
         )
+        # Per-token teacher payload column read by the full-vocabulary MOPD loss.
+        # Resolved by the driver in setup; absent means the feature is off and
+        # the column must stay out of every fetch.
+        self._opd_full_field: Optional[str] = (
+            self.cfg.get("on_policy_distillation_full") or {}
+        ).get("payload_field")
 
         # Forward to workers (replaces ``Policy.setup_data_plane`` call
         # site in the trainer — TQPolicy bundles bootstrap + worker
@@ -179,8 +186,11 @@ class TQPolicy(TQDriverMixin, Policy):
         """
         self.dp_client.register_partition(
             partition_id=self.tq_partition_id,
-            fields=fields_with_optional_routed_experts(
-                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+            fields=fields_with_optional_opd_full(
+                fields_with_optional_routed_experts(
+                    DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+                ),
+                field=self._opd_full_field,
             ),
             num_samples=num_samples,
             consumer_tasks=["prev_lp", "ref_lp", "train"],
@@ -198,8 +208,11 @@ class TQPolicy(TQDriverMixin, Policy):
         """
         self.dp_client.register_partition(
             partition_id=partition_id,
-            fields=fields_with_optional_routed_experts(
-                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+            fields=fields_with_optional_opd_full(
+                fields_with_optional_routed_experts(
+                    DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+                ),
+                field=self._opd_full_field,
             ),
             num_samples=num_samples,
             consumer_tasks=[partition_id],
@@ -394,7 +407,9 @@ class TQPolicy(TQDriverMixin, Policy):
         # forward would run image-blind while the logprob forwards saw images.
         train_meta = self._with_route_fields(
             meta,
-            train_fields,
+            tuple(
+                fields_with_optional_opd_full(train_fields, field=self._opd_full_field)
+            ),
             task_name="train",
             want_routes=True,
         )
@@ -524,8 +539,11 @@ class TQPolicy(TQDriverMixin, Policy):
             meta,
             # Raw fields, not pre-wrapped in fields_with_optional_routed_experts:
             # _with_route_fields applies that wrapper itself, gated on both
-            # router replay and route-plan passthrough.
-            train_fields,
+            # router replay and route-plan passthrough. The opd_full payload
+            # column has no such gate, so it is appended here.
+            tuple(
+                fields_with_optional_opd_full(train_fields, field=self._opd_full_field)
+            ),
             task_name="train",
             want_routes=True,
         )

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2203,8 +2203,8 @@ class MegatronPolicyWorkerImpl(
 
         Returns:
             A BatchedDataDict with ``logprobs`` ``[B, S]`` on every rank and
-            ``teacher_full_payload`` ``[B, S, D]`` on the last pipeline stage
-            (``None`` elsewhere).
+            ``teacher_full_payload`` ``[B, S, D]`` on CPU on the last pipeline
+            stage (``None`` elsewhere).
 
         Raises:
             ValueError: If ``payload`` is ``"hidden_states"`` but this teacher
@@ -2298,11 +2298,11 @@ class MegatronPolicyWorkerImpl(
                         value=0.0,
                     )
                 padded_logprobs.append(logprobs_mb)
-                # Concatenating on the GPU would hold a second copy of the whole
-                # DP shard's payload; release each microbatch as it is copied out.
-                padded_payloads.append(payload_mb.to("cpu"))
-                microbatch_output["teacher_full_payload"] = None
+                padded_payloads.append(payload_mb)
             tensors = {"logprobs": torch.cat(padded_logprobs, dim=0)}
+            # Already on CPU: the post-processor moves each microbatch off the
+            # device as it is produced, so this pad-and-concatenate never puts
+            # the payload back on the GPU.
             teacher_full_payload = torch.cat(padded_payloads, dim=0)
         else:
             tensors = {"logprobs": None}

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -705,8 +705,8 @@ class MegatronPolicyWorkerImpl(
         # module, so it stays invisible to checkpoint saving and refit.
         opd_full_cfg = self.cfg.get("on_policy_distillation_full") or {}
         self._opd_full_enabled = bool(opd_full_cfg)
-        self._opd_full_lm_head_lifecycle: str = (
-            opd_full_cfg["teacher_lm_head_lifecycle"] if opd_full_cfg else "offload"
+        self._opd_full_lm_head_lifecycle: Optional[str] = (
+            opd_full_cfg["teacher_lm_head_lifecycle"] if opd_full_cfg else None
         )
         self._opd_full_teacher_lm_head: Optional[torch.Tensor] = None
         self._opd_full_teacher_checkpoint_path: Optional[str] = None
@@ -2093,8 +2093,9 @@ class MegatronPolicyWorkerImpl(
             f"after unwrapping {type(model).__qualname__}. Megatron builds "
             "output_layer only on the last pipeline stage "
             f"(pipeline_model_parallel_size={pipeline_size}); the teacher LM head "
-            "cannot be loaded per-stage because the load is a whole-world "
-            "collective. Use pipeline_model_parallel_size=1 or "
+            "cannot be loaded per-stage because resolving its checkpoint iteration "
+            "(Megatron-Bridge read_train_state) broadcasts over the whole world. "
+            "Use pipeline_model_parallel_size=1 or "
             "on_policy_distillation.full.teacher_payload='logits'."
         )
 
@@ -2108,8 +2109,9 @@ class MegatronPolicyWorkerImpl(
         module needs.
 
         Args:
-            teacher_path_config: Teacher policy config with `pretrained_checkpoint`
-                cleared, so resolution keys off the teacher's own model name.
+            teacher_path_config: The teacher group's own policy config, which
+                carries no `pretrained_checkpoint`, so resolution keys off the
+                teacher's model name.
 
         Returns:
             The resolved Megatron checkpoint root of the teacher.
@@ -2203,7 +2205,33 @@ class MegatronPolicyWorkerImpl(
             A BatchedDataDict with ``logprobs`` ``[B, S]`` on every rank and
             ``teacher_full_payload`` ``[B, S, D]`` on the last pipeline stage
             (``None`` elsewhere).
+
+        Raises:
+            ValueError: If ``payload`` is ``"hidden_states"`` but this teacher
+                transforms its logits after ``output_layer``, which the student's
+                reconstruction cannot reproduce.
         """
+        if payload == "hidden_states":
+            # The student rebuilds teacher logits as output_layer(h) with no
+            # post-transform. A teacher whose forward rescales or softcaps its
+            # logits after the linear (Gemma2/Gemma4 final_logit_softcapping,
+            # MuseGlimmer output_multiplier, MuP) would be silently
+            # mis-reconstructed; the logits payload is exact for those models.
+            model_config = self._get_model_config()
+            if (
+                getattr(model_config, "final_logit_softcapping", None)
+                or getattr(model_config, "output_multiplier", 1.0) != 1.0
+                or getattr(model_config, "use_mup", False)
+            ):
+                raise ValueError(
+                    "on_policy_distillation.full.teacher_payload='hidden_states' "
+                    "reconstructs teacher logits as output_layer(h), but this "
+                    "teacher post-processes its logits after output_layer "
+                    "(final_logit_softcapping / output_multiplier / MuP), so the "
+                    "reconstruction would be silently wrong. Use "
+                    "teacher_payload='logits'."
+                )
+
         self.timer.start("get_logprobs_with_full_payload")
         no_grad = torch.no_grad()
         no_grad.__enter__()
@@ -2270,9 +2298,12 @@ class MegatronPolicyWorkerImpl(
                         value=0.0,
                     )
                 padded_logprobs.append(logprobs_mb)
-                padded_payloads.append(payload_mb)
+                # Concatenating on the GPU would hold a second copy of the whole
+                # DP shard's payload; release each microbatch as it is copied out.
+                padded_payloads.append(payload_mb.to("cpu"))
+                microbatch_output["teacher_full_payload"] = None
             tensors = {"logprobs": torch.cat(padded_logprobs, dim=0)}
-            teacher_full_payload = torch.cat(padded_payloads, dim=0).to("cpu")
+            teacher_full_payload = torch.cat(padded_payloads, dim=0)
         else:
             tensors = {"logprobs": None}
         logprobs = broadcast_tensors_from_last_stage(tensors)["logprobs"]

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -45,7 +45,7 @@ from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
 )
 from megatron.core.optimizer import ChainedOptimizer
 from megatron.core.rerun_state_machine import get_rerun_state_machine
-from megatron.core.utils import get_model_config
+from megatron.core.utils import get_model_config, unwrap_model
 from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
@@ -85,6 +85,7 @@ from nemo_rl.models.megatron.setup import (
     build_inference_model,
     finalize_megatron_setup,
     handle_model_import,
+    load_teacher_output_layer_weight,
     setup_distributed,
     setup_model_and_optimizer,
     setup_reference_model_state,
@@ -95,6 +96,7 @@ from nemo_rl.models.megatron.setup import (
 from nemo_rl.models.megatron.train import (
     LogprobsPostProcessor,
     LossPostProcessor,
+    TeacherFullPayloadPostProcessor,
     TopkLogitsPostProcessor,
     aggregate_training_statistics,
     megatron_forward_backward,
@@ -104,6 +106,7 @@ from nemo_rl.models.policy.interfaces import (
     ColocatablePolicyInterface,
     LogprobOutputSpec,
     ReferenceLogprobOutputSpec,
+    TeacherFullPayloadOutputSpec,
 )
 from nemo_rl.models.policy.utils import (
     broadcast_hf_buckets_via_distributed_impl,
@@ -697,6 +700,17 @@ class MegatronPolicyWorkerImpl(
         ## used for streaming update inference engine weights
         self._held_gather_buffer = None
 
+        # Full-vocabulary MOPD: this rank's teacher LM-head shard, loaded on
+        # demand (see load_opd_full_teacher_lm_head). A plain tensor, not a
+        # module, so it stays invisible to checkpoint saving and refit.
+        opd_full_cfg = self.cfg.get("on_policy_distillation_full") or {}
+        self._opd_full_enabled = bool(opd_full_cfg)
+        self._opd_full_lm_head_lifecycle: str = (
+            opd_full_cfg["teacher_lm_head_lifecycle"] if opd_full_cfg else "offload"
+        )
+        self._opd_full_teacher_lm_head: Optional[torch.Tensor] = None
+        self._opd_full_teacher_checkpoint_path: Optional[str] = None
+
         self._init_inference_engine_state()
         self._setup_colocated_cuda_graph_managers()
 
@@ -914,6 +928,7 @@ class MegatronPolicyWorkerImpl(
                     num_microbatches=num_microbatches,
                     sampling_params=self.sampling_params,
                     draft_model=self.draft_model,
+                    teacher_output_layer_weight=self._opd_full_teacher_lm_head,
                 )
 
                 rerun_state_machine = get_rerun_state_machine()
@@ -1568,6 +1583,7 @@ class MegatronPolicyWorkerImpl(
             num_microbatches=num_microbatches,
             sampling_params=self.sampling_params,
             draft_model=self.draft_model,
+            teacher_output_layer_weight=self._opd_full_teacher_lm_head,
         )
 
         # Placeholder N=1: loss returns un-normalized sums. ``backward``
@@ -2052,6 +2068,221 @@ class MegatronPolicyWorkerImpl(
         no_grad.__exit__(None, None, None)
         self.timer.stop("get_logprobs")
         return BatchedDataDict[LogprobOutputSpec](logprobs=logprobs).to("cpu")
+
+    def _resolve_output_layer_owner(self) -> Any:
+        """Return the unwrapped module that owns ``output_layer`` on this rank.
+
+        Raises:
+            AttributeError: If this rank has no output layer. Megatron only builds
+                one on the last pipeline stage, so this is the expected failure
+                when opd_full runs with student pipeline parallelism.
+        """
+        model = unwrap_model(self.model)
+        if hasattr(model, "output_layer"):
+            return model
+        language_model = getattr(model, "language_model", None)
+        if language_model is not None and hasattr(language_model, "output_layer"):
+            return language_model
+        pipeline_size = (
+            parallel_state.get_pipeline_model_parallel_world_size()
+            if torch.distributed.is_initialized()
+            else 1
+        )
+        raise AttributeError(
+            "opd_full requires an output_layer on this rank, but none was found "
+            f"after unwrapping {type(model).__qualname__}. Megatron builds "
+            "output_layer only on the last pipeline stage "
+            f"(pipeline_model_parallel_size={pipeline_size}); the teacher LM head "
+            "cannot be loaded per-stage because the load is a whole-world "
+            "collective. Use pipeline_model_parallel_size=1 or "
+            "on_policy_distillation.full.teacher_payload='logits'."
+        )
+
+    def load_opd_full_teacher_lm_head(self, teacher_path_config: PolicyConfig) -> str:
+        """Resolve and load the teacher LM head for full-vocabulary MOPD.
+
+        Called after the teacher worker groups exist, because the teacher's
+        Megatron checkpoint is only materialized by their HF conversion. Path
+        resolution happens here rather than on the driver: the driver process
+        is never provisioned with the mcore extra that validate_model_paths'
+        module needs.
+
+        Args:
+            teacher_path_config: Teacher policy config with `pretrained_checkpoint`
+                cleared, so resolution keys off the teacher's own model name.
+
+        Returns:
+            The resolved Megatron checkpoint root of the teacher.
+        """
+        _, teacher_pretrained_path, _ = validate_model_paths(teacher_path_config)
+        self._load_opd_full_teacher_lm_head_from_path(teacher_pretrained_path)
+        return teacher_pretrained_path
+
+    def _load_opd_full_teacher_lm_head_from_path(
+        self, teacher_pretrained_path: str
+    ) -> None:
+        """Load this rank's shard of the teacher LM head from an already-resolved path."""
+        owner = self._resolve_output_layer_owner()
+        output_layer = owner.output_layer
+        output_weight = output_layer.weight
+        if output_weight is None:
+            output_weight = owner.shared_embedding_or_output_weight()
+
+        self._opd_full_teacher_checkpoint_path = teacher_pretrained_path
+        teacher_lm_head = load_teacher_output_layer_weight(
+            teacher_pretrained_path=teacher_pretrained_path,
+            local_vocab_size=output_layer.output_size_per_partition,
+            dtype=output_weight.dtype,
+        )
+        self._opd_full_teacher_lm_head = teacher_lm_head
+        if self._opd_full_lm_head_lifecycle == "none":
+            self._move_opd_full_teacher_lm_head("cuda")
+
+    @torch.no_grad()
+    def _move_opd_full_teacher_lm_head(self, device: str) -> None:
+        """Move the cached teacher LM-head shard between CPU and GPU."""
+        if self._opd_full_teacher_lm_head is None:
+            return
+        target_device = torch.device(device)
+        if self._opd_full_teacher_lm_head.device == target_device:
+            return
+        self._opd_full_teacher_lm_head = self._opd_full_teacher_lm_head.to(
+            device=target_device, non_blocking=True
+        )
+
+    def _release_opd_full_teacher_lm_head(self) -> None:
+        """Apply the configured lifecycle policy after a training phase."""
+        if self._opd_full_teacher_lm_head is None:
+            return
+        if self._opd_full_lm_head_lifecycle == "offload":
+            self._move_opd_full_teacher_lm_head("cpu")
+        elif self._opd_full_lm_head_lifecycle == "evict":
+            self._opd_full_teacher_lm_head = None
+
+    def _stage_opd_full_teacher_lm_head_for_training(self) -> None:
+        """Make the teacher LM-head shard resident on GPU for a train step."""
+        if not self._opd_full_enabled:
+            return
+        if (
+            self._opd_full_teacher_lm_head is None
+            and self._opd_full_lm_head_lifecycle == "evict"
+            and self._opd_full_teacher_checkpoint_path is not None
+        ):
+            self._load_opd_full_teacher_lm_head_from_path(
+                self._opd_full_teacher_checkpoint_path
+            )
+        self._move_opd_full_teacher_lm_head("cuda")
+
+    @wrap_with_nvtx_name("megatron_policy_worker/get_logprobs_with_full_payload")
+    def get_logprobs_with_full_payload(
+        self,
+        *,
+        data: BatchedDataDict[Any],
+        payload: str,
+        payload_dtype: str,
+        micro_batch_size: Optional[int] = None,
+    ) -> BatchedDataDict[TeacherFullPayloadOutputSpec]:
+        """Run a teacher forward returning sampled-token logprobs and the full payload.
+
+        Full-vocabulary MOPD needs the teacher's whole next-token distribution.
+        Both outputs come from a single forward: adding a second entrypoint would
+        double the teacher's cost for the same tokens.
+
+        Unlike ``get_logprobs``, the payload is deliberately **not** broadcast off
+        the last pipeline stage -- it is orders of magnitude larger than the
+        scalar logprob column, and the caller writes it back from the stage that
+        already owns it.
+
+        Args:
+            data: Right-padded batch to score.
+            payload: ``"hidden_states"`` or ``"logits"``.
+            payload_dtype: Torch dtype name for the transported payload.
+            micro_batch_size: Overrides the configured logprob batch size.
+
+        Returns:
+            A BatchedDataDict with ``logprobs`` ``[B, S]`` on every rank and
+            ``teacher_full_payload`` ``[B, S, D]`` on the last pipeline stage
+            (``None`` elsewhere).
+        """
+        self.timer.start("get_logprobs_with_full_payload")
+        no_grad = torch.no_grad()
+        no_grad.__enter__()
+        logprob_batch_size = (
+            micro_batch_size
+            if micro_batch_size is not None
+            else self.cfg["logprob_batch_size"]
+        )
+
+        self.model.eval()
+        attach_media_token_validity_mask(data, self.media_placeholder_token_id)
+
+        (
+            mb_iterator,
+            num_microbatches,
+            micro_batch_size,
+            seq_length,
+            padded_seq_length,
+        ) = get_microbatch_iterator(
+            data,
+            self.cfg,
+            logprob_batch_size,
+            straggler_timer=self.mcore_state.straggler_timer,
+            delegate_pack_to_model=self.delegate_pack_to_model,
+            delegate_mtp_loss_mask_to_model=self.delegate_mtp_loss_mask_to_model,
+            model_slices_context_parallel_inputs=self.model_slices_context_parallel_inputs,
+        )
+
+        list_of_outputs = megatron_forward_backward(
+            model=self.model,
+            data_iterator=mb_iterator,
+            seq_length=padded_seq_length,
+            mbs=micro_batch_size,
+            num_microbatches=num_microbatches,
+            post_processing_fn=TeacherFullPayloadPostProcessor(
+                cfg=self.cfg,
+                payload=payload,
+                payload_dtype=getattr(torch, payload_dtype),
+                sampling_params=self.sampling_params,
+            ),
+            forward_only=True,
+            defer_fp32_logits=self.defer_fp32_logits,
+            sampling_params=self.sampling_params,
+            straggler_timer=self.mcore_state.straggler_timer,
+            enable_opd_full_capture=(payload == "hidden_states"),
+        )
+
+        teacher_full_payload = None
+        if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+            padded_logprobs = []
+            padded_payloads = []
+            for microbatch_output in list_of_outputs:
+                logprobs_mb = microbatch_output["logprobs"]
+                payload_mb = microbatch_output["teacher_full_payload"]
+                padding_needed = seq_length - logprobs_mb.shape[1]
+                if padding_needed > 0:
+                    logprobs_mb = torch.nn.functional.pad(
+                        logprobs_mb, (0, padding_needed), mode="constant", value=0.0
+                    )
+                    payload_mb = torch.nn.functional.pad(
+                        payload_mb,
+                        (0, 0, 0, padding_needed),
+                        mode="constant",
+                        value=0.0,
+                    )
+                padded_logprobs.append(logprobs_mb)
+                padded_payloads.append(payload_mb)
+            tensors = {"logprobs": torch.cat(padded_logprobs, dim=0)}
+            teacher_full_payload = torch.cat(padded_payloads, dim=0).to("cpu")
+        else:
+            tensors = {"logprobs": None}
+        logprobs = broadcast_tensors_from_last_stage(tensors)["logprobs"]
+
+        no_grad.__exit__(None, None, None)
+        self.timer.stop("get_logprobs_with_full_payload")
+        return BatchedDataDict[TeacherFullPayloadOutputSpec](
+            logprobs=logprobs.to("cpu"),
+            teacher_full_payload=teacher_full_payload,
+        )
 
     def _apply_state_dict_to_model(
         self,
@@ -3410,6 +3641,10 @@ class MegatronPolicyWorkerImpl(
         ):
             self.move_optimizer("cpu")
 
+        # No teacher projection happens during logprob inference, so the head can
+        # follow the configured offload policy here too.
+        self._release_opd_full_teacher_lm_head()
+
         gc.collect()
         torch.cuda.empty_cache()
         self._log_gpu_mem("lp_prep_exit")
@@ -3443,6 +3678,10 @@ class MegatronPolicyWorkerImpl(
             self.model, "cuda", move_grads=True, move_params=True
         )
         self.model.train()
+
+        # The opd_full teacher LM head follows the model: the loss projects the
+        # teacher payload with it on every microbatch.
+        self._stage_opd_full_teacher_lm_head_for_training()
 
         # Training expects optimizer state on CUDA. Keep this unconditional rather
         # than trying to mirror every path that may have offloaded it to CPU.
@@ -3500,6 +3739,7 @@ class MegatronPolicyWorkerImpl(
     @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
     def offload_before_refit(self):
         """Offload the optimizer and buffers to the CPU."""
+        self._release_opd_full_teacher_lm_head()
         # An in-flight async checkpoint keeps references to the CUDA tensors in
         # its sharded state dict until the write is finalized. Offloading swaps
         # those tensors for CPU storage, so the checkpoint references would keep

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -254,6 +254,7 @@ project-includes = [
   "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/megatron/hybridep.py",
   "nemo_rl/models/megatron/memory_saver.py",
+  "nemo_rl/models/megatron/opd_full_capture.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
   "nemo_rl/models/policy/tq_policy.py",

--- a/tests/test_suites/llm/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.sh
+++ b/tests/test_suites/llm/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# GB200 variant of the H100 3n8g full-vocabulary MOPD sanity test: exact reverse
+# KL over the whole vocabulary. Qwen3-1.7B self-distillation, divergence ~0.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=3
+GPUS_PER_NODE=4
+STEPS_PER_RUN=5
+MAX_STEPS=5
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+# Wider than the top-k sibling: payload transport + divergence kernels cost more.
+NUM_MINUTES=25
+USES_SANDBOX=1
+USE_GYM_CONTAINER=true
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+cd $PROJECT_ROOT
+uv run examples/run_grpo_single_controller.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=False \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    "$@" \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Gate on train/loss, which every run emits. Keying this on an opd_full metric
+# would make "the objective silently never engaged" indistinguishable from "the
+# assertions passed": the key would be absent, jq would print nothing, and the
+# whole block would be skipped with exit 0. check_metrics.py fails on a missing
+# key, so the opd_full assertions below are still required, not optional.
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    # Reverse KL is non-negative, so a negative value means the kernel is wrong.
+    # -1.0 is aggregate_step_metrics' no-valid-token marker, not a real value.
+    # teacher_full_payload_tokens is emitted only by opd_full, so it is the one
+    # assertion here that is not satisfied by a run that learned nothing.
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'abs(median(data["train/loss"])) < 0.02' \
+        'abs(median(data["train/opd_full_reverse_kl"])) < 0.02' \
+        'max(data["train/opd_full_reverse_kl_max"]) < 0.5' \
+        'min({k: v for k, v in data["train/opd_full_reverse_kl_min"].items() if v != -1.0}) > -1e-3' \
+        'max(data["train/on_policy_distillation/teacher_full_payload_tokens"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_batches"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_samples"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_model_unique"]) == 1'
+
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.sh
+++ b/tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Full-vocabulary MOPD sanity test: exact reverse KL over the whole vocabulary.
+# Qwen3-1.7B self-distillation, so the divergence should sit at ~0.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=3
+GPUS_PER_NODE=8
+STEPS_PER_RUN=5
+MAX_STEPS=5
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+# Wider than the top-k sibling: payload transport + divergence kernels cost more.
+NUM_MINUTES=25
+USES_SANDBOX=1
+USE_GYM_CONTAINER=true
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+cd $PROJECT_ROOT
+uv run examples/run_grpo_single_controller.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=False \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    "$@" \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Gate on train/loss, which every run emits. Keying this on an opd_full metric
+# would make "the objective silently never engaged" indistinguishable from "the
+# assertions passed": the key would be absent, jq would print nothing, and the
+# whole block would be skipped with exit 0. check_metrics.py fails on a missing
+# key, so the opd_full assertions below are still required, not optional.
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    # Reverse KL is non-negative, so a negative value means the kernel is wrong.
+    # -1.0 is aggregate_step_metrics' no-valid-token marker, not a real value.
+    # teacher_full_payload_tokens is emitted only by opd_full, so it is the one
+    # assertion here that is not satisfied by a run that learned nothing.
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'abs(median(data["train/loss"])) < 0.02' \
+        'abs(median(data["train/opd_full_reverse_kl"])) < 0.02' \
+        'max(data["train/opd_full_reverse_kl_max"]) < 0.5' \
+        'min({k: v for k, v in data["train/opd_full_reverse_kl_min"].items() if v != -1.0}) > -1e-3' \
+        'max(data["train/on_policy_distillation/teacher_full_payload_tokens"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_batches"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_samples"]) > 0' \
+        'max(data["train/on_policy_distillation/teacher_model_unique"]) == 1'
+
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -293,6 +293,10 @@ tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.sh
 # In addition to near-zero loss, it asserts positive teacher-stage activity.
 tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller.sh
 
+# Full-vocabulary sibling of the two above: exact reverse KL over the whole
+# vocabulary. GB200 3n4g variant is in nightly_gb200.txt.
+tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.sh
+
 # Cross-tokenizer off-policy distillation (xtoken): Qwen3-4B -> Llama-3.2-1B P-KL, student TP4xCP2 <- teacher TP2xCP2, guards sharded-loss parallelism-invariance.
 tests/test_suites/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.sh
 

--- a/tests/test_suites/nightly_gb200.txt
+++ b/tests/test_suites/nightly_gb200.txt
@@ -98,6 +98,12 @@ tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n4g-megatron-tp1pp2cp
 # Nano3 hybrid MoE/Mamba ModelOpt layer-spec smoke. Keeps
 # policy.disable_modelopt_layer_spec=false to cover modelopt_mamba_stack_spec.
 tests/test_suites/llm/distillation-nano3-30ba3b-4n4g-megatron-qa-nvfp4-modelopt-spec.sh
+
+# Full-vocabulary MOPD (on_policy_distillation.full): exact reverse KL over the
+# whole vocabulary. Qwen3-1.7B self-distillation, so the divergence must sit at
+# ~0. 5 GPU-hours. Thresholds are smoke bounds derived from the objective, not
+# measured -- read a first failure as a question about the bound.
+tests/test_suites/llm/mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.sh
 # SGLang backend
 tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n4g-fsdp2tp1-sglang.sh
 tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n4g-megatrontp1-sglang.sh

--- a/tests/unit/algorithms/test_opd.py
+++ b/tests/unit/algorithms/test_opd.py
@@ -1211,3 +1211,87 @@ def test_create_advantage_estimator_opd_branch():
         estimator = _create_advantage_estimator(master_config)
     assert isinstance(estimator, OPDAdvantageEstimator)
     assert len(caught) == 3
+
+
+def _meta_teacher_class():
+    class MetaTeacher:
+        def __init__(self):
+            self.sharding_annotations = _MockShardingAnnotations(1)
+
+        def get_logprobs_from_meta(self, meta):
+            del meta
+
+    return MetaTeacher
+
+
+def test_tq_teacher_enrichment_advertises_the_full_payload_column(monkeypatch):
+    """With ``full.enabled`` the enriched meta names the payload column too.
+
+    The training fetch only sees what ``enrich`` returns, so a coordinator that
+    forgot the column would leave the loss without its teacher payload.
+    """
+    import asyncio
+
+    from nemo_rl.algorithms import opd
+    from nemo_rl.data_plane.schema import OPD_FULL_HIDDEN_STATES_FIELD
+
+    monkeypatch.setattr(opd, "read_columns", lambda *a, **kw: None)
+    monkeypatch.setattr(opd, "write_columns", lambda *a, **kw: None)
+    coordinator = opd.TQTeacherLogprobCoordinator(
+        dp_client=object(),
+        teacher_worker_groups={"primary": _meta_teacher_class()()},
+        alias_to_group_alias={"math": "primary"},
+        on_policy_distillation_cfg={
+            "teacher_model_by_agent_name": {"math": "/ckpt/shared"},
+            "full": {"enabled": True, "teacher_payload": "hidden_states"},
+        },
+    )
+    meta = _teacher_meta("group", batch_size=3, seq_len=5)
+
+    enriched = asyncio.run(coordinator.enrich(meta, _teacher_record("math")))
+
+    assert "teacher_reference_logprobs" in enriched.fields
+    assert OPD_FULL_HIDDEN_STATES_FIELD in enriched.fields
+    metrics = coordinator.drain_metrics()
+    # Tokens, not bytes: 3 samples x 5 tokens.
+    assert metrics["on_policy_distillation/teacher_full_payload_tokens"] == 15.0
+    # Drained: the counter resets with the rest.
+    assert (
+        coordinator.drain_metrics()[
+            "on_policy_distillation/teacher_full_payload_tokens"
+        ]
+        == 0.0
+    )
+
+
+def test_tq_teacher_enrichment_does_not_advertise_a_payload_when_full_is_disabled(
+    monkeypatch,
+):
+    import asyncio
+
+    from nemo_rl.algorithms import opd
+    from nemo_rl.data_plane.schema import OPD_FULL_FIELDS
+
+    monkeypatch.setattr(opd, "read_columns", lambda *a, **kw: None)
+    monkeypatch.setattr(opd, "write_columns", lambda *a, **kw: None)
+    coordinator = opd.TQTeacherLogprobCoordinator(
+        dp_client=object(),
+        teacher_worker_groups={"primary": _meta_teacher_class()()},
+        alias_to_group_alias={"math": "primary"},
+        on_policy_distillation_cfg={
+            "teacher_model_by_agent_name": {"math": "/ckpt/shared"},
+            "full": {"enabled": False},
+        },
+    )
+
+    enriched = asyncio.run(
+        coordinator.enrich(
+            _teacher_meta("group", batch_size=2, seq_len=4), _teacher_record("math")
+        )
+    )
+
+    assert not set(OPD_FULL_FIELDS) & set(enriched.fields)
+    assert (
+        "on_policy_distillation/teacher_full_payload_tokens"
+        not in coordinator.drain_metrics()
+    )

--- a/tests/unit/algorithms/test_opd_full.py
+++ b/tests/unit/algorithms/test_opd_full.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 """Full-vocabulary MOPD (``on_policy_distillation.full``) config and loss.
 
-Everything here is CPU-only and process-group free: the divergence kernels
-themselves are covered in ``tests/unit/distributed/test_model_utils.py``, and
-``_opd_full_call`` only masks and normalizes a divergence tensor that
-``prepare_loss_input`` has already produced.
+Everything here is CPU-only, and process-group free except for
+``prepare_opd_full_loss_input``, whose TP collectives are neutralized the way
+``tests/unit/distributed/test_model_utils.py`` does. The divergence kernels
+themselves are covered there, and ``_opd_full_call`` only masks and normalizes a
+divergence tensor that ``prepare_loss_input`` has already produced.
 """
 
 from __future__ import annotations
@@ -26,7 +27,10 @@ import torch
 
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
 from nemo_rl.algorithms.loss.interfaces import LossInputType, MetricNormalizer
-from nemo_rl.algorithms.loss.utils import reconstruct_opd_full_teacher_logits
+from nemo_rl.algorithms.loss.utils import (
+    prepare_opd_full_loss_input,
+    reconstruct_opd_full_teacher_logits,
+)
 from nemo_rl.algorithms.loss.wrapper import _SEQ_METRIC_MAX, _SEQ_METRIC_MIN
 from nemo_rl.algorithms.opd import (
     OnPolicyDistillationFullConfig,
@@ -35,6 +39,7 @@ from nemo_rl.algorithms.opd import (
 from nemo_rl.data_plane.column_io import TOKEN_ALIGNED_FIELDS
 from nemo_rl.data_plane.schema import (
     OPD_FULL_FIELDS,
+    OPD_FULL_HIDDEN_STATES_FIELD,
     OPD_FULL_LOGITS_FIELD,
     SC_ROLLOUT_SCHEMA_FIELDS,
     fields_with_optional_opd_full,
@@ -342,6 +347,50 @@ def test_opd_full_requires_a_differentiable_logprob_for_the_reference_kl():
         )
 
 
+def test_opd_full_reference_kl_gradient_carries_the_score_function_term():
+    """The sampled penalty needs a score-function term the divergence does not.
+
+    Its weight is 1 in the forward pass, so only the gradient and the metric
+    together make a dropped weight visible.
+    """
+    penalty = 0.01
+    next_token_logprobs = torch.tensor(
+        [[-0.5, -1.0, -2.0], [-0.25, -1.5, -3.0]], requires_grad=True
+    )
+    data = _microbatch()
+    data["reference_policy_logprobs"] = torch.tensor(
+        [[0.0, -0.75, -1.25, -2.5], [0.0, -0.5, -2.0, -1.0]]
+    )
+
+    with pytest.warns(UserWarning, match="second KL"):
+        loss_fn = _loss_fn(reference_policy_kl_penalty=penalty, token_level_loss=True)
+
+    loss, metrics = loss_fn(
+        next_token_logprobs=next_token_logprobs,
+        data=data,
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+    )
+    loss.backward()
+
+    mask = data["token_mask"][:, 1:] * data["sample_mask"].unsqueeze(-1)
+    logr = data["reference_policy_logprobs"][:, 1:] - next_token_logprobs.detach()
+    k3 = torch.exp(logr) - 1.0 - logr
+    # d(k3)/dx = -(exp(r) - 1); the weight adds k3 on top.
+    expected_grad = penalty * mask * (k3 - (torch.exp(logr) - 1.0)) / _GLOBAL_VALID_TOKS
+
+    # The score-function term is ~6e-5 here, which the default atol of 1e-5
+    # would nearly swallow.
+    torch.testing.assert_close(
+        next_token_logprobs.grad, expected_grad, rtol=1e-5, atol=1e-9
+    )
+    # Forward is unweighted: the metric stays the plain k3.
+    assert metrics["kl_penalty"] == pytest.approx(
+        float((k3 * mask).sum() / _GLOBAL_VALID_TOKS), rel=1e-6
+    )
+
+
 def test_opd_full_requires_the_divergence_tensor():
     """Reaching the loss without it means prepare_loss_input silently no-oped."""
     with pytest.raises(ValueError, match="opd_full_divergence"):
@@ -602,3 +651,99 @@ def test_opd_full_filtered_sequences_receive_no_gradient():
     assert divergence.grad is not None
     torch.testing.assert_close(divergence.grad[2], torch.zeros(3))
     assert divergence.grad[0, 0].item() == pytest.approx(1 / 5, rel=1e-5)
+
+
+def test_opd_full_normalizes_by_the_global_counts_not_the_microbatch():
+    """The other fixtures use global counts equal to the microbatch's own.
+
+    A microbatch is one slice of the step, so dividing by its own counts would
+    over-weight small microbatches.
+    """
+    global_valid_seqs = torch.tensor(8.0)
+    global_valid_toks = torch.tensor(20.0)
+
+    loss, metrics = _loss_fn(token_level_loss=True)(
+        data=_microbatch(),
+        global_valid_seqs=global_valid_seqs,
+        global_valid_toks=global_valid_toks,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    assert loss.item() == pytest.approx((1 + 3 + 2 + 5 + 7) / 20)
+    assert metrics["opd_full_reverse_kl"] == pytest.approx((1 + 3 + 2 + 5 + 7) / 20)
+
+    loss, _ = _loss_fn(token_level_loss=False)(
+        data=_microbatch(),
+        global_valid_seqs=global_valid_seqs,
+        global_valid_toks=global_valid_toks,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    # seq0 averages to 2.0, seq1 to 6.0; the outer mean divides by the global count.
+    assert loss.item() == pytest.approx((2.0 + 6.0) / 8)
+
+
+# ── prepare_opd_full_loss_input ────────────────────────────────────────────
+# TP=1 limit with the kernels' collectives neutralized, as in test_model_utils.py.
+
+
+@pytest.fixture
+def _single_rank_collectives(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda tensor, *a, **kw: None)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional,
+        "all_reduce",
+        lambda tensor, *a, **kw: tensor,
+    )
+    # from_parallel_logits_to_logprobs reads the CP rank off the default group
+    # even at cp_size == 1; there is no process group here.
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+
+
+def test_prepare_opd_full_loss_input_projects_the_payload_and_drops_the_last_position(
+    _single_rank_collectives,
+):
+    """The [B, S-1] divergence pairs position t with token t+1, like LOGPROB.
+
+    Shifting the window by one or forgetting the slice both leave a tensor of a
+    plausible shape; only the closed form at every position catches it.
+    """
+    torch.manual_seed(11)
+    batch_size, seq_len, hidden, vocab = 2, 5, 3, 6
+    student_logits = torch.randn(batch_size, seq_len, vocab, requires_grad=True)
+    lm_head = torch.randn(vocab, hidden)
+    payload = torch.randn(batch_size, seq_len, hidden)
+    data = BatchedDataDict(
+        {
+            "input_ids": torch.zeros(batch_size, seq_len, dtype=torch.long),
+            OPD_FULL_HIDDEN_STATES_FIELD: payload,
+        }
+    )
+
+    loss_input = prepare_opd_full_loss_input(
+        student_logits,
+        data,
+        _loss_fn(),
+        vocab_parallel_rank=0,
+        vocab_parallel_group=object(),  # opaque: every collective is neutralized
+        context_parallel_group=None,
+        sampling_params=None,
+        chunk_size=None,
+        teacher_output_layer_weight=lm_head,
+    )
+
+    student_log_probs = torch.log_softmax(student_logits.detach(), dim=-1)
+    teacher_log_probs = torch.log_softmax(payload @ lm_head.t(), dim=-1)
+    expected = (student_log_probs.exp() * (student_log_probs - teacher_log_probs)).sum(
+        -1
+    )
+    divergence = loss_input["opd_full_divergence"]
+
+    assert divergence.shape == (batch_size, seq_len - 1)
+    torch.testing.assert_close(divergence, expected[:, :-1], rtol=1e-5, atol=1e-6)
+    # The divergence is the objective, so it must carry the student's gradient.
+    assert divergence.requires_grad
+    # Decomposition off and no reference KL: nothing else is computed.
+    assert loss_input["opd_full_entropy"] is None
+    assert loss_input["opd_full_cross_entropy"] is None
+    assert "next_token_logprobs" not in loss_input

--- a/tests/unit/algorithms/test_opd_full.py
+++ b/tests/unit/algorithms/test_opd_full.py
@@ -1,0 +1,604 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Full-vocabulary MOPD (``on_policy_distillation.full``) config and loss.
+
+Everything here is CPU-only and process-group free: the divergence kernels
+themselves are covered in ``tests/unit/distributed/test_model_utils.py``, and
+``_opd_full_call`` only masks and normalizes a divergence tensor that
+``prepare_loss_input`` has already produced.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
+from nemo_rl.algorithms.loss.interfaces import LossInputType, MetricNormalizer
+from nemo_rl.algorithms.loss.utils import reconstruct_opd_full_teacher_logits
+from nemo_rl.algorithms.loss.wrapper import _SEQ_METRIC_MAX, _SEQ_METRIC_MIN
+from nemo_rl.algorithms.opd import (
+    OnPolicyDistillationFullConfig,
+    get_opd_full_config,
+)
+from nemo_rl.data_plane.column_io import TOKEN_ALIGNED_FIELDS
+from nemo_rl.data_plane.schema import (
+    OPD_FULL_FIELDS,
+    OPD_FULL_LOGITS_FIELD,
+    SC_ROLLOUT_SCHEMA_FIELDS,
+    fields_with_optional_opd_full,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _full(**overrides) -> OnPolicyDistillationFullConfig:
+    return OnPolicyDistillationFullConfig(enabled=True, **overrides)
+
+
+def _loss_fn(*, opd_full=None, **cfg_overrides) -> ClippedPGLossFn:
+    """Build an opd_full loss with the knobs its validator insists on.
+
+    ``reference_policy_kl_penalty`` defaults to 0.01, which under opd_full is
+    legal but stacks a second KL and then demands differentiable current-policy
+    logprobs. Default it off so each test opts in explicitly.
+    """
+    cfg_overrides.setdefault("disable_ppo_ratio", True)
+    cfg_overrides.setdefault("reference_policy_kl_penalty", 0.0)
+    return ClippedPGLossFn(
+        ClippedPGLossConfig(**cfg_overrides),
+        opd_full=_full() if opd_full is None else opd_full,
+    )
+
+
+# ── Config schema ──────────────────────────────────────────────────────────
+
+
+def test_opd_full_config_rejects_a_degenerate_chunk_size():
+    with pytest.raises(ValueError, match="chunk_size must be >= 1"):
+        OnPolicyDistillationFullConfig(chunk_size=0)
+    # None means "the whole sequence in one chunk" and must stay legal.
+    assert OnPolicyDistillationFullConfig(chunk_size=None).chunk_size is None
+
+
+def test_get_opd_full_config_requires_both_switches():
+    """``full.enabled`` alone must not arm the teacher payload column.
+
+    The payload column is only written when OPD itself is on, so a run with
+    ``full.enabled`` but no OPD would ask the data plane for a column nobody
+    wrote.
+    """
+    assert get_opd_full_config({}) is None
+    assert get_opd_full_config({"on_policy_distillation": {"enabled": True}}) is None
+    assert (
+        get_opd_full_config(
+            {"on_policy_distillation": {"enabled": True, "full": {"enabled": False}}}
+        )
+        is None
+    )
+    assert (
+        get_opd_full_config(
+            {"on_policy_distillation": {"enabled": False, "full": {"enabled": True}}}
+        )
+        is None
+    )
+
+    resolved = get_opd_full_config(
+        {"on_policy_distillation": {"enabled": True, "full": {"enabled": True}}}
+    )
+    assert resolved is not None
+    assert resolved.teacher_payload == "hidden_states"
+
+
+# ── Data-plane column registration ─────────────────────────────────────────
+
+
+def test_fields_with_optional_opd_full_is_a_no_op_when_disabled():
+    base = ["input_ids", "advantages"]
+    assert fields_with_optional_opd_full(base, field=None) == base
+
+    once = fields_with_optional_opd_full(base, field=OPD_FULL_LOGITS_FIELD)
+    assert once == [*base, OPD_FULL_LOGITS_FIELD]
+    # Several call sites wrap overlapping field lists; wrapping twice must not
+    # register the column twice.
+    assert fields_with_optional_opd_full(once, field=OPD_FULL_LOGITS_FIELD) == once
+    # The input list is never mutated in place.
+    assert base == ["input_ids", "advantages"]
+
+
+def test_opd_full_columns_are_registered_token_aligned():
+    """A payload column that is not token-aligned would be stored rectangular.
+
+    ``pack_jagged_fields`` only trims a column to its per-row length when the
+    column is declared token-aligned; otherwise the payload silently
+    desynchronizes from ``input_ids`` after any repack.
+    """
+    assert set(OPD_FULL_FIELDS) <= TOKEN_ALIGNED_FIELDS
+    # Pre-registered so TransferQueue does not race on lazy field creation.
+    assert set(OPD_FULL_FIELDS) <= set(SC_ROLLOUT_SCHEMA_FIELDS)
+
+
+# ── Loss construction ──────────────────────────────────────────────────────
+
+
+def test_disabled_opd_full_leaves_the_logprob_path_intact():
+    """``full.enabled=false`` must not flip input_type nor run the validator.
+
+    The disabled block still reaches the constructor because it is resolved
+    from config; if it armed the validator, an ordinary GRPO run that happened
+    to carry the block would be rejected for its policy-gradient knobs.
+    """
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(use_cispo=True),
+        opd_full=OnPolicyDistillationFullConfig(enabled=False),
+    )
+    assert loss_fn.opd_full is None
+    assert loss_fn.input_type is LossInputType.LOGPROB
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"disable_ppo_ratio": False}, "disable_ppo_ratio"),
+        ({"ratio_clip_c": 3.0}, "dual PPO clipping"),
+        ({"use_cispo": True}, "CISPO"),
+        ({"force_on_policy_ratio": True}, "force_on_policy_ratio"),
+        ({"use_on_policy_kl_approximation": True}, "use_on_policy_kl_approximation"),
+        (
+            {"sequence_level_importance_ratios": True},
+            "sequence_level_importance_ratios",
+        ),
+        ({"use_importance_sampling_correction": True}, "exact expectation"),
+        (
+            {"truncated_importance_sampling_type": "tis"},
+            "truncated_importance_sampling_type",
+        ),
+        ({"positive_example_nll_weight": 0.1}, "positive_example_nll_weight"),
+        ({"use_kl_in_reward": True}, "use_kl_in_reward"),
+    ],
+)
+def test_opd_full_rejects_knobs_with_no_code_path(overrides, match):
+    """Every dead knob fails at construction rather than being ignored.
+
+    ``use_on_policy_kl_approximation`` is the one the shipped recipe inherits
+    as ``true`` from its grandparent, so without this rejection it would have
+    been silently dropped on a real run.
+    """
+    with pytest.raises(ValueError, match=match):
+        _loss_fn(**overrides)
+
+
+def test_opd_full_rejects_fused_linear_logprobs():
+    """The fused forward returns logprobs, but the reverse KL needs raw logits."""
+    with pytest.raises(ValueError, match="use_fused_linear_logprobs"):
+        ClippedPGLossFn(
+            ClippedPGLossConfig(
+                disable_ppo_ratio=True, reference_policy_kl_penalty=0.0
+            ),
+            use_fused_linear_logprobs=True,
+            opd_full=_full(),
+        )
+
+
+def test_opd_full_warns_but_allows_a_second_reference_kl():
+    """Stacking a reference KL on the teacher KL is legal but worth saying."""
+    with pytest.warns(UserWarning, match="second KL"):
+        loss_fn = _loss_fn(reference_policy_kl_penalty=0.01)
+    assert loss_fn.reference_policy_kl_penalty == 0.01
+
+
+def test_opd_full_declares_a_normalizer_for_every_metric_it_emits():
+    """Split-API trainers rescale by these; a missing key silently mis-scales."""
+    plain = _loss_fn()
+    assert set(plain.metric_normalizations) == {
+        "loss",
+        "kl_penalty",
+        "num_valid_samples",
+        "opd_full_reverse_kl",
+        "opd_full_reverse_kl_min",
+        "opd_full_reverse_kl_max",
+    }
+
+    decomposed = _loss_fn(opd_full=_full(validate_decomposition=True))
+    assert set(decomposed.metric_normalizations) == set(plain.metric_normalizations) | {
+        "opd_full_entropy",
+        "opd_full_cross_entropy",
+        "opd_full_decomposition_error",
+    }
+    # Extrema and the residual are already reduced, so rescaling them by a token
+    # or sequence count would be meaningless.
+    for key in (
+        "opd_full_reverse_kl_min",
+        "opd_full_reverse_kl_max",
+        "opd_full_decomposition_error",
+    ):
+        assert decomposed.metric_normalizations[key] is MetricNormalizer.NONE
+
+
+def test_opd_full_extrema_are_reduced_by_both_accumulation_layers():
+    """Two independent layers combine microbatch metrics, and both must agree.
+
+    ``SequencePackingLossWrapper`` folds per-sequence metrics and the
+    SingleController utils fold per-microbatch ones. A name present in one set
+    but not the other gets *summed* there, reporting a "min" larger than any
+    individual value.
+    """
+    # Deferred: single_controller_utils pulls the whole SingleController and
+    # data-plane stack, which nothing else in this loss-level module needs.
+    from nemo_rl.algorithms.single_controller_utils.utils import (
+        _MB_METRIC_MAX,
+        _MB_METRIC_MIN,
+    )
+
+    assert "opd_full_reverse_kl_min" in _SEQ_METRIC_MIN & _MB_METRIC_MIN
+    assert {"opd_full_reverse_kl_max", "opd_full_decomposition_error"} <= (
+        _SEQ_METRIC_MAX & _MB_METRIC_MAX
+    )
+
+
+# ── _opd_full_call reduction ───────────────────────────────────────────────
+
+
+def _microbatch() -> BatchedDataDict:
+    """Two sequences of 3 predicted tokens; the second one is a token short."""
+    return BatchedDataDict(
+        {
+            "token_mask": torch.tensor(
+                [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 0.0]],
+            ),
+            "sample_mask": torch.tensor([1.0, 1.0]),
+        }
+    )
+
+
+_DIVERGENCE = torch.tensor([[1.0, 3.0, 2.0], [5.0, 7.0, 0.0]])
+_GLOBAL_VALID_SEQS = torch.tensor(2.0)
+_GLOBAL_VALID_TOKS = torch.tensor(5.0)
+
+
+def test_opd_full_token_level_loss_normalizes_by_the_global_token_count():
+    loss, metrics = _loss_fn(token_level_loss=True)(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    assert loss.item() == pytest.approx((1 + 3 + 2 + 5 + 7) / 5)
+    assert metrics["num_valid_samples"] == pytest.approx(2.0)
+
+
+def test_opd_full_sequence_level_loss_averages_within_each_sequence_first():
+    """A flat masked_mean here would scale the loss by the mean sequence length.
+
+    SEQUENCE_LEVEL divides by a *sequence* count, so summing tokens first and
+    dividing once would mix the two units; each sequence must be averaged over
+    its own valid tokens before the outer mean.
+    """
+    loss, _ = _loss_fn(token_level_loss=False)(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    # seq0 averages 1, 3, 2 -> 2.0; seq1 has two valid tokens -> 6.0.
+    assert loss.item() == pytest.approx((2.0 + 6.0) / 2)
+
+
+def test_opd_full_diagnostics_stay_token_normalized_under_sequence_level_loss():
+    """``opd_full_reverse_kl`` declares MetricNormalizer.TOKENS either way."""
+    _, metrics = _loss_fn(token_level_loss=False)(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    assert metrics["opd_full_reverse_kl"] == pytest.approx((1 + 3 + 2 + 5 + 7) / 5)
+    # The masked-out trailing position must not drag the minimum to 0.
+    assert metrics["opd_full_reverse_kl_min"] == pytest.approx(1.0)
+    assert metrics["opd_full_reverse_kl_max"] == pytest.approx(7.0)
+
+
+def test_opd_full_reports_no_kl_penalty_when_the_coefficient_is_zero():
+    """Regression: ``kl_penalty`` divides by the coefficient to undo it.
+
+    ``kl`` is a 0-dim tensor whose ``numel()`` is always 1, so guarding on
+    ``kl.numel()`` instead of the coefficient divides by zero on the very first
+    microbatch of a default-configured run.
+    """
+    _, metrics = _loss_fn(reference_policy_kl_penalty=0.0)(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+    )
+
+    assert metrics["kl_penalty"] == 0
+
+
+def test_opd_full_requires_a_differentiable_logprob_for_the_reference_kl():
+    """``prev_logprobs`` is stale and detached, so it cannot carry the penalty."""
+    with pytest.warns(UserWarning, match="second KL"):
+        loss_fn = _loss_fn(reference_policy_kl_penalty=0.01)
+
+    with pytest.raises(ValueError, match="next_token_logprobs"):
+        loss_fn(
+            data=_microbatch(),
+            global_valid_seqs=_GLOBAL_VALID_SEQS,
+            global_valid_toks=_GLOBAL_VALID_TOKS,
+            opd_full_divergence=_DIVERGENCE,
+        )
+
+
+def test_opd_full_requires_the_divergence_tensor():
+    """Reaching the loss without it means prepare_loss_input silently no-oped."""
+    with pytest.raises(ValueError, match="opd_full_divergence"):
+        _loss_fn()(
+            data=_microbatch(),
+            global_valid_seqs=_GLOBAL_VALID_SEQS,
+            global_valid_toks=_GLOBAL_VALID_TOKS,
+        )
+
+
+def test_opd_full_reports_the_decomposition_residual():
+    """entropy + cross entropy - reverse KL, reported when asked for.
+
+    This residual is an algebraic identity, not a correctness signal: all three
+    kernels read the same logits, so a corrupted teacher cancels out of it. It
+    pins the kernels' own arithmetic and nothing upstream of them.
+    """
+    entropy = torch.tensor([[-2.0, -2.0, -2.0], [-2.0, -2.0, 0.0]])
+    cross_entropy = _DIVERGENCE - entropy
+
+    _, metrics = _loss_fn(opd_full=_full(validate_decomposition=True))(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+        opd_full_entropy=entropy,
+        opd_full_cross_entropy=cross_entropy,
+    )
+
+    assert metrics["opd_full_decomposition_error"] == pytest.approx(0.0, abs=1e-6)
+    # Entropy is reported sign-flipped: the kernel returns sum_v p log p.
+    assert metrics["opd_full_entropy"] == pytest.approx(2.0 * 5 / 5)
+    assert metrics["opd_full_cross_entropy"] == pytest.approx(
+        (3.0 + 5.0 + 4.0 + 7.0 + 9.0) / 5
+    )
+
+
+def test_opd_full_decomposition_residual_is_masked():
+    """A residual at a masked position must not fail an otherwise clean step."""
+    entropy = torch.tensor([[-2.0, -2.0, -2.0], [-2.0, -2.0, 0.0]])
+    cross_entropy = _DIVERGENCE - entropy
+    # Position [1, 2] is masked out by token_mask.
+    cross_entropy[1, 2] += 100.0
+
+    _, metrics = _loss_fn(opd_full=_full(validate_decomposition=True))(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=_DIVERGENCE,
+        opd_full_entropy=entropy,
+        opd_full_cross_entropy=cross_entropy,
+    )
+
+    assert metrics["opd_full_decomposition_error"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_opd_full_loss_is_differentiable_through_the_divergence():
+    """The reverse KL *is* the objective; nothing else carries the gradient."""
+    divergence = _DIVERGENCE.clone().requires_grad_(True)
+
+    loss, _ = _loss_fn()(
+        data=_microbatch(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=divergence,
+    )
+    loss.backward()
+
+    assert divergence.grad is not None
+    # Masked positions get no gradient; valid ones share 1 / global_valid_toks.
+    assert divergence.grad[1, 2].item() == pytest.approx(0.0)
+    assert divergence.grad[0, 0].item() == pytest.approx(1 / 5, rel=1e-5)
+
+
+# ── Teacher payload reconstruction ─────────────────────────────────────────
+# With no context-parallel group this is pure torch. It owns three silent
+# failure modes -- a transposed projection, the wrong vocabulary window, and
+# padding the wrong dimension -- each of which yields a merely plausible teacher.
+
+
+def test_reconstruct_projects_hidden_states_through_the_teacher_lm_head():
+    """Deliberately non-square: a transposed matmul would still run on a square."""
+    payload = torch.randn(2, 6, 3)  # [B, S, H_teacher]
+    lm_head = torch.randn(5, 3)  # [V_local, H_teacher]
+
+    teacher_logits = reconstruct_opd_full_teacher_logits(
+        payload,
+        teacher_payload="hidden_states",
+        student_logits=torch.zeros(2, 6, 5),
+        vocab_parallel_rank=0,
+        context_parallel_group=None,
+        teacher_output_layer_weight=lm_head,
+    )
+
+    torch.testing.assert_close(teacher_logits, payload @ lm_head.t())
+
+
+@pytest.mark.parametrize("vocab_parallel_rank", [0, 1, 2])
+def test_reconstruct_slices_this_ranks_vocabulary_window(vocab_parallel_rank):
+    """A window off by one shard distills against another rank's vocabulary."""
+    payload = torch.randn(1, 3, 12)
+    shard = 4
+
+    teacher_logits = reconstruct_opd_full_teacher_logits(
+        payload,
+        teacher_payload="logits",
+        student_logits=torch.zeros(1, 3, shard),
+        vocab_parallel_rank=vocab_parallel_rank,
+        context_parallel_group=None,
+        teacher_output_layer_weight=None,
+    )
+
+    start = vocab_parallel_rank * shard
+    torch.testing.assert_close(teacher_logits, payload[..., start : start + shard])
+
+
+def test_reconstruct_right_pads_a_short_payload_on_the_sequence_dim():
+    """Padding the vocabulary dim instead would put mass on real tokens."""
+    payload = torch.randn(1, 3, 4)
+
+    teacher_logits = reconstruct_opd_full_teacher_logits(
+        payload,
+        teacher_payload="logits",
+        student_logits=torch.zeros(1, 5, 4),
+        vocab_parallel_rank=0,
+        context_parallel_group=None,
+        teacher_output_layer_weight=None,
+    )
+
+    assert teacher_logits.shape == (1, 5, 4)
+    torch.testing.assert_close(teacher_logits[:, :3], payload)
+    torch.testing.assert_close(teacher_logits[:, 3:], torch.zeros(1, 2, 4))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {
+                "teacher_payload": "hidden_states",
+                "teacher_output_layer_weight": None,
+            },
+            "requires a loaded teacher",
+        ),
+        (
+            {
+                "teacher_payload": "hidden_states",
+                "teacher_output_layer_weight": torch.randn(4, 7),
+            },
+            "do not match the loaded teacher LM head",
+        ),
+        (
+            {
+                "teacher_payload": "hidden_states",
+                "teacher_output_layer_weight": torch.randn(9, 3),
+            },
+            "must match the student vocabulary shard",
+        ),
+    ],
+)
+def test_reconstruct_rejects_an_unusable_teacher_lm_head(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        reconstruct_opd_full_teacher_logits(
+            torch.randn(1, 3, 3),
+            student_logits=torch.zeros(1, 3, 4),
+            vocab_parallel_rank=0,
+            context_parallel_group=None,
+            **kwargs,
+        )
+
+
+def test_reconstruct_rejects_a_payload_narrower_than_this_ranks_window():
+    """Silently short-slicing here would hand the top rank a partial vocabulary."""
+    with pytest.raises(ValueError, match="narrower than this rank's vocabulary"):
+        reconstruct_opd_full_teacher_logits(
+            torch.randn(1, 3, 6),
+            teacher_payload="logits",
+            student_logits=torch.zeros(1, 3, 4),
+            vocab_parallel_rank=1,
+            context_parallel_group=None,
+            teacher_output_layer_weight=None,
+        )
+
+
+def test_reconstruct_rejects_a_payload_longer_than_the_forward_window():
+    """A longer payload means the teacher and student disagree on the batch."""
+    with pytest.raises(ValueError, match="longer than the student forward window"):
+        reconstruct_opd_full_teacher_logits(
+            torch.randn(1, 9, 4),
+            teacher_payload="logits",
+            student_logits=torch.zeros(1, 3, 4),
+            vocab_parallel_rank=0,
+            context_parallel_group=None,
+            teacher_output_layer_weight=None,
+        )
+
+
+# ── Filtered samples ───────────────────────────────────────────────────────
+
+
+def _microbatch_with_a_filtered_sequence() -> BatchedDataDict:
+    """Three sequences, the third dropped by ``sample_mask``.
+
+    ``overlong_filtering`` zeroes ``sample_mask`` rather than ``token_mask``, so
+    a reduction that forgot the outer mask would still see this row's tokens.
+    """
+    return BatchedDataDict(
+        {
+            "token_mask": torch.tensor(
+                [
+                    [1.0, 1.0, 1.0, 1.0],
+                    [1.0, 1.0, 1.0, 0.0],
+                    [1.0, 1.0, 1.0, 1.0],
+                ],
+            ),
+            "sample_mask": torch.tensor([1.0, 1.0, 0.0]),
+        }
+    )
+
+
+def test_opd_full_excludes_sequences_masked_out_by_sample_mask():
+    """Regression: ``mask = token_mask * sample_mask`` -- both factors matter.
+
+    Dropping the ``sample_mask`` factor leaves every other assertion in this
+    module passing while filtered samples keep contributing gradient. The third
+    row's divergence is set far above the others so its leakage is unmissable.
+    """
+    divergence = torch.tensor([[1.0, 3.0, 2.0], [5.0, 7.0, 0.0], [99.0, 99.0, 99.0]])
+
+    loss, metrics = _loss_fn(token_level_loss=True)(
+        data=_microbatch_with_a_filtered_sequence(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=divergence,
+    )
+
+    # Identical to the unfiltered fixture: the third row contributes nothing.
+    assert loss.item() == pytest.approx((1 + 3 + 2 + 5 + 7) / 5)
+    assert metrics["opd_full_reverse_kl"] == pytest.approx((1 + 3 + 2 + 5 + 7) / 5)
+    assert metrics["opd_full_reverse_kl_max"] == pytest.approx(7.0)
+    assert metrics["num_valid_samples"] == pytest.approx(2.0)
+
+
+def test_opd_full_filtered_sequences_receive_no_gradient():
+    """A filtered row must not steer the update at all."""
+    divergence = torch.tensor(
+        [[1.0, 3.0, 2.0], [5.0, 7.0, 0.0], [99.0, 99.0, 99.0]], requires_grad=True
+    )
+
+    loss, _ = _loss_fn(token_level_loss=True)(
+        data=_microbatch_with_a_filtered_sequence(),
+        global_valid_seqs=_GLOBAL_VALID_SEQS,
+        global_valid_toks=_GLOBAL_VALID_TOKS,
+        opd_full_divergence=divergence,
+    )
+    loss.backward()
+
+    assert divergence.grad is not None
+    torch.testing.assert_close(divergence.grad[2], torch.zeros(3))
+    assert divergence.grad[0, 0].item() == pytest.approx(1 / 5, rel=1e-5)

--- a/tests/unit/algorithms/test_opd_full.py
+++ b/tests/unit/algorithms/test_opd_full.py
@@ -525,6 +525,44 @@ def test_reconstruct_right_pads_a_short_payload_on_the_sequence_dim():
     torch.testing.assert_close(teacher_logits[:, 3:], torch.zeros(1, 2, 4))
 
 
+def test_reconstruct_takes_the_cp_window_before_projecting(monkeypatch):
+    """Projecting first costs cp_size times the matmul and a full-sequence tensor.
+
+    The result is identical either way, so only the shape handed to the matmul
+    distinguishes them -- and that allocation is ``[B, S, V_local]``, which the
+    divergence kernel's chunking cannot bound.
+    """
+    from nemo_rl.distributed.model_utils import _get_tokens_on_this_cp_rank
+
+    cp_size, cp_rank = 4, 0
+    payload = torch.randn(1, 32, 3)
+    lm_head = torch.randn(5, 3)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: cp_size)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: cp_rank)
+
+    projected_shapes = []
+    real_matmul = torch.matmul
+
+    def spy(a, b, *args, **kwargs):
+        projected_shapes.append(tuple(a.shape))
+        return real_matmul(a, b, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "matmul", spy)
+
+    teacher_logits = reconstruct_opd_full_teacher_logits(
+        payload,
+        teacher_payload="hidden_states",
+        student_logits=torch.zeros(1, 8, 5),
+        vocab_parallel_rank=0,
+        context_parallel_group=object(),  # opaque: world size and rank are stubbed
+        teacher_output_layer_weight=lm_head,
+    )
+
+    window = _get_tokens_on_this_cp_rank(payload, cp_rank, cp_size, seq_dim=1)
+    assert projected_shapes == [tuple(window.shape)]
+    torch.testing.assert_close(teacher_logits, window @ lm_head.t())
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [

--- a/tests/unit/data_plane/test_codec_jagged.py
+++ b/tests/unit/data_plane/test_codec_jagged.py
@@ -30,6 +30,10 @@ from nemo_rl.data_plane.codec import (
     response_from_nested,
     to_nested_by_length,
 )
+from nemo_rl.data_plane.schema import (
+    OPD_FULL_HIDDEN_STATES_FIELD,
+    OPD_FULL_LOGITS_FIELD,
+)
 
 from ._rollout_shapes import make_rollout_batch
 
@@ -257,3 +261,57 @@ def test_pack_jagged_fields_forced_per_token_field_drops_extra_padding() -> None
     assert torch.equal(out["advantages"][1], advantages[1, :5])
     assert torch.equal(out["advantages"][0, 3:], torch.zeros(2))
     assert torch.equal(out["extra_2d"], extra)
+
+
+# ── 3-D per-token columns (full-vocabulary MOPD teacher payload) ────────────
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_pack_jagged_fields_round_trips_a_3d_teacher_payload(
+    dtype: torch.dtype,
+) -> None:
+    """``teacher_full_*`` is the first 3-D column to enter TOKEN_ALIGNED_FIELDS.
+
+    Everything else on that list is ``(N, S)``. The seq dim must be trimmed to
+    each row's own length while the payload width is left alone; the input is
+    deliberately wider than ``max(lengths)`` because mcore SP rounds the
+    forward output's seq dim up to a multiple of TP.
+    """
+    lengths = torch.tensor([3, 5], dtype=torch.long)
+    hidden = torch.randn(2, 8, 4).to(dtype)
+
+    td = pack_jagged_fields(
+        {OPD_FULL_HIDDEN_STATES_FIELD: hidden},
+        lengths=lengths,
+        token_aligned_fields=frozenset({OPD_FULL_HIDDEN_STATES_FIELD}),
+    )
+    out = materialize(td, layout="padded")[OPD_FULL_HIDDEN_STATES_FIELD]
+
+    assert out.shape == (2, 5, 4)
+    assert out.dtype == dtype
+    assert torch.equal(out[0, :3], hidden[0, :3])
+    assert torch.equal(out[1], hidden[1, :5])
+    assert torch.equal(out[0, 3:], torch.zeros(2, 4, dtype=dtype))
+
+
+def test_materialize_pads_a_3d_payload_on_the_seq_dim_only() -> None:
+    """``pad_to_seqlen`` must widen S and leave the payload width untouched.
+
+    ``materialize`` builds its pad spec as ``[0, 0] * (dim - 2) + [0, pad]``,
+    and ``F.pad`` reads that from the last dimension backwards -- so a 3-D
+    column only pads correctly because of the leading ``[0, 0]``.
+    """
+    lengths = torch.tensor([2, 4], dtype=torch.long)
+    payload = torch.randn(2, 4, 3)
+
+    td = pack_jagged_fields(
+        {OPD_FULL_LOGITS_FIELD: payload},
+        lengths=lengths,
+        token_aligned_fields=frozenset({OPD_FULL_LOGITS_FIELD}),
+    )
+    out = materialize(td, layout="padded", pad_to_seqlen=6)[OPD_FULL_LOGITS_FIELD]
+
+    assert out.shape == (2, 6, 3)
+    assert torch.equal(out[0, :2], payload[0, :2])
+    assert torch.equal(out[1, :4], payload[1, :4])
+    assert torch.equal(out[0, 2:], torch.zeros(4, 3))

--- a/tests/unit/data_plane/test_multimodal_wire_roundtrip.py
+++ b/tests/unit/data_plane/test_multimodal_wire_roundtrip.py
@@ -311,6 +311,7 @@ def _stub_tq_policy(monkeypatch, captured: dict[str, KVBatchMeta]):
     pol = object.__new__(_StubTQPolicy)
     pol.cfg = {}
     pol._router_replay_enabled = False
+    pol._opd_full_field = None  # opd_full off, as __init__ leaves it
     pol.flops_tracker = None
     pol.sharding_annotations = SimpleNamespace(get_axis_size=lambda _axis: 1)
     pol.worker_group = SimpleNamespace(

--- a/tests/unit/data_plane/test_tq_policy_routes.py
+++ b/tests/unit/data_plane/test_tq_policy_routes.py
@@ -29,6 +29,7 @@ from nemo_rl.models.policy.tq_policy import TQPolicy
 def _policy() -> TQPolicy:
     policy = object.__new__(TQPolicy)
     policy._router_replay_enabled = True
+    policy._opd_full_field = None  # opd_full off, as __init__ leaves it
     return policy
 
 

--- a/tests/unit/distributed/test_distributed_logprob.py
+++ b/tests/unit/distributed/test_distributed_logprob.py
@@ -25,9 +25,11 @@ import pytest
 import torch
 
 from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedCrossEntropyToFixedLogits,
     ChunkedDistributedEntropy,
     ChunkedDistributedGatherLogprob,
     ChunkedDistributedLogprob,
+    ChunkedDistributedReverseKLToFixedLogits,
     DistributedLogprob,
     _compute_distributed_log_softmax,
     get_next_token_logprobs_from_logits,
@@ -519,4 +521,83 @@ def test_get_next_token_logprobs_chunk_equivalence(
     distributed_test_runner, tp_size, dtype
 ):
     test_fn = functools.partial(_run_chunk_equivalence, tp_size=tp_size, dtype=dtype)
+    distributed_test_runner(test_fn, world_size=tp_size)
+
+
+# ---------------------------------------------------------------------------
+# opd_full student/teacher divergence kernels
+# ---------------------------------------------------------------------------
+
+
+def _run_student_teacher_divergence(rank, world_size, tp_size, chunk_size, kernel_name):
+    """Both opd_full kernels against a single-GPU baseline at real TP.
+
+    The CPU tests in test_model_utils.py neutralize the collectives, so they
+    only pin the TP=1 limit, where the teacher-side log-softmax needs no
+    cross-shard reduction at all. The nightly recipes self-distill, so every
+    per-vocabulary weight is zero there and a shard-local reduction is
+    indistinguishable from the global one. A teacher distinct from the student
+    at TP>1 is the only place the teacher-side normalization is observable.
+    """
+    kernel = {
+        "reverse_kl": ChunkedDistributedReverseKLToFixedLogits,
+        "cross_entropy": ChunkedDistributedCrossEntropyToFixedLogits,
+    }[kernel_name]
+    tp_group = torch.distributed.new_group(ranks=list(range(tp_size)))
+
+    batch_size, seq_len, vocab_size = 2, 16, 256
+    vocab_part_size = vocab_size // tp_size
+    vocab_start_index = rank * vocab_part_size
+    vocab_end_index = (rank + 1) * vocab_part_size
+
+    torch.manual_seed(1337)
+    student_logits = torch.randn(batch_size, seq_len, vocab_size, device="cuda")
+    teacher_logits = torch.randn(batch_size, seq_len, vocab_size, device="cuda")
+    grad_output = torch.randn(batch_size, seq_len, device="cuda")
+
+    baseline_student = student_logits.clone().detach().requires_grad_(True)
+    baseline_student_log_probs = torch.nn.functional.log_softmax(
+        baseline_student, dim=-1
+    )
+    baseline_teacher_log_probs = torch.nn.functional.log_softmax(teacher_logits, dim=-1)
+    baseline_probs = baseline_student_log_probs.exp()
+    if kernel_name == "reverse_kl":
+        baseline = (
+            baseline_probs * (baseline_student_log_probs - baseline_teacher_log_probs)
+        ).sum(dim=-1)
+    else:
+        baseline = (-baseline_probs * baseline_teacher_log_probs).sum(dim=-1)
+    baseline.backward(grad_output)
+    baseline_grad = baseline_student.grad[
+        :, :, vocab_start_index:vocab_end_index
+    ].clone()
+
+    local_student = (
+        student_logits[:, :, vocab_start_index:vocab_end_index]
+        .clone()
+        .detach()
+        .requires_grad_(True)
+    )
+    local_teacher = (
+        teacher_logits[:, :, vocab_start_index:vocab_end_index].clone().detach()
+    )
+
+    divergence = kernel.apply(local_student, local_teacher, chunk_size, tp_group, False)
+    torch.testing.assert_close(divergence, baseline.detach(), rtol=1e-4, atol=1e-4)
+
+    divergence.backward(grad_output)
+    torch.testing.assert_close(local_student.grad, baseline_grad, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("kernel_name", ["reverse_kl", "cross_entropy"])
+@pytest.mark.parametrize("tp_size, chunk_size", [(1, 5), (2, 4)])
+def test_student_teacher_divergence_kernels(
+    distributed_test_runner, tp_size, chunk_size, kernel_name
+):
+    test_fn = functools.partial(
+        _run_student_teacher_divergence,
+        tp_size=tp_size,
+        chunk_size=chunk_size,
+        kernel_name=kernel_name,
+    )
     distributed_test_runner(test_fn, world_size=tp_size)

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -1928,3 +1928,67 @@ def test_student_teacher_reduction_normalizes_both_sides_across_tp(monkeypatch):
     )
     # Per chunk: one normalizer SUM for each of the two distributions.
     assert autograd_ops == [torch.distributed.ReduceOp.SUM] * 4
+
+
+def test_student_teacher_backward_reduces_the_normalizer_across_tp(monkeypatch):
+    """``dL/dz = p_s * (w - L)`` needs the GLOBAL ``L`` in backward as well.
+
+    The forward trace above stops at ``inference_only=True``. Backward
+    recomputes both log-softmaxes and ``L`` from the saved shards, so a backward
+    that forgot the SUM all-reduce on ``L`` would be exact at TP=1 and silently
+    wrong at TP>1 -- the same blind spot, one call later.
+    """
+    plain_ops: list[object] = []
+    autograd_ops: list[object] = []
+
+    def fake_all_reduce(tensor, *args, **kwargs):
+        plain_ops.append(kwargs["op"])
+
+    def fake_autograd_all_reduce(tensor, *args, **kwargs):
+        autograd_ops.append(kwargs["op"])
+        return tensor
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional, "all_reduce", fake_autograd_all_reduce
+    )
+
+    torch.manual_seed(7)
+    student = torch.randn(1, 4, 6, requires_grad=True)
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, torch.randn(1, 4, 6), 2, None, False
+    )
+    # Keep only the backward's collectives.
+    plain_ops.clear()
+    autograd_ops.clear()
+
+    reverse_kl.sum().backward()
+
+    # Per chunk: MAX for the student log-softmax, MAX for the teacher's, and the
+    # SUM that turns the shard-local ``L`` into the global one.
+    assert (
+        plain_ops
+        == [
+            torch.distributed.ReduceOp.MAX,
+            torch.distributed.ReduceOp.MAX,
+            torch.distributed.ReduceOp.SUM,
+        ]
+        * 2
+    )
+    assert autograd_ops == [torch.distributed.ReduceOp.SUM] * 4
+
+
+def test_student_teacher_kernels_normalize_bf16_logits_in_fp32(
+    single_rank_collectives,
+):
+    """A log-softmax taken in bf16 is off by ~1e-2; the fp32 path is within 1e-5."""
+    torch.manual_seed(5)
+    student = torch.randn(1, 4, 8, dtype=torch.bfloat16)
+    teacher = torch.randn(1, 4, 8, dtype=torch.bfloat16)
+
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, teacher, 2, None, True
+    )
+
+    expected_kl, _, _ = _student_teacher_reference(student, teacher)
+    torch.testing.assert_close(reverse_kl, expected_kl, rtol=1e-5, atol=1e-5)

--- a/tests/unit/distributed/test_model_utils.py
+++ b/tests/unit/distributed/test_model_utils.py
@@ -20,9 +20,12 @@ import torch
 
 from nemo_rl.algorithms.logits_sampling_utils import apply_top_k_top_p
 from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedCrossEntropyToFixedLogits,
+    ChunkedDistributedEntropy,
     ChunkedDistributedGatherLogprob,
     ChunkedDistributedLogprob,
     ChunkedDistributedLogprobWithSampling,
+    ChunkedDistributedReverseKLToFixedLogits,
     DistributedLogprob,
     DistributedLogprobWithSampling,
     _compute_distributed_log_softmax,
@@ -1682,3 +1685,246 @@ def test_distributed_vocab_topk_ops(
         worker_group.shutdown(force=True)
     finally:
         cluster.shutdown()
+
+
+# ── Full-vocabulary MOPD divergence kernels ─────────────────────────────────
+# At TP=1 the distributed log-softmax degenerates to a plain one, so both
+# opd_full kernels can be pinned against a closed-form reference with no GPU and
+# no process group -- same monkeypatch style as _compute_distributed_selected_logprobs.
+
+
+@pytest.fixture
+def single_rank_collectives(monkeypatch):
+    """Neutralize the collectives so the kernels compute their TP=1 limit.
+
+    ``_compute_distributed_log_softmax`` reduces through two different entry
+    points -- ``torch.distributed.all_reduce`` for the running max and the
+    *differentiable* ``torch.distributed.nn.functional.all_reduce`` for the
+    normalizer -- and the per-token reduction uses the first one again. Patching
+    only one of them would silently leave a real collective in the path.
+    """
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda tensor, *a, **kw: None)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional,
+        "all_reduce",
+        lambda tensor, *a, **kw: tensor,
+    )
+
+
+def _student_teacher_reference(
+    student: torch.Tensor, teacher: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Closed-form [B, S] reverse KL, cross entropy, and sum_v p_s log p_s."""
+    student_log_probs = torch.log_softmax(student.float(), dim=-1)
+    teacher_log_probs = torch.log_softmax(teacher.float(), dim=-1)
+    student_probs = student_log_probs.exp()
+    return (
+        (student_probs * (student_log_probs - teacher_log_probs)).sum(-1),
+        (-student_probs * teacher_log_probs).sum(-1),
+        (student_probs * student_log_probs).sum(-1),
+    )
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 32])
+def test_student_teacher_kernels_match_closed_form(single_rank_collectives, chunk_size):
+    """Forward values and chunk invariance for both opd_full kernels.
+
+    chunk_size 3 and 7 straddle S=7 so both the ragged-tail and the
+    single-chunk ``out_chunks[0]`` shortcut are exercised; 32 > S covers the
+    "whole sequence at once" default that ``chunk_size: null`` resolves to.
+    """
+    torch.manual_seed(0)
+    student = torch.randn(2, 7, 11)
+    teacher = torch.randn(2, 7, 11)
+    expected_kl, expected_ce, expected_neg_entropy = _student_teacher_reference(
+        student, teacher
+    )
+
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, teacher, chunk_size, None, True
+    )
+    cross_entropy = ChunkedDistributedCrossEntropyToFixedLogits.apply(
+        student, teacher, chunk_size, None, True
+    )
+
+    torch.testing.assert_close(reverse_kl, expected_kl, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(cross_entropy, expected_ce, rtol=1e-5, atol=1e-6)
+    # Both kernels normalize in fp32 regardless of the input dtype.
+    assert reverse_kl.dtype == torch.float32
+    assert cross_entropy.dtype == torch.float32
+
+
+def test_student_teacher_decomposition_identity(single_rank_collectives):
+    """entropy + cross entropy == reverse KL, the residual the recipe gates on.
+
+    ``opd_full_decomposition_error`` in the nightly recipe asserts this holds;
+    pin the true noise floor here so a regression cannot hide under that
+    recipe's much looser threshold.
+    """
+    torch.manual_seed(1)
+    student = torch.randn(3, 5, 13)
+    teacher = torch.randn(3, 5, 13)
+
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, teacher, 2, None, True
+    )
+    cross_entropy = ChunkedDistributedCrossEntropyToFixedLogits.apply(
+        student, teacher, 2, None, True
+    )
+    neg_entropy = ChunkedDistributedEntropy.apply(student, 2, None, True)
+
+    torch.testing.assert_close(
+        neg_entropy + cross_entropy, reverse_kl, rtol=0, atol=1e-5
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        ChunkedDistributedReverseKLToFixedLogits,
+        ChunkedDistributedCrossEntropyToFixedLogits,
+    ],
+)
+@pytest.mark.parametrize("chunk_size", [2, 5])
+def test_student_teacher_backward_matches_autograd(
+    single_rank_collectives, kernel, chunk_size
+):
+    """The hand-written backward equals autograd through the reference.
+
+    Both kernels share ``dL/dz = p_s * (w - L)``, which drops the
+    ``dw/dlog p_s`` term because it is constant and cancels against
+    ``sum_v p_s = 1``. That cancellation is the whole reason the two weights can
+    share one backward, and nothing else checks it.
+    """
+    torch.manual_seed(2)
+    teacher = torch.randn(2, 5, 9)
+    grad_output = torch.randn(2, 5)
+
+    student = torch.randn(2, 5, 9, requires_grad=True)
+    kernel.apply(student, teacher, chunk_size, None, False).mul(
+        grad_output
+    ).sum().backward()
+
+    reference_student = student.detach().clone().requires_grad_(True)
+    reference_kl, reference_ce, _ = _student_teacher_reference(
+        reference_student, teacher
+    )
+    reference = (
+        reference_kl
+        if kernel is ChunkedDistributedReverseKLToFixedLogits
+        else reference_ce
+    )
+    reference.mul(grad_output).sum().backward()
+
+    torch.testing.assert_close(
+        student.grad, reference_student.grad, rtol=1e-4, atol=1e-5
+    )
+
+
+def test_student_teacher_backward_leaves_teacher_gradient_free(
+    single_rank_collectives,
+):
+    """The teacher is a frozen constant: no gradient may flow back into it."""
+    torch.manual_seed(3)
+    student = torch.randn(1, 4, 6, requires_grad=True)
+    teacher = torch.randn(1, 4, 6, requires_grad=True)
+
+    ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, teacher, 2, None, False
+    ).sum().backward()
+
+    assert student.grad is not None
+    assert teacher.grad is None
+
+
+def test_reverse_kl_vanishes_for_identical_logits(single_rank_collectives):
+    """The self-distillation invariant the nightly recipe gates on, unit-sized."""
+    torch.manual_seed(4)
+    logits = torch.randn(1, 4, 13)
+
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        logits, logits.clone(), 4, None, True
+    )
+
+    torch.testing.assert_close(
+        reverse_kl, torch.zeros_like(reverse_kl), rtol=0, atol=1e-6
+    )
+
+
+def test_student_teacher_kernels_accept_bf16_logits(single_rank_collectives):
+    """bf16 logits in, fp32 value and fp32 grad out -- the mainline dtype path."""
+    torch.manual_seed(5)
+    student = torch.randn(1, 4, 8, dtype=torch.bfloat16, requires_grad=True)
+    teacher = torch.randn(1, 4, 8, dtype=torch.bfloat16)
+
+    reverse_kl = ChunkedDistributedReverseKLToFixedLogits.apply(
+        student, teacher, 2, None, False
+    )
+    reverse_kl.sum().backward()
+
+    assert reverse_kl.dtype == torch.float32
+    assert student.grad is not None
+    # The kernel hands autograd an fp32 grad for a bf16 input, matching
+    # ChunkedDistributedEntropy; autograd casts it back to the leaf's dtype.
+    assert student.grad.dtype == student.dtype
+
+
+@pytest.mark.parametrize(
+    ("student_shape", "teacher_shape", "match"),
+    [
+        ((2, 5, 9), (2, 5, 8), r"same \[B, S, V_local\] shape"),
+        ((5, 9), (5, 9), "must be rank 3"),
+    ],
+)
+def test_student_teacher_kernels_reject_misaligned_shards(
+    single_rank_collectives, student_shape, teacher_shape, match
+):
+    """A teacher shard that is not this rank's vocabulary window must not run."""
+    with pytest.raises(ValueError, match=match):
+        ChunkedDistributedReverseKLToFixedLogits.apply(
+            torch.randn(*student_shape), torch.randn(*teacher_shape), 2, None, True
+        )
+
+
+def test_student_teacher_reduction_normalizes_both_sides_across_tp(monkeypatch):
+    """Both distributions are TP-normalized, not just the student's.
+
+    This is the one part of the kernels that TP=1 cannot observe: skipping the
+    teacher's log-softmax collectives is exactly correct at TP=1 and silently
+    wrong at TP>1, because the teacher's softmax denominator would then only
+    span this rank's vocabulary shard. Assert the collective trace instead.
+    """
+    plain_ops: list[object] = []
+    autograd_ops: list[object] = []
+
+    def fake_all_reduce(tensor, *args, **kwargs):
+        plain_ops.append(kwargs["op"])
+
+    def fake_autograd_all_reduce(tensor, *args, **kwargs):
+        autograd_ops.append(kwargs["op"])
+        return tensor
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional, "all_reduce", fake_autograd_all_reduce
+    )
+
+    torch.manual_seed(6)
+    # S=4 over chunks of 2 -> two chunks, so the counts below are per-chunk x2.
+    ChunkedDistributedReverseKLToFixedLogits.apply(
+        torch.randn(1, 4, 6), torch.randn(1, 4, 6), 2, None, True
+    )
+
+    # Per chunk: a MAX for the student log-softmax, a MAX for the teacher's, and
+    # a SUM for the per-token reduction across vocabulary shards.
+    assert (
+        plain_ops
+        == [
+            torch.distributed.ReduceOp.MAX,
+            torch.distributed.ReduceOp.MAX,
+            torch.distributed.ReduceOp.SUM,
+        ]
+        * 2
+    )
+    # Per chunk: one normalizer SUM for each of the two distributions.
+    assert autograd_ops == [torch.distributed.ReduceOp.SUM] * 4

--- a/tests/unit/models/megatron/test_group_experts.py
+++ b/tests/unit/models/megatron/test_group_experts.py
@@ -85,7 +85,7 @@ def test_build_hf_to_local_param_map_train_side():
     w = object.__new__(MegatronPolicyWorkerImpl)  # no __init__ / no megatron state
     # opd_full off, mirroring __init__ when the config block is absent.
     w._opd_full_enabled = False
-    w._opd_full_lm_head_lifecycle = "offload"
+    w._opd_full_lm_head_lifecycle = None
     w._opd_full_teacher_lm_head = None
     w._opd_full_teacher_checkpoint_path = None
     prefix = "model.layers.0.mlp.experts"

--- a/tests/unit/models/megatron/test_group_experts.py
+++ b/tests/unit/models/megatron/test_group_experts.py
@@ -83,6 +83,11 @@ def test_build_hf_to_local_param_map_train_side():
     from nemo_rl.weight_sync.nccl_reshard_utils import HFToLocalParamMap
 
     w = object.__new__(MegatronPolicyWorkerImpl)  # no __init__ / no megatron state
+    # opd_full off, mirroring __init__ when the config block is absent.
+    w._opd_full_enabled = False
+    w._opd_full_lm_head_lifecycle = "offload"
+    w._opd_full_teacher_lm_head = None
+    w._opd_full_teacher_checkpoint_path = None
     prefix = "model.layers.0.mlp.experts"
     direct = torch.randn(8, 16)  # a dense FFN down_proj local shard view
     e0 = torch.randn(128, 16)  # this rank's local expert 0 gate_proj

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -159,7 +159,7 @@ def _make_worker(loss_type):
     w._router_replay_enabled = False
     # opd_full off, mirroring __init__ when the config block is absent.
     w._opd_full_enabled = False
-    w._opd_full_lm_head_lifecycle = "offload"
+    w._opd_full_lm_head_lifecycle = None
     w._opd_full_teacher_lm_head = None
     w._opd_full_teacher_checkpoint_path = None
     w.media_placeholder_token_id = None

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -157,6 +157,11 @@ def _make_worker(loss_type):
     w.dtype = torch.float32
     w._is_reward_model = False
     w._router_replay_enabled = False
+    # opd_full off, mirroring __init__ when the config block is absent.
+    w._opd_full_enabled = False
+    w._opd_full_lm_head_lifecycle = "offload"
+    w._opd_full_teacher_lm_head = None
+    w._opd_full_teacher_checkpoint_path = None
     w.media_placeholder_token_id = None
     # Model-capability flags __init__ derives from self.model, which
     # object.__new__ skips. train_microbatch passes all three straight through

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -46,6 +46,18 @@ from tests.unit.test_utils import SimpleLossFn
 pytestmark = pytest.mark.mcore
 
 
+def _disable_opd_full(worker) -> None:
+    """Set the opd_full attributes to the state __init__ gives them when off.
+
+    These doubles are built with ``object.__new__``, so every attribute the
+    paths under test read has to be set here by hand.
+    """
+    worker._opd_full_enabled = False
+    worker._opd_full_lm_head_lifecycle = "offload"
+    worker._opd_full_teacher_lm_head = None
+    worker._opd_full_teacher_checkpoint_path = None
+
+
 def test_model_owned_packing_capability_is_detected():
     from nemo_rl.models.policy.workers.megatron_policy_worker import (
         _model_self_packs_for_cp,
@@ -164,6 +176,7 @@ def test_model_cp_slicing_accepts_data_plane_setup():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model_slices_context_parallel_inputs = True
     worker._dp_client = None
 
@@ -188,6 +201,7 @@ def test_model_cp_slicing_accepts_transfer_queue_setup(monkeypatch):
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model_slices_context_parallel_inputs = True
     worker._dp_client = None
 
@@ -270,6 +284,7 @@ def test_megatron_offload_before_refit_finalizes_async_save_first(monkeypatch):
 
     events = []
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = object()
     worker.optimizer = None
     worker.optimizer_cpu_offload = False
@@ -314,6 +329,7 @@ def test_megatron_offload_before_refit_honors_offload_optimizer_for_refit(
 
     moved = []
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = object()
     worker.optimizer = object()
     worker.optimizer_cpu_offload = False
@@ -364,6 +380,7 @@ def test_megatron_offload_after_refit_finalizes_before_model_move(
     events = []
     move_kwargs = []
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = _FakeTrainableModel()
     worker.model.eval = lambda: events.append("eval")
     worker.cfg = (
@@ -411,6 +428,7 @@ def test_megatron_finish_inference_evals_before_model_offload(monkeypatch):
     events = []
     move_kwargs = []
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = _FakeTrainableModel()
     worker.model.eval = lambda: events.append("eval")
     worker.move_model = lambda model, device, **kwargs: (
@@ -434,6 +452,7 @@ def test_megatron_save_checkpoint_onloads_model_before_save(monkeypatch):
 
     events = []
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = _FakeTrainableModel()
     worker.model.training = False
     worker.optimizer = object()
@@ -548,6 +567,7 @@ def test_megatron_move_model_does_not_serialize_extra_state():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     model = _ModelWithNonSerializableExtraState()
 
     moved_model = MegatronPolicyWorkerImpl.move_model(worker, model, "cpu")
@@ -563,6 +583,7 @@ def test_megatron_prepare_for_training_restores_optimizer():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     model = _FakeTrainableModel()
     restored_devices = []
 
@@ -586,6 +607,7 @@ def test_megatron_prepare_for_training_leaves_native_cpu_optimizer_placement():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     model = _FakeTrainableModel()
 
     worker.model = model
@@ -609,6 +631,7 @@ def test_set_moe_grad_scale_func_sets_and_clears_on_model_config():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     model_config = SimpleNamespace()
     worker.model = SimpleNamespace(config=model_config)
 
@@ -630,6 +653,7 @@ def test_set_moe_grad_scale_func_handles_float16module_wrapper():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     inner_config = SimpleNamespace()
     worker.model = SimpleNamespace(module=SimpleNamespace(config=inner_config))
 
@@ -647,6 +671,7 @@ def test_set_moe_grad_scale_func_noop_when_no_config():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
     worker.model = SimpleNamespace()  # no .config and no .module
 
     # Should not raise even though there is no config to set the func on.
@@ -660,6 +685,7 @@ def test_compute_moe_grad_scale_normalizes_by_valid_tokens():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
 
     scale_fn = MegatronPolicyWorkerImpl._compute_moe_grad_scale(
         worker, torch.tensor(4.0)
@@ -674,6 +700,7 @@ def test_compute_moe_grad_scale_clamps_zero_valid_tokens():
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
+    _disable_opd_full(worker)
 
     scale_fn = MegatronPolicyWorkerImpl._compute_moe_grad_scale(
         worker, torch.tensor(0.0)

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -53,7 +53,7 @@ def _disable_opd_full(worker) -> None:
     paths under test read has to be set here by hand.
     """
     worker._opd_full_enabled = False
-    worker._opd_full_lm_head_lifecycle = "offload"
+    worker._opd_full_lm_head_lifecycle = None
     worker._opd_full_teacher_lm_head = None
     worker._opd_full_teacher_checkpoint_path = None
 
@@ -186,6 +186,81 @@ def test_model_cp_slicing_accepts_data_plane_setup():
 
     worker.setup_data_plane(LocalDataPlaneConfig())
     assert worker._dp_client is client
+
+
+def _opd_full_teacher_worker(model_config):
+    """A teacher double whose only live attribute is its model config.
+
+    The guard runs before the timer, the model and the microbatch iterator, so
+    none of them need to exist.
+    """
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    worker = object.__new__(MegatronPolicyWorkerImpl)
+    worker.model = SimpleNamespace(config=model_config)
+    return worker
+
+
+class _PastTheGuard(Exception):
+    """Raised by the sentinel timer once the payload guard has been passed."""
+
+
+class _SentinelTimer:
+    def start(self, name):
+        raise _PastTheGuard(name)
+
+
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        pytest.param(
+            SimpleNamespace(final_logit_softcapping=30.0), id="gemma_softcapping"
+        ),
+        pytest.param(SimpleNamespace(output_multiplier=2.0), id="output_multiplier"),
+        pytest.param(SimpleNamespace(use_mup=True), id="mup"),
+    ],
+)
+def test_full_payload_rejects_hidden_states_when_logits_are_post_processed(
+    model_config,
+):
+    """The student rebuilds teacher logits as ``output_layer(h)``.
+
+    A teacher that softcaps or rescales them afterwards would be silently
+    mis-reconstructed: no error, just a wrong target.
+    """
+    worker = _opd_full_teacher_worker(model_config)
+
+    with pytest.raises(ValueError, match="teacher_payload='logits'"):
+        worker.get_logprobs_with_full_payload(
+            data=BatchedDataDict({}),
+            payload="hidden_states",
+            payload_dtype="bfloat16",
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_config", "payload"),
+    [
+        pytest.param(SimpleNamespace(hidden_size=8), "hidden_states", id="plain_mcore"),
+        # The logits payload is exact for a post-processed teacher.
+        pytest.param(
+            SimpleNamespace(final_logit_softcapping=30.0), "logits", id="softcap_logits"
+        ),
+    ],
+)
+def test_full_payload_admits_reconstructible_teachers(model_config, payload):
+    """The guard is the method's first statement, so a sentinel timer marks it passed."""
+    worker = _opd_full_teacher_worker(model_config)
+    worker.timer = _SentinelTimer()
+
+    with pytest.raises(_PastTheGuard):
+        worker.get_logprobs_with_full_payload(
+            data=BatchedDataDict({}),
+            payload=payload,
+            payload_dtype="bfloat16",
+        )
 
 
 def test_model_cp_slicing_accepts_transfer_queue_setup(monkeypatch):

--- a/tests/unit/models/policy/test_split_api_wrappers.py
+++ b/tests/unit/models/policy/test_split_api_wrappers.py
@@ -117,6 +117,8 @@ def _make_tq_policy() -> tuple[TQPolicy, MagicMock]:
     p = object.__new__(TQPolicy)
     p.cfg = {"train_global_batch_size": 8, "train_micro_batch_size": 2}
     p._router_replay_enabled = False
+    # opd_full off, as __init__ leaves it when the config block is absent.
+    p._opd_full_field = None
     p.flops_tracker = None
     wg = MagicMock()
     wg.run_all_workers_single_data.return_value = ["f0", "f1"]

--- a/tests/unit/models/policy/test_split_api_wrappers.py
+++ b/tests/unit/models/policy/test_split_api_wrappers.py
@@ -32,7 +32,12 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from nemo_rl.data_plane import KVBatchMeta
-from nemo_rl.data_plane.schema import DP_TRAIN_FIELDS, ROUTED_EXPERTS_FIELD
+from nemo_rl.data_plane.schema import (
+    DP_TRAIN_FIELDS,
+    OPD_FULL_HIDDEN_STATES_FIELD,
+    OPD_FULL_LOGITS_FIELD,
+    ROUTED_EXPERTS_FIELD,
+)
 from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
 from nemo_rl.models.policy.tq_policy import TQPolicy
 
@@ -263,3 +268,48 @@ class TestTQPolicySplitFanout:
             "abort_train_step_presharded"
         )
         mock_ray.get.assert_called_once_with(["f0", "f1"])
+
+
+class TestTQPolicyOPDFullColumn:
+    def test_train_microbatches_request_the_teacher_payload_column(self):
+        p, _ = _make_tq_policy()
+        p._opd_full_field = OPD_FULL_HIDDEN_STATES_FIELD
+        meta = _meta()
+        with (
+            patch.object(TQPolicy, "_stamp_pad_seqlen"),
+            patch.object(TQPolicy, "_packing_args", return_value=(None, None)),
+            patch(
+                "nemo_rl.models.policy.tq_policy.shard_meta_for_dp",
+                return_value=([meta, meta], None),
+            ) as mock_shard,
+        ):
+            p.train_microbatches_from_meta(meta)
+
+        train_meta = mock_shard.call_args.args[0]
+        assert train_meta.fields == [*DP_TRAIN_FIELDS, OPD_FULL_HIDDEN_STATES_FIELD]
+
+    def test_prepare_step_registers_the_teacher_payload_column(self):
+        """The TQ schema is fixed at registration.
+
+        A column missing there is rejected on the teacher's write rather than
+        silently created.
+        """
+        p, _ = _make_tq_policy()
+        p._opd_full_field = OPD_FULL_LOGITS_FIELD
+        p.tq_partition_id = "train"
+        p.dp_client = MagicMock()
+
+        p.prepare_step(num_samples=4, group_size=2)
+
+        fields = p.dp_client.register_partition.call_args.kwargs["fields"]
+        assert fields == [*DP_TRAIN_FIELDS, OPD_FULL_LOGITS_FIELD]
+
+    def test_prepare_step_leaves_the_schema_alone_when_opd_full_is_off(self):
+        p, _ = _make_tq_policy()
+        p.tq_partition_id = "train"
+        p.dp_client = MagicMock()
+
+        p.prepare_step(num_samples=4)
+
+        fields = p.dp_client.register_partition.call_args.kwargs["fields"]
+        assert fields == list(DP_TRAIN_FIELDS)

--- a/tests/unit/models/policy/test_teacher_worker_group.py
+++ b/tests/unit/models/policy/test_teacher_worker_group.py
@@ -22,6 +22,7 @@ from nemo_rl.data_plane.schema import (
     GLOBAL_FORWARD_PAD_SEQLEN,
     MICRO_BATCH_INDICES,
     MICRO_BATCH_LENGTHS,
+    OPD_FULL_HIDDEN_STATES_FIELD,
     TEACHER_LP_FIELDS,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -148,6 +149,68 @@ def test_teacher_worker_group_disables_student_router_replay(monkeypatch):
     assert captured["cfg"]["router_replay"]["enabled"] is False
     assert teacher.cfg["router_replay"]["enabled"] is False
     assert policy_config["router_replay"]["enabled"] is True
+
+
+def test_teacher_worker_group_drops_the_student_pretrained_checkpoint(monkeypatch):
+    """Left in, the teacher would load the student's weights and distill itself.
+
+    Resume keeps student weights out of the shared config by passing them as a
+    ``weights_path`` argument; this key arrives through the config instead.
+    """
+    import nemo_rl.distributed.worker_groups as worker_groups
+    from nemo_rl.models.policy.teacher_worker_group import (
+        TeacherConfig,
+        TeacherWorkerGroup,
+    )
+
+    captured = {}
+
+    class FakeWorkerBuilder:
+        def __init__(self, worker_path, cfg, **kwargs):
+            del worker_path, kwargs
+            captured["cfg"] = cfg
+
+    class FakeWorkerGroup:
+        def __init__(self, cluster, worker_builder, **kwargs):
+            del cluster, worker_builder, kwargs
+
+    monkeypatch.setattr(worker_groups, "RayWorkerBuilder", FakeWorkerBuilder)
+    monkeypatch.setattr(worker_groups, "RayWorkerGroup", FakeWorkerGroup)
+    cluster = MagicMock()
+    cluster.world_size.return_value = 1
+    policy_config = {
+        "model_name": "/ckpt/student",
+        "pretrained_checkpoint": {"format": "megatron_bridge", "path": "/ckpt/sft"},
+        "megatron_cfg": {"enabled": True},
+        "dtensor_cfg": {"enabled": False},
+        "sequence_packing": {"enabled": False},
+        "dynamic_batching": {"enabled": False},
+    }
+    teacher_config = TeacherConfig(
+        alias="teacher",
+        model_name="/ckpt/teacher",
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=1,
+        expert_model_parallel_size=1,
+        num_nodes=1,
+        gpus_per_node=1,
+        precision="bf16",
+        micro_batch_size=1,
+        megatron_cfg_overrides={},
+    )
+
+    teacher = TeacherWorkerGroup(
+        teacher_config,
+        cluster,
+        policy_config,
+        MagicMock(),
+    )
+
+    assert "pretrained_checkpoint" not in captured["cfg"]
+    assert "pretrained_checkpoint" not in teacher.cfg
+    # The student's own config is left alone.
+    assert policy_config["pretrained_checkpoint"]["path"] == "/ckpt/sft"
 
 
 def _disable_opd_full(teacher) -> None:
@@ -445,3 +508,149 @@ def test_teacher_worker_rejects_local_dynamic_batch_planning():
 
     with pytest.raises(RuntimeError, match="driver-provided global"):
         Worker().get_teacher_logprobs_presharded(meta)
+
+
+def test_get_logprobs_from_meta_forwards_the_opd_full_payload_request():
+    """With full-vocabulary MOPD on, every DP rank is told what to emit and where."""
+    from nemo_rl.models.policy.teacher_worker_group import TeacherWorkerGroup
+
+    class Sharding:
+        def get_axis_size(self, axis):
+            assert axis == "data_parallel"
+            return 1
+
+    worker_group = MagicMock()
+    worker_group.run_all_workers_sharded_data.return_value = "futures"
+    teacher = object.__new__(TeacherWorkerGroup)
+    teacher._opd_full_payload = "hidden_states"
+    teacher._opd_full_payload_dtype = "float16"
+    teacher._opd_full_payload_field = OPD_FULL_HIDDEN_STATES_FIELD
+    teacher.alias = "teacher"
+    teacher.use_sequence_packing = False
+    teacher.use_dynamic_batches = False
+    teacher.sequence_length_pad_multiple = 1
+    teacher.sharding_annotations = Sharding()
+    teacher.worker_group = worker_group
+    teacher._micro_batch_size = 2
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["a"],
+        fields=["input_ids", "input_lengths"],
+        sequence_lengths=[3],
+    )
+
+    teacher.get_logprobs_from_meta(meta)
+
+    common_kwargs = worker_group.run_all_workers_sharded_data.call_args.kwargs[
+        "common_kwargs"
+    ]
+    assert common_kwargs == {
+        "micro_batch_size": 2,
+        "opd_full_payload": "hidden_states",
+        "opd_full_payload_dtype": "float16",
+        "opd_full_payload_field": OPD_FULL_HIDDEN_STATES_FIELD,
+    }
+
+
+def _full_payload_worker_class():
+    from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
+
+    class Worker(TQWorkerMixin):
+        cfg = {"sequence_packing": {"enabled": False}}
+
+        def __init__(self, payload):
+            self.payload = payload
+            self.logprob_call = None
+            self.full_payload_call = None
+            self.stage_local_writes = []
+            self.written = None
+
+        def _fetch(self, meta):
+            del meta
+            return BatchedDataDict(
+                {
+                    "input_ids": torch.ones(1, 3, dtype=torch.long),
+                    "input_lengths": torch.tensor([3]),
+                }
+            )
+
+        def get_logprobs(self, data, micro_batch_size=None):
+            self.logprob_call = (data, micro_batch_size)
+            return BatchedDataDict({"logprobs": torch.full((1, 3), 0.25)})
+
+        def get_logprobs_with_full_payload(
+            self, *, data, payload, payload_dtype, micro_batch_size=None
+        ):
+            del data
+            self.full_payload_call = (payload, payload_dtype, micro_batch_size)
+            return BatchedDataDict(
+                {
+                    "logprobs": torch.full((1, 3), 0.5),
+                    "teacher_full_payload": self.payload,
+                }
+            )
+
+        def _write_back_stage_local(self, meta, fields):
+            self.stage_local_writes.append((meta, fields))
+
+        def _write_back_result_field(self, meta, result, *, result_key, tq_field):
+            self.written = (meta, result[result_key], tq_field)
+
+    return Worker
+
+
+def _presharded_meta():
+    return KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="teacher_lp:teacher",
+        sample_ids=["a"],
+        fields=["input_ids", "input_lengths"],
+        sequence_lengths=[3],
+        extra_info={MICRO_BATCH_INDICES: [[0]], MICRO_BATCH_LENGTHS: [3]},
+    )
+
+
+def test_teacher_worker_presharded_entrypoint_writes_the_full_payload_from_its_stage():
+    """The payload goes through the stage-local writer; logprobs keep their path."""
+    payload = torch.randn(1, 3, 4)
+    worker = _full_payload_worker_class()(payload)
+    meta = _presharded_meta()
+
+    worker.get_teacher_logprobs_presharded(
+        meta,
+        micro_batch_size=1,
+        opd_full_payload="hidden_states",
+        # Not the config default: the driver's value must win.
+        opd_full_payload_dtype="float16",
+        opd_full_payload_field=OPD_FULL_HIDDEN_STATES_FIELD,
+    )
+
+    # The single forward replaced get_logprobs; it received the payload request.
+    assert worker.logprob_call is None
+    assert worker.full_payload_call == ("hidden_states", "float16", 1)
+    # Sampled-token logprobs still land in the teacher column.
+    assert worker.written is not None
+    assert torch.allclose(worker.written[1], torch.full((1, 3), 0.5))
+    assert worker.written[2] == "teacher_reference_logprobs"
+    # The payload is written from this stage under the configured column.
+    assert len(worker.stage_local_writes) == 1
+    write_meta, fields = worker.stage_local_writes[0]
+    assert write_meta is meta
+    assert list(fields) == [OPD_FULL_HIDDEN_STATES_FIELD]
+    assert torch.equal(fields[OPD_FULL_HIDDEN_STATES_FIELD], payload)
+
+
+def test_teacher_worker_presharded_entrypoint_skips_the_payload_off_the_last_stage():
+    """A stage that produced no payload must not write an empty column."""
+    worker = _full_payload_worker_class()(None)
+
+    worker.get_teacher_logprobs_presharded(
+        _presharded_meta(),
+        opd_full_payload="hidden_states",
+        opd_full_payload_dtype="bfloat16",
+        opd_full_payload_field=OPD_FULL_HIDDEN_STATES_FIELD,
+    )
+
+    assert worker.stage_local_writes == []
+    assert worker.written is not None

--- a/tests/unit/models/policy/test_teacher_worker_group.py
+++ b/tests/unit/models/policy/test_teacher_worker_group.py
@@ -150,6 +150,17 @@ def test_teacher_worker_group_disables_student_router_replay(monkeypatch):
     assert policy_config["router_replay"]["enabled"] is True
 
 
+def _disable_opd_full(teacher) -> None:
+    """Set the opd_full attributes to the state __init__ gives them when off.
+
+    These doubles are built with ``object.__new__``, so every attribute the
+    dispatch path reads has to be set here by hand.
+    """
+    teacher._opd_full_payload = None
+    teacher._opd_full_payload_dtype = "bfloat16"
+    teacher._opd_full_payload_field = None
+
+
 def test_get_logprobs_from_meta_dispatches_tq_shards_to_teacher_workers():
     """TeacherWorkerGroup sends metadata, not token tensors, to each DP rank."""
     from nemo_rl.models.policy.teacher_worker_group import TeacherWorkerGroup
@@ -162,6 +173,7 @@ def test_get_logprobs_from_meta_dispatches_tq_shards_to_teacher_workers():
     worker_group = MagicMock()
     worker_group.run_all_workers_sharded_data.return_value = "futures"
     teacher = object.__new__(TeacherWorkerGroup)
+    _disable_opd_full(teacher)
     teacher.alias = "teacher"
     teacher.use_sequence_packing = False
     teacher.use_dynamic_batches = False
@@ -211,6 +223,7 @@ def test_get_logprobs_from_meta_builds_global_dynamic_batch_plan(monkeypatch):
     monkeypatch.setattr(teacher_module, "shard_meta_for_dp", capture_plan)
     worker_group = MagicMock()
     teacher = object.__new__(TeacherWorkerGroup)
+    _disable_opd_full(teacher)
     teacher.alias = "teacher"
     teacher.use_sequence_packing = False
     teacher.use_dynamic_batches = True
@@ -291,6 +304,7 @@ def test_get_logprobs_from_meta_builds_global_sequence_packing_plan(monkeypatch)
     monkeypatch.setattr(teacher_module, "shard_meta_for_dp", capture_plan)
     worker_group = MagicMock()
     teacher = object.__new__(TeacherWorkerGroup)
+    _disable_opd_full(teacher)
     teacher.alias = "teacher"
     teacher.use_sequence_packing = True
     teacher.use_dynamic_batches = False

--- a/tests/unit/models/policy/test_tq_policy_placed.py
+++ b/tests/unit/models/policy/test_tq_policy_placed.py
@@ -38,6 +38,7 @@ def _policy() -> tuple[TQPolicy, MagicMock]:
     policy = object.__new__(TQPolicy)
     policy.cfg = {"train_global_batch_size": 4, "train_micro_batch_size": 1}
     policy._router_replay_enabled = False
+    policy._opd_full_field = None  # opd_full off, as __init__ leaves it
     policy.flops_tracker = None
     policy.sharding_annotations = MagicMock()
     policy.sharding_annotations.get_axis_size.return_value = 2

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -48,8 +48,9 @@ from nemo_rl.algorithms.grpo import (
     RewardPenaltyConfig,
     _initial_grpo_save_state,
 )
-from nemo_rl.algorithms.loss import ClippedPGLossConfig
-from nemo_rl.algorithms.opd import OnPolicyDistillationConfig
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
+from nemo_rl.algorithms.loss.interfaces import LossInputType
+from nemo_rl.algorithms.opd import OnPolicyDistillationConfig, get_opd_full_config
 from nemo_rl.algorithms.single_controller_utils import (
     AsyncRLConfig,
     MasterConfig,
@@ -59,6 +60,7 @@ from nemo_rl.algorithms.single_controller_utils import (
 from nemo_rl.algorithms.single_controller_utils.config import (
     RolloutCheckpointConfig,
     TokenCaptureConfig,
+    _validate_opd_full_config,
     validate_single_controller_config,
 )
 from nemo_rl.algorithms.single_controller_utils.rollout_checkpoint import (
@@ -2187,3 +2189,153 @@ class TestNativeTQRecoverySetup:
                 partition_id="rollout_data",
                 sampler_name="in_order",
             )
+
+
+# ── Full-vocabulary MOPD (on_policy_distillation.full) ──────────────────────
+
+_FULLVOCAB_RECIPES = (
+    "mopd-qwen3-1.7b-3n8g-megatron-pack-single-controller-fullvocab.yaml",
+    "mopd-qwen3-1.7b-3n4g-megatron-pack-single-controller-fullvocab.yaml",
+)
+
+
+def _load_fullvocab_master_config(
+    recipe_name: str = _FULLVOCAB_RECIPES[0],
+) -> MasterConfig:
+    register_omegaconf_resolvers()
+    repo_root = Path(__file__).resolve().parents[3]
+    recipe = repo_root / "examples/configs/recipes/llm" / recipe_name
+    resolved = OmegaConf.to_container(load_config(recipe), resolve=True)
+    assert isinstance(resolved, dict)
+    return MasterConfig.model_validate(resolved)
+
+
+@pytest.mark.parametrize("recipe_name", _FULLVOCAB_RECIPES)
+def test_fullvocab_mopd_recipes_resolve_to_runtime_contract(recipe_name: str):
+    """Both shipped recipes load and survive every opd_full validator.
+
+    The loss-side validator rejects each policy-gradient knob that opd_full
+    would otherwise ignore, and the base MOPD recipe two levels up turns
+    several of them on -- so a recipe that forgets to override one fails at
+    construction. Nothing else catches that at PR time: these recipes only run
+    in the nightly suites (``nightly.txt`` / ``nightly_gb200.txt``), not in CI.
+    """
+    config = _load_fullvocab_master_config(recipe_name)
+    validate_single_controller_config(config)
+
+    full_cfg = get_opd_full_config(config)
+    assert full_cfg is not None
+    assert full_cfg.teacher_payload == "hidden_states"
+    assert full_cfg.chunk_size == 1024
+    # Off: the residual is an algebraic identity (all three kernels read the same
+    # logits), so it costs a second full-vocabulary log-softmax without being
+    # able to catch a corrupted teacher.
+    assert full_cfg.validate_decomposition is False
+
+    # opd_full still runs the OPD advantage estimator: `advantages` is a
+    # required training column and its stage gates the training step.
+    assert config.grpo.adv_estimator.name == "opd"
+    # Self-distillation: student and teacher are the same checkpoint, which is
+    # what makes "the divergence must stay ~0" a meaningful assertion.
+    assert (
+        config.on_policy_distillation.teacher_model_by_agent_name["default_teacher"]
+        == config.policy["model_name"]
+    )
+
+
+def test_fullvocab_recipe_builds_an_opd_full_loss_function():
+    """The recipe's loss block is accepted by the opd_full loss constructor."""
+    config = _load_fullvocab_master_config()
+    loss_fn = ClippedPGLossFn(
+        config.loss_fn,
+        opd_full=get_opd_full_config(config),
+    )
+    assert loss_fn.input_type is LossInputType.OPD_FULL
+
+
+class TestOPDFullValidation:
+    """``_validate_opd_full_config`` rejects at startup, not mid-training.
+
+    Each combination below otherwise fails only once the whole cluster and
+    every teacher worker are already up -- or, for the fused packing path, not
+    until the first training forward.
+    """
+
+    def test_accepts_the_shipped_recipe(self):
+        config = _load_fullvocab_master_config()
+        _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_is_a_no_op_when_full_is_absent(self):
+        config = _load_fullvocab_master_config()
+        config.on_policy_distillation.full = None
+        _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_fused_linear_logprobs(self):
+        """The fused forward bypasses output_layer, so the capture hook never fires."""
+        config = _load_fullvocab_master_config()
+        config.policy["megatron_cfg"]["use_fused_linear_logprobs"] = True
+        with pytest.raises(ValueError, match="use_fused_linear_logprobs"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_fused_packing_loss(self):
+        """prepare_packed_loss_input only supports LossInputType.LOGPROB.
+
+        Without this check the run dies inside the first training forward, and
+        a real production MOPD config (nemo_gym/nemotron-3-ultra) already sets
+        ``fuse_loss: true``.
+        """
+        config = _load_fullvocab_master_config()
+        config.policy["sequence_packing"]["enabled"] = True
+        config.policy["sequence_packing"]["fuse_loss"] = True
+        with pytest.raises(ValueError, match="fuse_loss"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_more_than_one_teacher_checkpoint(self):
+        """One LM head and one payload column exist; a second teacher needs both."""
+        config = _load_fullvocab_master_config()
+        config.on_policy_distillation.teacher_model_by_agent_name = {
+            "a": "/ckpt/teacher-a",
+            "b": "/ckpt/teacher-b",
+        }
+        with pytest.raises(ValueError, match="exactly one unique"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_pipeline_parallel_on_the_hidden_state_path(self):
+        """Megatron builds output_layer only on the last pipeline stage.
+
+        The teacher LM head loads through a collective spanning the whole
+        student world, so earlier stages would raise while the last stage hangs
+        inside that collective.
+        """
+        config = _load_fullvocab_master_config()
+        config.policy["megatron_cfg"]["pipeline_model_parallel_size"] = 2
+        with pytest.raises(ValueError, match="pipeline_model_parallel_size > 1"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_a_sampling_temperature_on_the_hidden_state_path(self):
+        """Temperature divides the training logits after the capture hook reads them.
+
+        The student would be scaled and the teacher -- reconstructed from
+        unscaled hidden states -- would not, silently optimizing a mismatched
+        objective that no self-distillation gate can detect.
+        """
+        config = _load_fullvocab_master_config()
+        config.policy["generation"]["temperature"] = 0.7
+        with pytest.raises(ValueError, match="temperature != 1.0"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_allows_a_sampling_temperature_on_the_logits_path(self):
+        """Both sides come from the same divided tensor there, so they agree."""
+        config = _load_fullvocab_master_config()
+        config.policy["generation"]["temperature"] = 0.7
+        assert config.on_policy_distillation.full is not None
+        config.on_policy_distillation.full.teacher_payload = "logits"
+        _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_allows_pipeline_parallel_on_the_logits_path(self):
+        """The logits payload needs no teacher LM head, so no such collective."""
+        config = _load_fullvocab_master_config()
+        config.policy["megatron_cfg"]["pipeline_model_parallel_size"] = 2
+        assert config.on_policy_distillation.full is not None
+        config.on_policy_distillation.full.teacher_payload = "logits"
+        _validate_opd_full_config(config, config.on_policy_distillation)

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -2303,9 +2303,9 @@ class TestOPDFullValidation:
     def test_rejects_pipeline_parallel_on_the_hidden_state_path(self):
         """Megatron builds output_layer only on the last pipeline stage.
 
-        The teacher LM head loads through a collective spanning the whole
-        student world, so earlier stages would raise while the last stage hangs
-        inside that collective.
+        Resolving the teacher checkpoint iteration goes through Megatron-Bridge's
+        read_train_state, whose broadcast spans the whole student world, so
+        earlier stages would raise while the last stage hangs inside it.
         """
         config = _load_fullvocab_master_config()
         config.policy["megatron_cfg"]["pipeline_model_parallel_size"] = 2
@@ -2339,3 +2339,66 @@ class TestOPDFullValidation:
         assert config.on_policy_distillation.full is not None
         config.on_policy_distillation.full.teacher_payload = "logits"
         _validate_opd_full_config(config, config.on_policy_distillation)
+
+    def test_rejects_a_non_megatron_backend(self):
+        """DTensor has no vocabulary-parallel logit path for the kernels."""
+        config = _load_fullvocab_master_config()
+        config.policy["megatron_cfg"]["enabled"] = False
+        with pytest.raises(ValueError, match="requires the Megatron backend"):
+            _validate_opd_full_config(config, config.on_policy_distillation)
+
+
+class _FakeTeacherGroup:
+    def __init__(self, model_name: str, cfg: dict):
+        self.model_name = model_name
+        self.cfg = cfg
+
+
+def _fake_trainer(result: str = "/resolved/teacher") -> Any:
+    trainer = MagicMock()
+    trainer.worker_group.run_all_workers_single_data.return_value = [result, result]
+    return trainer
+
+
+def test_load_opd_full_teacher_lm_heads_sends_the_teacher_groups_own_config(
+    monkeypatch,
+):
+    """The LM head must be resolved from the teacher, never from the student.
+
+    ``TeacherWorkerGroup`` drops ``pretrained_checkpoint`` from the config it
+    copies, so what arrives here already describes the teacher alone; a config
+    still carrying that key would resolve the student's checkpoint and distill
+    the student into itself with a divergence of exactly zero.
+    """
+    monkeypatch.setattr(sc_setup_mod, "ray", MagicMock(get=lambda futures: futures))
+    teacher_cfg = {"model_name": "Qwen/Qwen3-8B", "megatron_cfg": {"enabled": True}}
+    trainer = _fake_trainer()
+
+    sc_setup_mod._load_opd_full_teacher_lm_heads(
+        trainer, {"default_teacher": _FakeTeacherGroup("Qwen/Qwen3-8B", teacher_cfg)}
+    )
+
+    call = trainer.worker_group.run_all_workers_single_data.call_args
+    assert call.args == ("load_opd_full_teacher_lm_head",)
+    sent = call.kwargs["teacher_path_config"]
+    assert sent["model_name"] == "Qwen/Qwen3-8B"
+    assert "pretrained_checkpoint" not in sent
+
+
+def test_load_opd_full_teacher_lm_heads_rejects_two_teacher_checkpoints(monkeypatch):
+    monkeypatch.setattr(sc_setup_mod, "ray", MagicMock(get=lambda futures: futures))
+    trainer = _fake_trainer()
+
+    with pytest.raises(ValueError, match="exactly one teacher"):
+        sc_setup_mod._load_opd_full_teacher_lm_heads(
+            trainer,
+            {
+                "a": _FakeTeacherGroup(
+                    "Qwen/teacher-a", {"model_name": "Qwen/teacher-a"}
+                ),
+                "b": _FakeTeacherGroup(
+                    "Qwen/teacher-b", {"model_name": "Qwen/teacher-b"}
+                ),
+            },
+        )
+    trainer.worker_group.run_all_workers_single_data.assert_not_called()

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -284,7 +284,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_4368_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_4384_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -316,8 +316,8 @@ def test_nightly_compute_stays_below_4368_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 4368, (
-        f"Total GPU hours exceeded 4368: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 4384, (
+        f"Total GPU hours exceeded 4384: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
Adds `on_policy_distillation.full`, which replaces MOPD's sampled-token log-probability gap with the exact full-vocabulary reverse KL

    L_t = sum_v p_student(v) * (log p_student(v) - log p_teacher(v))

This is the K=V limit of the top-k MOPD estimator: with the support spanning the whole vocabulary the score-function tail term vanishes, so the objective is exact, deterministic, and free of that estimator's off-policy bias.

Because the loss now needs the teacher's whole distribution rather than one scalar per token, the teacher/student boundary changes. Two payload paths are supported, selected by `full.teacher_payload`:

* `hidden_states` (default): the teacher ships its pre-LM-head hidden states and the student projects them with an output-layer weight shard loaded from the teacher checkpoint. The payload is hidden_size wide, so teacher and student parallelism stay fully decoupled.
* `logits`: the teacher ships full-vocabulary logits and the student needs no teacher LM head. The payload is vocab_size wide -- roughly 74x larger for a 2k-hidden / 152k-vocab model -- so this is a numerical-reference and fallback path, not a production configuration.

Implementation notes:

* Two chunked tensor-parallel autograd functions sit beside ChunkedDistributedEntropy and share one backward: for both weights, dw/dlog p_s is constant and cancels against the sum_v p_s = 1 normalization, leaving dL/dz = p_s * (w - L). Both recompute their log-softmaxes in backward rather than caching the teacher's, matching the neighbouring kernel.
* The reconstruction and divergence run in prepare_loss_input, the only place holding the vocab- and context-parallel groups; the loss receives a plain [B, S-1] differentiable tensor and reduces it the same way the policy-gradient path does, including the nested per-sequence average under token_level_loss=false.
* Teacher hidden states are captured with a forward pre-hook on `output_layer` rather than a Megatron fork. Sequence parallelism shards that input, so the capture gathers it back -- without this a TP=1 run passes while TP>1 is silently wrong.
* The payload rides a new per-token TransferQueue column, written from the pipeline stage that produced it rather than broadcast back to the replica leader, which for a per-token payload would move gigabytes for nothing.
* The teacher LM-head shard is a plain tensor on the worker, so it stays invisible to checkpoint saving and to HF/vLLM refit conversion. Its checkpoint path is resolved from the teacher's own model name: TeacherWorkerGroup copies the student policy config wholesale, so a student `pretrained_checkpoint` would otherwise win and the student would be distilled into itself.
* Loss knobs with no code path under this objective (ratio clipping, CISPO, importance-sampling correction, truncated IS, VAPO) are rejected at construction rather than silently ignored.

First version limits: exactly one teacher checkpoint, and the hidden-state path additionally requires student pipeline_model_parallel_size=1, because Megatron builds output_layer only on the last pipeline stage while the LM-head load is a whole-world collective -- earlier stages would fail while the last stage hangs. The `logits` path has no such restriction. The payload column is shaped so a per-row teacher index can be added later without reworking it.

Ships two Qwen3-1.7B self-distillation recipes whose divergence must sit at ~0: an H100 3n8g one in `nightly.txt` (10 GPU-hours) and its GB200 3n4g variant in `nightly_gb200.txt` (5 GPU-hours). Their thresholds are smoke bounds derived from the objective rather than measured, so the first runs are also what validate them -- read an early failure as a question about the bound before assuming a regression. Adding the H100 run puts `nightly.txt` at 4354 GPU-hours, so its budget assertion moves 4344 -> 4360 (`test_nightly_compute_stays_below_4360_hours`).

Also included: unit coverage for the two divergence kernels (forward against a closed-form reference, the hand-written backward against autograd, chunk invariance, and a collective trace that pins the teacher-side normalization TP=1 cannot observe), for the teacher-payload reconstruction, for the loss-construction rejection matrix and reduction semantics, and for the first 3-D token-aligned data-plane column.

## Known follow-ups

Two TODOs are left in the code deliberately; neither blocks this PR and both are cheap to pick up separately.

- **`nemo_rl/algorithms/loss/wrapper.py`** -- the extremum-metric name sets (`_SEQ_METRIC_MIN` / `_SEQ_METRIC_MAX`) are duplicated across seven sites (here, `single_controller_utils/utils.py`, `grpo.py` x2, `grpo_sync.py`, `ppo.py` x2). The rule is level-independent, so every copy should hold the same names, but nothing enforces that: a loss that emits a new extremum metric has to update every site its path reaches, and omitting one silently *sums* extrema instead of reducing them, reporting a "min" larger than any individual value. This PR adds `opd_full_reverse_kl_min` / `_max` and `opd_full_decomposition_error` to that set, so it widens the exposure without creating it. Fix is to hoist the two sets into one shared definition in `loss/interfaces.py`, next to `MetricNormalizer`.

- **`nemo_rl/models/megatron/train.py`** -- `get_capture_context` should be renamed `get_draft_capture_context`. It is draft-model-specific, but standing next to the new opd_full capture the unqualified name now reads as the generic one. Not renamed here because it would pull `draft/hidden_capture.py`, `draft/__init__.py` and three `@patch` string paths in `tests/unit/models/megatron/test_train.py` into an unrelated feature's review.

Also still open from the first version, as noted above: exactly one teacher checkpoint, and the `hidden_states` path requires student `pipeline_model_parallel_size=1`. The payload column is already shaped so a per-row teacher index can be added without reworking it.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...



