### PR TITLE
feat: skip validation and reuse pre-converted arrow cache

### DIFF
--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -194,12 +194,27 @@ def main() -> None:
     # We assert here since this is right after the final config has been materialized.
     assert should_use_nemo_gym(config)
 
+    # `is_trajectory_collection` is a NeMo-RL-side control-flow knob; pop it
+    # before setup() so it is not forwarded into NeMo-Gym's global config. It
+    # also determines whether the validation dataset is the collection input.
+    is_trajectory_collection = bool(
+        config.env["nemo_gym"].pop("is_trajectory_collection", False)
+    )
+    should_load_validation = is_trajectory_collection or (
+        config.grpo.val_period > 0 or config.grpo.val_at_start or config.grpo.val_at_end
+    )
+
     # NeMo-Gym environment needs to get dp_openai_server_base_urls from policy_generation, so we don't setup env here.
     with rl_init_timer.time("data"):
         print("\n▶ Setting up data...")
         data_tokenizer = processor if processor is not None else tokenizer
+        if not should_load_validation and config.data.get("validation") is not None:
+            print("  - Skipping validation dataset because validation is disabled.")
         train_dataset, val_dataset = setup_response_data(
-            data_tokenizer, config.data, env_configs=None
+            data_tokenizer,
+            config.data,
+            env_configs=None,
+            load_validation=should_load_validation,
         )
 
     # Validation dataset config setup.
@@ -225,13 +240,6 @@ The validation set you pass in will directly be used for validation with no addi
 
     with rl_init_timer.time("ray_connect"):
         init_ray()
