### PR TITLE
fix(generation): report no OpenAI server as an empty list

### DIFF
--- a/nemo_rl/models/generation/dynamo/dynamo_generation.py
+++ b/nemo_rl/models/generation/dynamo/dynamo_generation.py
@@ -184,7 +184,7 @@ class DynamoGeneration(GenerationInterface):
         )
         self._token_wrapper_server: Optional[DynamoTokenWrapperServer] = None
         self._dynamo_frontend_base_url = ""
-        self.dp_openai_server_base_urls: list[Optional[str]] = []
+        self.dp_openai_server_base_urls: list[str] = []
         self._refit_channel: DynamoRefitChannel | None = None
         self._metrics_sampler: DynamoMetricsSampler | None = None
         try:
@@ -217,7 +217,9 @@ class DynamoGeneration(GenerationInterface):
                     flush=True,
                 )
             else:
-                self.dp_openai_server_base_urls = [None]
+                # No token wrapper means no OpenAI-compatible server to advertise;
+                # stay empty rather than holding a slot open with a placeholder.
+                self.dp_openai_server_base_urls = []
                 print(f"  [Dynamo] Forwarding rollouts to {url}", flush=True)
 
             if vllm_cfg.enable_vllm_metrics_logger:

--- a/nemo_rl/models/generation/megatron/megatron_generation.py
+++ b/nemo_rl/models/generation/megatron/megatron_generation.py
@@ -238,7 +238,7 @@ class MegatronGeneration(GenerationInterface):
         self._policy_config = config
         self.cfg: MCoreGenerationConfig = config["generation"]
         # Populated after the first prepare_for_generation (which starts the HTTP server).
-        self.dp_openai_server_base_urls: list[Optional[str]] = []
+        self.dp_openai_server_base_urls: list[str] = []
         # Installed by setup via create_weight_synchronizer.
         self.weight_synchronizer: Optional["WeightSynchronizer"] = None
 

--- a/nemo_rl/models/generation/trtllm/trtllm_generation.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_generation.py
@@ -261,16 +261,23 @@ class TrtllmGeneration(GenerationInterface):
             )
         return tied_groups
 
-    def _report_dp_openai_server_base_urls(self) -> list[Optional[str]]:
+    def _report_dp_openai_server_base_urls(self) -> list[str]:
         """Collect HTTP server base URLs from each DP-rank-0 worker."""
         if not self.cfg["trtllm_cfg"].get("expose_http_server"):
-            urls = [cast(Optional[str], None)] * self.dp_size
-            return urls
+            # Empty rather than one None per DP rank: with no server running there is
+            # no per-rank slot to hold open, and the length said otherwise.
+            return []
         futures = self.worker_group.run_all_workers_single_data(
             "report_dp_openai_server_base_url",
             run_rank_0_only_axes=["tensor_parallel"],
         )
