### PR TITLE
fix(models): preserve DTensor loading and custom FP8 factories

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1330,6 +1330,7 @@ def _apply_performance_config(model_cfg: Any, config: PolicyConfig) -> None:
             model_cfg.fp8 = fp8_cfg["fp8"]
             model_cfg.fp8_recipe = fp8_cfg["fp8_recipe"]
             model_cfg.fp8_param = fp8_cfg["fp8_param"]
+            model_cfg.fp8_quantizer_factory = fp8_cfg.get("fp8_quantizer_factory")
         except KeyError as e:
             raise KeyError(f"Missing key in fp8_cfg: {e}")
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -299,6 +299,8 @@ class Fp8Config(TypedDict):
     # When True, keep parameters in FP8. Can cause NaN token_mult_prob_error;
     # use with caution (see https://github.com/NVIDIA-NeMo/RL/issues/1164).
     fp8_param: NotRequired[bool]
+    # Python import path for a Transformer Engine custom recipe quantizer factory.
+    fp8_quantizer_factory: NotRequired[str]
     # When True, clear Transformer Engine's per-module _fp8_workspaces scratch
     # buffers in offload_before_refit (before weight transfer to the inference
     # engine). These FP8 workspace tensors anchor large CUDA segments and

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -56,18 +56,18 @@ except ImportError:
 
 from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 
