### PR TITLE
fix(grpo): harden async rollout sequence masking

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -50,9 +50,11 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym
 from nemo_rl.experience.interfaces import (
+    NEMO_GYM_ATTEMPT_INDEX_KEY,
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
     PENDING_PROMPTS_KEY,
+    TARGET_WEIGHT_VERSION_KEY,
 )
 from nemo_rl.experience.rollouts import (
     RolloutGroupResult,
@@ -1453,6 +1455,12 @@ class AsyncTrajectoryCollector:
     ) -> None:
         """Push one prompt group to the replay buffer with bounded backoff."""
         final_batch_cpu = rollout_result.final_batch.to("cpu")
+        if isinstance(self.master_config, GRPOMasterConfig):
+            final_batch_cpu[TARGET_WEIGHT_VERSION_KEY] = torch.full(
+                (final_batch_cpu.size,),
+                int(target_weight_version),
+                dtype=torch.long,
+            )
         rollout_metrics = rollout_result.rollout_metrics
 
         # Teacher inference is blocking. Keep it off this worker's event loop so
@@ -1605,6 +1613,14 @@ class AsyncTrajectoryCollector:
         last_error: Exception | None = None
         max_attempts = 1 + (_MAX_NEMO_GYM_STREAM_RETRIES if use_nemo_gym else 0)
         for attempt in range(1, max_attempts + 1):
+            if use_nemo_gym:
+                # Give every Gym submission a retry identity. This branch retries
+                # the full batch, so stamp the repeated rows immediately before
+                # each submission rather than relying on the source branch's
+                # pending-group-only retry implementation.
+                for row in repeated_batch["extra_env_info"]:
+                    row[NEMO_GYM_ATTEMPT_INDEX_KEY] = attempt - 1
+
             push_tasks: list[asyncio.Task[None]] = []
             scheduled_group_indices: set[int] = set()
             stream_error: Exception | None = None

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2333,100 +2333,6 @@ def _apply_mask_sample_filter(repeated_batch: BatchedDataDict[DatumSpec]) -> int
     return num_masked
 
 
-def _as_async_row_mask(
-    value: Any, *, batch_size: int, field_name: str, device: torch.device
-) -> torch.Tensor:
-    """Normalize one row-aligned mask column and validate its size."""
-    mask = value if isinstance(value, torch.Tensor) else torch.as_tensor(value)
-    mask = mask.reshape(-1)
-    if mask.numel() != batch_size:
-        raise ValueError(f"{field_name} has {mask.numel()} rows; expected {batch_size}")
-    return mask.to(device=device, dtype=torch.bool)
-
-
-def _apply_async_pre_training_sample_masks(
-    repeated_batch: BatchedDataDict[DatumSpec],
-    *,
-    overlong_filtering: bool,
-) -> dict[str, int]:
-    """Apply and log disjoint sample-mask reasons for async GRPO.
-
-    Reasons are attributed in precedence order: an entry-time zero
-    ``loss_multiplier``, recovered empty Gym output, enabled overlong filtering,
-    and the rollout's ``mask_sample`` flag. Each row contributes to at most one
-    reason metric here; logprob-error masking is added later from the remaining
-    eligible rows.
-    """
-    loss_multiplier = repeated_batch["loss_multiplier"].clone()
-    if loss_multiplier.ndim != 1:
-        raise ValueError(
-            "loss_multiplier must be one-dimensional, got "
-            f"shape={tuple(loss_multiplier.shape)}"
-        )
-    batch_size = loss_multiplier.numel()
-    eligible = loss_multiplier != 0
-    metrics = {
-        "num_masked_seqs_by_loss_multiplier": int((~eligible).sum().item()),
-        "num_masked_seqs_by_empty_response_output": 0,
-        "num_masked_seqs_by_overlong_filtering": 0,
-        "num_masked_seqs_by_rollout": 0,
-        "num_masked_seqs_by_logprob_error": 0,
-    }
-
-    for row_index in torch.nonzero(~eligible, as_tuple=False).flatten().tolist():
-        _emit_async_sample_event(
-            "sample_masked",
-            repeated_batch,
-            row_index,
-            reason="loss_multiplier",
-            stage="batch_entry",
-        )
-
-    def apply_reason(field_name: str, reason: str, metric_name: str) -> None:
-        nonlocal eligible
-        if field_name not in repeated_batch:
-            return
-        candidate_mask = _as_async_row_mask(
-            repeated_batch[field_name],
-            batch_size=batch_size,
-            field_name=field_name,
-            device=eligible.device,
-        )
-        newly_masked = eligible & candidate_mask
-        metrics[metric_name] = int(newly_masked.sum().item())
-        for row_index in torch.nonzero(newly_masked, as_tuple=False).flatten().tolist():
-            _emit_async_sample_event(
-                "sample_masked",
-                repeated_batch,
-                row_index,
-                reason=reason,
-                stage="pre_training",
-            )
-        loss_multiplier[newly_masked] = 0
-        eligible = eligible & ~newly_masked
-
-    apply_reason(
-        NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
-        "empty_response_output",
-        "num_masked_seqs_by_empty_response_output",
-    )
-    if overlong_filtering:
-        apply_reason(
-            "truncated",
-            "overlong_filtering",
-            "num_masked_seqs_by_overlong_filtering",
-        )
-    apply_reason(
-        "mask_sample",
-        "rollout",
-        "num_masked_seqs_by_rollout",
-    )
-
-    repeated_batch["loss_multiplier"] = loss_multiplier
-    metrics["num_masked_seqs_total"] = sum(metrics.values())
-    return metrics
-
-
 def _should_log_nemo_gym_responses(master_config: MasterConfig) -> bool:
     """Whether NeMo Gym is responsible for full response logging.
 
@@ -5094,9 +5000,97 @@ def async_grpo_train(
                 # Prepare training data (same as sync version)
                 with timer.time("data_processing"):
                     with timer.time("async_sample_masking"):
-                        async_mask_metrics = _apply_async_pre_training_sample_masks(
-                            repeated_batch,
-                            overlong_filtering=(master_config.grpo.overlong_filtering),
+                        loss_multiplier = repeated_batch["loss_multiplier"].clone()
+                        if loss_multiplier.ndim != 1:
+                            raise ValueError(
+                                "loss_multiplier must be one-dimensional, got "
+                                f"shape={tuple(loss_multiplier.shape)}"
+                            )
+                        batch_size = loss_multiplier.numel()
+                        eligible = loss_multiplier != 0
+                        async_mask_metrics = {
+                            "num_masked_seqs_by_loss_multiplier": int(
+                                (~eligible).sum().item()
+                            ),
+                            "num_masked_seqs_by_empty_response_output": 0,
+                            "num_masked_seqs_by_overlong_filtering": 0,
+                            "num_masked_seqs_by_rollout": 0,
+                            "num_masked_seqs_by_logprob_error": 0,
+                        }
+
+                        # Attribute overlapping masks in precedence order so each
+                        # row contributes to exactly one reason metric.
+                        for row_index in (
+                            torch.nonzero(~eligible, as_tuple=False).flatten().tolist()
+                        ):
+                            _emit_async_sample_event(
+                                "sample_masked",
+                                repeated_batch,
+                                row_index,
+                                reason="loss_multiplier",
+                                stage="batch_entry",
+                            )
+
+                        mask_reasons = [
+                            (
+                                NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
+                                "empty_response_output",
+                                "num_masked_seqs_by_empty_response_output",
+                            )
+                        ]
+                        if master_config.grpo.overlong_filtering:
+                            mask_reasons.append(
+                                (
+                                    "truncated",
+                                    "overlong_filtering",
+                                    "num_masked_seqs_by_overlong_filtering",
+                                )
+                            )
+                        mask_reasons.append(
+                            (
+                                "mask_sample",
+                                "rollout",
+                                "num_masked_seqs_by_rollout",
+                            )
+                        )
+
+                        for field_name, reason, metric_name in mask_reasons:
+                            if field_name not in repeated_batch:
+                                continue
+                            candidate_mask = repeated_batch[field_name]
+                            if not isinstance(candidate_mask, torch.Tensor):
+                                candidate_mask = torch.as_tensor(candidate_mask)
+                            candidate_mask = candidate_mask.reshape(-1)
+                            if candidate_mask.numel() != batch_size:
+                                raise ValueError(
+                                    f"{field_name} has {candidate_mask.numel()} rows; "
+                                    f"expected {batch_size}"
+                                )
+                            candidate_mask = candidate_mask.to(
+                                device=eligible.device, dtype=torch.bool
+                            )
+                            newly_masked = eligible & candidate_mask
+                            async_mask_metrics[metric_name] = int(
+                                newly_masked.sum().item()
+                            )
+                            for row_index in (
+                                torch.nonzero(newly_masked, as_tuple=False)
+                                .flatten()
+                                .tolist()
+                            ):
+                                _emit_async_sample_event(
+                                    "sample_masked",
+                                    repeated_batch,
+                                    row_index,
+                                    reason=reason,
+                                    stage="pre_training",
+                                )
+                            loss_multiplier[newly_masked] = 0
+                            eligible &= ~newly_masked
+
+                        repeated_batch["loss_multiplier"] = loss_multiplier
+                        async_mask_metrics["num_masked_seqs_total"] = sum(
+                            async_mask_metrics.values()
                         )
 
                     # Add loss mask to each message

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -16,6 +16,7 @@ import json
 import os
 import time
 import warnings
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from dataclasses import dataclass, fields
@@ -89,11 +90,15 @@ from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_actor
 from nemo_rl.experience.interfaces import (
     FRONTIER_ORDINAL_KEY,
+    NEMO_GYM_ATTEMPT_INDEX_KEY,
+    NEMO_GYM_ROLLOUT_INDEX_KEY,
     NEMO_GYM_TASK_INDEX_KEY,
+    NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
     PENDING_PROMPTS_KEY,
     RESUME_BASE_ORDINAL_KEY,
     RETAINED_TASK_INDICES_KEY,
+    TARGET_WEIGHT_VERSION_KEY,
     TRAINED_TASK_INDICES_KEY,
 )
 from nemo_rl.experience.metric_utils import is_histogram_metric
@@ -2046,12 +2051,82 @@ def _raise_if_reward_penalties_enabled_without_nemo_gym(
     )
 
 
+def _batch_row_value(batch: BatchedDataDict, key: str, row_index: int) -> Any:
+    """Read one row-aligned diagnostic value without affecting training."""
+    values = batch.get(key)
+    if values is None:
+        return None
+    try:
+        value = values[row_index]
+    except (IndexError, KeyError, TypeError):
+        return None
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return None
+        return value.detach().cpu().item()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _async_sample_identity_fields(
+    batch: BatchedDataDict, row_index: int
+) -> dict[str, Any]:
+    """Build a compact identity for one row in an async training batch."""
+    identity_fields: dict[str, Any] = {"batch_index": row_index}
+    for source_key, output_key in (
+        (NEMO_GYM_TASK_INDEX_KEY, "task_index"),
+        (NEMO_GYM_ROLLOUT_INDEX_KEY, "rollout_index"),
+        (NEMO_GYM_ATTEMPT_INDEX_KEY, "attempt_index"),
+        (TARGET_WEIGHT_VERSION_KEY, "target_weight_version"),
+    ):
+        value = _batch_row_value(batch, source_key, row_index)
+        if value is not None:
+            identity_fields[output_key] = value
+
+    agent_ref = _batch_row_value(batch, "agent_ref", row_index)
+    if isinstance(agent_ref, Mapping):
+        # Agent refs are normally just {"name": ...}. Keep scalar identity
+        # fields but avoid accidentally dumping a large nested config.
+        compact_agent_ref = {
+            str(key): value
+            for key, value in agent_ref.items()
+            if value is None or isinstance(value, (bool, float, int, str))
+        }
+        if compact_agent_ref:
+            identity_fields["agent_ref"] = compact_agent_ref
+        if agent_ref.get("name") is not None:
+            identity_fields["agent_name"] = agent_ref["name"]
+    elif agent_ref is not None:
+        identity_fields["agent_ref"] = str(agent_ref)
+    return identity_fields
+
+
+def _emit_async_sample_event(
+    event: str,
+    batch: BatchedDataDict,
+    row_index: int,
+    *,
+    message: Optional[str] = None,
+    **fields: Any,
+) -> None:
+    """Print one human-readable diagnostic with stable sample identity."""
+    diagnostic_fields = {
+        "event": event,
+        **_async_sample_identity_fields(batch, row_index),
+        **fields,
+    }
+    details = " ".join(f"{key}={value!r}" for key, value in diagnostic_fields.items())
+    print(f"{message or 'Async GRPO sample diagnostic'}; {details}", flush=True)
+
+
 def _apply_message_level_advantage_penalties(
     train_data: BatchedDataDict[ClippedPGLossDataDict],
     message_logs: list[LLMMessageLogType | VLMMessageLogType],
     invalid_tool_call_advantage: float | None,
     malformed_thinking_advantage: float | None,
     log_config: bool = False,
+    sample_metadata: Optional[BatchedDataDict] = None,
 ) -> Optional[dict[str, float]]:
     """Overwrite advantages for flagged assistant-message token spans.
 