-
-    # `is_trajectory_collection` is a NeMo-RL-side control-flow knob; pop it
-    # before setup() so it is not forwarded into NeMo-Gym's global config (the
-    # gym actor is now created inside setup()).
-    is_trajectory_collection = (
-        config.env["nemo_gym"].pop("is_trajectory_collection", False) or False
-    )
 
     with rl_init_timer.time("setup"):
         (

--- a/nemo_rl/data/datasets/response_datasets/nemogym_dataset.py
+++ b/nemo_rl/data/datasets/response_datasets/nemogym_dataset.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datasets import Dataset
-
 from nemo_rl.data.datasets.raw_dataset import RawDataset
+from nemo_rl.data.datasets.utils import load_dataset_from_path
 
 
 class NemoGymDataset(RawDataset):
     """Simple wrapper around the Nemo Gym dataset.
 
     Args:
-        data_path: Path to the dataset JSONL file
+        data_path: Path to a JSONL file or a pre-converted Arrow/Parquet dataset.
         repeat: Number of times to repeat the dataset, default is 1
     """
 
@@ -30,17 +29,25 @@ class NemoGymDataset(RawDataset):
         if self.task_name[0] == "-":
             self.task_name = self.task_name[1:]
 
-        # load raw line from jsonl
-        # will use `json.loads` to load to dict format at `nemo_gym_data_processor` later since `Dataset` cannot handle nested structure well
-        with open(data_path) as f:
-            self.dataset = [raw_line for raw_line in f]
-
-        # format the dataset
-        self.dataset = Dataset.from_dict(
-            {
-                "extra_env_info": self.dataset,
-                "task_name": [self.task_name] * len(self.dataset),
-            }
+        # Preserve JSONL records as raw strings because the NeMo-Gym processor
+        # intentionally parses the nested payload later. The Hugging Face text
+        # builder materializes a reusable Arrow cache instead of retaining the
+        # entire source file as a Python list of strings. Pre-converted Arrow,
+        # Parquet, and save_to_disk datasets are accepted as well.
+        self.dataset = load_dataset_from_path(data_path, preserve_jsonl_rows=True)
+        if "extra_env_info" in self.dataset.column_names:
+            self.dataset = self.dataset.select_columns(["extra_env_info"])
+        elif "text" in self.dataset.column_names:
+            self.dataset = self.dataset.select_columns(["text"]).rename_column(
+                "text", "extra_env_info"
+            )
+        else:
+            raise ValueError(
+                "A NeMo-Gym dataset must contain an 'extra_env_info' or 'text' "
+                f"column, but {data_path!r} contains {self.dataset.column_names}."
+            )
+        self.dataset = self.dataset.add_column(
+            "task_name", [self.task_name] * len(self.dataset)
         )
 
         # repeat the dataset

--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -98,6 +98,8 @@ def load_dataset_from_path(
     data_path: str,
     data_subset: Optional[str] = None,
     data_split: Optional[str] = "train",
+    *,
+    preserve_jsonl_rows: bool = False,
 ):
     """Load a dataset from a local file, huggingface dataset, or Arrow dataset (saved with save_to_disk).
 
@@ -105,6 +107,10 @@ def load_dataset_from_path(
         data_path: The path to the dataset.
         data_subset: The subset to load from the dataset. Only supported for huggingface datasets.
         data_split: The split to load from the dataset.
+        preserve_jsonl_rows: Load each JSONL row as an unparsed string in a
+            ``text`` column. Hugging Face materializes the text builder's
+            Arrow cache under ``HF_DATASETS_CACHE``, so subsequent jobs can
+            memory-map and reuse it instead of rebuilding Python strings.
     """
     FILEEXT2TYPE = {
         ".arrow": "arrow",
@@ -114,12 +120,14 @@ def load_dataset_from_path(
         ".parquet": "parquet",
         ".txt": "text",
     }
-    suffix = os.path.splitext(data_path)[-1]
+    suffix = os.path.splitext(data_path)[-1].lower()
     # load from local file (not save_to_disk format)
     if dataset_type := FILEEXT2TYPE.get(suffix):
         assert data_subset is None, (
             "data_subset is only supported for huggingface datasets"
         )
+        if suffix == ".jsonl" and preserve_jsonl_rows:
+            dataset_type = "text"
         raw_dataset = load_dataset(dataset_type, data_files=data_path)
     else:
         try:

--- a/nemo_rl/data/utils.py
+++ b/nemo_rl/data/utils.py
@@ -109,6 +109,8 @@ def setup_response_data(
     data_config: DataConfig,
     env_configs: Optional[dict[str, Any]] = None,
     is_vlm: bool = False,
+    *,
+    load_validation: bool = True,
 ) -> Union[
     tuple[
         Union[AllTaskProcessedDataset, dict[str, AllTaskProcessedDataset]],
@@ -133,6 +135,8 @@ def setup_response_data(
             - Algorithms like SFT which do not need environments.
             - Environments like NeMo-Gym which need to handle the environment creation outside of this function.
         is_vlm: Whether to use VLM training or not.
+        load_validation: Whether to load validation data configured directly or
+            split from a training dataset.
 
     Returns:
         If env_configs is not None:
@@ -228,24 +232,29 @@ def setup_response_data(
     val_data_list = []
 
     # validation dataset from train dataset (when train dataset's split_validation_size > 0)
-    for data in data_list:
-        if hasattr(data, "val_dataset") and data.val_dataset is not None:
-            val_data_list.append(data.val_dataset)
-            print(
-                f"  - Loaded validation dataset {data.task_name} with {len(data.val_dataset)} samples."
-            )
-            # bind task_name to task_data_processors and task_to_env
-            task_name = data.task_name
-            val_task_data_processors[task_name] = task_data_processors[task_name]
-            if task_name in task_data_preprocessors:
-                val_task_data_preprocessors[task_name] = task_data_preprocessors[
-                    task_name
-                ]
-            if has_envs:
-                val_task_to_env[task_name] = task_to_env[task_name]
+    if load_validation:
+        for data in data_list:
+            if hasattr(data, "val_dataset") and data.val_dataset is not None:
+                val_data_list.append(data.val_dataset)
+                print(
+                    f"  - Loaded validation dataset {data.task_name} with {len(data.val_dataset)} samples."
+                )
+                # bind task_name to task_data_processors and task_to_env
+                task_name = data.task_name
+                val_task_data_processors[task_name] = task_data_processors[task_name]
+                if task_name in task_data_preprocessors:
+                    val_task_data_preprocessors[task_name] = task_data_preprocessors[
+                        task_name
+                    ]
+                if has_envs:
+                    val_task_to_env[task_name] = task_to_env[task_name]
 
     # validation dataset from config
-    if "validation" in data_config and data_config["validation"] is not None:
+    if (
+        load_validation
+        and "validation" in data_config
+        and data_config["validation"] is not None
+    ):
         if isinstance(data_config["validation"], dict):
             data_config["validation"] = [data_config["validation"]]
 

--- a/tests/unit/data/datasets/test_nemogym_dataset.py
+++ b/tests/unit/data/datasets/test_nemogym_dataset.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+import datasets
+from datasets import Dataset
+
+from nemo_rl.data.datasets.response_datasets.nemogym_dataset import NemoGymDataset
+from nemo_rl.data.datasets.utils import load_dataset_from_path
+
+
+def test_jsonl_rows_are_cached_as_raw_text(tmp_path: Path, monkeypatch) -> None:
+    data_path = tmp_path / "train.jsonl"
+    rows = [
+        {"messages": [{"role": "user", "content": "one"}]},
+        {"different_nested_shape": {"value": 2}},
+    ]
+    data_path.write_text("".join(f"{json.dumps(row)}\n" for row in rows))
+
+    cache_dir = tmp_path / "hf_datasets_cache"
+    monkeypatch.setattr(datasets.config, "HF_DATASETS_CACHE", str(cache_dir))
+
+    first = load_dataset_from_path(str(data_path), preserve_jsonl_rows=True)
+    second = load_dataset_from_path(str(data_path), preserve_jsonl_rows=True)
+
+    assert first.column_names == ["text"]
+    assert [json.loads(row) for row in first["text"]] == rows
+    assert first.cache_files == second.cache_files
+    assert first.cache_files
+    assert Path(first.cache_files[0]["filename"]).is_file()
+    assert cache_dir in Path(first.cache_files[0]["filename"]).parents
+
+
+def test_nemogym_dataset_accepts_preconverted_parquet(tmp_path: Path) -> None:
+    data_path = tmp_path / "train.parquet"
+    rows = ['{"sample": 1}', '{"sample": 2}']
+    Dataset.from_dict({"extra_env_info": rows}).to_parquet(str(data_path))
+
+    dataset = NemoGymDataset(str(data_path))
+
+    assert dataset.dataset["extra_env_info"] == rows
+    assert dataset.dataset.column_names == ["extra_env_info", "task_name"]
+    assert len(set(dataset.dataset["task_name"])) == 1
+
+
+def test_nemogym_dataset_rejects_preconverted_dataset_without_raw_text(
+    tmp_path: Path,
+) -> None:
+    data_path = tmp_path / "train.parquet"
+    Dataset.from_dict({"parsed": [1]}).to_parquet(str(data_path))
+
+    try:
+        NemoGymDataset(str(data_path))
+    except ValueError as error:
+        assert "'extra_env_info' or 'text'" in str(error)
+    else:
+        raise AssertionError("Expected an invalid pre-converted schema to fail")

--- a/tests/unit/data/test_utils.py
+++ b/tests/unit/data/test_utils.py
@@ -21,6 +21,7 @@ index 0. They are pure Python and require no GPUs / Ray / models.
 """
 
 import os
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
@@ -29,7 +30,11 @@ import yaml
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.data.datasets import extract_necessary_env_names
-from nemo_rl.data.utils import get_train_dataset_name, load_dataloader_state
+from nemo_rl.data.utils import (
+    get_train_dataset_name,
+    load_dataloader_state,
+    setup_response_data,
+)
 
 # ---------------------------------------------------------------------------
 # Test fixtures / helpers
@@ -134,6 +139,54 @@ def test_extract_necessary_env_names_ignores_missing_or_none_entries():
     }
 
     assert extract_necessary_env_names(data_config) == []
+
+
+def test_setup_response_data_skips_all_validation_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    train_data = SimpleNamespace(
+        task_name="train",
+        dataset=["training row"],
+        val_dataset=["derived validation row"],
+        task_spec=object(),
+        processor=object(),
+        preprocessor=None,
+    )
+
+    def fake_load_response_dataset(config: dict[str, str]) -> SimpleNamespace:
+        calls.append(config["data_path"])
+        return train_data
+
+    class FakeProcessedDataset:
+        def __init__(self, dataset: list[str], *args: Any, **kwargs: Any) -> None:
+            self.dataset = dataset
+
+        def __len__(self) -> int:
+            return len(self.dataset)
+
+    monkeypatch.setattr(
+        "nemo_rl.data.utils.load_response_dataset", fake_load_response_dataset
+    )
+    monkeypatch.setattr(
+        "nemo_rl.data.utils.merge_datasets", lambda datasets: datasets[0]
+    )
+    monkeypatch.setattr(
+        "nemo_rl.data.utils.AllTaskProcessedDataset", FakeProcessedDataset
+    )
+
+    data_config = {
+        "max_input_seq_length": None,
+        "shuffle": False,
+        "train": {"data_path": "train.jsonl"},
+        "validation": {"data_path": "validation.jsonl"},
+    }
+    _, val_dataset = setup_response_data(
+        None, data_config, env_configs=None, load_validation=False
+    )
+
+    assert calls == ["train.jsonl"]
+    assert val_dataset is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

 - Load NeMo Gym JSONL through Hugging Face’s reusable Arrow cache while preserving raw rows and supporting pre-converted Arrow/Parquet datasets; observed dataset setup improved from ~152 seconds to 2.2 seconds.

- Skip validation dataset loading when validation is disabled, avoiding unnecessary duplicate data initialization while preserving validation and trajectory-collection behavior.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
