### PR TITLE
fix(ray.sub): revalidate log dir before sentinel existence checks

### DIFF
--- a/ray.sub
+++ b/ray.sub
@@ -920,6 +920,11 @@ done
 # Wait for the head to signal that its GCS is listening before connecting.
 echo "[INFO] Worker \$SLURM_PROCID: waiting for Ray head GCS to be ready..."
 while true; do
+  # Re-list the directory before the existence checks: on this cluster's shared
+  # filesystem a bare [[ -f ]] can read a stale negative dentry for minutes
+  # after the head creates the sentinel (observed: 52/128 workers stuck 8+ min
+  # while the file existed), and readdir forces revalidation.
+  ls "$LOG_DIR" > /dev/null 2>&1
   if [[ -f "$LOG_DIR/STARTED_RAY_HEAD" ]]; then
     log_phase "worker \$SLURM_PROCID connecting to Ray head"
     break


### PR DESCRIPTION
 # What does this PR do ?
  
  Prevents multi-node job startup failures caused by workers reading a stale negative dentry for the `STARTED_RAY_HEAD` sentinel on shared filesystems.
  
  # Issues
  
  Workers poll `[[ -f $LOG_DIR/STARTED_RAY_HEAD ]]`; a stale negative dentry can hide the file for many minutes after the head creates it. Observed on a 32-node run: only 52/128 worker units joined while the sentinel had existed for 8+ minutes, and the startup deadline killed three consecutive job-array windows the same way.
  
  # Usage
  
  No user-facing change — `ls "$LOG_DIR"` before the existence checks in the worker wait loop forces readdir revalidation.
  
  # Before your PR is "Ready for review"
  **Pre checks**:
  - [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
  - [ ] Did you write any new necessary tests?
  - [x] Did you run the unit tests and functional tests locally?
  - [ ] Did you add or update any necessary documentation?
  
  # Additional Information
  
  Same 32-node job array: startup previously failed 3/3 windows after the first; with this fix all subsequent windows started cleanly and resumed training.
  