@@ -2067,6 +2142,8 @@ def _apply_message_level_advantage_penalties(
         invalid_tool_call_advantage: Advantage value assigned to invalid tool calls.
         malformed_thinking_advantage: Advantage value assigned to malformed thinking.
         log_config: If True, print the configured penalty values once.
+        sample_metadata: Optional row-aligned async rollout metadata used to add
+            bounded sample identities to per-message diagnostics.
 
     Returns:
         Dictionary of penalty metrics if penalties are applied, otherwise None.
@@ -2122,17 +2199,39 @@ def _apply_message_level_advantage_penalties(
 
             if is_invalid:
                 num_invalid_tool_calls += 1
-                print(
-                    f"Setting negative advantage ({invalid_neg_adv}) for invalid tool call in assistant message {i} {j}",
-                    flush=True,
-                )
+                message = f"Setting negative advantage ({invalid_neg_adv}) for invalid tool call in assistant message {i} {j}"
+                if sample_metadata is not None:
+                    _emit_async_sample_event(
+                        "message_advantage_overridden",
+                        sample_metadata,
+                        i,
+                        message=message,
+                        reason="invalid_tool_call",
+                        message_index=j,
+                        token_start=token_offset,
+                        token_end=token_offset + msg_len,
+                        advantage=invalid_neg_adv,
+                    )
+                else:
+                    print(message, flush=True)
                 advantages[i, token_offset : token_offset + msg_len] = invalid_neg_adv
             elif is_malformed_thinking:
                 num_malformed_thinking += 1
-                print(
-                    f"Setting negative advantage ({malformed_neg_adv}) for malformed thinking in assistant message {i} {j}",
-                    flush=True,
-                )
+                message = f"Setting negative advantage ({malformed_neg_adv}) for malformed thinking in assistant message {i} {j}"
+                if sample_metadata is not None:
+                    _emit_async_sample_event(
+                        "message_advantage_overridden",
+                        sample_metadata,
+                        i,
+                        message=message,
+                        reason="malformed_thinking",
+                        message_index=j,
+                        token_start=token_offset,
+                        token_end=token_offset + msg_len,
+                        advantage=malformed_neg_adv,
+                    )
+                else:
+                    print(message, flush=True)
                 advantages[i, token_offset : token_offset + msg_len] = malformed_neg_adv
             token_offset += msg_len
 
@@ -2159,6 +2258,7 @@ def _apply_configured_message_level_advantage_penalties(
     message_logs: list[LLMMessageLogType | VLMMessageLogType],
     master_config: MasterConfig,
     log_config: bool = False,
+    sample_metadata: Optional[BatchedDataDict] = None,
 ) -> Optional[dict[str, float]]:
     """Resolve config and apply message-level advantage penalties."""
     (
@@ -2171,6 +2271,7 @@ def _apply_configured_message_level_advantage_penalties(
         invalid_tool_call_advantage=invalid_tool_call_advantage,
         malformed_thinking_advantage=malformed_thinking_advantage,
         log_config=log_config,
+        sample_metadata=sample_metadata,
     )
 
 
@@ -2230,6 +2331,100 @@ def _apply_mask_sample_filter(repeated_batch: BatchedDataDict[DatumSpec]) -> int
     loss_multiplier[mask_sample_bool] = 0
     repeated_batch["loss_multiplier"] = loss_multiplier
     return num_masked
+
+
+def _as_async_row_mask(
+    value: Any, *, batch_size: int, field_name: str, device: torch.device
+) -> torch.Tensor:
+    """Normalize one row-aligned mask column and validate its size."""
+    mask = value if isinstance(value, torch.Tensor) else torch.as_tensor(value)
+    mask = mask.reshape(-1)
+    if mask.numel() != batch_size:
+        raise ValueError(f"{field_name} has {mask.numel()} rows; expected {batch_size}")
+    return mask.to(device=device, dtype=torch.bool)
+
+
+def _apply_async_pre_training_sample_masks(
+    repeated_batch: BatchedDataDict[DatumSpec],
+    *,
+    overlong_filtering: bool,
+) -> dict[str, int]:
+    """Apply and log disjoint sample-mask reasons for async GRPO.
+
+    Reasons are attributed in precedence order: an entry-time zero
+    ``loss_multiplier``, recovered empty Gym output, enabled overlong filtering,
+    and the rollout's ``mask_sample`` flag. Each row contributes to at most one
+    reason metric here; logprob-error masking is added later from the remaining
+    eligible rows.
+    """
+    loss_multiplier = repeated_batch["loss_multiplier"].clone()
+    if loss_multiplier.ndim != 1:
+        raise ValueError(
+            "loss_multiplier must be one-dimensional, got "
+            f"shape={tuple(loss_multiplier.shape)}"
+        )
+    batch_size = loss_multiplier.numel()
+    eligible = loss_multiplier != 0
+    metrics = {
+        "num_masked_seqs_by_loss_multiplier": int((~eligible).sum().item()),
+        "num_masked_seqs_by_empty_response_output": 0,
+        "num_masked_seqs_by_overlong_filtering": 0,
+        "num_masked_seqs_by_rollout": 0,
+        "num_masked_seqs_by_logprob_error": 0,
+    }
+
+    for row_index in torch.nonzero(~eligible, as_tuple=False).flatten().tolist():
+        _emit_async_sample_event(
+            "sample_masked",
+            repeated_batch,
+            row_index,
+            reason="loss_multiplier",
+            stage="batch_entry",
+        )
+
+    def apply_reason(field_name: str, reason: str, metric_name: str) -> None:
+        nonlocal eligible
+        if field_name not in repeated_batch:
+            return
+        candidate_mask = _as_async_row_mask(
+            repeated_batch[field_name],
+            batch_size=batch_size,
+            field_name=field_name,
+            device=eligible.device,
+        )
+        newly_masked = eligible & candidate_mask
+        metrics[metric_name] = int(newly_masked.sum().item())
+        for row_index in torch.nonzero(newly_masked, as_tuple=False).flatten().tolist():
+            _emit_async_sample_event(
+                "sample_masked",
+                repeated_batch,
+                row_index,
+                reason=reason,
+                stage="pre_training",
+            )
+        loss_multiplier[newly_masked] = 0
+        eligible = eligible & ~newly_masked
+
+    apply_reason(
+        NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
+        "empty_response_output",
+        "num_masked_seqs_by_empty_response_output",
+    )
+    if overlong_filtering:
+        apply_reason(
+            "truncated",
+            "overlong_filtering",
+            "num_masked_seqs_by_overlong_filtering",
+        )
+    apply_reason(
+        "mask_sample",
+        "rollout",
+        "num_masked_seqs_by_rollout",
+    )
+
+    repeated_batch["loss_multiplier"] = loss_multiplier
+    metrics["num_masked_seqs_total"] = sum(metrics.values())
+    return metrics
 
 
 def _should_log_nemo_gym_responses(master_config: MasterConfig) -> bool:
@@ -2576,6 +2771,7 @@ def compute_and_apply_seq_logprob_error_masking(
     train_data: BatchedDataDict,
     rewards: torch.Tensor,
     seq_logprob_error_threshold: Optional[float],
+    sample_metadata: Optional[BatchedDataDict] = None,
 ) -> dict:
     """Compute sequence-level logprob error metrics and optionally mask high-error sequences.
 
@@ -2590,6 +2786,8 @@ def compute_and_apply_seq_logprob_error_masking(
         rewards: Reward tensor for computing statistics on masked sequences.
         seq_logprob_error_threshold: If set, mask sequences with mult_prob_error
                                     exceeding this threshold. If None, only compute metrics.
+        sample_metadata: Optional row-aligned async rollout metadata used to add
+            bounded sample identities to masking diagnostics.
 
     Returns:
         Dict with keys: max_seq_mult_prob_error, mean_seq_mult_prob_error,
@@ -2653,15 +2851,30 @@ def compute_and_apply_seq_logprob_error_masking(
             seq_mult_prob_error <= seq_logprob_error_threshold
         ).float() * original_sample_mask
 
-        diff_mask = original_sample_mask - seq_error_mask
-        num_masked_seqs = int(diff_mask.sum().item())
+        diff_mask_bool = original_sample_mask.bool() & ~seq_error_mask.bool()
+        num_masked_seqs = int(diff_mask_bool.sum().item())
 
         if num_masked_seqs > 0:
-            diff_mask_bool = diff_mask.bool()
             masked_correct_count = int(
                 (rewards.view(-1)[diff_mask_bool] == 1).sum().item()
             )
             masked_correct_pct = masked_correct_count / num_masked_seqs
+            if sample_metadata is not None:
+                for row_index in (
+                    torch.nonzero(diff_mask_bool, as_tuple=False).flatten().tolist()
+                ):
+                    _emit_async_sample_event(
+                        "sample_masked",
+                        sample_metadata,
+                        row_index,
+                        reason="seq_logprob_error",
+                        stage="pre_training",
+                        seq_mult_prob_error=float(
+                            seq_mult_prob_error[row_index].detach().cpu().item()
+                        ),
+                        threshold=seq_logprob_error_threshold,
+                        reward=float(rewards.view(-1)[row_index].detach().cpu().item()),
+                    )
 
         # Compute after-mask metrics (only for sequences that passed the threshold)
         kept_mask = seq_error_mask.bool() & valid_seq_mask
@@ -4679,7 +4892,7 @@ def async_grpo_train(
                 maybe_gpu_profile_step(policy_generation, step + 1)
 
             with timer.time("total_step_time"):
-                num_mask_sample_filtered = 0
+                async_mask_metrics: dict[str, int] = {}
 
                 # Sample trajectories from replay buffer
                 print("📦 Sampling from replay buffer...")
@@ -4880,22 +5093,10 @@ def async_grpo_train(
 
                 # Prepare training data (same as sync version)
                 with timer.time("data_processing"):
-                    # Apply overlong filtering - mask out truncated sequences from loss computation
-                    with timer.time("overlong_filter"):
-                        use_overlong_filtering = master_config.grpo.overlong_filtering
-                        if use_overlong_filtering:
-                            loss_multiplier = repeated_batch["loss_multiplier"].clone()
-                            truncated = repeated_batch["truncated"]
-
-                            if isinstance(truncated, list):
-                                truncated = torch.tensor(truncated, dtype=torch.bool)
-
-                            loss_multiplier[truncated] = 0
-                            repeated_batch["loss_multiplier"] = loss_multiplier
-
-                    with timer.time("mask_sample_filter"):
-                        num_mask_sample_filtered = _apply_mask_sample_filter(
-                            repeated_batch
+                    with timer.time("async_sample_masking"):
+                        async_mask_metrics = _apply_async_pre_training_sample_masks(
+                            repeated_batch,
+                            overlong_filtering=(master_config.grpo.overlong_filtering),
                         )
 
                     # Add loss mask to each message
@@ -4987,12 +5188,20 @@ def async_grpo_train(
                         train_data=train_data,
                         rewards=rewards,
                         seq_logprob_error_threshold=seq_logprob_error_threshold,
+                        sample_metadata=repeated_batch,
                     )
                     seq_logprob_error_metrics = seq_error_result
                     if "num_masked_seqs" in seq_logprob_error_metrics:
                         seq_logprob_error_metrics[
                             "num_masked_seqs_by_logprob_error"
                         ] = seq_logprob_error_metrics.pop("num_masked_seqs")
+                num_logprob_error_masks = int(
+                    seq_logprob_error_metrics["num_masked_seqs_by_logprob_error"]
+                )
+                async_mask_metrics["num_masked_seqs_by_logprob_error"] = (
+                    num_logprob_error_masks
+                )
+                async_mask_metrics["num_masked_seqs_total"] += num_logprob_error_masks
 
                 # Pad teacher logprobs to match train_data sequence length.
                 if trajectory_teacher_logprobs is not None:
@@ -5048,6 +5257,7 @@ def async_grpo_train(
                             repeated_batch["message_log"],
                             master_config,
                             log_config=True,
+                            sample_metadata=repeated_batch,
                         )
                     )
 
@@ -5055,6 +5265,13 @@ def async_grpo_train(
                     train_data["advantages"] = _clip_grpo_advantages(
                         train_data["advantages"], master_config.grpo
                     )
+
+                # Message logs are only needed through advantage penalties. Drop
+                # the large Python object graph before policy.train serializes its
+                # data-parallel shards.
+                with timer.time("driver_memory_cleanup"):
+                    del repeated_batch["message_log"]
+                    gc.collect()
 
                 print("▶ Preparing for training...")
                 with timer.time("training_prep"):
@@ -5246,7 +5463,7 @@ def async_grpo_train(
                 metrics = {
                     "loss": train_results["loss"].numpy(),
                     "reward": rewards.numpy(),
-                    "num_mask_sample_filtered": num_mask_sample_filtered,
+                    **async_mask_metrics,
                     "grad_norm": train_results["grad_norm"].numpy(),
                     "mean_prompt_length": repeated_batch["length"].numpy(),
                     "total_num_tokens": input_lengths.numpy(),

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -5260,13 +5260,6 @@ def async_grpo_train(
                         train_data["advantages"], master_config.grpo
                     )
 
-                # Message logs are only needed through advantage penalties. Drop
-                # the large Python object graph before policy.train serializes its
-                # data-parallel shards.
-                with timer.time("driver_memory_cleanup"):
-                    del repeated_batch["message_log"]
-                    gc.collect()
-
                 print("▶ Preparing for training...")
                 with timer.time("training_prep"):
                     policy.prepare_for_training()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2107,7 +2107,7 @@ def _emit_async_sample_event(
     batch: BatchedDataDict,
     row_index: int,
     *,
-    message: Optional[str] = None,
+    message: str,
     **fields: Any,
 ) -> None:
     """Print one human-readable diagnostic with stable sample identity."""
@@ -2117,7 +2117,7 @@ def _emit_async_sample_event(
         **fields,
     }
     details = " ".join(f"{key}={value!r}" for key, value in diagnostic_fields.items())
-    print(f"{message or 'Async GRPO sample diagnostic'}; {details}", flush=True)
+    print(f"{message}; {details}", flush=True)
 
 
 def _apply_message_level_advantage_penalties(
@@ -2765,6 +2765,8 @@ def compute_and_apply_seq_logprob_error_masking(
                 (rewards.view(-1)[diff_mask_bool] == 1).sum().item()
             )
             masked_correct_pct = masked_correct_count / num_masked_seqs
+            # Sync callers retain the aggregate masking message above. Only the
+            # async path has row identity metadata for per-sample diagnostics.
             if sample_metadata is not None:
                 for row_index in (
                     torch.nonzero(diff_mask_bool, as_tuple=False).flatten().tolist()
@@ -2773,6 +2775,10 @@ def compute_and_apply_seq_logprob_error_masking(
                         "sample_masked",
                         sample_metadata,
                         row_index,
+                        message=(
+                            "Masking async GRPO sample because its sequence-level "
+                            "logprob error exceeds the threshold"
+                        ),
                         reason="seq_logprob_error",
                         stage="pre_training",
                         seq_mult_prob_error=float(
@@ -4798,7 +4804,7 @@ def async_grpo_train(
                 maybe_gpu_profile_step(policy_generation, step + 1)
 
             with timer.time("total_step_time"):
-                async_mask_metrics: dict[str, int] = {}
+                sample_mask_metrics: dict[str, int] = {}
 
                 # Sample trajectories from replay buffer
                 print("📦 Sampling from replay buffer...")
@@ -5008,7 +5014,7 @@ def async_grpo_train(
                             )
                         batch_size = loss_multiplier.numel()
                         eligible = loss_multiplier != 0
-                        async_mask_metrics = {
+                        sample_mask_metrics = {
                             "num_masked_seqs_by_loss_multiplier": int(
                                 (~eligible).sum().item()
                             ),
@@ -5027,6 +5033,10 @@ def async_grpo_train(
                                 "sample_masked",
                                 repeated_batch,
                                 row_index,
+                                message=(
+                                    "Async GRPO sample entered training with a zero "
+                                    "loss multiplier"
+                                ),
                                 reason="loss_multiplier",
                                 stage="batch_entry",
                             )
@@ -5036,6 +5046,7 @@ def async_grpo_train(
                                 NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
                                 "empty_response_output",
                                 "num_masked_seqs_by_empty_response_output",
+                                "Masking async GRPO sample because its response output is empty",
                             )
                         ]
                         if master_config.grpo.overlong_filtering:
@@ -5044,6 +5055,7 @@ def async_grpo_train(
                                     "truncated",
                                     "overlong_filtering",
                                     "num_masked_seqs_by_overlong_filtering",
+                                    "Masking async GRPO sample because of overlong filtering",
                                 )
                             )
                         mask_reasons.append(
@@ -5051,10 +5063,16 @@ def async_grpo_train(
                                 "mask_sample",
                                 "rollout",
                                 "num_masked_seqs_by_rollout",
+                                "Masking async GRPO sample because the rollout marked it for masking",
                             )
                         )
 
-                        for field_name, reason, metric_name in mask_reasons:
+                        for (
+                            field_name,
+                            reason,
+                            metric_name,
+                            diagnostic_message,
+                        ) in mask_reasons:
                             if field_name not in repeated_batch:
                                 continue
                             candidate_mask = repeated_batch[field_name]
@@ -5070,7 +5088,7 @@ def async_grpo_train(
                                 device=eligible.device, dtype=torch.bool
                             )
                             newly_masked = eligible & candidate_mask
-                            async_mask_metrics[metric_name] = int(
+                            sample_mask_metrics[metric_name] = int(
                                 newly_masked.sum().item()
                             )
                             for row_index in (
@@ -5082,6 +5100,7 @@ def async_grpo_train(
                                     "sample_masked",
                                     repeated_batch,
                                     row_index,
+                                    message=diagnostic_message,
                                     reason=reason,
                                     stage="pre_training",
                                 )
@@ -5089,8 +5108,8 @@ def async_grpo_train(
                             eligible &= ~newly_masked
 
                         repeated_batch["loss_multiplier"] = loss_multiplier
-                        async_mask_metrics["num_masked_seqs_total"] = sum(
-                            async_mask_metrics.values()
+                        sample_mask_metrics["num_masked_seqs_total"] = sum(
+                            sample_mask_metrics.values()
                         )
 
                     # Add loss mask to each message
@@ -5192,10 +5211,10 @@ def async_grpo_train(
                 num_logprob_error_masks = int(
                     seq_logprob_error_metrics["num_masked_seqs_by_logprob_error"]
                 )
-                async_mask_metrics["num_masked_seqs_by_logprob_error"] = (
+                sample_mask_metrics["num_masked_seqs_by_logprob_error"] = (
                     num_logprob_error_masks
                 )
-                async_mask_metrics["num_masked_seqs_total"] += num_logprob_error_masks
+                sample_mask_metrics["num_masked_seqs_total"] += num_logprob_error_masks
 
                 # Pad teacher logprobs to match train_data sequence length.
                 if trajectory_teacher_logprobs is not None:
@@ -5450,7 +5469,7 @@ def async_grpo_train(
                 metrics = {
                     "loss": train_results["loss"].numpy(),
                     "reward": rewards.numpy(),
-                    **async_mask_metrics,
+                    **sample_mask_metrics,
                     "grad_norm": train_results["grad_norm"].numpy(),
                     "mean_prompt_length": repeated_batch["length"].numpy(),
                     "total_num_tokens": input_lengths.numpy(),

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -52,6 +52,7 @@ from nemo_rl.experience.failures import (
     RolloutDataFailure,
     http_status_is_infra,
 )
+from nemo_rl.experience.interfaces import NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY
 from nemo_rl.models.generation.interfaces import should_use_async_rollouts
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
@@ -926,6 +927,9 @@ Depending on your data shape, you may want to change these values."""
 
         processor = getattr(self, "_processor", None)
         response = nemo_gym_result["response"]
+        empty_response_output = (
+            isinstance(response.get("output"), list) and not response["output"]
+        )
         result_input = nemo_gym_result["responses_create_params"].get("input", [])
         request_input = nemo_gym_row.get("responses_create_params", {}).get("input")
         raw_input = (
@@ -1133,6 +1137,47 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                 output_item_dict["prompt_str"] = prompt_str
                 output_item_dict["generation_str"] = generation_str
 
+        if not nemo_rl_message_log and empty_response_output:
+            # Some agents intentionally terminate without asking the policy for a
+            # generation. Keep the row structurally valid so one such response
+            # cannot terminate the rollout stream, but mark it for unconditional
+            # masking by async GRPO. A single valid token is sufficient because
+            # the row has no trainable assistant span and its full Gym response is
+            # retained separately for diagnostics.
+            placeholder_token_id = getattr(tokenizer, "pad_token_id", None)
+            if placeholder_token_id is None:
+                placeholder_token_id = getattr(tokenizer, "eos_token_id", None)
+            if placeholder_token_id is None:
+                placeholder_token_id = 0
+            nemo_rl_message_log.append(
+                {
+                    "role": "user",
+                    "content": "",
+                    "token_ids": torch.tensor(
+                        [int(placeholder_token_id)], dtype=torch.long
+                    ),
+                }
+            )
+            raw_agent_ref = nemo_gym_row.get("agent_ref")
+            compact_agent_ref = (
+                {
+                    str(key): value
+                    for key, value in raw_agent_ref.items()
+                    if value is None or isinstance(value, (bool, float, int, str))
+                }
+                if isinstance(raw_agent_ref, Mapping)
+                else raw_agent_ref
+            )
+            print(
+                "⚠️ Recovered empty NeMo-Gym response.output; "
+                "event=actor_empty_response_output_recovered "
+                f"task_index={nemo_gym_row.get('_ng_task_index')!r} "
+                f"rollout_index={nemo_gym_row.get('_ng_rollout_index')!r} "
+                f"attempt_index={nemo_gym_row.get('_ng_attempt_index')!r} "
+                f"agent_ref={compact_agent_ref!r}",
+                flush=True,
+            )
+
         if not nemo_rl_message_log:
             input_messages = nemo_gym_result["responses_create_params"]["input"]
             try:
@@ -1175,6 +1220,8 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
             "input_message_log": nemo_rl_message_log[:1],
             "full_result": nemo_gym_result,
         }
+        if empty_response_output:
+            result[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY] = True
         if not include_initial_multimodal_data:
             result["_initial_multimodal_data_omitted"] = initial_multimodal_data_omitted
         return result

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -1140,10 +1140,12 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
         if not nemo_rl_message_log and empty_response_output:
             # Some agents intentionally terminate without asking the policy for a
             # generation. Keep the row structurally valid so one such response
-            # cannot terminate the rollout stream, but mark it for unconditional
-            # masking by async GRPO. A single valid token is sufficient because
-            # the row has no trainable assistant span and its full Gym response is
-            # retained separately for diagnostics.
+            # cannot terminate the rollout stream. The
+            # NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY marker added below is propagated
+            # through replay and consumed by async GRPO, which sets this row's
+            # loss multiplier to zero before training. A single valid token is
+            # sufficient because the row has no trainable assistant span and its
+            # full Gym response is retained separately for diagnostics.
             placeholder_token_id = getattr(tokenizer, "pad_token_id", None)
             if placeholder_token_id is None:
                 placeholder_token_id = getattr(tokenizer, "eos_token_id", None)

--- a/nemo_rl/experience/interfaces.py
+++ b/nemo_rl/experience/interfaces.py
@@ -18,6 +18,18 @@ from typing import Any, Optional
 from nemo_rl.data.interfaces import LLMMessageLogType, VLMMessageLogType
 
 NEMO_GYM_TASK_INDEX_KEY = "_ng_task_index"
+# Gym-visible generation identity within a task, conventionally in [0, K).
+# This is distinct from the private _rowidx ordering key even though both are
+# assigned the same value when a single prompt's K rollout rows are expanded.
+NEMO_GYM_ROLLOUT_INDEX_KEY = "_ng_rollout_index"
+# Zero-based retry attempt for a NeMo-Gym row. The initial attempt is 0.
+NEMO_GYM_ATTEMPT_INDEX_KEY = "_ng_attempt_index"
+# RL-local marker for a successful Gym response with no output items. Such rows
+# are retained for batch shape/accounting but must never contribute training loss.
+NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY = "_nemo_rl_empty_response_output"
+# Trainer version/step for which an async rollout was reserved. This is internal
+# replay metadata and is deliberately not sent to Gym or the generation backend.
+TARGET_WEIGHT_VERSION_KEY = "target_weight_version"
 NEXT_NEMO_GYM_TASK_INDEX_KEY = "next_ng_task_index"
 # Unconsumed suffix of a gap-fill dataloader batch, carried in the async
 # collector's rollouts state so a checkpoint cannot strand yielded prompts.

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -58,7 +58,12 @@ from nemo_rl.environments.nemo_gym import (
     DEFAULT_THINKING_TAGS,
     get_pad_dynamic_image_shapes,
 )
-from nemo_rl.experience.interfaces import NEMO_GYM_TASK_INDEX_KEY
+from nemo_rl.experience.interfaces import (
+    NEMO_GYM_ATTEMPT_INDEX_KEY,
+    NEMO_GYM_ROLLOUT_INDEX_KEY,
+    NEMO_GYM_TASK_INDEX_KEY,
+    NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
+)
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.models.generation.interfaces import (
     ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
@@ -2226,6 +2231,7 @@ def _prepare_nemo_gym_rows(
     sampling_params: GenerationSamplingParams,
 ) -> None:
     """Apply NeMo-RL sampling parameters and stable row indices in place."""
+    next_rollout_index_by_task: dict[Any, int] = defaultdict(int)
     for row_index, row in enumerate(rows):
         responses_create_params = row.get("responses_create_params")
         if not isinstance(responses_create_params, dict):
@@ -2243,6 +2249,11 @@ def _prepare_nemo_gym_rows(
             else configured_max_tokens
         )
         row["_rowidx"] = row_index
+
+        task_index = row.get(NEMO_GYM_TASK_INDEX_KEY)
+        if task_index is not None:
+            row[NEMO_GYM_ROLLOUT_INDEX_KEY] = next_rollout_index_by_task[task_index]
+            next_rollout_index_by_task[task_index] += 1
 
 
 def _tensorize_nemo_gym_result(result: dict) -> None:
@@ -2825,6 +2836,27 @@ def _postprocess_single_nemo_gym_group(
             ),
         }
     )
+    empty_response_output = torch.tensor(
+        [bool(r.get(NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY, False)) for r in results],
+        dtype=torch.bool,
+    )
+    # Keep this column on every NeMo-Gym prompt group. Async replay collation is
+    # intentionally strict about non-packed keys, so conditionally omitting an
+    # all-false group would make a later mixed normal/recovered batch fail.
+    final_batch[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY] = empty_response_output
+    # Preserve compact, row-aligned rollout identity through dynamic sampling
+    # and the async replay buffer. Missing fields are omitted rather than
+    # guessed, retaining compatibility with native and legacy rollout inputs.
+    for identity_key in (
+        NEMO_GYM_TASK_INDEX_KEY,
+        NEMO_GYM_ROLLOUT_INDEX_KEY,
+        NEMO_GYM_ATTEMPT_INDEX_KEY,
+    ):
+        identity_values = [row.get(identity_key) for row in nemo_gym_rows]
+        if identity_values and all(value is not None for value in identity_values):
+            final_batch[identity_key] = torch.tensor(
+                [int(value) for value in identity_values], dtype=torch.long
+            )
     # Env/agent mask flag: flagged samples are dropped from the loss but still
     # count for advantages. env.should_mask_flagged_samples=false skips this.
     if mask_env_flagged_samples:

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -61,6 +61,7 @@ from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
     PENDING_PROMPTS_KEY,
     RETAINED_TASK_INDICES_KEY,
+    TARGET_WEIGHT_VERSION_KEY,
 )
 from nemo_rl.experience.rollouts import EffortLevelsConfig
 
@@ -2849,6 +2850,10 @@ class TestAsyncTrajectoryCollector:
             )
             assert trajectory_group["rollout_metrics"]["trajectory_duration_s"] >= 0
             assert "_ng_task_index" not in trajectory_group
