### PR TITLE
fix(dtensor): keep v1 model loading on Transformers classes

### DIFF
--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -56,18 +56,18 @@ except ImportError:
 
 from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 
-# an automodel factory for loading the huggingface models from correct class
-
-AUTOMODEL_FACTORY: Dict[str, Any] = {
-    # Add an entry here when a model (1) uses HF's standard loading path
-    # (no custom NeMo automodel impl) AND (2) its architecture isn't
-    # loadable via AutoModelForCausalLM (e.g. VLMs using
-    # ForConditionalGeneration / ForImageTextToText). Models with a
-    # custom NeMo automodel impl (e.g. qwen3_5_moe) don't need an entry
-    # — the custom impl intercepts from_pretrained regardless of the
-    # parent AutoModel class. Check MODEL_ARCH_MAPPING in the NeMo
-    # automodel registry to see which architectures have custom impls:
-    # https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/_transformers/registry.py#L32-L146
+# Plain Hugging Face classes remain separate from the NeMo AutoModel wrappers so
+# callers that manage distribution can request them when NeMo AutoModel is installed.
+# Add an entry here whenever a model's architecture isn't loadable via
+# AutoModelForCausalLM (e.g. VLMs using ForConditionalGeneration /
+# ForImageTextToText). Unlike AUTOMODEL_FACTORY below, this dict is also read on
+# the ``use_nemo_automodel=False`` path (DTensor V1), where no NeMo custom impl
+# intercepts from_pretrained -- so a model that has a custom NeMo automodel impl
+# still needs an entry here when its parent AutoModel class is not
+# AutoModelForCausalLM. Check MODEL_ARCH_MAPPING in the NeMo automodel registry
+# to see which architectures have custom impls:
+# https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/_transformers/registry.py#L32-L146
+HF_AUTOMODEL_FACTORY: Dict[str, Any] = {
     "qwen2_5_vl": AutoModelForImageTextToText,
     "qwen2_vl": AutoModelForImageTextToText,
     "qwen2_5_omni": AutoModelForTextToWaveform,
@@ -80,6 +80,8 @@ AUTOMODEL_FACTORY: Dict[str, Any] = {
     "mistral3": AutoModelForImageTextToText,
     "llama4": AutoModelForImageTextToText,
 }
+
+AUTOMODEL_FACTORY: Dict[str, Any] = HF_AUTOMODEL_FACTORY
 
 if NEMO_AUTOMODEL_AVAILABLE:
     AUTOMODEL_FACTORY = {
@@ -129,11 +131,21 @@ def resolve_policy_worker_cls(default_cls: str, config: dict) -> str:
     return POLICY_WORKER_OVERRIDES.get(default_cls, default_cls)
 
 
-def resolve_model_class(model_name: str) -> Any:
-    """Resolve the appropriate model class for a given model name."""
-    if NEMO_AUTOMODEL_AVAILABLE:
+def resolve_model_class(
+    model_name: str,
+    *,
+    use_nemo_automodel: bool = True,
+) -> Any:
+    """Resolve the model class for a model type.
+
+    Args:
+        model_name: Model type to resolve.
+        use_nemo_automodel: Whether to prefer NeMo AutoModel wrappers when they
+            are available.
+    """
+    if use_nemo_automodel and NEMO_AUTOMODEL_AVAILABLE:
         return AUTOMODEL_FACTORY.get(model_name.lower(), NeMoAutoModelForCausalLM)
-    return AUTOMODEL_FACTORY.get(model_name.lower(), AutoModelForCausalLM)
+    return HF_AUTOMODEL_FACTORY.get(model_name.lower(), AutoModelForCausalLM)
 
 
 def is_vllm_v1_engine_enabled() -> bool:

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -343,7 +343,12 @@ class DTensorPolicyWorkerImpl(
                 raise ValueError(f"Unknown reward model type: {rm_type}")
         else:
             # DO NOT assume AutoModelForCausalLM, multimodal models can inherit from AutoModelForImageTextToText, AutoModelForTextToWaveform, etc.
-            model_class = resolve_model_class(model_config.model_type)
+            # This worker loads weights on rank 0 and applies FSDP itself. NeMo
+            # AutoModel wrappers may run collectives while the other ranks wait.
+            model_class = resolve_model_class(
+                model_config.model_type,
+                use_nemo_automodel=False,
+            )
 
         full_state_dict = None
         if self.rank == 0:

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -31,8 +31,73 @@ from nemo_rl.models.policy.utils import (
     ensure_teacher_ipc_buffer,
     get_megatron_checkpoint_dir,
     rebuild_cuda_tensor_from_ipc,
+    resolve_model_class,
     stream_weights_via_ipc_zmq_impl,
 )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "hf_class_name", "nemo_class_name"),
+    [
+        ("qwen2_5_vl", "hf_image_text", "nemo_image_text"),
+        ("qwen2_5_omni", "hf_text_waveform", "nemo_text_waveform"),
+        ("unknown_model", "hf_causal_lm", "nemo_causal_lm"),
+    ],
+)
+@pytest.mark.parametrize("nemo_available", [False, True])
+def test_resolve_model_class_selects_requested_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    hf_class_name: str,
+    nemo_class_name: str,
+    nemo_available: bool,
+) -> None:
+    """The caller chooses plain Transformers or NeMo AutoModel classes."""
+    hf_classes = {
+        "hf_image_text": object(),
+        "hf_text_waveform": object(),
+        "hf_causal_lm": object(),
+    }
+    nemo_classes = {
+        "nemo_image_text": object(),
+        "nemo_text_waveform": object(),
+        "nemo_causal_lm": object(),
+    }
+
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.HF_AUTOMODEL_FACTORY",
+        {
+            "qwen2_5_vl": hf_classes["hf_image_text"],
+            "qwen2_5_omni": hf_classes["hf_text_waveform"],
+        },
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.AUTOMODEL_FACTORY",
+        {
+            "qwen2_5_vl": nemo_classes["nemo_image_text"],
+            "qwen2_5_omni": nemo_classes["nemo_text_waveform"],
+        },
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.AutoModelForCausalLM",
+        hf_classes["hf_causal_lm"],
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.NeMoAutoModelForCausalLM",
+        nemo_classes["nemo_causal_lm"],
+    )
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.NEMO_AUTOMODEL_AVAILABLE", nemo_available
+    )
+
+    assert (
+        resolve_model_class(model_type, use_nemo_automodel=False)
+        is hf_classes[hf_class_name]
+    )
+    expected_default = (
+        nemo_classes[nemo_class_name] if nemo_available else hf_classes[hf_class_name]
+    )
+    assert resolve_model_class(model_type) is expected_default
 
 
 class TestGetMegatronCheckpointDir:


### PR DESCRIPTION
# What does this PR do ?

Keep DTensor V1 model loading on plain Transformers classes.

DTensor V1 loads the full checkpoint on rank 0, then distributes it through FSDP. NeMo AutoModel wrappers may enter distributed collectives during construction, while the other ranks wait for DTensor V1 to finish its rank-0 load. A separate Transformers model map keeps this loading path under DTensor V1's control. AutoModel and DTensor V2 retain the NeMo-aware default.

# Issues

N/A

# Usage

No configuration change is required.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Validation:

- All changed-file pre-commit hooks pass in Lima.
- The six focused model-class resolver tests pass in Lima.
- No documentation change is needed; the default behavior remains unchanged.
