### PR TITLE
feat(fp8): pass custom quantizer factory to MCore

### DIFF
--- a/docs/fp8.md
+++ b/docs/fp8.md
@@ -87,13 +87,14 @@ must continue to use `quantization_ignored_layer_kws`.
 
 To train with FP8, you need to set the Megatron path and configure it using the following settings:
 
-```
+```yaml
     policy:
         megatron_cfg:
             fp8_cfg:
                 fp8: "hybrid"               # choices: [hybrid, e4m3]
-                fp8_recipe: "tensorwise"    # choices: [tensorwise, blockwise, mxfp8]
+                fp8_recipe: "tensorwise"    # choices: [tensorwise, blockwise, mxfp8, custom]
                 fp8_param: false            # boolean value
+                fp8_quantizer_factory: null # required for "custom" recipe; importable Python path e.g. package.module.quantizer_factory
 ```
 
 ### Per-module Transformer Engine precision recipes

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1330,6 +1330,7 @@ def _apply_performance_config(model_cfg: Any, config: PolicyConfig) -> None:
             model_cfg.fp8 = fp8_cfg["fp8"]
             model_cfg.fp8_recipe = fp8_cfg["fp8_recipe"]
             model_cfg.fp8_param = fp8_cfg["fp8_param"]
+            model_cfg.fp8_quantizer_factory = fp8_cfg.get("fp8_quantizer_factory")
         except KeyError as e:
             raise KeyError(f"Missing key in fp8_cfg: {e}")
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -299,6 +299,8 @@ class Fp8Config(TypedDict):
     # When True, keep parameters in FP8. Can cause NaN token_mult_prob_error;
     # use with caution (see https://github.com/NVIDIA-NeMo/RL/issues/1164).
     fp8_param: NotRequired[bool]
+    # Python import path for a Transformer Engine custom recipe quantizer factory.
+    fp8_quantizer_factory: NotRequired[str]
     # When True, clear Transformer Engine's per-module _fp8_workspaces scratch
     # buffers in offload_before_refit (before weight transfer to the inference
     # engine). These FP8 workspace tensors anchor large CUDA segments and

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -1502,12 +1502,30 @@ class TestApplyPerformanceConfig:
 
         assert "activation_func must be set" in str(exc_info.value)
 
-    def test_fp8_configuration(self):
+    @pytest.mark.parametrize(
+        ("fp8_recipe", "fp8_quantizer_factory"),
+        [
+            ("default", None),
+            ("custom", "test_quantizers.create_quantizers"),
+        ],
+        ids=["factory-absent", "factory-present"],
+    )
+    def test_fp8_configuration(
+        self, fp8_recipe: str, fp8_quantizer_factory: str | None
+    ) -> None:
         """Test FP8 configuration."""
         from nemo_rl.models.megatron.setup import _apply_performance_config
 
         model_cfg = MagicMock()
         model_cfg.gated_linear_unit = True
+        fp8_cfg = {
+            "enabled": True,
+            "fp8": "e4m3",
+            "fp8_recipe": fp8_recipe,
+            "fp8_param": False,
+        }
+        if fp8_quantizer_factory is not None:
+            fp8_cfg["fp8_quantizer_factory"] = fp8_quantizer_factory
         config = {
             "megatron_cfg": {
                 "activation_checkpointing": False,
@@ -1515,20 +1533,16 @@ class TestApplyPerformanceConfig:
                 "bias_activation_fusion": False,
                 "gradient_accumulation_fusion": False,
                 "use_fused_weighted_squared_relu": False,
-                "fp8_cfg": {
-                    "enabled": True,
-                    "fp8": "e4m3",
-                    "fp8_recipe": "default",
-                    "fp8_param": False,
-                },
+                "fp8_cfg": fp8_cfg,
             }
         }
 
         _apply_performance_config(model_cfg, config)
 
         assert model_cfg.fp8 == "e4m3"
-        assert model_cfg.fp8_recipe == "default"
+        assert model_cfg.fp8_recipe == fp8_recipe
         assert model_cfg.fp8_param is False
+        assert model_cfg.fp8_quantizer_factory == fp8_quantizer_factory
 
     def test_fine_grained_activation_offloading_enabled(self):
         """Test happy path: enabled with non-empty offload_modules list."""


### PR DESCRIPTION
# What does this PR do ?

Pass custom FP8 quantizer factories from the policy configuration to Megatron Core.

Megatron Core accepts a dotted factory import path for custom FP8 recipes. It resolves that path and uses the returned Transformer Engine quantizers. NeMo RL already passes the other FP8 recipe fields but drops this one.

# Issues

N/A

# Usage

Set a factory for a custom FP8 recipe:

```yaml
policy:
  megatron_cfg:
    fp8_cfg:
      enabled: true
      fp8: e4m3
      fp8_recipe: custom
      fp8_quantizer_factory: package.module.quantizer_factory
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Validation:

- All changed-file pre-commit hooks pass in Lima.
- The MCore-marked test requires the MCore test environment and will run in CI.
- No documentation change is needed; the field belongs to the typed policy configuration.
