### PR TITLE
fix(vllm): realign multimodal placeholders after prefix replacement

### DIFF
--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -50,8 +50,36 @@ def remap_multimodal_placeholders(
     multimodal features remain aligned.
 
     Ranges are matched in global prompt order because different media items can
-    accumulate different shifts. A missing span fails closed rather than
-    submitting token IDs with incorrect multimodal positions.
+    accumulate different shifts. Coincident ranges resolve to the same offset:
+    Qwen2.5-Omni derives an audio range from its paired video range with an
+    identical ``(offset, length)``, so a span is only consumed once.
+
+    A span that cannot be located fails closed rather than submitting token IDs
+    with incorrect multimodal positions. Note that an *ambiguous* match is not
+    detected: media spans are bare runs of one repeated pad token, so if a run
+    is longer in ``final_token_ids`` than in the template, a later item can
+    match inside an earlier item's run. Locating spans by search is only
+    necessary because the splice boundary computed by ``replace_prefix_tokens``
+    is not threaded through to here; passing it would make the suffix region
+    pure arithmetic and remove that ambiguity entirely.
+
+    Args:
+        template_token_ids: The chat-template token sequence vLLM used to
+            compute ``mm_placeholders``.
+        final_token_ids: The exact-token prompt produced by
+            ``replace_prefix_tokens``, which will be submitted to the engine.
+        mm_placeholders: vLLM's per-modality placeholder ranges, in
+            ``template_token_ids`` coordinates.
+
+    Returns:
+        A new per-modality mapping with the same item ordering, whose ranges are
+        expressed in ``final_token_ids`` coordinates.
+
+    Raises:
+        ValueError: If an input range is out of bounds for
+            ``template_token_ids``, or if a media span cannot be relocated in
+            ``final_token_ids``.
+        TypeError: If a range is neither a mapping nor a dataclass instance.
     """
     if template_token_ids == final_token_ids or not mm_placeholders:
         return {modality: list(ranges) for modality, ranges in mm_placeholders.items()}
@@ -76,25 +104,33 @@ def remap_multimodal_placeholders(
             entries.append((offset, modality, item_index, placeholder_range, length))
 
     search_start = 0
+    resolved: dict[tuple[int, int], int] = {}
     for old_offset, modality, item_index, placeholder_range, length in sorted(
         entries, key=lambda entry: entry[0]
     ):
-        expected = template_token_ids[old_offset : old_offset + length]
-        max_start = len(final_token_ids) - length
-        new_offset = next(
-            (
-                candidate
-                for candidate in range(search_start, max_start + 1)
-                if final_token_ids[candidate] == expected[0]
-                and final_token_ids[candidate : candidate + length] == expected
-            ),
-            None,
-        )
+        # Two modalities can describe the same span, so a resolved offset is
+        # reused instead of scanning past it. Only a newly located span
+        # advances the cursor.
+        new_offset = resolved.get((old_offset, length))
         if new_offset is None:
-            raise ValueError(
-                f"Could not locate {modality} placeholder range {item_index} "
-                f"from template offset {old_offset} in the final exact-token prompt"
+            expected = template_token_ids[old_offset : old_offset + length]
+            max_start = len(final_token_ids) - length
+            new_offset = next(
+                (
+                    candidate
+                    for candidate in range(search_start, max_start + 1)
+                    if final_token_ids[candidate] == expected[0]
+                    and final_token_ids[candidate : candidate + length] == expected
+                ),
+                None,
             )
+            if new_offset is None:
+                raise ValueError(
+                    f"Could not locate {modality} placeholder range {item_index} "
+                    f"from template offset {old_offset} in the final exact-token prompt"
+                )
+            resolved[(old_offset, length)] = new_offset
+            search_start = new_offset + length
 
         if isinstance(placeholder_range, Mapping):
             updated_range = dict(placeholder_range)
@@ -108,7 +144,6 @@ def remap_multimodal_placeholders(
             )
 
         remapped[modality][item_index] = updated_range
-        search_start = new_offset + length
 
     return remapped
 

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import is_dataclass, replace
 from typing import Any, Optional
 
 import torch
@@ -31,6 +33,84 @@ VLLM_LOGPROB_FLOOR = -9999.0
 # The expert-id range vs carry dtype is model-constant, so it is verified on the
 # first non-empty routed-experts tensor per process and skipped afterwards.
 G_ROUTED_EXPERTS_RANGE_CHECKED = False
+
+
+def remap_multimodal_placeholders(
+    *,
+    template_token_ids: list[int],
+    final_token_ids: list[int],
+    mm_placeholders: Mapping[str, list[Any]],
+) -> dict[str, list[Any]]:
+    """Move vLLM multimodal ranges into the final prompt coordinates.
+
+    vLLM computes multimodal placeholder offsets while preprocessing the
+    chat-template token sequence. NeMo-RL can subsequently replace the
+    re-tokenized history with the exact model-generated token prefix. Locate
+    each unchanged media-token span in that final sequence so its associated
+    multimodal features remain aligned.
+
+    Ranges are matched in global prompt order because different media items can
+    accumulate different shifts. A missing span fails closed rather than
+    submitting token IDs with incorrect multimodal positions.
+    """
+    if template_token_ids == final_token_ids or not mm_placeholders:
+        return {modality: list(ranges) for modality, ranges in mm_placeholders.items()}
+
+    entries: list[tuple[int, str, int, Any, int]] = []
+    remapped = {modality: list(ranges) for modality, ranges in mm_placeholders.items()}
+    for modality, ranges in mm_placeholders.items():
+        for item_index, placeholder_range in enumerate(ranges):
+            if isinstance(placeholder_range, Mapping):
+                offset = int(placeholder_range["offset"])
+                length = int(placeholder_range["length"])
+            else:
+                offset = int(placeholder_range.offset)
+                length = int(placeholder_range.length)
+
+            if offset < 0 or length <= 0 or offset + length > len(template_token_ids):
+                raise ValueError(
+                    f"Invalid {modality} placeholder range {item_index}: "
+                    f"offset={offset}, length={length}, "
+                    f"template_length={len(template_token_ids)}"
+                )
+            entries.append((offset, modality, item_index, placeholder_range, length))
+
+    search_start = 0
+    for old_offset, modality, item_index, placeholder_range, length in sorted(
+        entries, key=lambda entry: entry[0]
+    ):
+        expected = template_token_ids[old_offset : old_offset + length]
+        max_start = len(final_token_ids) - length
+        new_offset = next(
+            (
+                candidate
+                for candidate in range(search_start, max_start + 1)
+                if final_token_ids[candidate] == expected[0]
+                and final_token_ids[candidate : candidate + length] == expected
+            ),
+            None,
+        )
+        if new_offset is None:
+            raise ValueError(
+                f"Could not locate {modality} placeholder range {item_index} "
+                f"from template offset {old_offset} in the final exact-token prompt"
+            )
+
+        if isinstance(placeholder_range, Mapping):
+            updated_range = dict(placeholder_range)
+            updated_range["offset"] = new_offset
+        elif is_dataclass(placeholder_range):
+            updated_range = replace(placeholder_range, offset=new_offset)
+        else:
+            raise TypeError(
+                "Multimodal placeholder ranges must be mappings or dataclass "
+                f"instances, got {type(placeholder_range).__name__}"
+            )
+
+        remapped[modality][item_index] = updated_range
+        search_start = new_offset + length
+
+    return remapped
 
 
 def _as_routed_experts_tensor(

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -590,6 +590,10 @@ class VllmAsyncGenerationWorkerImpl(
                     template_token_ids=engine_prompt["prompt_token_ids"],
                 )
 
+                # Must precede the reassignment below: the remap reads the
+                # current value of prompt_token_ids as the template-coordinate
+                # sequence the placeholders were computed against. Reordering
+                # these two statements silently degrades to a no-op.
                 if mm_placeholders := engine_prompt.get("mm_placeholders"):
                     engine_prompt["mm_placeholders"] = remap_multimodal_placeholders(
                         template_token_ids=engine_prompt["prompt_token_ids"],

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -49,6 +49,7 @@ from nemo_rl.models.generation.vllm.utils import (
     format_prompt_for_vllm_generation,
     model_dump_chat_response_with_dynamic_message_fields,
     pad_and_align_routed_expert_indices,
+    remap_multimodal_placeholders,
 )
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 from nemo_rl.models.generation.openai_server_utils import (
@@ -588,6 +589,13 @@ class VllmAsyncGenerationWorkerImpl(
                     template_prefix_token_ids=actual_corresponding_token_ids,
                     template_token_ids=engine_prompt["prompt_token_ids"],
                 )
+
+                if mm_placeholders := engine_prompt.get("mm_placeholders"):
+                    engine_prompt["mm_placeholders"] = remap_multimodal_placeholders(
+                        template_token_ids=engine_prompt["prompt_token_ids"],
+                        final_token_ids=final_prompt_token_ids,
+                        mm_placeholders=mm_placeholders,
+                    )
 
                 engine_prompt["prompt_token_ids"] = final_prompt_token_ids
 

--- a/tests/unit/models/generation/test_vllm_chat_template_wiring.py
+++ b/tests/unit/models/generation/test_vllm_chat_template_wiring.py
@@ -25,8 +25,10 @@ These tests drive the real _setup_vllm_openai_api_server against a fake vLLM
 module tree and inspect what each consumer was constructed with.
 """
 
+import asyncio
 import sys
 import types
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
@@ -243,3 +245,105 @@ def test_absent_kwargs_render_as_empty_dict(monkeypatch):
 
     assert renderer[0].kwargs["default_chat_template_kwargs"] == {}
     assert tokenization[0].kwargs["default_chat_template_kwargs"] == {}
+
+
+# ---------------------------------------------------------------------------
+# preprocess_chat: multimodal placeholders after exact-prefix replacement
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PlaceholderRange:
+    """Mirrors vllm.multimodal.inputs.PlaceholderRange (v0.25.1)."""
+
+    offset: int
+    length: int
+    is_embed: object | None = None
+
+
+class _Request:
+    """Enough of ChatCompletionRequest for the prefix-replacement branch."""
+
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+    def model_copy(self, update):
+        merged = dict(self.__dict__)
+        merged.update(update)
+        return _Request(**merged)
+
+
+# eos = 2. History re-tokenizes 1002,1003 as the single token 1001, so the
+# exact-token prompt is one longer than the template render and every media
+# span after the splice point slides by one.
+_TEMPLATE_PREFIX = [7, 8, 1001, 2]
+_TEMPLATE_TOKENS = [7, 8, 1001, 2, 30, 90, 90, 90, 31]
+_MODEL_PREFIX = [7, 8, 1002, 1003, 2]
+_EXACT_TOKENS = [7, 8, 1002, 1003, 2, 30, 90, 90, 90, 31]
+
+
+def _renderer_with_stubbed_super(monkeypatch, mm_placeholders):
+    """Build the real NeMoRLOnlineRenderer over a scripted vLLM base class."""
+    renderer, _, _ = _build_server(monkeypatch, {})
+    instance = renderer[0]
+    instance.renderer = MagicMock(tokenizer=MagicMock(eos_token_id=2))
+
+    engine_prompt = {"prompt_token_ids": list(_TEMPLATE_TOKENS)}
+    if mm_placeholders is not None:
+        engine_prompt["mm_placeholders"] = mm_placeholders
+
+    async def fake_preprocess_chat(self, *, request, messages, **_kwargs):
+        # The history-only call passes the truncated message list.
+        if len(messages) == len(_MESSAGES):
+            return [], [engine_prompt]
+        return [], [{"prompt_token_ids": list(_TEMPLATE_PREFIX)}]
+
+    monkeypatch.setattr(
+        _OnlineRenderer, "preprocess_chat", fake_preprocess_chat, raising=False
+    )
+    return instance, engine_prompt
+
+
+_MESSAGES = [
+    {"role": "user", "content": "first"},
+    {"role": "assistant", "content": "reply"},
+    {"role": "user", "content": "look at this"},
+]
+
+
+async def _run_preprocess_chat(instance):
+    return await instance.preprocess_chat(
+        request=_Request(required_prefix_token_ids=list(_MODEL_PREFIX)),
+        messages=[dict(m) for m in _MESSAGES],
+        default_template=None,
+        default_template_content_format="auto",
+        default_template_kwargs={},
+    )
+
+
+def test_preprocess_chat_moves_mm_placeholders_onto_the_exact_token_prompt(monkeypatch):
+    """The remap must actually land on engine_prompt, under vLLM's key name.
+
+    remap_multimodal_placeholders is unit-tested in isolation, but the whole
+    repair is a no-op if the call site reads a key vLLM does not populate --
+    ``mm_placeholders`` on MultiModalInput (vllm/inputs/engine.py, v0.25.1).
+    """
+    instance, engine_prompt = _renderer_with_stubbed_super(
+        monkeypatch, {"image": [_PlaceholderRange(offset=5, length=3)]}
+    )
+
+    asyncio.run(_run_preprocess_chat(instance))
+
+    assert engine_prompt["prompt_token_ids"] == _EXACT_TOKENS
+    assert [r.offset for r in engine_prompt["mm_placeholders"]["image"]] == [6]
+    assert [r.length for r in engine_prompt["mm_placeholders"]["image"]] == [3]
+
+
+def test_preprocess_chat_leaves_text_only_prompts_without_mm_placeholders(monkeypatch):
+    """A text-only request must not grow an empty mm_placeholders key."""
+    instance, engine_prompt = _renderer_with_stubbed_super(monkeypatch, None)
+
+    asyncio.run(_run_preprocess_chat(instance))
+
+    assert engine_prompt["prompt_token_ids"] == _EXACT_TOKENS
+    assert "mm_placeholders" not in engine_prompt

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -55,7 +55,7 @@ def test_remap_multimodal_placeholders_handles_accumulated_per_item_shift():
     final_token_ids = [1, *media_tokens, 2, *media_tokens, 3, 21, 21, 22]
     placeholders = {
         # Deliberately list modalities in the opposite order from prompt order.
-        "audio": [{"offset": 13, "length": 3}],
+        "audio": [_PlaceholderRange(offset=13, length=3)],
         "image": [
             _PlaceholderRange(offset=1, length=4),
             _PlaceholderRange(offset=7, length=4, is_embed=embed_mask),
@@ -70,18 +70,135 @@ def test_remap_multimodal_placeholders_handles_accumulated_per_item_shift():
 
     assert [item.offset for item in result["image"]] == [1, 6]
     assert result["image"][1].is_embed is embed_mask
-    assert result["audio"] == [{"offset": 11, "length": 3}]
+    assert result["audio"] == [_PlaceholderRange(offset=11, length=3)]
+
+
+def test_remap_multimodal_placeholders_reuses_a_span_shared_by_two_modalities():
+    """Coincident ranges must both land on the one span they describe.
+
+    vLLM's Qwen2.5-Omni use_audio_in_video path derives the audio range from
+    its paired video range, reusing start_idx and tokens and differing only in
+    is_embed -- so the two ranges are identical. Consuming the span for the
+    first would leave the second unfindable.
+    """
+    media_tokens = [19, 18, 18]
+    template_token_ids = [1, 2, *media_tokens, 9]
+    final_token_ids = [1, *media_tokens, 9]
+    embed_mask = object()
+
+    result = remap_multimodal_placeholders(
+        template_token_ids=template_token_ids,
+        final_token_ids=final_token_ids,
+        mm_placeholders={
+            "video": [_PlaceholderRange(offset=2, length=3)],
+            "audio": [_PlaceholderRange(offset=2, length=3, is_embed=embed_mask)],
+        },
+    )
+
+    assert [item.offset for item in result["video"]] == [1]
+    assert [item.offset for item in result["audio"]] == [1]
+    assert result["audio"][0].is_embed is embed_mask
+
+
+def test_remap_multimodal_placeholders_without_media_returns_empty():
+    """The shortcut also covers a changed prompt that carries no media."""
+    assert (
+        remap_multimodal_placeholders(
+            template_token_ids=[1, 2, 3],
+            final_token_ids=[9, 9, 1, 2, 3],
+            mm_placeholders={},
+        )
+        == {}
+    )
 
 
 def test_remap_multimodal_placeholders_fails_closed_when_span_is_missing():
-    with pytest.raises(
-        ValueError, match="Could not locate image placeholder range 0"
-    ):
+    with pytest.raises(ValueError, match="Could not locate image placeholder range 0"):
         remap_multimodal_placeholders(
             template_token_ids=[1, 18, 18, 2],
             final_token_ids=[1, 2],
             mm_placeholders={"image": [_PlaceholderRange(offset=1, length=2)]},
         )
+
+
+def test_remap_multimodal_placeholders_noop_returns_detached_containers():
+    """The unchanged-prompt shortcut must still hand back its own lists.
+
+    Returning the caller's lists aliases them into engine_prompt, so a later
+    in-place edit of one silently rewrites the other.
+    """
+    original = _PlaceholderRange(offset=1, length=2)
+    placeholders = {"image": [original]}
+
+    result = remap_multimodal_placeholders(
+        template_token_ids=[1, 18, 18, 2],
+        final_token_ids=[1, 18, 18, 2],
+        mm_placeholders=placeholders,
+    )
+
+    assert result == placeholders
+    assert result["image"] is not placeholders["image"]
+    assert result["image"][0] is original
+
+
+@pytest.mark.parametrize(
+    "offset,length",
+    [(-1, 2), (1, 0), (2, 3)],
+    ids=["negative-offset", "zero-length", "runs-past-template"],
+)
+def test_remap_multimodal_placeholders_rejects_out_of_range_input(offset, length):
+    """A range vLLM never could have produced is a bug, not something to remap.
+
+    Without the guard, ``template_token_ids[offset : offset + length]`` slices
+    silently short (or wraps for a negative offset) and the span is then
+    matched -- and moved -- against the wrong tokens.
+    """
+    with pytest.raises(ValueError, match="Invalid image placeholder range 0"):
+        remap_multimodal_placeholders(
+            template_token_ids=[1, 18, 18, 2],
+            final_token_ids=[1, 18, 18],
+            mm_placeholders={"image": [{"offset": offset, "length": length}]},
+        )
+
+
+def test_remap_multimodal_placeholders_rejects_unsupported_range_type():
+    """Only mappings and dataclasses can be rebuilt with a new offset."""
+
+    class _OpaqueRange:
+        offset = 1
+        length = 2
+
+    with pytest.raises(TypeError, match="got _OpaqueRange"):
+        remap_multimodal_placeholders(
+            template_token_ids=[1, 18, 18, 2],
+            final_token_ids=[9, 1, 18, 18, 2],
+            mm_placeholders={"image": [_OpaqueRange()]},
+        )
+
+
+@pytest.mark.vllm
+def test_remap_multimodal_placeholders_rebuilds_real_vllm_placeholder_range():
+    """Guard the stand-in above against vLLM's actual PlaceholderRange.
+
+    ``dataclasses.replace`` is what moves a dataclass range, and it breaks if
+    vLLM ever adds an ``init=False`` field or ``__slots__``; is_embed is a real
+    tensor there, and it must survive the move untouched.
+    """
+    from vllm.multimodal.inputs import PlaceholderRange
+
+    is_embed = torch.tensor([True, False, True])
+    result = remap_multimodal_placeholders(
+        template_token_ids=[1, 18, 18, 18, 2],
+        final_token_ids=[9, 9, 1, 18, 18, 18, 2],
+        mm_placeholders={
+            "image": [PlaceholderRange(offset=1, length=3, is_embed=is_embed)]
+        },
+    )
+
+    moved = result["image"][0]
+    assert isinstance(moved, PlaceholderRange)
+    assert (moved.offset, moved.length) == (3, 3)
+    assert moved.is_embed is is_embed
 
 
 def _decoded_routes(payload: str) -> list:

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -35,8 +36,52 @@ from nemo_rl.models.generation.vllm.utils import (
     format_prompt_for_vllm_generation,
     model_dump_chat_response_with_dynamic_message_fields,
     pad_and_align_routed_expert_indices,
+    remap_multimodal_placeholders,
 )
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
+
+
+@dataclass(frozen=True)
+class _PlaceholderRange:
+    offset: int
+    length: int
+    is_embed: object | None = None
+
+
+def test_remap_multimodal_placeholders_handles_accumulated_per_item_shift():
+    embed_mask = object()
+    media_tokens = [19, 18, 18, 20]
+    template_token_ids = [1, *media_tokens, 13, 2, *media_tokens, 13, 3, 21, 21, 22]
+    final_token_ids = [1, *media_tokens, 2, *media_tokens, 3, 21, 21, 22]
+    placeholders = {
+        # Deliberately list modalities in the opposite order from prompt order.
+        "audio": [{"offset": 13, "length": 3}],
+        "image": [
+            _PlaceholderRange(offset=1, length=4),
+            _PlaceholderRange(offset=7, length=4, is_embed=embed_mask),
+        ],
+    }
+
+    result = remap_multimodal_placeholders(
+        template_token_ids=template_token_ids,
+        final_token_ids=final_token_ids,
+        mm_placeholders=placeholders,
+    )
+
+    assert [item.offset for item in result["image"]] == [1, 6]
+    assert result["image"][1].is_embed is embed_mask
+    assert result["audio"] == [{"offset": 11, "length": 3}]
+
+
+def test_remap_multimodal_placeholders_fails_closed_when_span_is_missing():
+    with pytest.raises(
+        ValueError, match="Could not locate image placeholder range 0"
+    ):
+        remap_multimodal_placeholders(
+            template_token_ids=[1, 18, 18, 2],
+            final_token_ids=[1, 2],
+            mm_placeholders={"image": [_PlaceholderRange(offset=1, length=2)]},
+        )
 
 
 def _decoded_routes(payload: str) -> list:


### PR DESCRIPTION
## Summary

- Backports the current state of #3858 at source head `5282b117ea7f05a8bb0e331ec71897d417ba314b` to `super-v3.5-posttraining`.
- Realigns vLLM multimodal placeholder offsets after exact multi-turn prefix-token replacement.
- Handles accumulated shifts, mixed modalities, coincident ranges, invalid ranges, and unchanged/text-only fast paths.

The source PR is still open; this backport intentionally snapshots its current two-commit state.

## Backport notes

- Both source commits were cherry-picked with `-x` and applied without content conflicts.
- Preserved source authorship and coauthor credit. The second source commit has no DCO trailer, so the cherry-picker's sign-off was added.

## Testing

- 11 focused default unit tests passed.
- 1 focused test passed against the branch's pinned vLLM `PlaceholderRange` with `--vllm-only`.
- All file-scoped pre-commit hooks pass for the four changed files, including both Ruff checks and Ruff format.
- Repository-wide Pyrefly still reports the pre-existing target-branch error in unchanged `nemo_rl/experience/rollouts.py:2755`.

Source: #3858
