### PR TITLE
fix(dynamo): emit each generation metric as a single series

### DIFF
--- a/nemo_rl/models/generation/dynamo/metrics.py
+++ b/nemo_rl/models/generation/dynamo/metrics.py
@@ -39,6 +39,11 @@ CURATED_METRICS_INCLUDE_PREFIXES = (
     "vllm:prompt_tokens_total",
     "vllm:inter_token_latency",
 )
+# Canonical series name -> every raw metric that can carry it, in precedence
+# order. A managed Dynamo worker exports the Dynamo gauge *and* the vLLM twin
+# underneath it, so an alias routinely has more than one source present.
+# ``snapshot`` takes the value from the first source present and consumes the
+# rest, so each quantity reaches the logger exactly once.
 CANONICAL_LOGGER_ALIASES = {
     "inflight_batch_sizes": [
         "dynamo_component_inflight_requests",
@@ -47,11 +52,16 @@ CANONICAL_LOGGER_ALIASES = {
     "num_pending_samples": [
         "dynamo_work_handler_queue_depth",
         "vllm_num_requests_waiting",
+        # vLLM (0.23.0, which the Dynamo venv pins) also exports the waiting
+        # count split by reason, and the curated ``vllm:num_requests_waiting``
+        # prefix matches it. Summed over its labels it is the same quantity, so
+        # list it as a source to be consumed rather than letting it through as a
+        # second waiting-request series.
+        "vllm_num_requests_waiting_by_reason",
     ],
     "kv_cache_usage_perc": [
         "dynamo_component_gpu_cache_usage_percent",
         "vllm_kv_cache_usage_perc",
-        "vllm_gpu_cache_usage_perc",
     ],
     "generation_tokens": [
         "vllm_generation_tokens_total",
@@ -189,10 +199,15 @@ class DynamoMetricsSampler:
         for alias, sources in CANONICAL_LOGGER_ALIASES.items():
             if alias in metrics:
                 continue
-            source = next((name for name in sources if name in metrics), None)
-            metrics[alias] = dict(metrics[source]) if source is not None else {}
-            if source is not None:
-                del metrics[source]
+            present = [name for name in sources if name in metrics]
+            metrics[alias] = dict(metrics[present[0]]) if present else {}
+            # Consume every source, not only the one that supplied the value.
+            # Deleting just the winner left each surviving twin in the dict to be
+            # plotted next to the alias it already fed -- the whole reason this
+            # backend shipped fourteen generation_metrics series where the vLLM
+            # backend ships four.
+            for name in present:
+                del metrics[name]
         return metrics
 
     def clear(self) -> None:

--- a/tests/unit/models/generation/test_dynamo_generation.py
+++ b/tests/unit/models/generation/test_dynamo_generation.py
@@ -404,6 +404,84 @@ def test_metrics_parser_and_sampler_aliases() -> None:
     assert "python_gc_objects_collected_total" not in parsed
 
 
+def _curated_sampler() -> DynamoMetricsSampler:
+    return DynamoMetricsSampler(
+        [{"instance_id": "a", "system_url": "http://worker:4000"}],
+        interval_s=1,
+        include_prefixes=None,
+        exclude_prefixes=None,
+    )
+
+
+def _curated_snapshot(exposition: str) -> dict[str, Any]:
+    """Sample one scrape of ``exposition`` through the curated prefixes."""
+    sampler = _curated_sampler()
+    parsed = parse_prometheus_metrics(
+        exposition,
+        sampler._include_prefixes,
+        sampler._exclude_prefixes,
+    )
+    sampler._samples = {name: {0: [value]} for name, value in parsed.items()}
+    return sampler.snapshot()
+
+
+def test_snapshot_consumes_every_source_of_an_alias() -> None:
+    """A managed worker exports the Dynamo gauge and the vLLM twin at once.
+
+    Only the source that supplied the value used to be deleted, which left the
+    twin in the dict to be plotted beside the alias it had already fed.
+    """
+    metrics = _curated_snapshot(
+        'dynamo_component_inflight_requests{instance="0"} 3\n'
+        'vllm:num_requests_running{model_name="model",engine="0"} 3\n'
+    )
+
+    # The Dynamo gauge leads the source list, so it supplies the value.
+    assert metrics["inflight_batch_sizes"] == {0: [3.0]}
+    assert "dynamo_component_inflight_requests" not in metrics
+    assert "vllm_num_requests_running" not in metrics
+
+
+def test_snapshot_folds_vllm_waiting_by_reason_into_the_pending_alias() -> None:
+    """``vllm:num_requests_waiting`` is a prefix, so it also matches vLLM's
+    ``vllm:num_requests_waiting_by_reason``. Summed over its labels that is the
+    same waiting count, which must not surface as a second pending series.
+    """
+    metrics = _curated_snapshot(
+        'vllm:num_requests_waiting{model_name="model",engine="0"} 5\n'
+        'vllm:num_requests_waiting_by_reason{reason="capacity"} 4\n'
+        'vllm:num_requests_waiting_by_reason{reason="deferred"} 1\n'
+    )
+
+    assert metrics["num_pending_samples"] == {0: [5.0]}
+    assert "vllm_num_requests_waiting_by_reason" not in metrics
+
+
+def test_curated_snapshot_leaves_no_alias_source_beside_its_alias() -> None:
+    """Every alias here has both of its sources scraped, as on a real worker."""
+    metrics = _curated_snapshot(
+        'dynamo_component_inflight_requests{instance="0"} 3\n'
+        'vllm:num_requests_running{model_name="model",engine="0"} 3\n'
+        'dynamo_work_handler_queue_depth{instance="0"} 2\n'
+        'vllm:num_requests_waiting{model_name="model",engine="0"} 2\n'
+        'vllm:num_requests_waiting_by_reason{reason="capacity"} 2\n'
+        'dynamo_component_gpu_cache_usage_percent{instance="0"} 0.4\n'
+        'vllm:kv_cache_usage_perc{model_name="model",engine="0"} 0.4\n'
+        'vllm:generation_tokens_total{model_name="model",engine="0"} 7\n'
+    )
+
+    every_source = {
+        source
+        for sources in metrics_module.CANONICAL_LOGGER_ALIASES.values()
+        for source in sources
+    }
+    assert every_source.isdisjoint(metrics)
+    assert metrics["inflight_batch_sizes"] == {0: [3.0]}
+    assert metrics["num_pending_samples"] == {0: [2.0]}
+    assert metrics["kv_cache_usage_perc"] == {0: [0.4]}
+    assert metrics["generation_tokens"] == {0: [7.0]}
+
+
 def test_metrics_http_errors_are_ignored(monkeypatch) -> None:
     monkeypatch.setattr(
         metrics_module.urllib.request,


### PR DESCRIPTION
# What does this PR do ?

**Makes the managed Dynamo backend log each generation metric as a single series instead of plotting the alias next to the raw source it was built from.**

`DynamoMetricsSampler.snapshot` resolves each entry of `CANONICAL_LOGGER_ALIASES` to the first source name present in the sample dict, then deletes only that one:

```python
source = next((name for name in sources if name in metrics), None)
metrics[alias] = dict(metrics[source]) if source is not None else {}
if source is not None:
    del metrics[source]
```

A managed Dynamo worker exports the Dynamo gauge *and* the vLLM twin underneath it, so an alias usually has more than one source present. Only the winner was removed, so each losing twin stayed in the dict and got logged beside the alias it had just fed: `inflight_batch_sizes` next to `vllm_num_requests_running`, `num_pending_samples` next to `vllm_num_requests_waiting`, `kv_cache_usage_perc` next to `vllm_kv_cache_usage_perc`. `logger.py` then plots every surviving key twice, once as `per_worker_` and once as `average_`.

The fix is to consume every source that is present and keep the first one as the value, so precedence is unchanged.

Two strays called out in LE-21 fall out of the same mechanism rather than needing new machinery:

* `vllm:num_requests_waiting` is a curated *prefix*, so it also matches `vllm:num_requests_waiting_by_reason`. That metric exists in vLLM 0.23.0 ([`v1/metrics/loggers.py`](https://github.com/vllm-project/vllm/blob/v0.23.0/vllm/v1/metrics/loggers.py)), which is what the Dynamo venv gets from `ai-dynamo[vllm]==1.3.0.post1`. Summed over its `reason` labels it is the same waiting count, so I listed it as a source of `num_pending_samples` and let it be consumed instead of surfacing on its own.
* `vllm_gpu_cache_usage_perc` was unreachable as an alias source. No curated include prefix collects `vllm:gpu_cache_usage_perc`, and the existing `test_metrics_parser_and_sampler_aliases` already asserts `"vllm_gpu_cache_usage_perc" not in parsed`. It is the older vLLM spelling of what `vllm_kv_cache_usage_perc` already covers, so I dropped it instead of adding the prefix back. Happy to go the other way if you would rather keep a fallback for older vLLM reachable.

One thing I deliberately left alone: LE-21 also notes that `kv_cache_usage_perc` resolves to `dynamo_component_gpu_cache_usage_percent` here but to `vllm:kv_cache_usage_perc` on the vLLM backend, and that Dynamo's own docs disagree on the scale ([`prometheus_names.rs`](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/lib/runtime/src/metrics/prometheus_names.rs#L788-L789) says 0.0-1.0, [`DASHBOARD_METRICS.md`](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/dev/observability/grafana_dashboards/DASHBOARD_METRICS.md#L73) says 0-100). Normalizing that changes the meaning of a logged value across backends, so it seemed like your call rather than mine. Can follow up once you decide which scale is canonical.

# Issues

Addresses **LE-21** of #3459. Leaving that issue open since the other items are untouched.

# Usage

No config or API change. Existing runs with `policy.generation.backend: dynamo` just stop emitting the duplicate series. For one scrape carrying both sources of all four aliases:

| | series emitted |
|---|---|
| before | `generation_tokens`, `inflight_batch_sizes`, `kv_cache_usage_perc`, `num_pending_samples`, `vllm_kv_cache_usage_perc`, `vllm_num_requests_running`, `vllm_num_requests_waiting`, `vllm_num_requests_waiting_by_reason` |
| after | `generation_tokens`, `inflight_batch_sizes`, `kv_cache_usage_perc`, `num_pending_samples` |

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Three tests added next to the existing one in `tests/unit/models/generation/test_dynamo_generation.py`:

* `test_snapshot_consumes_every_source_of_an_alias` - Dynamo gauge and vLLM twin both scraped; the alias keeps the Dynamo value and neither source survives.
* `test_snapshot_folds_vllm_waiting_by_reason_into_the_pending_alias` - the `by_reason` variant is absorbed instead of plotted.
* `test_curated_snapshot_leaves_no_alias_source_beside_its_alias` - the general invariant, that no alias source name is left in a snapshot.

All three fail on `main` and pass with the change. Reverting just `metrics.py` to its pre-fix version:

```
PASSED test_metrics_parser_and_sampler_aliases
FAILED test_snapshot_consumes_every_source_of_an_alias
FAILED test_snapshot_folds_vllm_waiting_by_reason_into_the_pending_alias
FAILED test_curated_snapshot_leaves_no_alias_source_beside_its_alias
3 failed, 1 passed
```

The existing `test_metrics_parser_and_sampler_aliases` passes either way. It only ever has one source present per alias, which is why this went unnoticed.

With the change, the five Dynamo unit files pass together:

```
pytest tests/unit/models/generation/test_dynamo_{generation,arguments,http_client,managed_runtime,token_wrapper}.py
104 passed
```

That is CPU only. I don't have a GPU box, so the vLLM-backed modules in `tests/unit/models/generation/` don't import for me and I could not run the functional suite; this change doesn't touch either path, but a CI run would be good to confirm.

`ruff 0.9.9` check, import sort and format are clean on both files.

No docs change: `docs/guides/dynamo-generation.md` does not enumerate the metric series, so there is nothing there that goes stale. Say the word if you want the canonical four listed in the guide and I will add them here.
