### PR TITLE
test: disable classifier dropout in the tiny Qwen2 test checkpoint

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -652,6 +652,7 @@ def tiny_qwen2_model_path():
         vocab_size=151936,
         tie_word_embeddings=False,
         num_key_value_heads=None,
+        classifier_dropout=0.0,
     )
     model = Qwen2ForCausalLM(config=config)
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-1.5B")


### PR DESCRIPTION
# What does this PR do ?

Saves `classifier_dropout: 0.0` into the tiny Qwen2 test checkpoint so the value-head tests train without HF's default 0.1 dropout, which made `test_value_worker_train_decreases_loss` flaky (about 1 failure in 20 runs).

# Issues
#3999 

# Usage
Not applicable: test-asset change only.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally?
- [x] Did you add or update any necessary documentation?

# Additional Information

**Why the test was flaky.** The regression value head is a `Qwen2ForTokenClassification` head. `GenericForTokenClassification` builds `nn.Dropout(classifier_dropout)` and falls back to 0.1 when the model config defines neither `classifier_dropout` nor `hidden_dropout`; `Qwen2Config` defines neither. The test trains three steps at `lr=5e-6` on a fixed batch and asserts `losses[-1] <= losses[0] + 1e-3`. Over two steps the genuine change is about -2.6e-4, while the dropout noise per step has a standard deviation of about 6.4e-4, so the tolerance sits inside the noise.

Measured on the same 2-GPU environment, 100 runs each, one fresh process per run:

| | Before | After |
|---|---|---|
| Failures | 5 / 100 | 0 / 100 |
| Runs where the loss rose over the two steps | 38 | 0 |
| Monotone decrease | 21 / 100 | 100 / 100 |
| Mean change over two steps | -2.3e-4 | -2.6e-4 |
| Std. dev. of that change | 6.9e-4 | 7.4e-5 |

The training signal is unchanged; only the noise is gone.