### PR TITLE
feat(vlm): mixed image+video Gym manifests and video media alignment verification

### DIFF
--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -373,10 +373,18 @@ def get_tokenizer(
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
+    def set_chat_template(chat_template: str) -> None:
+        # Keep the processor's template in sync with the tokenizer's: rendered
+        # text (e.g. reasoning extraction) must not depend on which of the two
+        # applies the template.
+        tokenizer.chat_template = chat_template
+        if processor is not None:
+            processor.chat_template = chat_template
+
     if "chat_template" in tokenizer_config:
         if tokenizer_config["chat_template"] is None:
             print("Using passthrough chat template")
-            tokenizer.chat_template = COMMON_CHAT_TEMPLATES.passthrough_prompt_response
+            set_chat_template(COMMON_CHAT_TEMPLATES.passthrough_prompt_response)
         elif tokenizer_config["chat_template"].lower() == "default":
             print("Using tokenizer's default chat template")
         elif tokenizer_config["chat_template"].endswith(".jinja"):
@@ -384,10 +392,10 @@ def get_tokenizer(
             template_path = tokenizer_config["chat_template"]
             print(f"Loading chat template from file: {template_path}")
             with open(template_path, "r") as f:
-                tokenizer.chat_template = f.read()
+                set_chat_template(f.read())
         else:
             print("Using custom chat template")
-            tokenizer.chat_template = tokenizer_config["chat_template"]
+            set_chat_template(tokenizer_config["chat_template"])
     else:
         print("No chat template provided, using tokenizer's default")
 

--- a/nemo_rl/data/__init__.py
+++ b/nemo_rl/data/__init__.py
@@ -38,6 +38,7 @@ class ResponseDatasetConfig(TypedDict):
     video_temporal_patch_size: NotRequired[int]
     video_maintain_aspect_ratio: NotRequired[bool]
     min_generation_tokens: NotRequired[int]
+    image_max_num_tiles: NotRequired[int]
 
 
 class PreferenceDatasetConfig(TypedDict):
@@ -57,6 +58,7 @@ class PreferenceDatasetConfig(TypedDict):
     video_temporal_patch_size: NotRequired[int]
     video_maintain_aspect_ratio: NotRequired[bool]
     min_generation_tokens: NotRequired[int]
+    image_max_num_tiles: NotRequired[int]
 
 
 class DataConfig(TypedDict):

--- a/nemo_rl/data/datasets/raw_dataset.py
+++ b/nemo_rl/data/datasets/raw_dataset.py
@@ -78,4 +78,5 @@ class RawDataset:
                 "video_maintain_aspect_ratio"
             ),
             min_generation_tokens=self.data_config.get("min_generation_tokens"),
+            image_max_num_tiles=self.data_config.get("image_max_num_tiles"),
         )

--- a/nemo_rl/data/interfaces.py
+++ b/nemo_rl/data/interfaces.py
@@ -66,6 +66,7 @@ class TaskDataSpec:
     video_temporal_patch_size: Optional[int] = None
     video_maintain_aspect_ratio: Optional[bool] = None
     min_generation_tokens: Optional[int] = None
