### PR TITLE
fix(grpo): reject epoch bounds that train zero steps

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -709,6 +709,8 @@ def setup(
             flush=True,
         )
 
+    _validate_training_bounds(grpo_config, train_sample_count)
+
     # Load validation dataset if provided
     val_dataloader: Optional[StatefulDataLoader] = None
     # If validation is enabled, load the validation dataloader
@@ -2656,6 +2658,36 @@ def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
     }
 
 
+def _validate_training_bounds(
+    grpo_config: GRPOConfig, train_sample_count: int
+) -> None:
+    """Reject bounds that would train zero steps, before anything is allocated.
+
+    Both trainers gate on ``current_epoch < max_num_epochs`` and the async one
+    additionally clamps ``max_num_steps`` to ``max_num_epochs * len(dataloader)``,
+    so either operand at zero ends the run having trained nothing -- silently, in
+    every path but one.
+    """
+    # Not the -1 convention v1 async PPO uses: GRPO has never had a sentinel for
+    # an unbounded epoch count, and `None` is the shape upstream reaches for
+    # elsewhere when it wants one.
+    if grpo_config.max_num_epochs <= 0:
+        raise ValueError(
+            f"grpo.max_num_epochs={grpo_config.max_num_epochs} trains zero steps: "
+            "the training loop gates on current_epoch < max_num_epochs, and GRPO "
+            "has no -1 convention. Set a positive grpo.max_num_epochs and bound "
+            "the run with grpo.max_num_steps."
+        )
+    if train_sample_count == 0:
+        raise ValueError(
+            "The training dataloader yields 0 batches, so the run is bounded at 0 "
+            "steps. The dataloader drops the last partial batch, so a dataset "
+            "smaller than grpo.num_prompts_per_step="
+            f"{grpo_config.num_prompts_per_step} yields none at all. Lower "
+            "grpo.num_prompts_per_step or use a larger dataset."
+        )
+
+
 def _validate_use_kl_in_reward_compat(master_config: MasterConfig) -> None:
     """Reject ``use_kl_in_reward`` when the KL term would read zero placeholder logprobs.
 
@@ -4517,13 +4549,13 @@ def async_grpo_train(
 
     # Training state
     step = grpo_save_state.current_step
-    max_num_epochs = master_config.grpo.max_num_epochs
-    if max_num_epochs is not None and max_num_epochs > 0:
-        master_config.grpo.max_num_steps = min(
-            master_config.grpo.max_num_steps,
-            max_num_epochs * len(dataloader),
-        )
-    max_num_steps = master_config.grpo.max_num_steps
+    # Bound the loop locally: master_config is written into every checkpoint, so
+    # a value derived here does not belong in it. setup() has already rejected
+    # the bounds that would make this zero.
+    max_num_steps = min(
+        master_config.grpo.max_num_steps,
+        master_config.grpo.max_num_epochs * len(dataloader),
+    )
     if step >= max_num_steps:
         print(
             "Async GRPO training is already complete: "
@@ -4877,7 +4909,7 @@ def async_grpo_train(
             step=step,
             num_prompts_per_step=num_prompts_per_step,
             max_trajectory_age_steps=max_trajectory_age_steps,
-            max_num_steps=master_config.grpo.max_num_steps,
+            max_num_steps=max_num_steps,
         )
         if current_step_ready and not pipeline_ready:
             print(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2658,9 +2658,7 @@ def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
     }
 
 
-def _validate_training_bounds(
-    grpo_config: GRPOConfig, train_sample_count: int
-) -> None:
+def _validate_training_bounds(grpo_config: GRPOConfig, train_sample_count: int) -> None:
     """Reject bounds that would train zero steps, before anything is allocated.
 
     Both trainers gate on ``current_epoch < max_num_epochs`` and the async one

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2770,7 +2770,12 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # setup() rejects a dataloader that yields nothing, and a bare
+            # MagicMock has len() 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
@@ -3049,7 +3054,12 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # setup() rejects a dataloader that yields nothing, and a bare
+            # MagicMock has len() 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
@@ -3098,7 +3108,12 @@ def test_noncolocated_opd_teacher_must_fit_on_one_cluster_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger"),
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # setup() rejects a dataloader that yields nothing, and a bare
+            # MagicMock has len() 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         patch(
             "nemo_rl.algorithms.grpo.opd_module.reserve_teacher_clusters"
         ) as mock_reserve_teacher_clusters,

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -52,6 +52,7 @@ from nemo_rl.algorithms.grpo import (
     _save_async_replay_buffer_checkpoint,
     _startup_pipeline_ready,
     _validate_multimodal_dedup_capability,
+    _validate_training_bounds,
     _validate_use_kl_in_reward_compat,
     aggregate_rollout_metrics,
     async_grpo_train,
@@ -829,6 +830,26 @@ def test_raise_if_message_level_advantage_penalties_enabled_raises_when_set(
     master_config.grpo.invalid_tool_call_advantage = -5.0
     with pytest.raises(NotImplementedError, match="data_plane.enabled=true"):
         _raise_if_message_level_advantage_penalties_enabled(master_config)
+
+
+def test_training_bounds_reject_non_positive_epochs(mock_grpo_components):
+    grpo_config = mock_grpo_components["master_config"].grpo
+
+    for epochs in (0, -1):
+        grpo_config.max_num_epochs = epochs
+        with pytest.raises(ValueError, match="trains zero steps"):
+            _validate_training_bounds(grpo_config, train_sample_count=10)
+
+    grpo_config.max_num_epochs = 1
+    _validate_training_bounds(grpo_config, train_sample_count=10)
+
+
+def test_training_bounds_reject_an_empty_dataloader(mock_grpo_components):
+    grpo_config = mock_grpo_components["master_config"].grpo
+    grpo_config.max_num_epochs = 1
+
+    with pytest.raises(ValueError, match="yields 0 batches"):
+        _validate_training_bounds(grpo_config, train_sample_count=0)
 
 
 def test_multimodal_dedup_rejects_unqualified_transfer_paths(
@@ -4757,7 +4778,9 @@ def test_async_grpo_exit_on_max_epochs(mock_grpo_components, tmp_path):
     ] == [20]
     assert grpo_save_state.current_step == 20
     assert grpo_save_state.total_steps == 20
-    assert master_config.grpo.max_num_steps == 20
+    # The bound is the loop's, not the config's: master_config is written into
+    # every checkpoint and logged, so the derived value must not leak into it.
+    assert master_config.grpo.max_num_steps == 100
     cycling_dataloader_cls.assert_called_once_with(
         mock_grpo_components["train_dataloader"]
     )


### PR DESCRIPTION
# What does this PR do ?

**Rejects, at setup time, the two `max_num_epochs` bounds that make a run train zero steps — and stops the async bound from being written into the config it derives from.**

Three follow-ups to #3248.

**`max_num_epochs <= 0` was skipped by that commit's `> 0` guard**, so an async run went to `max_num_steps` (default 1,000,000) unbounded. Both synchronous trainers gate on `while current_epoch < max_num_epochs` (`grpo.py`, `grpo_sync.py`) and fall straight through, returning 0 having trained nothing.

**An empty training dataloader made the bound 0.** `StatefulDataLoader` is built with `drop_last=True`, so a dataset smaller than `num_prompts_per_step` yields no batches; the clamp becomes 0, a fresh run satisfies `step >= max_num_steps` before the collector starts, and it prints "Async GRPO training is already complete … limit of 0 steps" and returns 0. Before #3248 the same misconfiguration failed loudly at the exhausted collector.

Both are configuration errors, so they are rejected in `setup()` beside the other `_validate_*` helpers rather than at the top of `async_grpo_train`. That placement matters three ways:

- it fails **before** the Ray placement groups and engines are built, per the "validate the complete boundary before allocating Ray placement groups" comment already in `setup()`;
- it covers the synchronous trainers too, which otherwise keep exiting 0 with nothing trained — checking only the async path would trade one async/sync divergence for another;
- `setup()` derives the Megatron `train_iters` from the same two operands with no `max(..., 1)` floor (`ppo.py` and `single_controller_utils/setup.py` both have one), so a non-positive bound handed Megatron-Bridge a scheduler horizon of 0.

The `<= 0` rejection follows `_validate_algo_settings` in `single_controller_utils/config.py`, which makes the same call for the same field, with the same reasoning in its comment.

**Third**, the bound was applied by mutating `master_config.grpo.max_num_steps`. `init_tmp_checkpoint(step + 1, vars(grpo_save_state), master_config)` serializes that object into every checkpoint, so a run configured for `max_num_steps: 1000000` recorded the derived value instead of what the user wrote. It is a local now, as `setup()` already does with `total_train_iters`.

# Issues

Follows up #3248. Our earlier PR for the same underlying bug, #3948, is closed as superseded by it.

# Usage

Unchanged for valid configs. The two rejected cases now fail at setup:

```
ValueError: grpo.max_num_epochs=0 trains zero steps: the training loop gates on
current_epoch < max_num_epochs, and GRPO has no -1 convention. Set a positive
grpo.max_num_epochs and bound the run with grpo.max_num_steps.
```

```
ValueError: The training dataloader yields 0 batches, so the run is bounded at 0
steps. The dataloader drops the last partial batch, so a dataset smaller than
grpo.num_prompts_per_step=32 yields none at all. Lower grpo.num_prompts_per_step
or use a larger dataset.
```

**On `-1`:** v1 async PPO uses `max_num_epochs: -1` to mean "no epoch bound", and `examples/run_ppo.py` raises unless it is exactly that. GRPO has never had that sentinel — `GRPOConfig.max_num_epochs` is `int = 1`, no shipped GRPO recipe or doc uses `-1` or `0`, and `_validate_algo_settings` already rejects `<= 0` for `GRPOConfig` on the SingleController path. Raising here cannot break a PPO recipe. If GRPO ever wants "unbounded", the shape used elsewhere in the codebase is `None`, which this leaves available.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* Two tests added for the validator, in the shape of the neighbouring `_validate_*` tests. The existing `test_async_grpo_exit_on_max_epochs` keeps covering the clamp; its assertion changed from "the config was mutated" to "the config is untouched".
* The unit tests were **not** run locally — `tests/unit/algorithms/test_grpo.py` needs the `nemo` module, which is not importable in the environment this was written in.
