### PR TITLE
fix(vlm): recognize Super Omni placeholder processor

### DIFF
--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -63,6 +63,7 @@ _PLACEHOLDER_STYLE_PROCESSOR_NAMES = frozenset(
     {
         "NemotronNanoVLV2Processor",
         "NemotronH_Nano_Omni_Reasoning_V3Processor",
+        "NemotronH_Omni_Reasoning_V3Processor",
     }
 )
 


### PR DESCRIPTION
## Summary
- recognize `NemotronH_Omni_Reasoning_V3Processor` as a placeholder-style multimodal processor
- preserve image-placeholder alignment for the Super Omni processor

## Testing
- `git diff --check`
- targeted pytest not run locally (`uv` is unavailable on the submission host); requesting `CI:L1`