-# an automodel factory for loading the huggingface models from correct class
-
-AUTOMODEL_FACTORY: Dict[str, Any] = {
-    # Add an entry here when a model (1) uses HF's standard loading path
-    # (no custom NeMo automodel impl) AND (2) its architecture isn't
-    # loadable via AutoModelForCausalLM (e.g. VLMs using
-    # ForConditionalGeneration / ForImageTextToText). Models with a
-    # custom NeMo automodel impl (e.g. qwen3_5_moe) don't need an entry
-    # — the custom impl intercepts from_pretrained regardless of the
-    # parent AutoModel class. Check MODEL_ARCH_MAPPING in the NeMo
-    # automodel registry to see which architectures have custom impls:
-    # https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/_transformers/registry.py#L32-L146
+# Plain Hugging Face classes remain separate from the NeMo AutoModel wrappers so
+# callers that manage distribution can request them when NeMo AutoModel is installed.
+# Add an entry here when a model (1) uses HF's standard loading path
+# (no custom NeMo automodel impl) AND (2) its architecture isn't
+# loadable via AutoModelForCausalLM (e.g. VLMs using
+# ForConditionalGeneration / ForImageTextToText). Models with a
+# custom NeMo automodel impl (e.g. qwen3_5_moe) don't need an entry
+# — the custom impl intercepts from_pretrained regardless of the
+# parent AutoModel class. Check MODEL_ARCH_MAPPING in the NeMo
+# automodel registry to see which architectures have custom impls:
+# https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/_transformers/registry.py#L32-L146
+HF_AUTOMODEL_FACTORY: Dict[str, Any] = {
     "qwen2_5_vl": AutoModelForImageTextToText,
     "qwen2_vl": AutoModelForImageTextToText,
     "qwen2_5_omni": AutoModelForTextToWaveform,
@@ -80,6 +80,8 @@ AUTOMODEL_FACTORY: Dict[str, Any] = {
     "mistral3": AutoModelForImageTextToText,
     "llama4": AutoModelForImageTextToText,
 }
+
+AUTOMODEL_FACTORY: Dict[str, Any] = HF_AUTOMODEL_FACTORY
 
 if NEMO_AUTOMODEL_AVAILABLE:
     AUTOMODEL_FACTORY = {
@@ -129,11 +131,21 @@ def resolve_policy_worker_cls(default_cls: str, config: dict) -> str:
     return POLICY_WORKER_OVERRIDES.get(default_cls, default_cls)
 
 
-def resolve_model_class(model_name: str) -> Any:
-    """Resolve the appropriate model class for a given model name."""
-    if NEMO_AUTOMODEL_AVAILABLE:
+def resolve_model_class(
+    model_name: str,
+    *,
+    use_nemo_automodel: bool = True,
+) -> Any:
+    """Resolve the model class for a model type.
+
+    Args:
+        model_name: Model type to resolve.
+        use_nemo_automodel: Whether to prefer NeMo AutoModel wrappers when they
+            are available.
+    """
+    if use_nemo_automodel and NEMO_AUTOMODEL_AVAILABLE:
         return AUTOMODEL_FACTORY.get(model_name.lower(), NeMoAutoModelForCausalLM)
-    return AUTOMODEL_FACTORY.get(model_name.lower(), AutoModelForCausalLM)
+    return HF_AUTOMODEL_FACTORY.get(model_name.lower(), AutoModelForCausalLM)
 
 
 def is_vllm_v1_engine_enabled() -> bool:

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -340,7 +340,12 @@ class DTensorPolicyWorkerImpl(
                 raise ValueError(f"Unknown reward model type: {rm_type}")
         else:
             # DO NOT assume AutoModelForCausalLM, multimodal models can inherit from AutoModelForImageTextToText, AutoModelForTextToWaveform, etc.
-            model_class = resolve_model_class(model_config.model_type)
+            # This worker loads weights on rank 0 and applies FSDP itself. NeMo
+            # AutoModel wrappers may run collectives while the other ranks wait.
+            model_class = resolve_model_class(
+                model_config.model_type,
+                use_nemo_automodel=False,
+            )
 
         full_state_dict = None
         if self.rank == 0:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -1502,12 +1502,30 @@ class TestApplyPerformanceConfig:
 
         assert "activation_func must be set" in str(exc_info.value)
 
-    def test_fp8_configuration(self):
+    @pytest.mark.parametrize(
+        ("fp8_recipe", "fp8_quantizer_factory"),
+        [
+            ("default", None),
+            ("custom", "test_quantizers.create_quantizers"),
+        ],
+        ids=["factory-absent", "factory-present"],
+    )
+    def test_fp8_configuration(
+        self, fp8_recipe: str, fp8_quantizer_factory: str | None
+    ) -> None:
         """Test FP8 configuration."""
         from nemo_rl.models.megatron.setup import _apply_performance_config
 
         model_cfg = MagicMock()
         model_cfg.gated_linear_unit = True
+        fp8_cfg = {
+            "enabled": True,
+            "fp8": "e4m3",
+            "fp8_recipe": fp8_recipe,
+            "fp8_param": False,
+        }
+        if fp8_quantizer_factory is not None:
+            fp8_cfg["fp8_quantizer_factory"] = fp8_quantizer_factory
         config = {
             "megatron_cfg": {
                 "activation_checkpointing": False,
@@ -1515,20 +1533,16 @@ class TestApplyPerformanceConfig:
                 "bias_activation_fusion": False,
                 "gradient_accumulation_fusion": False,
                 "use_fused_weighted_squared_relu": False,
-                "fp8_cfg": {
-                    "enabled": True,
-                    "fp8": "e4m3",
-                    "fp8_recipe": "default",
-                    "fp8_param": False,
-                },
+                "fp8_cfg": fp8_cfg,
             }
         }
 
         _apply_performance_config(model_cfg, config)
 
         assert model_cfg.fp8 == "e4m3"
-        assert model_cfg.fp8_recipe == "default"
+        assert model_cfg.fp8_recipe == fp8_recipe
         assert model_cfg.fp8_param is False
+        assert model_cfg.fp8_quantizer_factory == fp8_quantizer_factory
 
     def test_fine_grained_activation_offloading_enabled(self):
         """Test happy path: enabled with non-empty offload_modules list."""

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -31,8 +31,73 @@ from nemo_rl.models.policy.utils import (
     ensure_teacher_ipc_buffer,
     get_megatron_checkpoint_dir,
     rebuild_cuda_tensor_from_ipc,
+    resolve_model_class,
     stream_weights_via_ipc_zmq_impl,
 )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "hf_class_name", "nemo_class_name"),
+    [
+        ("qwen2_5_vl", "hf_image_text", "nemo_image_text"),
+        ("qwen2_5_omni", "hf_text_waveform", "nemo_text_waveform"),
+        ("unknown_model", "hf_causal_lm", "nemo_causal_lm"),
+    ],
+)
+@pytest.mark.parametrize("nemo_available", [False, True])
+def test_resolve_model_class_selects_requested_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    hf_class_name: str,
+    nemo_class_name: str,
+    nemo_available: bool,
+) -> None:
+    """The caller chooses plain Transformers or NeMo AutoModel classes."""
+    hf_classes = {
+        "hf_image_text": object(),
+        "hf_text_waveform": object(),
+        "hf_causal_lm": object(),
+    }
+    nemo_classes = {
+        "nemo_image_text": object(),
+        "nemo_text_waveform": object(),
+        "nemo_causal_lm": object(),
+    }
+
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.HF_AUTOMODEL_FACTORY",
+        {
+            "qwen2_5_vl": hf_classes["hf_image_text"],
+            "qwen2_5_omni": hf_classes["hf_text_waveform"],
+        },
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.AUTOMODEL_FACTORY",
+        {
+            "qwen2_5_vl": nemo_classes["nemo_image_text"],
+            "qwen2_5_omni": nemo_classes["nemo_text_waveform"],
+        },
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.AutoModelForCausalLM",
+        hf_classes["hf_causal_lm"],
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.NeMoAutoModelForCausalLM",
+        nemo_classes["nemo_causal_lm"],
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.NEMO_AUTOMODEL_AVAILABLE", nemo_available
+    )
+
+    assert (
+        resolve_model_class(model_type, use_nemo_automodel=False)
+        is hf_classes[hf_class_name]
+    )
+    expected_default = (
+        nemo_classes[nemo_class_name] if nemo_available else hf_classes[hf_class_name]
+    )
+    assert resolve_model_class(model_type) is expected_default
 
 
 class TestGetMegatronCheckpointDir:


### PR DESCRIPTION
# What does this PR do ?

Keep DTensor V1 model loading on Transformers classes and pass custom FP8 quantizer factories to Megatron Core.

DTensor V1 loads the full checkpoint on rank 0, then distributes it through FSDP. It must select plain Transformers classes for that path. Other policy implementations keep the NeMo AutoModel default.

Custom FP8 recipes need the configured factory import path. Megatron Core resolves that path and uses the returned Transformer Engine quantizers.

# Issues

N/A

# Usage

Set a factory for a custom FP8 recipe:

```yaml
policy:
  megatron_cfg:
    fp8_cfg:
      enabled: true
      fp8: e4m3
      fp8_recipe: custom
      fp8_quantizer_factory: package.module.quantizer_factory
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Validation:

- All changed-file pre-commit hooks pass in Lima.
- The six focused model-class resolver tests pass in Lima.
- The MCore-marked FP8 test requires the MCore test environment and will run in CI.
- No documentation change is needed; the field already belongs to the typed policy configuration.
