### PR TITLE
  fix(megatron): make mtp_num_layers=0 strip MTP for repeated-layer checkpoints

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1174,6 +1174,22 @@ def _apply_mtp_config(model_cfg: Any, config: PolicyConfig) -> None:
         # mtp_use_repeated_layer is False) and the number of times the MTP layer
         # is repeated (when mtp_use_repeated_layer is True).
         model_cfg.mtp_num_layers = megatron_cfg["mtp_num_layers"]
+        if megatron_cfg["mtp_num_layers"] == 0:
+            # mtp_num_layers=0 means "do not build MTP at all". For checkpoints
+            # trained with a repeated MTP layer, HybridProvider.finalize() still
+            # appends one MTP section to the layer pattern (max(1, 0) copies)
+            # whenever mtp_use_repeated_layer/mtp_hybrid_override_pattern are
+            # set, and HybridModel.forward then hits
+            # ``assert self.config.mtp_num_layers > 0``. Strip every MTP source
+            # so the pattern stays main-decoder only.
+            if getattr(model_cfg, "mtp_hybrid_override_pattern", None):
+                model_cfg.mtp_hybrid_override_pattern = None
+            if getattr(model_cfg, "mtp_use_repeated_layer", False):
+                model_cfg.mtp_use_repeated_layer = False
+            for pattern_attr in ("hybrid_layer_pattern", "hybrid_override_pattern"):
+                pattern = getattr(model_cfg, pattern_attr, None)
+                if isinstance(pattern, str) and "/" in pattern:
+                    setattr(model_cfg, pattern_attr, pattern.split("/")[0])
     if "mtp_loss_scaling_factor" in megatron_cfg:
         model_cfg.mtp_loss_scaling_factor = megatron_cfg["mtp_loss_scaling_factor"]
     if "mtp_use_repeated_layer" in megatron_cfg:


### PR DESCRIPTION
 # What does this PR do ?
  
  Makes `mtp_num_layers: 0` actually disable MTP for checkpoints trained with a shared/repeated MTP layer, fixing a deterministic all-rank crash at the first training step.
  
  # Issues
  
  For repeated-MTP checkpoints (e.g. Nemotron Super Omni), the bridge sets `mtp_use_repeated_layer=True` and `HybridProvider.finalize()` appends one MTP pattern section even at `mtp_num_layers=0` (`num_pattern_copies = max(1, 0)`). The model builds with `mtp_process=True` and Megatron-LM's forward fails `assert self.config.mtp_num_layers > 0` on every rank —
  blocking any GRPO recipe that uses the standard `mtp_num_layers: 0` disable on these checkpoints.
  
  # Usage
  
  ```yaml
  policy:
    megatron_cfg:
      mtp_num_layers: 0   # now builds no MTP module, as on the pre-merge branch
  ``` 
      
  The fix runs in `_apply_mtp_config` (before `finalize()`): clears `mtp_hybrid_override_pattern`, sets `mtp_use_repeated_layer=False`, and strips already-combined `/...` MTP sections from the layer pattern. Only triggers at exactly 0, so MTP-training configs (e.g. `mtp_num_layers: 5`) are unaffected.
  
  # Before your PR is "Ready for review"
  **Pre checks**:
  - [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
  - [ ] Did you write any new necessary tests?
  - [x] Did you run the unit tests and functional tests locally?
  - [ ] Did you add or update any necessary documentation?
  
  # Additional Information
  
  Verified on 32-node async GRPO (Nemotron Super Omni, Megatron backend): previously a 16/16-rank crash at the first training forward; with this fix, runs train 20+ steps across multiple job windows. 
  