+    image_max_num_tiles: Optional[int] = None
 
     def __post_init__(self) -> None:
         def load_prompt_file(

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -15,7 +15,6 @@
 import base64
 import inspect
 import logging
-import math
 import re
 import uuid
 from collections import defaultdict
@@ -23,7 +22,6 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from io import BytesIO
-from types import SimpleNamespace
 from typing import Any, Optional, Union
 
 import requests
@@ -43,6 +41,12 @@ MULTIMODAL_CONTENT_TYPES = frozenset(
     {*IMAGE_CONTENT_TYPES, *VIDEO_CONTENT_TYPES, *AUDIO_CONTENT_TYPES}
 )
 NEMO_GYM_IMAGE_ENCODE_MAX_WORKERS = 8
+# Provenance marker set on user messages whose media tensors were attached
+# rollout-matched (repaired to the rollout's per-image placeholder runs). The
+# driver-side static reattach must not overwrite such media; key presence
+# alone is not provenance (targets may carry placeholder or stale payloads
+# that the reattach is expected to replace).
+ROLLOUT_MATCHED_MEDIA_KEY = "_rollout_matched_media"
 
 # List of allowed placeholder strings for different media types in the dataset string
 # e.g. "This is an example of <image>"
@@ -103,70 +107,6 @@ def uses_image_placeholder(processor: Any) -> bool:
     return type(processor).__name__ in _PLACEHOLDER_STYLE_PROCESSOR_NAMES
 
 
-def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
-    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
-    tokenizer = getattr(processor, "tokenizer", None)
-    if tokenizer is None or not uses_image_placeholder(processor):
-        return None
-    tokens = [
-        getattr(processor, "image_token", "<image>"),
-        getattr(processor, "image_start_token", "<img>"),
-        getattr(processor, "image_end_token", "</img>"),
-    ]
-    ids = tokenizer.convert_tokens_to_ids(tokens)
-    unk_id = getattr(tokenizer, "unk_token_id", None)
-    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
-        return None
-    return int(ids[0]), int(ids[1]), int(ids[2])
-
-
-def supports_image_placeholder_run_parity(processor: Any) -> bool:
-    """Whether rollout tokens can be parsed into per-image placeholder runs."""
-    return get_image_placeholder_token_ids(processor) is not None
-
-
-def count_image_placeholder_runs(
-    token_ids: "Sequence[int] | torch.Tensor", processor: Any
-) -> list[int]:
-    """Per-image placeholder run lengths from rollout token ids, in order.
-
-    The rollout engine (and this processor) expand each image to
-    ``<img><image>*N</img>``; each run's N is the exact number of projected
-    media features the model expects for that image.
-    """
-    placeholder_ids = get_image_placeholder_token_ids(processor)
-    if placeholder_ids is None:
-        raise ValueError(
-            f"{type(processor).__name__} does not expose image placeholder "
-            "tokens; cannot count image placeholder runs."
-        )
-    image_id, start_id, end_id = placeholder_ids
-    if isinstance(token_ids, torch.Tensor):
-        token_ids = token_ids.tolist()
-    runs: list[int] = []
-    current: "int | None" = None
-    for token in token_ids:
-        if token == start_id:
-            if current is not None:
-                raise ValueError("Nested <img> region in rollout tokens.")
-            current = 0
-        elif token == end_id:
-            if current is None:
-                raise ValueError("Unmatched </img> in rollout tokens.")
-            runs.append(current)
-            current = None
-        elif token == image_id:
-            if current is None:
-                raise ValueError(
-                    "Image placeholder token outside an <img>...</img> region "
-                    "in rollout tokens."
-                )
-            current += 1
-    if current is not None:
-        raise ValueError("Unterminated <img> region in rollout tokens.")
-    return runs
-
-
 def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
     """(width, height) of an image source, without decoding pixel data."""
     if isinstance(source, Image.Image):
@@ -183,47 +123,6 @@ def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
             return image.width, image.height
     image = resolve_to_image(source)
     return image.width, image.height
-
-
-def predicted_static_image_num_tokens(
-    processor: Any, image_sizes: list[tuple[int, int]]
-) -> "list[int] | None":
-    """Predict per-image token counts of the processor's static image path.
-
-    Mirrors the budget selection in the checkpoint's image processor
-    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
-    for the grid math, so it costs no pixel work. Returns None when the
-    processor does not expose the needed hooks (callers must then assume the
-    static output is unverified and attach rollout-matched media themselves).
-    """
-    image_processor = getattr(processor, "image_processor", None)
-    required = (
-        "max_model_len",
-        "min_num_patches",
-        "max_num_patches",
-        "_compute_target_patches",
-    )
-    if image_processor is None or not all(
-        hasattr(image_processor, name) for name in required
-    ):
-        return None
-    downsample = getattr(image_processor, "_downsample_factor", None)
-    if not downsample:
-        ratio = getattr(image_processor, "downsample_ratio", None)
-        if not ratio:
-            return None
-        downsample = int(round(1.0 / ratio))
-    budget = (image_processor.max_model_len - 4) * downsample**2
-    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
-    max_patches = image_processor.max_num_patches
-    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
-    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
-    num_tokens = []
-    for width, height in image_sizes:
-        shim = SimpleNamespace(width=width, height=height)
-        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
-        num_tokens.append((grid_w * grid_h) // downsample**2)
-    return num_tokens
 
 
 class PackedTensor:
@@ -1144,122 +1043,6 @@ def _image_num_tokens_from_processed(processed: dict[str, Any]) -> list[int]:
     return [int(item) for item in value]
 
 
-def _closest_aspect_grid(
-    target_patches: int, height: int, width: int, divisor: int
-) -> tuple[int, int]:
-    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
-    units = divisor * divisor
-    if target_patches <= 0 or target_patches % units:
-        raise ValueError(
-            f"Rollout image placeholder run implies {target_patches} patches, "
-            f"which is not a positive multiple of the pixel-shuffle factor "
-            f"squared ({units}); the rollout tokens do not describe a valid "
-            "image tile."
-        )
-    base = target_patches // units
-    aspect = math.log(max(height, 1) / max(width, 1))
-    best: "tuple[float, int, int] | None" = None
-    for low in range(1, math.isqrt(base) + 1):
-        if base % low:
-            continue
-        high = base // low
-        for h_units, w_units in ((low, high), (high, low)):
-            grid_h, grid_w = h_units * divisor, w_units * divisor
-            score = abs(math.log(grid_h / grid_w) - aspect)
-            if best is None or score < best[0]:
-                best = (score, grid_h, grid_w)
-    assert best is not None
-    return best[1], best[2]
-
-
-def _process_single_image_at_num_tokens(
-    processor: Any, image: Image.Image, num_tokens: int
-) -> dict[str, Any]:
-    """Run the processor on one image, pinned to an exact media token count."""
-    image_processor = processor.image_processor
-    image_token = getattr(processor, "image_token", "<image>")
-    downsample = getattr(image_processor, "_downsample_factor", None) or int(
-        round(1.0 / image_processor.downsample_ratio)
-    )
-
-    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
-        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
-        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
-        # patches. Instance mutation is the only knob: the wrapper's
-        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
-        # run this on a single thread with no awaits in between (same pattern
-        # as the processor's own _is_video_mode flag).
-        original = image_processor.max_model_len
-        try:
-            image_processor.max_model_len = num_tokens + 4
-            return dict(
-                processor(text=image_token, images=[single_image], return_tensors=None)
-            )
-        finally:
-            image_processor.max_model_len = original
-
-    processed = run_pinned(image)
-    if _image_num_tokens_from_processed(processed) == [num_tokens]:
-        return processed
-
-    # Grid rounding is not idempotent for every (size, budget); force the exact
-    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
-    # patches passes _compute_target_patches unchanged under the pinned budget.
-    grid_h, grid_w = _closest_aspect_grid(
-        num_tokens * downsample * downsample, image.height, image.width, downsample
-    )
-    patch = image_processor.patch_size
-    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
-    processed = run_pinned(resized)
-    actual = _image_num_tokens_from_processed(processed)
-    if actual != [num_tokens]:
-        raise ValueError(
-            "Cannot match the rollout's image tiling: the rollout expanded a "
-            f"{image.width}x{image.height} image to {num_tokens} placeholder "
-            f"tokens, but the training processor produced {actual[0]} tokens "
-            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
-            "train on misaligned media."
-        )
-    return processed
-
-
-def _reprocess_images_at_rollout_budgets(
-    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
-) -> dict[str, Any]:
-    """Re-run the processor per image at the rollout's exact per-image budget."""
-    parts = [
-        _process_single_image_at_num_tokens(processor, image, count)
-        for image, count in zip(images, expected_num_tokens, strict=True)
-    ]
-    pixel_values: list[torch.Tensor] = []
-    imgs_sizes: list[list[int]] = []
-    input_ids: list[torch.Tensor] = []
-    for part in parts:
-        tile = part["pixel_values"]
-        if isinstance(tile, list):
-            tile = torch.as_tensor(tile[0])
-        else:
-            tile = torch.as_tensor(tile)
-            if tile.ndim == 4:
-                tile = tile[0]
-        pixel_values.append(tile)
-        imgs_sizes.extend(
-            [int(h), int(w)]
-            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
-        )
-        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
-    merged: dict[str, Any] = {
-        "input_ids": torch.cat(input_ids, dim=1),
-        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
-        "num_tokens": list(expected_num_tokens),
-        "num_patches": [1] * len(images),
-    }
-    merged["pixel_values"] = (
-        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
-    )
-    return merged
-
-
 def attach_image_model_inputs_to_message(
     message: dict[str, Any],
     *,
@@ -1303,11 +1086,21 @@ def attach_image_model_inputs_to_message(
     if expected_num_tokens_per_image is not None:
         expected = [int(count) for count in expected_num_tokens_per_image]
         if _image_num_tokens_from_processed(processed) != expected:
-            processed = _reprocess_images_at_rollout_budgets(
-                processor, images, expected
+            # Local import: the exact-count repair is Nemotron-processor
+            # specific and lives with the other Nemotron helpers.
+            from nemo_rl.environments.nemotron_utils import (
+                reprocess_images_at_rollout_budgets,
             )
+
+            processed = reprocess_images_at_rollout_budgets(processor, images, expected)
             # Corrected tiles may be ragged even when the originals were not.
             allow_ragged_output = len(images) > 1
+            # Explicit provenance for the driver-side static reattach: only a
+            # REPAIRED turn carries media that differs from the statically
+            # budgeted prompt copy and must not be overwritten. Unrepaired
+            # turns keep no marker, so the reattach still restores the shared
+            # tensor set across a prompt group's repeated rows.
+            message[ROLLOUT_MATCHED_MEDIA_KEY] = True
     if allow_ragged_output:
         processed = _materialize_ragged_pixel_values(processed, processor)
     model_inputs = extract_multimodal_model_inputs(processor, processed)

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -124,6 +124,13 @@ def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
     image = resolve_to_image(source)
     return image.width, image.height
 
+_FIXED_TILE_IMAGE_PROCESSOR_NAMES = frozenset({"NemotronNanoVLV2Processor"})
+
+
+def uses_fixed_tile_image_processor(processor: Any) -> bool:
+    """Return whether stacked image tiles must keep their legacy metadata contract."""
+    return type(processor).__name__ in _FIXED_TILE_IMAGE_PROCESSOR_NAMES
+
 
 class PackedTensor:
     """A logical batch of rows backed by packable tensor segments.

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -15,6 +15,7 @@
 import base64
 import inspect
 import logging
+import math
 import re
 import uuid
 from collections import defaultdict
@@ -22,6 +23,7 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from io import BytesIO
+from types import SimpleNamespace
 from typing import Any, Optional, Union
 
 import requests
@@ -99,6 +101,129 @@ def uses_image_placeholder(processor: Any) -> bool:
         rather than tokenized ``apply_chat_template``.
     """
     return type(processor).__name__ in _PLACEHOLDER_STYLE_PROCESSOR_NAMES
+
+
+def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
+    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None or not uses_image_placeholder(processor):
+        return None
+    tokens = [
+        getattr(processor, "image_token", "<image>"),
+        getattr(processor, "image_start_token", "<img>"),
+        getattr(processor, "image_end_token", "</img>"),
+    ]
+    ids = tokenizer.convert_tokens_to_ids(tokens)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
+        return None
+    return int(ids[0]), int(ids[1]), int(ids[2])
+
+
+def supports_image_placeholder_run_parity(processor: Any) -> bool:
+    """Whether rollout tokens can be parsed into per-image placeholder runs."""
+    return get_image_placeholder_token_ids(processor) is not None
+
+
+def count_image_placeholder_runs(
+    token_ids: "Sequence[int] | torch.Tensor", processor: Any
+) -> list[int]:
+    """Per-image placeholder run lengths from rollout token ids, in order.
+
+    The rollout engine (and this processor) expand each image to
+    ``<img><image>*N</img>``; each run's N is the exact number of projected
+    media features the model expects for that image.
+    """
+    placeholder_ids = get_image_placeholder_token_ids(processor)
+    if placeholder_ids is None:
+        raise ValueError(
+            f"{type(processor).__name__} does not expose image placeholder "
+            "tokens; cannot count image placeholder runs."
+        )
+    image_id, start_id, end_id = placeholder_ids
+    if isinstance(token_ids, torch.Tensor):
+        token_ids = token_ids.tolist()
+    runs: list[int] = []
+    current: "int | None" = None
+    for token in token_ids:
+        if token == start_id:
+            if current is not None:
+                raise ValueError("Nested <img> region in rollout tokens.")
+            current = 0
+        elif token == end_id:
+            if current is None:
+                raise ValueError("Unmatched </img> in rollout tokens.")
+            runs.append(current)
+            current = None
+        elif token == image_id:
+            if current is None:
+                raise ValueError(
+                    "Image placeholder token outside an <img>...</img> region "
+                    "in rollout tokens."
+                )
+            current += 1
+    if current is not None:
+        raise ValueError("Unterminated <img> region in rollout tokens.")
+    return runs
+
+
+def image_size_from_source(source: "str | Image.Image") -> tuple[int, int]:
+    """(width, height) of an image source, without decoding pixel data."""
+    if isinstance(source, Image.Image):
+        return source.width, source.height
+    if isinstance(source, str) and source.startswith("data:"):
+        _, encoded = source.split(",", 1)
+        with Image.open(BytesIO(base64.b64decode(encoded))) as image:
+            return image.width, image.height
+    if isinstance(source, str) and source.startswith("file://"):
+        with Image.open(source.removeprefix("file://")) as image:
+            return image.width, image.height
+    if isinstance(source, str) and not source.startswith(("http://", "https://")):
+        with Image.open(source) as image:
+            return image.width, image.height
+    image = resolve_to_image(source)
+    return image.width, image.height
+
+
+def predicted_static_image_num_tokens(
+    processor: Any, image_sizes: list[tuple[int, int]]
+) -> "list[int] | None":
+    """Predict per-image token counts of the processor's static image path.
+
+    Mirrors the budget selection in the checkpoint's image processor
+    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
+    for the grid math, so it costs no pixel work. Returns None when the
+    processor does not expose the needed hooks (callers must then assume the
+    static output is unverified and attach rollout-matched media themselves).
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    required = (
+        "max_model_len",
+        "min_num_patches",
+        "max_num_patches",
+        "_compute_target_patches",
+    )
+    if image_processor is None or not all(
+        hasattr(image_processor, name) for name in required
+    ):
+        return None
+    downsample = getattr(image_processor, "_downsample_factor", None)
+    if not downsample:
+        ratio = getattr(image_processor, "downsample_ratio", None)
+        if not ratio:
+            return None
+        downsample = int(round(1.0 / ratio))
+    budget = (image_processor.max_model_len - 4) * downsample**2
+    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
+    max_patches = image_processor.max_num_patches
+    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
+    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
+    num_tokens = []
+    for width, height in image_sizes:
+        shim = SimpleNamespace(width=width, height=height)
+        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
+        num_tokens.append((grid_w * grid_h) // downsample**2)
+    return num_tokens
 
 
 class PackedTensor:
@@ -1007,16 +1132,161 @@ def _restore_tensors(processed: dict[str, Any]) -> None:
                 continue
 
 
+def _image_num_tokens_from_processed(processed: dict[str, Any]) -> list[int]:
+    value = processed.get("num_tokens")
+    if value is None:
+        raise ValueError(
+            "Processor output has no per-image 'num_tokens'; cannot verify "
+            "image parity with the rollout tokens."
+        )
+    if isinstance(value, torch.Tensor):
+        return [int(item) for item in value.tolist()]
+    return [int(item) for item in value]
+
+
+def _closest_aspect_grid(
+    target_patches: int, height: int, width: int, divisor: int
+) -> tuple[int, int]:
+    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
+    units = divisor * divisor
+    if target_patches <= 0 or target_patches % units:
+        raise ValueError(
+            f"Rollout image placeholder run implies {target_patches} patches, "
+            f"which is not a positive multiple of the pixel-shuffle factor "
+            f"squared ({units}); the rollout tokens do not describe a valid "
+            "image tile."
+        )
+    base = target_patches // units
+    aspect = math.log(max(height, 1) / max(width, 1))
+    best: "tuple[float, int, int] | None" = None
+    for low in range(1, math.isqrt(base) + 1):
+        if base % low:
+            continue
+        high = base // low
+        for h_units, w_units in ((low, high), (high, low)):
+            grid_h, grid_w = h_units * divisor, w_units * divisor
+            score = abs(math.log(grid_h / grid_w) - aspect)
+            if best is None or score < best[0]:
+                best = (score, grid_h, grid_w)
+    assert best is not None
+    return best[1], best[2]
+
+
+def _process_single_image_at_num_tokens(
+    processor: Any, image: Image.Image, num_tokens: int
+) -> dict[str, Any]:
+    """Run the processor on one image, pinned to an exact media token count."""
+    image_processor = processor.image_processor
+    image_token = getattr(processor, "image_token", "<image>")
+    downsample = getattr(image_processor, "_downsample_factor", None) or int(
+        round(1.0 / image_processor.downsample_ratio)
+    )
+
+    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
+        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
+        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
+        # patches. Instance mutation is the only knob: the wrapper's
+        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
+        # run this on a single thread with no awaits in between (same pattern
+        # as the processor's own _is_video_mode flag).
+        original = image_processor.max_model_len
+        try:
+            image_processor.max_model_len = num_tokens + 4
+            return dict(
+                processor(text=image_token, images=[single_image], return_tensors=None)
+            )
+        finally:
+            image_processor.max_model_len = original
+
+    processed = run_pinned(image)
+    if _image_num_tokens_from_processed(processed) == [num_tokens]:
+        return processed
+
+    # Grid rounding is not idempotent for every (size, budget); force the exact
+    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
+    # patches passes _compute_target_patches unchanged under the pinned budget.
+    grid_h, grid_w = _closest_aspect_grid(
+        num_tokens * downsample * downsample, image.height, image.width, downsample
+    )
+    patch = image_processor.patch_size
+    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
+    processed = run_pinned(resized)
+    actual = _image_num_tokens_from_processed(processed)
+    if actual != [num_tokens]:
+        raise ValueError(
+            "Cannot match the rollout's image tiling: the rollout expanded a "
+            f"{image.width}x{image.height} image to {num_tokens} placeholder "
+            f"tokens, but the training processor produced {actual[0]} tokens "
+            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
+            "train on misaligned media."
+        )
+    return processed
+
+
+def _reprocess_images_at_rollout_budgets(
+    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
+) -> dict[str, Any]:
+    """Re-run the processor per image at the rollout's exact per-image budget."""
+    parts = [
+        _process_single_image_at_num_tokens(processor, image, count)
+        for image, count in zip(images, expected_num_tokens, strict=True)
+    ]
+    pixel_values: list[torch.Tensor] = []
+    imgs_sizes: list[list[int]] = []
+    input_ids: list[torch.Tensor] = []
+    for part in parts:
+        tile = part["pixel_values"]
+        if isinstance(tile, list):
+            tile = torch.as_tensor(tile[0])
+        else:
+            tile = torch.as_tensor(tile)
+            if tile.ndim == 4:
+                tile = tile[0]
+        pixel_values.append(tile)
+        imgs_sizes.extend(
+            [int(h), int(w)]
+            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
+        )
+        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
+    merged: dict[str, Any] = {
+        "input_ids": torch.cat(input_ids, dim=1),
+        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
+        "num_tokens": list(expected_num_tokens),
+        "num_patches": [1] * len(images),
+    }
+    merged["pixel_values"] = (
+        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
+    )
+    return merged
+
+
 def attach_image_model_inputs_to_message(
     message: dict[str, Any],
     *,
     images: list[Image.Image],
     processor: Any,
     pad_dynamic_image_shapes: bool = False,
+    expected_num_tokens_per_image: "Sequence[int] | None" = None,
 ) -> None:
-    """Attach processor-owned image tensors without replacing rollout tokens."""
+    """Attach processor-owned image tensors without replacing rollout tokens.
+
+    When ``expected_num_tokens_per_image`` is given (per-image placeholder run
+    lengths read off the rollout's token ids), the processor output is verified
+    against it and mismatching turns are re-processed at the rollout's exact
+    per-image budgets, so the training-side projected feature count always
+    matches the rollout placeholders. Raises ValueError when parity cannot be
+    established, rather than attaching misaligned media.
+    """
     if not images or processor is None:
         return
+    if expected_num_tokens_per_image is not None and len(
+        expected_num_tokens_per_image
+    ) != len(images):
+        raise ValueError(
+            f"Got {len(images)} images but {len(expected_num_tokens_per_image)} "
+            "rollout placeholder runs for this turn. Refusing to train on "
+            "misaligned media."
+        )
 
     image_token = getattr(processor, "image_token", "<image>")
     # Processors that emit dynamic per-image resolutions return a ragged CHW list
@@ -1030,6 +1300,14 @@ def attach_image_model_inputs_to_message(
         return_tensors=None if allow_ragged_output else "pt",
     )
     processed = dict(processed)
+    if expected_num_tokens_per_image is not None:
+        expected = [int(count) for count in expected_num_tokens_per_image]
+        if _image_num_tokens_from_processed(processed) != expected:
+            processed = _reprocess_images_at_rollout_budgets(
+                processor, images, expected
+            )
+            # Corrected tiles may be ragged even when the originals were not.
+            allow_ragged_output = len(images) > 1
     if allow_ragged_output:
         processed = _materialize_ragged_pixel_values(processed, processor)
     model_inputs = extract_multimodal_model_inputs(processor, processed)

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -464,6 +464,7 @@ def vlm_hf_data_processor(
         get_multimodal_default_settings_from_processor,
         get_multimodal_keys_from_processor,
         resolve_to_image,
+        uses_fixed_tile_image_processor,
         uses_image_placeholder,
     )
 
@@ -608,13 +609,12 @@ def vlm_hf_data_processor(
     user_message["token_ids"] = message["input_ids"][0]
     # add all keys and values to the user message, and the list of keys
     multimodal_keys = list(get_multimodal_keys_from_processor(processor))
-    # Current Nemotron Omni processors emit imgs_sizes. Historical MMPR
-    # checkpoints instead emit a batch of fixed-size image tiles and only
-    # declare pixel_values. Treat each tile as one dynamic-resolution image so
-    # the Nemotron Omni path can patchify it and preserve the processor's exact
-    # placeholder count.
+    # Dynamic Nemotron Omni processors may omit imgs_sizes from older remote
+    # code. Backfill it for that contract, but never for legacy Nano V2 fixed
+    # tiles: adding dynamic metadata changes Megatron's vision-encoding path.
     if (
         uses_placeholder
+        and not uses_fixed_tile_image_processor(processor)
         and "pixel_values" in message
         and "imgs_sizes" not in message
         and message["pixel_values"].ndim == 4
@@ -811,11 +811,63 @@ def nemo_gym_data_processor(
             task_name=datum_dict["task_name"],
             data_config=task_data_spec,
         )
-        if video_output is None:
-            raise ValueError(
-                "Gym video data configuration requires a static video in every row"
+        # A single NeMo-Gym manifest may mix static-video rows with regular
+        # multimodal rows (for example CAPRL video + SAV tracking images). The
+        # shared data spec still carries video preprocessing settings so video
+        # rows can use the lossless cached-frame path, but those settings must
+        # not turn still-image rows into invalid video examples. Non-video rows
+        # use the normal Gym placeholder below and receive their image tensors
+        # during full-trajectory postprocessing.
+        if video_output is not None:
+            return cast(DatumSpec, video_output)
+
+    if task_data_spec is not None and task_data_spec.image_max_num_tiles is not None:
+        image_max_num_tiles = task_data_spec.image_max_num_tiles
+        if image_max_num_tiles < 1:
+            raise ValueError("image_max_num_tiles must be at least 1.")
+        image_processor = getattr(tokenizer, "image_processor", None)
+        if image_processor is None:
+            raise TypeError(
+                "Gym image_max_num_tiles requires a multimodal processor with "
+                "an image_processor attribute"
             )
-        return cast(DatumSpec, video_output)
+
+        if hasattr(image_processor, "max_num_tiles"):
+            pass
+        elif all(
+            hasattr(image_processor, name)
+            for name in ("min_num_patches", "max_num_patches")
+        ):
+            min_num_patches = image_processor.min_num_patches
+            if (
+                not isinstance(min_num_patches, int)
+                or isinstance(min_num_patches, bool)
+                or min_num_patches < 1
+            ):
+                raise ValueError(
+                    "The configured dynamic image processor has an invalid "
+                    "min_num_patches value."
+                )
+        else:
+            raise ValueError(
+                "The configured image processor supports neither max_num_tiles "
+                "nor a dynamic min_num_patches/max_num_patches budget."
+            )
+
+        # Keep the logical tile cap for Megatron postprocessing and send its
+        # vLLM-facing equivalent with the Gym request. The vLLM
+        # NanoNemotronVLProcessor uses max_num_tiles for both InternVL and
+        # dynamic-resolution checkpoints. The async worker adapts that logical
+        # tile cap to a dynamic min/max patch budget when necessary.
+        extra_env_info["_nemo_rl_image_max_num_tiles"] = image_max_num_tiles
+        from nemo_rl.environments.nemo_gym_video import (
+            _inject_vllm_mm_processor_kwargs,
+        )
+
+        _inject_vllm_mm_processor_kwargs(
+            extra_env_info,
+            {"max_num_tiles": image_max_num_tiles},
+        )
 
     output: DatumSpec = {
         # load to dict format here since `Dataset` cannot handle nested structure well in `NemoGymDataset`
@@ -824,7 +876,16 @@ def nemo_gym_data_processor(
         "idx": idx,
         "task_name": datum_dict["task_name"],
         # fake keys for compatibility with the current GRPO implementation
-        "message_log": [{"role": "user", "content": "", "token_ids": torch.tensor([])}],
+        # Empty placeholders must use the same dtype as real tokenizer output.
+        # Otherwise a mixed still-image/video Gym batch combines float32 SAV
+        # placeholders with int64 video token IDs and fails before rollout.
+        "message_log": [
+            {
+                "role": "user",
+                "content": "",
+                "token_ids": torch.empty(0, dtype=torch.long),
+            }
+        ],
         "length": 0,
     }
     return output

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -34,9 +34,13 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.data.multimodal_utils import (
     attach_image_model_inputs_to_message,
+    count_image_placeholder_runs,
     encode_images_in_examples,
     extract_input_image_sources_from_responses_messages,
+    image_size_from_source,
+    predicted_static_image_num_tokens,
     resolve_to_image,
+    supports_image_placeholder_run_parity,
     uses_image_placeholder,
 )
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
@@ -608,6 +612,7 @@ def _attach_multimodal_data_to_user_message(
     images: list[Image.Image],
     processor: Any,
     pad_dynamic_image_shapes: bool = False,
+    expected_num_tokens_per_image: "list[int] | None" = None,
 ) -> None:
     """Attach per-turn multimodal tensors to ``user_message``.
 
@@ -624,6 +629,7 @@ def _attach_multimodal_data_to_user_message(
         images=images,
         processor=processor,
         pad_dynamic_image_shapes=pad_dynamic_image_shapes,
+        expected_num_tokens_per_image=expected_num_tokens_per_image,
     )
 
 
@@ -973,6 +979,47 @@ Depending on your data shape, you may want to change these values."""
             and initial_media_matches_raw_input
             and returned_media_matches_raw_input
         )
+        parity_processor = (
+            processor
+            if processor is not None
+            and supports_image_placeholder_run_parity(processor)
+            else None
+        )
+        # Dedup omission is only safe when the statically-budgeted tensors the
+        # driver pre-attached provably match the rollout's per-image expansion.
+        # vLLM sizes image tiles per request (shrinking as prompts approach
+        # max_model_len), so budget-bound rows must be attached here, from the
+        # rollout tokens, instead.
+        if (
+            initial_multimodal_data_omitted
+            and parity_processor is not None
+            and raw_initial_sources
+        ):
+            first_trainable_item = next(
+                (
+                    item
+                    for item in response["output"]
+                    if _is_trainable_output_item(item)
+                ),
+                None,
+            )
+            predicted = predicted_static_image_num_tokens(
+                parity_processor,
+                [image_size_from_source(source) for source in raw_initial_sources],
+            )
+            first_turn_runs = (
+                count_image_placeholder_runs(
+                    first_trainable_item["prompt_token_ids"], parity_processor
+                )
+                if first_trainable_item is not None
+                else []
+            )
+            if (
+                predicted is None
+                or len(first_turn_runs) < len(predicted)
+                or first_turn_runs[: len(predicted)] != predicted
+            ):
+                initial_multimodal_data_omitted = False
         if initial_multimodal_data_omitted:
             media_messages, _ = _without_initial_image_sources(
                 media_messages, raw_initial_sources
@@ -1071,6 +1118,29 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                 images_this_turn = (
                     per_turn_images[turn_idx] if turn_idx < len(per_turn_images) else []
                 )
+                expected_num_tokens: "list[int] | None" = None
+                if images_this_turn and parity_processor is not None:
+                    turn_runs = count_image_placeholder_runs(
+                        new_prompt_token_ids, parity_processor
+                    )
+                    # Under dedup omission, turn 0's leading runs belong to the
+                    # initial images whose (verified) tensors the driver
+                    # restores; only the trailing runs are attached here.
+                    omitted_leading_runs = (
+                        len(raw_initial_sources)
+                        if initial_multimodal_data_omitted and turn_idx == 0
+                        else 0
+                    )
+                    if len(turn_runs) != omitted_leading_runs + len(images_this_turn):
+                        raise ValueError(
+                            f"Rollout/image mismatch on NeMo Gym turn {turn_idx}: "
+                            f"the prompt delta contains {len(turn_runs)} image "
+                            f"placeholder runs but {len(images_this_turn)} images "
+                            f"were collected for this turn (plus "
+                            f"{omitted_leading_runs} deduplicated initial images). "
+                            "Refusing to train on misaligned media."
+                        )
+                    expected_num_tokens = turn_runs[omitted_leading_runs:]
                 _attach_multimodal_data_to_user_message(
                     user_message,
                     images=images_this_turn,
@@ -1082,6 +1152,7 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                     pad_dynamic_image_shapes=getattr(
                         self, "_pad_dynamic_image_shapes", False
                     ),
+                    expected_num_tokens_per_image=expected_num_tokens,
                 )
             # Valid tool calls go through the structured API (tool_calls field) and get
             # executed by NeMo-Gym. If tool call patterns appear in the text content instead,

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -34,14 +34,16 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.data.multimodal_utils import (
     attach_image_model_inputs_to_message,
-    count_image_placeholder_runs,
     encode_images_in_examples,
     extract_input_image_sources_from_responses_messages,
     image_size_from_source,
-    predicted_static_image_num_tokens,
     resolve_to_image,
-    supports_image_placeholder_run_parity,
     uses_image_placeholder,
+)
+from nemo_rl.environments.nemotron_utils import (
+    count_image_placeholder_runs,
+    predicted_static_image_num_tokens,
+    supports_image_placeholder_run_parity,
 )
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import (

--- a/nemo_rl/environments/nemotron_utils.py
+++ b/nemo_rl/environments/nemotron_utils.py
@@ -14,7 +14,9 @@
 
 import copy
 import math
+from collections.abc import Sequence
 from functools import lru_cache
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -22,6 +24,11 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 from transformers import AutoConfig
+
+from nemo_rl.data.multimodal_utils import (
+    _image_num_tokens_from_processed,
+    uses_image_placeholder,
+)
 
 NEMOTRON_VIDEO_PROCESSOR_NAMES = frozenset(
     {
@@ -358,3 +365,230 @@ def process_nemotron_video_frames(
         "pixel_values": torch.stack(pixel_values),
         "imgs_sizes": torch.tensor(image_sizes, dtype=torch.int32),
     }
+
+
+# --- Rollout/train image-tiling parity helpers (Nemotron placeholder-style
+# processors). The rollout engine expands each image to <img><image>*N</img>;
+# these helpers read those runs back as the authoritative per-image budgets
+# and force the training-side processor to reproduce them exactly.
+
+
+def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
+    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None or not uses_image_placeholder(processor):
+        return None
+    tokens = [
+        getattr(processor, "image_token", "<image>"),
+        getattr(processor, "image_start_token", "<img>"),
+        getattr(processor, "image_end_token", "</img>"),
+    ]
+    ids = tokenizer.convert_tokens_to_ids(tokens)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
+        return None
+    return int(ids[0]), int(ids[1]), int(ids[2])
+
+
+def supports_image_placeholder_run_parity(processor: Any) -> bool:
+    """Whether rollout tokens can be parsed into per-image placeholder runs."""
+    return get_image_placeholder_token_ids(processor) is not None
+
+
+def count_image_placeholder_runs(
+    token_ids: "Sequence[int] | torch.Tensor", processor: Any
+) -> list[int]:
+    """Per-image placeholder run lengths from rollout token ids, in order.
+
+    The rollout engine (and this processor) expand each image to
+    ``<img><image>*N</img>``; each run's N is the exact number of projected
+    media features the model expects for that image.
+    """
+    placeholder_ids = get_image_placeholder_token_ids(processor)
+    if placeholder_ids is None:
+        raise ValueError(
+            f"{type(processor).__name__} does not expose image placeholder "
+            "tokens; cannot count image placeholder runs."
+        )
+    image_id, start_id, end_id = placeholder_ids
+    if isinstance(token_ids, torch.Tensor):
+        token_ids = token_ids.tolist()
+    runs: list[int] = []
+    current: "int | None" = None
+    for token in token_ids:
+        if token == start_id:
+            if current is not None:
+                raise ValueError("Nested <img> region in rollout tokens.")
+            current = 0
+        elif token == end_id:
+            if current is None:
+                raise ValueError("Unmatched </img> in rollout tokens.")
+            runs.append(current)
+            current = None
+        elif token == image_id:
+            if current is None:
+                raise ValueError(
+                    "Image placeholder token outside an <img>...</img> region "
+                    "in rollout tokens."
+                )
+            current += 1
+    if current is not None:
+        raise ValueError("Unterminated <img> region in rollout tokens.")
+    return runs
+
+
+def predicted_static_image_num_tokens(
+    processor: Any, image_sizes: list[tuple[int, int]]
+) -> "list[int] | None":
+    """Predict per-image token counts of the processor's static image path.
+
+    Mirrors the budget selection in the checkpoint's image processor
+    ``_preprocess`` (image path) and reuses its own ``_compute_target_patches``
+    for the grid math, so it costs no pixel work. Returns None when the
+    processor does not expose the needed hooks (callers must then assume the
+    static output is unverified and attach rollout-matched media themselves).
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    required = (
+        "max_model_len",
+        "min_num_patches",
+        "max_num_patches",
+        "_compute_target_patches",
+    )
+    if image_processor is None or not all(
+        hasattr(image_processor, name) for name in required
+    ):
+        return None
+    downsample = getattr(image_processor, "_downsample_factor", None)
+    if not downsample:
+        ratio = getattr(image_processor, "downsample_ratio", None)
+        if not ratio:
+            return None
+        downsample = int(round(1.0 / ratio))
+    budget = (image_processor.max_model_len - 4) * downsample**2
+    budget = max(budget, image_processor.min_num_patches * len(image_sizes))
+    max_patches = image_processor.max_num_patches
+    max_budget = max_patches if (max_patches and max_patches > 0) else float("inf")
+    per_image_budget = max(min(budget, max_budget), image_processor.min_num_patches)
+    num_tokens = []
+    for width, height in image_sizes:
+        shim = SimpleNamespace(width=width, height=height)
+        grid_w, grid_h = image_processor._compute_target_patches(shim, per_image_budget)
+        num_tokens.append((grid_w * grid_h) // downsample**2)
+    return num_tokens
+
+
+def _closest_aspect_grid(
+    target_patches: int, height: int, width: int, divisor: int
+) -> tuple[int, int]:
+    """Aspect-closest (grid_h, grid_w), both divisible by ``divisor``, whose product is exactly ``target_patches``."""
+    units = divisor * divisor
+    if target_patches <= 0 or target_patches % units:
+        raise ValueError(
+            f"Rollout image placeholder run implies {target_patches} patches, "
+            f"which is not a positive multiple of the pixel-shuffle factor "
+            f"squared ({units}); the rollout tokens do not describe a valid "
+            "image tile."
+        )
+    base = target_patches // units
+    aspect = math.log(max(height, 1) / max(width, 1))
+    best: "tuple[float, int, int] | None" = None
+    for low in range(1, math.isqrt(base) + 1):
+        if base % low:
+            continue
+        high = base // low
+        for h_units, w_units in ((low, high), (high, low)):
+            grid_h, grid_w = h_units * divisor, w_units * divisor
+            score = abs(math.log(grid_h / grid_w) - aspect)
+            if best is None or score < best[0]:
+                best = (score, grid_h, grid_w)
+    assert best is not None
+    return best[1], best[2]
+
+
+def _process_single_image_at_num_tokens(
+    processor: Any, image: Image.Image, num_tokens: int
+) -> dict[str, Any]:
+    """Run the processor on one image, pinned to an exact media token count."""
+    image_processor = processor.image_processor
+    image_token = getattr(processor, "image_token", "<image>")
+    downsample = getattr(image_processor, "_downsample_factor", None) or int(
+        round(1.0 / image_processor.downsample_ratio)
+    )
+
+    def run_pinned(single_image: Image.Image) -> dict[str, Any]:
+        # The image-path per-image budget is clamp((max_model_len-4)*ds^2, ...),
+        # so max_model_len = num_tokens + 4 requests exactly num_tokens*ds^2
+        # patches. Instance mutation is the only knob: the wrapper's
+        # ImagesKwargs silently ignore unknown kwargs. Both attach call sites
+        # run this on a single thread with no awaits in between (same pattern
+        # as the processor's own _is_video_mode flag).
+        original = image_processor.max_model_len
+        try:
+            image_processor.max_model_len = num_tokens + 4
+            return dict(
+                processor(text=image_token, images=[single_image], return_tensors=None)
+            )
+        finally:
+            image_processor.max_model_len = original
+
+    processed = run_pinned(image)
+    if _image_num_tokens_from_processed(processed) == [num_tokens]:
+        return processed
+
+    # Grid rounding is not idempotent for every (size, budget); force the exact
+    # grid by pre-resizing to it. An even grid of exactly num_tokens*ds^2
+    # patches passes _compute_target_patches unchanged under the pinned budget.
+    grid_h, grid_w = _closest_aspect_grid(
+        num_tokens * downsample * downsample, image.height, image.width, downsample
+    )
+    patch = image_processor.patch_size
+    resized = image.resize((grid_w * patch, grid_h * patch), Image.BICUBIC)
+    processed = run_pinned(resized)
+    actual = _image_num_tokens_from_processed(processed)
+    if actual != [num_tokens]:
+        raise ValueError(
+            "Cannot match the rollout's image tiling: the rollout expanded a "
+            f"{image.width}x{image.height} image to {num_tokens} placeholder "
+            f"tokens, but the training processor produced {actual[0]} tokens "
+            f"even when pinned to a {grid_h}x{grid_w} patch grid. Refusing to "
+            "train on misaligned media."
+        )
+    return processed
+
+
+def reprocess_images_at_rollout_budgets(
+    processor: Any, images: list[Image.Image], expected_num_tokens: list[int]
+) -> dict[str, Any]:
+    """Re-run the processor per image at the rollout's exact per-image budget."""
+    parts = [
+        _process_single_image_at_num_tokens(processor, image, count)
+        for image, count in zip(images, expected_num_tokens, strict=True)
+    ]
+    pixel_values: list[torch.Tensor] = []
+    imgs_sizes: list[list[int]] = []
+    input_ids: list[torch.Tensor] = []
+    for part in parts:
+        tile = part["pixel_values"]
+        if isinstance(tile, list):
+            tile = torch.as_tensor(tile[0])
+        else:
+            tile = torch.as_tensor(tile)
+            if tile.ndim == 4:
+                tile = tile[0]
+        pixel_values.append(tile)
+        imgs_sizes.extend(
+            [int(h), int(w)]
+            for h, w in torch.as_tensor(part["imgs_sizes"]).reshape(-1, 2).tolist()
+        )
+        input_ids.append(torch.as_tensor(part["input_ids"]).reshape(1, -1))
+    merged: dict[str, Any] = {
+        "input_ids": torch.cat(input_ids, dim=1),
+        "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
+        "num_tokens": list(expected_num_tokens),
+        "num_patches": [1] * len(images),
+    }
+    merged["pixel_values"] = (
+        pixel_values[0].unsqueeze(0) if len(pixel_values) == 1 else pixel_values
+    )
+    return merged

--- a/nemo_rl/environments/nemotron_utils.py
+++ b/nemo_rl/environments/nemotron_utils.py
@@ -374,21 +374,39 @@ def process_nemotron_video_frames(
 # and force the training-side processor to reproduce them exactly.
 
 
+def image_placeholder_token_ids_from_tokenizer(
+    tokenizer: Any,
+    *,
+    image_token: str = "<image>",
+    image_start_token: str = "<img>",
+    image_end_token: str = "</img>",
+) -> "tuple[int, int, int] | None":
+    """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
+    if tokenizer is not None and not hasattr(tokenizer, "convert_tokens_to_ids"):
+        # Callers sometimes hold a processor rather than a bare tokenizer.
+        tokenizer = getattr(tokenizer, "tokenizer", None)
+    if tokenizer is None or not hasattr(tokenizer, "convert_tokens_to_ids"):
+        return None
+    ids = tokenizer.convert_tokens_to_ids(
+        [image_token, image_start_token, image_end_token]
+    )
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
+        return None
+    return int(ids[0]), int(ids[1]), int(ids[2])
+
+
 def get_image_placeholder_token_ids(processor: Any) -> "tuple[int, int, int] | None":
     """(image_token_id, image_start_id, image_end_id), or None if unavailable."""
     tokenizer = getattr(processor, "tokenizer", None)
     if tokenizer is None or not uses_image_placeholder(processor):
         return None
-    tokens = [
-        getattr(processor, "image_token", "<image>"),
-        getattr(processor, "image_start_token", "<img>"),
-        getattr(processor, "image_end_token", "</img>"),
-    ]
-    ids = tokenizer.convert_tokens_to_ids(tokens)
-    unk_id = getattr(tokenizer, "unk_token_id", None)
-    if any(i is None or (unk_id is not None and i == unk_id) for i in ids):
-        return None
-    return int(ids[0]), int(ids[1]), int(ids[2])
+    return image_placeholder_token_ids_from_tokenizer(
+        tokenizer,
+        image_token=getattr(processor, "image_token", "<image>"),
+        image_start_token=getattr(processor, "image_start_token", "<img>"),
+        image_end_token=getattr(processor, "image_end_token", "</img>"),
+    )
 
 
 def supports_image_placeholder_run_parity(processor: Any) -> bool:
@@ -411,6 +429,14 @@ def count_image_placeholder_runs(
             f"{type(processor).__name__} does not expose image placeholder "
             "tokens; cannot count image placeholder runs."
         )
+    return placeholder_runs_from_token_ids(token_ids, placeholder_ids)
+
+
+def placeholder_runs_from_token_ids(
+    token_ids: "Sequence[int] | torch.Tensor",
+    placeholder_ids: "tuple[int, int, int]",
+) -> list[int]:
+    """Per-media placeholder run lengths from token ids, in order."""
     image_id, start_id, end_id = placeholder_ids
     if isinstance(token_ids, torch.Tensor):
         token_ids = token_ids.tolist()
@@ -436,6 +462,91 @@ def count_image_placeholder_runs(
     if current is not None:
         raise ValueError("Unterminated <img> region in rollout tokens.")
     return runs
+
+
+def _is_static_video_turn(message: dict[str, Any]) -> bool:
+    """Whether a source user turn carries a statically-preprocessed video.
+
+    Still-image turns also carry ``num_frames`` (one ``1`` per image, added by
+    the image attach path); a video turn is the one whose frame count exceeds 1.
+    """
+    num_frames = message.get("num_frames")
+    tensors = getattr(num_frames, "tensors", None)
+    if tensors is None:
+        return False
+    return any(
+        tensor is not None and bool((tensor > 1).any()) for tensor in tensors
+    )
+
+
+def verify_static_video_media_alignment(
+    source_message: dict[str, Any],
+    target_message: dict[str, Any],
+    tokenizer: Any,
+) -> None:
+    """Verify rollout tokens match the static video tensors before attach.
+
+    The static video datum expands its video to one ``<img><image>*k</img>``
+    run per tubelet, and its tensors project exactly ``sum(k)`` features. The
+    rollout engine performs its own expansion; if the two disagree, training
+    would crash deep in Megatron with an unattributable "media alignment
+    failed". Compare the run structures here and raise a diagnostic that names
+    the mismatch (tubelet count vs per-tubelet token count) instead.
+
+    A no-op for non-video turns or when placeholder ids cannot be resolved.
+    """
+    if not _is_static_video_turn(source_message):
+        return
+    placeholder_ids = image_placeholder_token_ids_from_tokenizer(tokenizer)
+    if placeholder_ids is None:
+        return
+    source_token_ids = source_message.get("token_ids")
+    target_token_ids = target_message.get("token_ids")
+    if source_token_ids is None or target_token_ids is None:
+        return
+    source_runs = placeholder_runs_from_token_ids(source_token_ids, placeholder_ids)
+    target_runs = placeholder_runs_from_token_ids(target_token_ids, placeholder_ids)
+    if source_runs == target_runs:
+        return
+    first_mismatch = next(
+        (
+            i
+            for i, (s, t) in enumerate(zip(source_runs, target_runs))
+            if s != t
+        ),
+        min(len(source_runs), len(target_runs)),
+    )
+    num_frames = source_message.get("num_frames")
+    frame_counts = [
+        tensor.tolist()
+        for tensor in getattr(num_frames, "tensors", [])
+        if tensor is not None
+    ]
+    imgs_sizes = source_message.get("imgs_sizes")
+    frame_sizes = [
+        tensor[0].tolist() if len(tensor) else None
+        for tensor in getattr(imgs_sizes, "tensors", [])
+        if tensor is not None
+    ]
+    raise ValueError(
+        "Rollout/video media alignment failed: the rollout's placeholder "
+        "expansion disagrees with the statically-preprocessed video tensors "
+        "about to be attached for training. "
+        f"static: {len(source_runs)} tubelet runs, "
+        f"{sum(source_runs)} placeholder tokens total, "
+        f"run lengths {sorted(set(source_runs))}; "
+        f"rollout: {len(target_runs)} tubelet runs, "
+        f"{sum(target_runs)} placeholder tokens total, "
+        f"run lengths {sorted(set(target_runs))}; "
+        f"first mismatching run index {first_mismatch} "
+        f"(static {source_runs[first_mismatch] if first_mismatch < len(source_runs) else 'absent'} "
+        f"vs rollout {target_runs[first_mismatch] if first_mismatch < len(target_runs) else 'absent'}); "
+        f"num_frames={frame_counts}, frame size (h, w)={frame_sizes}. "
+        "Equal run counts with different lengths mean vLLM resolved a "
+        "different per-frame token grid (target_num_patches / aspect-ratio "
+        "settings); different run counts mean a frame/tubelet sampling "
+        "mismatch. Refusing to train on misaligned media."
+    )
 
 
 def predicted_static_image_num_tokens(

--- a/nemo_rl/environments/nemotron_utils.py
+++ b/nemo_rl/environments/nemotron_utils.py
@@ -34,6 +34,7 @@ NEMOTRON_VIDEO_PROCESSOR_NAMES = frozenset(
     {
         "NemotronNanoVLV2Processor",
         "NemotronH_Nano_Omni_Reasoning_V3Processor",
+        "NemotronH_Omni_Reasoning_V3Processor",
     }
 )
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -786,9 +786,13 @@ class AsyncNemoGymRolloutImpl:
             rollout_inputs, timer, timer_prefix
         )
         source_message_log = input_sample["message_log"]
-        attach_static_multimodal_payload(prompt_message_log, source_message_log)
+        attach_static_multimodal_payload(
+            prompt_message_log, source_message_log, self._tokenizer
+        )
         for completion in completions:
-            attach_static_multimodal_payload(completion.message_log, source_message_log)
+            attach_static_multimodal_payload(
+                completion.message_log, source_message_log, self._tokenizer
+            )
 
         timer.stop(f"{timer_prefix}/total")
         rollout_metrics.update(timer.get_timing_metrics("sum"))

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -233,8 +233,14 @@ def attach_static_multimodal_payload(
         )
     for source, target in zip(source_users, target_users):
         for key, value in source.items():
-            if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS:
-                target[key] = value
+            if not (isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS):
+                continue
+            if key in target:
+                # The Gym actor attached rollout-matched media for this turn
+                # (e.g. after vetoing dedup omission on a budget-bound row);
+                # never overwrite it with the statically-budgeted prompt copy.
+                continue
+            target[key] = value
 
 
 def _add_r3_fallback_metrics(

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -43,6 +43,7 @@ from nemo_rl.data.llm_message_utils import (
     get_keys_from_message_log,
 )
 from nemo_rl.data.multimodal_utils import (
+    ROLLOUT_MATCHED_MEDIA_KEY,
     NATIVE_MULTIMODAL_KEYS,
     VLLM_MULTIMODAL_DATA_KEYS,
     PackedTensor,
@@ -232,15 +233,16 @@ def attach_static_multimodal_payload(
             "turns than the source prompt."
         )
     for source, target in zip(source_users, target_users):
+        if target.pop(ROLLOUT_MATCHED_MEDIA_KEY, False):
+            # The Gym actor attached rollout-matched media for this turn (e.g.
+            # after vetoing dedup omission on a budget-bound row); never
+            # overwrite it with the statically-budgeted prompt copy. Key
+            # presence alone is not provenance: targets may carry placeholder
+            # or stale payloads that this copy is expected to replace.
+            continue
         for key, value in source.items():
-            if not (isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS):
-                continue
-            if key in target:
-                # The Gym actor attached rollout-matched media for this turn
-                # (e.g. after vetoing dedup omission on a budget-bound row);
-                # never overwrite it with the statically-budgeted prompt copy.
-                continue
-            target[key] = value
+            if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS:
+                target[key] = value
 
 
 def _add_r3_fallback_metrics(

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -51,6 +51,9 @@ from nemo_rl.data.multimodal_utils import (
     extract_input_images_from_responses_messages,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.nemotron_utils import (
+    verify_static_video_media_alignment,
+)
 from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
@@ -207,20 +210,28 @@ def _reattach_original_multimodal_payloads(
 def _reattach_static_multimodal_payloads_to_result(
     result: dict[str, Any],
     source_message_log: list[dict[str, Any]],
+    tokenizer: Any = None,
 ) -> None:
     """Restore static media to each Gym-authored message-log representation."""
     for log_key in ("input_message_log", "message_log"):
         target_log = result.get(log_key)
         if not target_log:
             continue
-        attach_static_multimodal_payload(target_log, source_message_log)
+        attach_static_multimodal_payload(target_log, source_message_log, tokenizer)
 
 
 def attach_static_multimodal_payload(
     target_message_log: list[dict[str, Any]],
     source_message_log: list[dict[str, Any]],
+    tokenizer: Any = None,
 ) -> None:
-    """Copy policy-ready media from static source turns to Gym-authored turns."""
+    """Copy policy-ready media from static source turns to Gym-authored turns.
+
+    When ``tokenizer`` is provided, video turns are verified before the copy:
+    the rollout's placeholder expansion must match the static tensors, or the
+    attach raises a diagnostic naming the mismatch instead of letting training
+    crash on unattributable media misalignment.
+    """
     source_users = [
         message for message in source_message_log if message.get("role") == "user"
     ]
@@ -240,6 +251,8 @@ def attach_static_multimodal_payload(
             # presence alone is not provenance: targets may carry placeholder
             # or stale payloads that this copy is expected to replace.
             continue
+        if tokenizer is not None:
+            verify_static_video_media_alignment(source, target, tokenizer)
         for key, value in source.items():
             if isinstance(value, PackedTensor) or key in NATIVE_MULTIMODAL_KEYS:
                 target[key] = value
@@ -2469,7 +2482,7 @@ async def run_async_nemo_gym_rollout(
                 completed_group = accumulator.add(rowidx, result)
                 if original_message_logs is not None:
                     _reattach_static_multimodal_payloads_to_result(
-                        result, original_message_logs[rowidx]
+                        result, original_message_logs[rowidx], tokenizer
                     )
                     result.pop("_initial_multimodal_data_omitted", None)
                 if completed_group is not None:

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -188,7 +188,14 @@ class VllmConfig(GenerationConfig):
 
 def resolve_vllm_video_config(config: VllmConfig) -> VllmVideoConfig | None:
     """Validate and return the optional vLLM video sampling contract."""
-    raw_video_config = config["vllm_cfg"].get("video")
+    vllm_config = cast(dict[str, Any], config["vllm_cfg"])
+    if "video_loader" in vllm_config:
+        raise ValueError(
+            "policy.generation.vllm_cfg.video_loader is not supported; "
+            "use policy.generation.vllm_cfg.video"
+        )
+
+    raw_video_config = vllm_config.get("video")
     if raw_video_config is None:
         return None
     return VllmVideoConfig.model_validate(raw_video_config)

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -213,6 +213,48 @@ def test_attach_image_model_inputs_is_a_noop_without_images_or_processor():
     assert set(message) == {"role", "content", "token_ids"}
 
 
+def test_reattach_preserves_rollout_matched_media_marker():
+    """Media the Gym actor attached rollout-matched must not be overwritten.
+
+    Provenance is the explicit marker, not key presence: an unmarked
+    placeholder value is still replaced (see the neighboring test), while a
+    marked turn keeps its actor-attached tensors and the marker is consumed.
+    """
+    from nemo_rl.data.multimodal_utils import ROLLOUT_MATCHED_MEDIA_KEY
+
+    static_image = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
+    rollout_matched = PackedTensor(torch.tensor([[9.0]]), dim_to_pack=0)
+    original_logs = [
+        [
+            {"role": "user", "content": "first", "pixel_values": static_image},
+        ]
+    ]
+    results = [
+        {
+            "_initial_multimodal_data_omitted": True,
+            "input_message_log": [
+                {"role": "user", "content": "first"},
+            ],
+            "message_log": [
+                {
+                    "role": "user",
+                    "content": "first",
+                    "pixel_values": rollout_matched,
+                    ROLLOUT_MATCHED_MEDIA_KEY: True,
+                },
+            ],
+        }
+    ]
+
+    _reattach_original_multimodal_payloads(results, original_logs)
+
+    marked_user = results[0]["message_log"][0]
+    assert marked_user["pixel_values"] is rollout_matched
+    assert ROLLOUT_MATCHED_MEDIA_KEY not in marked_user
+    # The unmarked representation is still restored from the static source.
+    assert results[0]["input_message_log"][0]["pixel_values"] is static_image
+
+
 def test_reattach_original_multimodal_payloads_is_media_only_and_turn_aligned():
     first_image = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
     second_image = PackedTensor(torch.tensor([[2.0]]), dim_to_pack=0)


### PR DESCRIPTION
# What does this PR do ?
  
  Adds mixed image+video NeMo-Gym manifest support and a video media alignment verification that turns an unattributable Megatron crash into a named diagnostic.
  
  > **Depends on #3940** — stacked on `fix/vlm-image-tiling-rollout-parity` and reuses the placeholder-run helpers it introduces in `nemo_rl/environments/nemotron_utils.py`. Please review/merge #3940 first; only the last 3 commits here are new.
  
  # Issues
  
  1. A single Gym manifest mixing static-video rows (e.g. CapRL) with still-image rows (e.g. SA-V tracking) previously broke: video rows now early-return through the video datum path while image rows keep the standard path (plus dtype fix for empty token tensors, per-row `image_max_num_tiles`, fixed-tile processor predicate, fail-fast for the legacy `vllm_cfg.video_loader` key, processor/tokenizer chat-template sync).
  2. `NEMOTRON_VIDEO_PROCESSOR_NAMES` was missing `NemotronH_Omni_Reasoning_V3Processor` (#3989 covered only the placeholder-style list), so Super Omni video rows fell through to generic preprocessing.
  3. When vLLM's video placeholder expansion disagrees with the statically-preprocessed tensors (different per-frame grid or tubelet count), training crashed deep in Megatron with "Expanded-sequence media alignment failed". The new verification compares placeholder-run structure at static-media attach and raises a diagnostic naming the mismatch (run counts,  per-run lengths, first divergent run, frame counts/sizes).
  
  # Usage 
  
  ```yaml
  # vLLM resolves the square isqrt grid for video frames regardless of
  # video_maintain_aspect_ratio; recipes must match on the static side:
  data:
    default:
      video_target_num_patches: 1024
      video_maintain_aspect_ratio: false
  ```
      
  # Before your PR is "Ready for review"
  **Pre checks**:
  - [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
  - [x] Did you write any new necessary tests?
  - [x] Did you run the unit tests and functional tests locally?
  - [ ] Did you add or update any necessary documentation?
  
  # Additional Information
  
  Validated in 32-node async GRPO on a combined SA-V tracking + CapRL video blend (Nemotron Super Omni, 64-frame videos): the verification caught an aspect-ratio grid mismatch on the first batch, and with matched config the runs train 20+ steps with healthy rewards.