+            assert (
+                trajectory_group["batch"][TARGET_WEIGHT_VERSION_KEY].tolist()
+                == [target_weight] * 3
+            )
             assert generation_weight == 2
             assert target == target_weight
         assert target_weight not in collector._generating_targets
@@ -2955,6 +2960,7 @@ class TestAsyncTrajectoryCollector:
             }
         )
         rollout_calls = 0
+        rollout_call_attempt_indices = []
 
         def _rollout_result(task_index):
             return SimpleNamespace(
@@ -2973,6 +2979,12 @@ class TestAsyncTrajectoryCollector:
                 low_penalty=1.0,
                 low_ub=15_000,
                 low_string="{reasoning effort: efficient}",
+            )
+            rollout_call_attempt_indices.append(
+                [
+                    row["_ng_attempt_index"]
+                    for row in kwargs["input_batch"]["extra_env_info"]
+                ]
             )
             rollout_calls += 1
             yield _rollout_result(7)
@@ -2999,6 +3011,7 @@ class TestAsyncTrajectoryCollector:
         )
 
         assert rollout_calls == 2
+        assert rollout_call_attempt_indices == [[0, 0, 0, 0], [1, 1, 1, 1]]
         assert replay_buffer.add.task_indices == [7, 8]
         assert target_weight not in collector._generating_targets
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -36,7 +36,6 @@ from nemo_rl.algorithms.grpo import (
     MasterConfig,
     RewardPenaltyConfig,
     RewardScalingConfig,
-    _apply_async_pre_training_sample_masks,
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
@@ -263,58 +262,6 @@ class TestMaskSampleFilter:
         assert torch.equal(
             repeated_batch["loss_multiplier"], torch.tensor([1.0, 0.5, 1.0])
         )
-
-
-def test_apply_async_pre_training_sample_masks_logs_disjoint_reasons(capsys):
-    repeated_batch = BatchedDataDict(
-        {
-            "loss_multiplier": torch.tensor([0.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
-            NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY: torch.tensor(
-                [False, True, False, False, False, False]
-            ),
-            "truncated": torch.tensor([False, True, True, False, False, False]),
-            "mask_sample": torch.tensor([True, True, True, True, False, False]),
-            NEMO_GYM_TASK_INDEX_KEY: torch.arange(100, 106),
-            NEMO_GYM_ROLLOUT_INDEX_KEY: torch.arange(6),
-            NEMO_GYM_ATTEMPT_INDEX_KEY: torch.zeros(6, dtype=torch.long),
-            TARGET_WEIGHT_VERSION_KEY: torch.full((6,), 9, dtype=torch.long),
-            "agent_ref": [{"name": f"agent-{i}"} for i in range(6)],
-        }
-    )
-
-    metrics = _apply_async_pre_training_sample_masks(
-        repeated_batch, overlong_filtering=True
-    )
-
-    assert metrics == {
-        "num_masked_seqs_by_loss_multiplier": 1,
-        "num_masked_seqs_by_empty_response_output": 1,
-        "num_masked_seqs_by_overlong_filtering": 1,
-        "num_masked_seqs_by_rollout": 1,
-        "num_masked_seqs_by_logprob_error": 0,
-        "num_masked_seqs_total": 4,
-    }
-    torch.testing.assert_close(
-        repeated_batch["loss_multiplier"],
-        torch.tensor([0.0, 0.0, 0.0, 0.0, 1.0, 1.0]),
-    )
-    lines = [
-        line
-        for line in capsys.readouterr().out.splitlines()
-        if "event='sample_masked'" in line
-    ]
-    assert len(lines) == 4
-    for line, reason, task_index, agent_name in zip(
-        lines,
-        ("loss_multiplier", "empty_response_output", "overlong_filtering", "rollout"),
-        range(100, 104),
-        ("agent-0", "agent-1", "agent-2", "agent-3"),
-        strict=True,
-    ):
-        assert f"reason={reason!r}" in line
-        assert f"task_index={task_index}" in line
-        assert f"agent_name={agent_name!r}" in line
-        assert "target_weight_version=9" in line
 
 
 def test_initial_policy_generation_stale() -> None:
@@ -1892,6 +1839,58 @@ def test_async_initial_buffer_wait_is_included_in_first_step_timing(
     assert first_step_counts["total_step_time"] == 2
     # Startup wait + replay sample coordination + pre-refit collector wait.
     assert first_step_counts["exposed_generation"] == 3
+
+
+def test_async_grpo_masks_empty_response_before_training(
+    mock_grpo_components,
+) -> None:
+    master_config = mock_grpo_components["master_config"]
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.grpo.overlong_filtering = True
+    master_config.env["should_log_nemo_gym_responses"] = True
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_batch[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY] = torch.tensor([True])
+    mock_batch["truncated"] = torch.tensor([True])
+    mock_batch["mask_sample"] = torch.tensor([True])
+
+    with mock_async_grpo_infrastructure(
+        mock_batch,
+        {"mean_gen_tokens_per_sample": 2.0},
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    train_data = mock_grpo_components["policy"].train.call_args.args[0]
+    assert train_data["sample_mask"].tolist() == [0.0]
+
+    metrics = _logged_train_metrics_with_key(
+        mock_grpo_components["logger"],
+        "num_masked_seqs_by_empty_response_output",
+    )
+    assert metrics["num_masked_seqs_by_loss_multiplier"] == 0
+    assert metrics["num_masked_seqs_by_empty_response_output"] == 1
+    assert metrics["num_masked_seqs_by_overlong_filtering"] == 0
+    assert metrics["num_masked_seqs_by_rollout"] == 0
+    assert metrics["num_masked_seqs_by_logprob_error"] == 0
+    assert metrics["num_masked_seqs_total"] == 1
 
 
 def test_async_grpo_awaits_resume_after_refit_failure(mock_grpo_components) -> None:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -36,6 +36,7 @@ from nemo_rl.algorithms.grpo import (
     MasterConfig,
     RewardPenaltyConfig,
     RewardScalingConfig,
+    _apply_async_pre_training_sample_masks,
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
@@ -78,11 +79,15 @@ from nemo_rl.environments.interfaces import (
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym
 from nemo_rl.experience.interfaces import (
     FRONTIER_ORDINAL_KEY,
+    NEMO_GYM_ATTEMPT_INDEX_KEY,
+    NEMO_GYM_ROLLOUT_INDEX_KEY,
     NEMO_GYM_TASK_INDEX_KEY,
+    NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
     PENDING_PROMPTS_KEY,
     RESUME_BASE_ORDINAL_KEY,
     RETAINED_TASK_INDICES_KEY,
+    TARGET_WEIGHT_VERSION_KEY,
     TRAINED_TASK_INDICES_KEY,
 )
 from nemo_rl.experience.rollouts import calculate_rewards
@@ -258,6 +263,58 @@ class TestMaskSampleFilter:
         assert torch.equal(
             repeated_batch["loss_multiplier"], torch.tensor([1.0, 0.5, 1.0])
         )
+
+
+def test_apply_async_pre_training_sample_masks_logs_disjoint_reasons(capsys):
+    repeated_batch = BatchedDataDict(
+        {
+            "loss_multiplier": torch.tensor([0.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY: torch.tensor(
+                [False, True, False, False, False, False]
+            ),
+            "truncated": torch.tensor([False, True, True, False, False, False]),
+            "mask_sample": torch.tensor([True, True, True, True, False, False]),
+            NEMO_GYM_TASK_INDEX_KEY: torch.arange(100, 106),
+            NEMO_GYM_ROLLOUT_INDEX_KEY: torch.arange(6),
+            NEMO_GYM_ATTEMPT_INDEX_KEY: torch.zeros(6, dtype=torch.long),
+            TARGET_WEIGHT_VERSION_KEY: torch.full((6,), 9, dtype=torch.long),
+            "agent_ref": [{"name": f"agent-{i}"} for i in range(6)],
+        }
+    )
+
+    metrics = _apply_async_pre_training_sample_masks(
+        repeated_batch, overlong_filtering=True
+    )
+
+    assert metrics == {
+        "num_masked_seqs_by_loss_multiplier": 1,
+        "num_masked_seqs_by_empty_response_output": 1,
+        "num_masked_seqs_by_overlong_filtering": 1,
+        "num_masked_seqs_by_rollout": 1,
+        "num_masked_seqs_by_logprob_error": 0,
+        "num_masked_seqs_total": 4,
+    }
+    torch.testing.assert_close(
+        repeated_batch["loss_multiplier"],
+        torch.tensor([0.0, 0.0, 0.0, 0.0, 1.0, 1.0]),
+    )
+    lines = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "event='sample_masked'" in line
+    ]
+    assert len(lines) == 4
+    for line, reason, task_index, agent_name in zip(
+        lines,
+        ("loss_multiplier", "empty_response_output", "overlong_filtering", "rollout"),
+        range(100, 104),
+        ("agent-0", "agent-1", "agent-2", "agent-3"),
+        strict=True,
+    ):
+        assert f"reason={reason!r}" in line
+        assert f"task_index={task_index}" in line
+        assert f"agent_name={agent_name!r}" in line
+        assert "target_weight_version=9" in line
 
 
 def test_initial_policy_generation_stale() -> None:
@@ -547,7 +604,9 @@ def _logged_train_metrics_with_key(logger, key: str):
     raise AssertionError(f"No train metrics payload contained {key}")
 
 
-def test_apply_message_level_advantage_penalties_targets_flagged_message_spans():
+def test_apply_message_level_advantage_penalties_targets_flagged_message_spans(
+    capsys,
+):
     train_data = BatchedDataDict(
         {
             "advantages": torch.tensor(
@@ -560,6 +619,11 @@ def test_apply_message_level_advantage_penalties_targets_flagged_message_spans()
     )
     repeated_batch = BatchedDataDict(
         {
+            NEMO_GYM_TASK_INDEX_KEY: torch.tensor([7, 8]),
+            NEMO_GYM_ROLLOUT_INDEX_KEY: torch.tensor([0, 1]),
+            NEMO_GYM_ATTEMPT_INDEX_KEY: torch.tensor([0, 0]),
+            TARGET_WEIGHT_VERSION_KEY: torch.tensor([3, 3]),
+            "agent_ref": [{"name": "agent-a"}, {"name": "agent-b"}],
             "message_log": [
                 [
                     {
@@ -596,7 +660,7 @@ def test_apply_message_level_advantage_penalties_targets_flagged_message_spans()
                         "generation_logprobs": torch.tensor([0.8, 0.9]),
                     },
                 ],
-            ]
+            ],
         }
     )
     _apply_message_level_advantage_penalties(
@@ -604,6 +668,7 @@ def test_apply_message_level_advantage_penalties_targets_flagged_message_spans()
         message_logs=repeated_batch["message_log"],
         invalid_tool_call_advantage=-5.0,
         malformed_thinking_advantage=-7.0,
+        sample_metadata=repeated_batch,
     )
 
     expected = torch.tensor(
@@ -613,6 +678,25 @@ def test_apply_message_level_advantage_penalties_targets_flagged_message_spans()
         ]
     )
     torch.testing.assert_close(train_data["advantages"], expected)
+    lines = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "event='message_advantage_overridden'" in line
+    ]
+    assert len(lines) == 2
+    for line, reason, task_index, agent_name, advantage in zip(
+        lines,
+        ("invalid_tool_call", "malformed_thinking"),
+        (7, 8),
+        ("agent-a", "agent-b"),
+        (-5.0, -7.0),
+        strict=True,
+    ):
+        assert f"reason={reason!r}" in line
+        assert f"task_index={task_index}" in line
+        assert f"agent_name={agent_name!r}" in line
+        assert "target_weight_version=3" in line
+        assert f"advantage={advantage}" in line
 
 
 def test_apply_message_level_advantage_penalties_materializes_broadcasted_advantages():
@@ -5310,7 +5394,7 @@ class TestComputeAndApplySeqLogprobErrorMasking:
         # Verify sample_mask is unchanged
         assert torch.equal(train_data["sample_mask"], original_sample_mask)
 
-    def test_masking_with_threshold(self):
+    def test_masking_with_threshold(self, capsys):
         """Test that sequences exceeding threshold are masked."""
         batch_size, seq_length = 4, 10
 
@@ -5338,7 +5422,22 @@ class TestComputeAndApplySeqLogprobErrorMasking:
 
         # Use threshold 1.2 which should mask sequences 2 and 3
         result = compute_and_apply_seq_logprob_error_masking(
-            train_data, rewards, seq_logprob_error_threshold=1.2
+            train_data,
+            rewards,
+            seq_logprob_error_threshold=1.2,
+            sample_metadata=BatchedDataDict(
+                {
+                    NEMO_GYM_TASK_INDEX_KEY: torch.tensor([100, 101, 102, 103]),
+                    NEMO_GYM_ROLLOUT_INDEX_KEY: torch.tensor([0, 1, 2, 3]),
+                    TARGET_WEIGHT_VERSION_KEY: torch.full((4,), 11),
+                    "agent_ref": [
+                        {"name": "agent-a"},
+                        {"name": "agent-a"},
+                        {"name": "agent-b"},
+                        {"name": "agent-b"},
+                    ],
+                }
+            ),
         )
 
         # Verify masking occurred
@@ -5355,6 +5454,18 @@ class TestComputeAndApplySeqLogprobErrorMasking:
         assert torch.allclose(train_data["sample_mask"], expected_mask), (
             "Should mask sequences 2 and 3"
         )
+        lines = [
+            line
+            for line in capsys.readouterr().out.splitlines()
+            if "event='sample_masked'" in line
+        ]
+        assert len(lines) == 2
+        for line, task_index in zip(lines, (102, 103), strict=True):
+            assert "reason='seq_logprob_error'" in line
+            assert f"task_index={task_index}" in line
+            assert "agent_name='agent-b'" in line
+            assert "target_weight_version=11" in line
+            assert "threshold=1.2" in line
 
     def test_no_sequences_masked_when_all_below_threshold(self):
         """Test that no sequences are masked when all are below threshold."""

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -60,6 +60,7 @@ from nemo_rl.environments.nemotron_utils import (
     _expand_nemotron_video_placeholders,
     _flatten_nemotron_video_frame_messages,
 )
+from nemo_rl.experience.interfaces import NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY
 from nemo_rl.experience.rollouts import (
     _reattach_original_multimodal_payloads,
     attach_static_multimodal_payload,
@@ -1635,6 +1636,43 @@ def test_nemo_gym_run_rollouts_normalizes_mixed_media_before_dispatch(tmp_path):
         assert streamed_results[0][1] == {"message_log": []}
 
     asyncio.run(_run())
+
+
+def test_nemo_gym_postprocess_empty_output_returns_masked_placeholder(capsys):
+    class _Tokenizer:
+        pad_token_id = 17
+
+    nemo_gym_row = {
+        "_ng_task_index": 42,
+        "_ng_rollout_index": 3,
+        "_ng_attempt_index": 1,
+        "agent_ref": {"name": "conversational_tool_use_agent"},
+    }
+    nemo_gym_result = {
+        "response": {"output": []},
+        "responses_create_params": {"input": [{"role": "user", "content": "hi"}]},
+    }
+
+    class _MockSelf:
+        cfg = {}
+
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _MockSelf(), nemo_gym_row, nemo_gym_result, _Tokenizer()
+        )
+    )
+
+    assert result[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY] is True
+    assert result["full_result"]["response"]["output"] == []
+    assert len(result["message_log"]) == 1
+    assert result["message_log"][0]["role"] == "user"
+    assert result["message_log"][0]["token_ids"].tolist() == [17]
+    log = capsys.readouterr().out
+    assert "event=actor_empty_response_output_recovered" in log
+    assert "task_index=42" in log
+    assert "rollout_index=3" in log
+    assert "attempt_index=1" in log
+    assert "agent_ref={'name': 'conversational_tool_use_agent'}" in log
 
 
 def test_nemo_gym_postprocess_no_generation_data_raises():

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -45,6 +45,12 @@ from nemo_rl.environments.games.sliding_puzzle import (
     SlidingPuzzleMetadata,
 )
 from nemo_rl.environments.interfaces import EnvironmentReturn
+from nemo_rl.experience.interfaces import (
+    NEMO_GYM_ATTEMPT_INDEX_KEY,
+    NEMO_GYM_ROLLOUT_INDEX_KEY,
+    NEMO_GYM_TASK_INDEX_KEY,
+    NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY,
+)
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.experience.rollout_manager import (
     AsyncNemoGymRolloutImpl,
@@ -1847,6 +1853,8 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
             timer_prefix,
             deduplicate_multimodal_data,
         ):
+            assert all(NEMO_GYM_TASK_INDEX_KEY in row for row in rows)
+            assert [row[NEMO_GYM_ROLLOUT_INDEX_KEY] for row in rows] == [0, 1, 0, 1]
             del rows, timer_prefix
             assert deduplicate_multimodal_data is True
             # Both groups complete out of order internally and group 1 completes first.
@@ -1946,10 +1954,9 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
     monkeypatch.setattr(
         rollouts_mod,
         "collect_multimodal_payload_metrics",
-        lambda payload, boundary, enabled: payload_calls.append(
-            (payload, boundary, enabled)
-        )
-        or {},
+        lambda payload, boundary, enabled: (
+            payload_calls.append((payload, boundary, enabled)) or {}
+        ),
     )
     monkeypatch.setattr(
         rollouts_mod, "print_multimodal_payload_metrics", lambda metrics: None
@@ -2060,11 +2067,16 @@ def test_nemo_gym_stream_accumulator_rejects_mixed_agent_group():
 @pytest.mark.parametrize("log_full_result_tables", [False, True])
 def test_postprocess_nemo_gym_group_returns_task_index(log_full_result_tables):
     rows = [
-        {"agent_ref": {"name": "agent"}, "_ng_task_index": 42},
-        {"agent_ref": {"name": "agent"}, "_ng_task_index": 42},
+        {
+            "agent_ref": {"name": "agent"},
+            NEMO_GYM_TASK_INDEX_KEY: 42,
+            NEMO_GYM_ROLLOUT_INDEX_KEY: rollout_index,
+            NEMO_GYM_ATTEMPT_INDEX_KEY: 1,
+        }
+        for rollout_index in range(2)
     ]
     results = []
-    for reward in (1.0, 2.0):
+    for result_index, reward in enumerate((1.0, 2.0)):
         input_message = {
             "role": "user",
             "content": "prompt",
@@ -2083,6 +2095,7 @@ def test_postprocess_nemo_gym_group_returns_task_index(log_full_result_tables):
                     },
                 ],
                 "full_result": {"reward": reward},
+                NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY: result_index == 1,
             }
         )
 
@@ -2103,6 +2116,13 @@ def test_postprocess_nemo_gym_group_returns_task_index(log_full_result_tables):
 
     assert rollout_result.task_index == 42
     assert rollout_result.final_batch["total_reward"].tolist() == [1.0, 2.0]
+    assert rollout_result.final_batch[NEMO_GYM_TASK_INDEX_KEY].tolist() == [42, 42]
+    assert rollout_result.final_batch[NEMO_GYM_ROLLOUT_INDEX_KEY].tolist() == [0, 1]
+    assert rollout_result.final_batch[NEMO_GYM_ATTEMPT_INDEX_KEY].tolist() == [1, 1]
+    assert rollout_result.final_batch[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY].tolist() == [
+        False,
+        True,
+    ]
     assert (
         "agent/full_result" in rollout_result.rollout_metrics
     ) is log_full_result_tables
@@ -2162,6 +2182,7 @@ def test_postprocess_nemo_gym_group_reports_per_agent_truncation_rate():
         1.0
     )
     assert rollout_result.final_batch["truncated"].tolist() == is_truncated
+    assert not rollout_result.final_batch[NEMO_RL_EMPTY_RESPONSE_OUTPUT_KEY].any()
 
 
 def test_run_nemo_gym_rollout_sync_drains_entire_batch(monkeypatch):


### PR DESCRIPTION
Recover successful NeMo-Gym rollouts with empty response output as structurally valid placeholder rows, then ensure async GRPO excludes them from training.

Carry task, rollout, retry-attempt, agent, and target-weight identity through collection and replay. Centralize async masking with disjoint metrics for pre-masked, empty, overlong, rollout-flagged, and logprob-error sequences, and include those identities in plain-text masking and advantage-override logs.

Keep this branch's full-batch retry behavior and existing logging format rather than importing the source branch's structured tracing and pending-group retry machinery. Drop message logs after advantage penalties to reduce driver memory before policy training.

This is a narrow backport of 12f320f1e638b3e09b202e391fcded0028df6349, with only the required identity-stamping pieces from 13f70e108 and fe873aa88.