-        return ray.get(futures)
+        results = ray.get(futures)
+        # All-or-nothing, like the guarded branch above: expose_http_server is one
+        # config value for every worker. Collapsing the whole list rather than
+        # filtering keeps one entry per DP rank for anything that reads it by index.
+        if not any(results):
+            return []
+        return results
 
     def _report_device_id(self) -> list[list[str]]:
         futures = self.worker_group.run_all_workers_single_data(

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -524,10 +524,10 @@ class VllmGeneration(GenerationInterface):
         results = ray.get(futures)
         return results
 
-    def _report_dp_openai_server_base_urls(self) -> list[Optional[str]]:
+    def _report_dp_openai_server_base_urls(self) -> list[str]:
         """Report the data parallel OpenAI server base URLs of vLLM workers, only populated if it is async vLLM engine and the HTTP server is active."""
         if not self.cfg["vllm_cfg"]["async_engine"]:
-            return [None]  # Not applicable since this is sync
+            return []  # Not applicable since this is sync
 
         # Use run_all_workers_single_data for methods that don't need data
         futures = self.worker_group.run_all_workers_single_data(
@@ -536,22 +536,34 @@ class VllmGeneration(GenerationInterface):
         )
         # Wait for all futures to complete
         results = ray.get(futures)
+        # A worker leaves base_url unset unless expose_http_server started a server, so
+        # an async engine without one answers with all Nones -- report that as no URLs,
+        # for the same reason the sync branch returns empty. Collapse the whole list
+        # rather than filtering entry by entry: expose_http_server is one config value
+        # for every worker, so the answer is all-or-nothing, and GenerationFleetHealth
+        # indexes this list by shard and length-checks it against shard_count.
+        if not any(results):
+            return []
         return results
 
-    def _collect_reserved_urls(self) -> list[Optional[str]]:
+    def _collect_reserved_urls(self) -> list[str]:
         """Collect reserved URLs from DP leaders before model loading.
 
         Only called when defer_model_load=True. Workers have bound ports
         during __init__ and can report their reserved URLs immediately.
         """
         if not self.cfg["vllm_cfg"]["async_engine"]:
-            return [None]
+            return []
 
         futures = self.worker_group.run_all_workers_single_data(
             "get_reserved_url",
             run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
         )
         results = ray.get(futures)
+        # Only expose_http_server reserves a socket, so without one every worker
+        # reports None here too. Collapsed as a whole, per the note above.
+        if not any(results):
+            return []
         return results
 
     def load_and_start(self) -> None:

--- a/tests/unit/models/generation/test_dynamo_generation.py
+++ b/tests/unit/models/generation/test_dynamo_generation.py
@@ -164,7 +164,8 @@ def test_runtime_start_world_size_sender_geometry_and_shutdown(monkeypatch) -> N
 
     assert calls[:2] == ["init", "start"]
     assert generation.frontend_url == "http://10.0.0.1:3000/v1"
-    assert generation.dp_openai_server_base_urls == [None]
+    # No token wrapper started, so there is no OpenAI-compatible server to name.
+    assert generation.dp_openai_server_base_urls == []
     assert generation.get_inference_world_size() == 4
     sender = generation.get_collective_sender_spec()
     assert sender.nccl_peer == "vllm"

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -233,6 +233,66 @@ def test_vllm_generation_rejects_partial_refit_pause_and_resume(
         generation.resume_generation_after_refit()
 
 
+def _url_reporting_generation(*, async_engine: bool) -> VllmGeneration:
+    generation = VllmGeneration.__new__(VllmGeneration)
+    generation.cfg = {"vllm_cfg": {"async_engine": async_engine}}
+    generation.worker_group = MagicMock()
+    return generation
+
+
+def test_sync_engine_reports_no_openai_server_urls() -> None:
+    """A sync engine runs no HTTP server, so there is no URL to report."""
+    generation = _url_reporting_generation(async_engine=False)
+
+    assert generation._report_dp_openai_server_base_urls() == []
+    assert generation._collect_reserved_urls() == []
+
+
+def test_async_engine_without_http_server_reports_no_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workers answer None unless expose_http_server started a server.
+
+    The list used to keep those Nones, which made a plain truth test read as
+    "we have URLs" when every entry stood for the absence of one.
+    """
+    generation = _url_reporting_generation(async_engine=True)
+    monkeypatch.setattr(ray, "get", MagicMock(return_value=[None, None]))
+
+    assert generation._report_dp_openai_server_base_urls() == []
+    assert generation._collect_reserved_urls() == []
+
+
+def test_async_engine_with_http_server_reports_served_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _url_reporting_generation(async_engine=True)
+    served = ["http://10.0.0.1:8000/v1", "http://10.0.0.2:8000/v1"]
+    monkeypatch.setattr(ray, "get", MagicMock(return_value=list(served)))
+
+    assert generation._report_dp_openai_server_base_urls() == served
+    assert generation._collect_reserved_urls() == served
+
+
+def test_partially_reported_urls_keep_one_entry_per_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report emptiness as a whole list, never by dropping individual entries.
+
+    ``expose_http_server`` is one config value for every worker, so a mixed answer
+    is not reachable today. Asserted anyway because ``GenerationFleetHealth``
+    indexes these URLs by shard and rejects a list whose length does not match
+    ``shard_count``: shortening one would turn a degraded shard into a startup
+    failure with a length error that names neither cause.
+    """
+    generation = _url_reporting_generation(async_engine=True)
+    partial = ["http://10.0.0.1:8000/v1", None]
+    monkeypatch.setattr(ray, "get", MagicMock(return_value=list(partial)))
+
+    assert generation._report_dp_openai_server_base_urls() == partial
+    assert generation._collect_reserved_urls() == partial
+
+
 def test_sampling_params_preserve_bad_words():
     worker = object.__new__(VllmGenerationWorkerImpl)
     worker.cfg = {

--- a/tests/unit/models/generation/trtllm/test_trtllm_generation.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_generation.py
@@ -170,6 +170,27 @@ def test_cross_node_tp_replicas_use_unified_placement_group():
     ]
 
 
+def test_no_http_server_reports_an_empty_url_list():
+    """Without a server there is no per-rank slot, so the length said nothing.
+
+    This used to be one None per DP rank, which is truthy and carries a length
+    that reads like real URLs were collected.
+    """
+    generation = _bare_generation(dp_size=2)
+    generation.dp_size = 2
+
+    assert generation._report_dp_openai_server_base_urls() == []
+
+
+def test_exposed_http_server_reports_served_addresses(monkeypatch):
+    generation = _bare_generation(dp_size=2, expose_http_server=True)
+    generation.dp_size = 2
+    served = ["http://10.0.0.1:8000/v1", "http://10.0.0.2:8000/v1"]
+    monkeypatch.setattr(trtllm_generation.ray, "get", lambda futures: list(served))
+
+    assert generation._report_dp_openai_server_base_urls() == served
+
+
 @pytest.mark.asyncio
 async def test_generate_async_dispatches_round_robin_and_returns_leader_index():
     generation = _bare_generation(dp_size=2)


### PR DESCRIPTION
# What does this PR do ?

**Makes all four generation backends report "no OpenAI server" the same way, as an empty list, and narrows `dp_openai_server_base_urls` to `list[str]`.**

Megatron already returns `[]` and filters its `None`s out. vLLM, TRT-LLM and Dynamo returned a list of `None`s instead. As #3977 says, the placeholder does not stand for anything: in those branches there is no server at all, so the length carries no information, but `[None]` is truthy, so "we have URLs" reads as true when there are none.

Changed to match Megatron:

| backend | before | after |
|---|---|---|
| vLLM (sync engine) | `[None]` | `[]` |
| vLLM (deferred load, sync engine) | `[None]` | `[]` |
| TRT-LLM (no HTTP server) | `[None] * dp_size` | `[]` |
| Dynamo (no token wrapper) | `[None]` | `[]` |

`NemoGymConfig.base_urls` and `spinup_nemo_gym_actor` already declare `list[str]`, so this makes the producers match what the consumers were asking for rather than widening anything. The gap is not theoretical: #3367 had to add a `cast(list[str], deferred_vllm.dp_openai_server_base_urls)` in `distillation.py` to bridge it, which is the same review that prompted #3977. I left that cast in place, since it is correct either way, and the caller cleanup reads better as its own change.

## One case the issue does not list

vLLM needed more than swapping the sentinel. A worker leaves `base_url` unset unless `expose_http_server` started a server ([`vllm_worker_async.py:104`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/vllm/vllm_worker_async.py#L104) assigns `None`, [`:206-210`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/vllm/vllm_worker_async.py#L206-L210) only sets it under that flag), and `get_reserved_url` returns `None` unless a socket was reserved under the same flag. So `async_engine: true` with `expose_http_server: false` produced `[None] * dp_size` from the workers themselves, never reaching the guarded branch, which is a longer, still-truthy version of the same problem.

## Why emptiness is decided for the whole list

Both new code paths test `if not any(results)` and return `[]`, rather than filtering `None`s out entry by entry. Two reasons:

* `expose_http_server` is one config value shared by every worker, so the answer is genuinely all-or-nothing. A mixed list is not reachable today.
* If one ever were, dropping entries would be the wrong response. [`GenerationFleetHealth`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/fleet_health.py#L143-L167) indexes these URLs by shard and rejects a list whose length does not match `shard_count`. Filtering would turn a single degraded shard into a startup failure reporting `base_urls has N entries for M shards`: a length error that names neither the shard nor the cause. Keeping one entry per DP rank preserves the graceful path.

# Issues

Closes #3977.

# Usage

No config or API change. `if not urls` is now a correct emptiness test on every backend.

```python
# before, on a sync vLLM engine
generation.dp_openai_server_base_urls   # [None]  -> truthy, len 1
# after
generation.dp_openai_server_base_urls   # []      -> falsy, len 0
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

## Callers

I went through every reader before changing the producers. None needed edits, and none reads the length in the no-server case:

* `_shard_base_urls` ([`setup.py:769`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/algorithms/single_controller_utils/setup.py#L769)) collapses an all-`None` list to `None` via `if not any(urls)`; an empty list takes the same branch.
* `_maybe_start_generation_router` filters falsy entries into `backend_urls` and raises when that is empty, so `[None]` and `[]` already produced the identical error.
* NeMo-Gym spinup is reachable only behind the `should_expose_http_server` assert in `nemo_rl/environments/nemo_gym.py`, so the no-server list never gets there.
* `MegatronGeneration.verify_served_address` only ever saw Megatron's list, which was already `[]`.
* No production caller indexes `dp_openai_server_base_urls` directly. The one `len()` call, [`grpo.py:1556`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/algorithms/grpo.py#L1556), is a print on the deferred vLLM path. It now says `Reserved 0 vLLM server URLs: []` instead of `Reserved 1 vLLM server URLs: [None]`, which is the symptom the issue calls out.

Per the issue I left the now-redundant `any(...)` guards alone. They stay correct either way and are cleaner to remove separately.

## Tests

Six added, plus the existing Dynamo assertion at `test_dynamo_generation.py:167` updated from `[None]` to `[]`.

`tests/unit/models/generation/test_vllm_generation.py`:
* `test_sync_engine_reports_no_openai_server_urls`
* `test_async_engine_without_http_server_reports_no_urls`: the case above, workers answering all `None`s
* `test_async_engine_with_http_server_reports_served_urls`: guards the happy path against over-collapsing
* `test_partially_reported_urls_keep_one_entry_per_rank`: pins the whole-list rule so a later refactor cannot reintroduce per-entry filtering

`tests/unit/models/generation/trtllm/test_trtllm_generation.py`:
* `test_no_http_server_reports_an_empty_url_list`
* `test_exposed_http_server_reports_served_addresses`

Reverting each backend to its pre-fix version, the no-server tests fail and the served-address tests still pass:

```
# vllm_generation.py reverted
FAILED test_sync_engine_reports_no_openai_server_urls
FAILED test_async_engine_without_http_server_reports_no_urls
PASSED test_async_engine_with_http_server_reports_served_urls

# trtllm_generation.py reverted
FAILED test_no_http_server_reports_an_empty_url_list
PASSED test_exposed_http_server_reports_served_addresses
```

`test_partially_reported_urls_keep_one_entry_per_rank` also fails against an entry-filtering implementation, which is how I settled on the whole-list rule.

With the change, merged onto current `main`, the CPU-only tests in the touched suites pass, 29 before and 33 after, same deselect set:

```
pytest tests/unit/models/generation/test_vllm_generation.py   # GPU tests deselected
  main:      29 passed
  this PR:   33 passed

pytest tests/unit/models/generation/test_dynamo_generation.py              23 passed
pytest tests/unit/models/generation/trtllm/test_trtllm_generation.py       19 passed
pytest tests/unit/single_controller/test_setup.py -k 'url or shard or gym or router'   14 passed
pytest tests/unit/algorithms/test_grpo.py -k 'dynamo or trtllm or url'                  5 passed
pytest tests/unit/environments/test_nemo_gym.py -k url                                  3 passed
```

CPU only. I don't have a GPU box, so the vLLM/TRT-LLM tests that need a real engine and the functional suite did not run here. The `--trtllm-only` selection needed a stub `tensorrt_llm` locally to get past the conftest gate; the two tests themselves only use `_bare_generation` and a mocked worker group.

`ruff 0.9.9` check, import sort and format are clean on all seven files.

