### PR TITLE
docs: add a sampling-params reference for the generation backends

### DIFF
--- a/docs/design-docs/generation.md
+++ b/docs/design-docs/generation.md
@@ -20,6 +20,10 @@ The core of the generation system is defined in `interfaces.py`, which establish
        model_name: str           # Name or path of the model
    ```
 
+   The backends do not all interpret `temperature` / `top_p` / `top_k` identically — in
+   particular, the value meaning "no top-k restriction" differs between them. See
+   [Sampling Parameters Across Generation Backends](sampling-params.md).
+
 2. **GenerationDatumSpec**: A TypedDict that defines the input data format:
    ```python
    class GenerationDatumSpec(TypedDict):

--- a/docs/design-docs/sampling-params.md
+++ b/docs/design-docs/sampling-params.md
@@ -1,0 +1,119 @@
+# Sampling Parameters Across Generation Backends
+
+`temperature`, `top_p` and `top_k` are configured in one place — `policy.generation` — but the
+generation backends do not all read them the same way. The value that means "no top-k
+restriction" differs between backends, and one path ignores `top_k` altogether. This page is the
+reference for what each backend actually does, so the answer does not have to be re-derived from
+six `_build_sampling_params` implementations.
+
+For the surrounding generation config and the backend interface, see
+[Generation](generation.md).
+
+## Configuring sampling
+
+All three values live under `policy.generation`, and validation runs share them through
+`val_temperature` / `val_top_p` / `val_top_k`:
+
+```yaml
+policy:
+  generation:
+    backend: vllm
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null        # null is the portable "unrestricted" value
+    val_temperature: ${.temperature}
+    val_top_p: ${.top_p}
+    val_top_k: ${.top_k}
+```
+
+Top-p and top-k sampling were added in
+[#2053](https://github.com/NVIDIA-NeMo/RL/pull/2053). They narrow the rollout distribution, so
+they interact with importance sampling and off-policy correction: the tighter the truncation, the
+further the sampled distribution sits from the policy the loss assumes. Keep the training and
+validation values deliberate rather than inherited by accident.
+
+## Use `null`, not `-1` or `0`
+
+**`top_k: null` is the only portable way to say "unrestricted".** Each backend translates it to
+whatever its engine expects. Writing the engine-level sentinel directly in YAML does not
+travel:
+
+| you write | vLLM / SGLang | TRT-LLM / Megatron |
+|---|---|---|
+| `top_k: null` | becomes `-1` — unrestricted | becomes `0` — unrestricted |
+| `top_k: -1` | unrestricted | **raises** — TRT-LLM requires `top_k >= 0` |
+| `top_k: 0` | top-k of 0 — not the disable sentinel | unrestricted |
+
+TRT-LLM's `SamplingParams` rejects negatives outright (`require top_k >= 0`) and documents `0` as
+"all logits". So a config carrying `top_k: -1` — which is what
+[`examples/configs/evals/eval.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/examples/configs/evals/eval.yaml)
+uses, commented `# -1 means disable` — works on vLLM and fails at request time on TRT-LLM.
+
+## What each path does
+
+Verified against `main`:
+
+| path | "disabled" spelled as | honors `cfg["top_k"]` | source |
+|---|---|---|---|
+| vLLM `generate()` / `generate_async()` | `-1` | yes | `BaseVllmGenerationWorker._build_sampling_params`, `nemo_rl/models/generation/vllm/vllm_worker.py` |
+| vLLM `generate_text()` | `-1` | yes | `nemo_rl/models/generation/vllm/vllm_worker.py` |
+| **vLLM HTTP** (NeMo-Gym rollouts) | forced `-1` | **no — config ignored** | `nemo_rl/models/generation/vllm/vllm_worker_async.py` |
+| SGLang | `-1`, key omitted entirely | yes | `nemo_rl/models/generation/sglang/sglang_generation.py` |
+| TRT-LLM `generate()` | `0` | yes | `nemo_rl/models/generation/trtllm/trtllm_worker_async.py` |
+| TRT-LLM HTTP | `0` | yes | `nemo_rl/models/generation/trtllm/trtllm_http_server.py` |
+| Megatron | `0` | yes | `nemo_rl/models/generation/megatron/megatron_worker.py` |
+
+SGLang goes one step further than the others: when the resolved value is `-1` it drops the
+`top_k` key from the request dict rather than sending the sentinel.
+
+`temperature` and `top_p` need no such translation — every backend passes them through as
+floats.
+
+## The vLLM HTTP path ignores `top_k`
+
+The vLLM OpenAI-compatible server, which is what NeMo-Gym agentic rollouts talk to, asserts that
+the incoming request carries no top-k and then pins it:
+
+```python
+# nemo_rl/models/generation/vllm/vllm_worker_async.py
+assert request.top_k in (None, -1), (
+    f"Top k sampling parameter must be unset, empty, or -1. Got `{request.top_k}`"
+)
+request.top_k = -1
+```
+
+The comment above it says this matches
+`BaseVllmGenerationWorker::_build_sampling_params`. That holds only while `top_k` is `null`. Set
+`policy.generation.top_k: 50` and the direct path samples with top-k 50 while the HTTP path
+samples unrestricted — so the same config produces different rollout distributions depending on
+whether the rollout went through the engine directly or over HTTP.
+
+TRT-LLM's HTTP server used to have the same drift and no longer does; it was aligned in
+[#3537](https://github.com/NVIDIA-NeMo/RL/pull/3537), whose description carries a
+direct-vs-HTTP comparison worth reading. **Until the vLLM HTTP path is threaded the same way,
+treat agentic rollouts on vLLM as top-k-free.** For an on-policy run this matters: the trainer
+computes logprobs under the policy, and a rollout distribution the config did not ask for is off-policy
+by construction.
+
+## Greedy decoding
+
+Greedy is a parameter of the *direct* generation call, not a config field. Every backend that
+takes a `greedy` flag resolves it the same way — `temperature=0.0` and `top_k=1`:
+
+- `BaseVllmGenerationWorker._build_sampling_params` (vLLM)
+- `generate_text` / `generate_text_async` (vLLM)
+- `sglang_generation.py` (SGLang)
+- `trtllm_worker_async.py` (TRT-LLM)
+- `megatron_worker.py` (Megatron)
+
+The HTTP paths have no `greedy` flag at all. A caller wanting greedy decoding over HTTP sets the
+sampling fields on the request itself, subject to the top-k caveat above.
+
+## Summary
+
+- Write `top_k: null` for unrestricted. `-1` and `0` are engine-level spellings and are not
+  interchangeable.
+- `-1` on TRT-LLM raises; `0` on vLLM is a literal top-k of 0.
+- vLLM HTTP rollouts ignore `top_k` entirely.
+- Greedy means `temperature=0.0, top_k=1` on every backend that accepts the flag, and does not
+  exist on the HTTP paths.

--- a/docs/index.md
+++ b/docs/index.md
@@ -372,6 +372,7 @@ design-docs/uv.md
 design-docs/dependency-management.md
 design-docs/chat-datasets.md
 design-docs/generation.md
+design-docs/sampling-params.md
 design-docs/dynamo-integration.md
 design-docs/sparse-delta-refit.md
 design-docs/checkpoint-engines.md


### PR DESCRIPTION
# What does this PR do ?

**Adds `docs/design-docs/sampling-params.md`, a reference for how each generation backend interprets `temperature` / `top_p` / `top_k`.**

`generation.md` lists them as config fields but never says how the backends read them, and they genuinely disagree, including on what "disabled" means. The page covers the two questions in #3776: how to set the params across backends, and what actually reaches each engine.

Linked from the design-docs toctree in `docs/index.md` and from the `GenerationConfig` block in `docs/design-docs/generation.md`.

# Issues

Closes #3776.

# Usage

The headline rule the page exists to state:

| you write | vLLM / SGLang | TRT-LLM / Megatron |
|---|---|---|
| `top_k: null` | becomes `-1`, unrestricted | becomes `0`, unrestricted |
| `top_k: -1` | unrestricted | **raises**, `require top_k >= 0` |
| `top_k: 0` | literal top-k of 0 | unrestricted |

So `null` is the portable "unrestricted" value, and `examples/configs/evals/eval.yaml`'s `top_k: -1 # -1 means disable` is vLLM-shaped, so it raises at request time on a TRT-LLM run. I left that config alone since it is a behaviour change rather than a docs one; happy to fix it here or in a follow-up, whichever you prefer.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

Docs-only, so no tests. `python -m sphinx -b html docs/ <out>` builds clean, the new page renders, and no warning references any of the three files.

# Additional Information

## Verification

I re-checked every row of the table in the issue against `main` rather than copying it, since it was written on Aug 23. All six rows still hold. Two details came out differently, and the page reflects the verified behaviour:

**Greedy is not uniform across all paths.** The issue says every backend uses `top_k=1` for greedy. That is true of every path that *takes* a `greedy` flag: `BaseVllmGenerationWorker._build_sampling_params`, `generate_text` / `generate_text_async`, `sglang_generation.py`, `trtllm_worker_async.py`, `megatron_worker.py`, all resolving to `temperature=0.0, top_k=1`. But `trtllm_http_server.py` has no `greedy` parameter at all, and neither does the vLLM chat-completions handler; on the HTTP paths greedy is whatever the caller puts on the request. The page states that rather than implying a `greedy` flag exists there.

**SGLang drops the key.** It does not send `top_k: -1`; it omits `top_k` from the request dict entirely when the resolved value is `-1`. Worth stating since it is the one backend where "disabled" is not a value at all.

**`require top_k >= 0` is upstream, not in this repo.** There is no such check in `nemo_rl/models/generation/trtllm/`. It lives in TRT-LLM's own `SamplingParams` (`if self.top_k is not None and self.top_k < 0: raise ValueError(f"require top_k >= 0, got top_k={self.top_k}")`), whose docstring also documents `0` as "all logits". `tensorrt-llm==1.3.0rc21` is what `pyproject.toml` pins. I verified it against upstream before writing it down.

## Scope

Kept to the suggested scope: the table, the `null` vs `-1` vs `0` rule, the vLLM-HTTP `top_k` gap, greedy, and a pointer from `generation.md`. It references #2053 for where top-p/top-k support came from and #3537 for the TRT-LLM direct-vs-HTTP alignment.

I did not change any behaviour. In particular the vLLM HTTP path still ignores `top_k`, and the page says so explicitly rather than pretending the config applies. If you would rather that path thread `top_k` like TRT-LLM's now does, that is a code change and I am happy to open it separately.

