### PR TITLE
feat: length-aware rollout scheduling for cross-DP generation

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.33.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     if: ${{ vars.BUILD_TEST_PUBLISH_WHEEL == 'true' }}
     with:
       dry-run: true

--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -131,7 +131,7 @@
         "filename": "docs/testing.md",
         "hashed_secret": "3f3b8ce7c4fec509b2b74ee3e1d98170278ffe4b",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 113
       }
     ],
     "tests/unit/test_version_check.py": [
@@ -144,5 +144,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T15:55:12Z"
+  "generated_at": "2026-04-02T18:53:27Z"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ code_snapshots*/
 
 # Claude Code review memory (local only)
 .claude/review-memory/
+
+# pytest-testmon local state
+.testmondata*

--- a/3rdparty/Megatron-Bridge-workspace/setup.py
+++ b/3rdparty/Megatron-Bridge-workspace/setup.py
@@ -56,7 +56,7 @@ CACHED_DEPENDENCIES = [
     "flash-linear-attention",
     "timm",
     "open-clip-torch>=3.2.0",
-    "mlflow>=3.5.0",
+    "mlflow>=3.9.0",
     "comet-ml>=3.50.0",
     "torch>=2.6.0",
 ]

--- a/3rdparty/Megatron-LM-workspace/setup.py
+++ b/3rdparty/Megatron-LM-workspace/setup.py
@@ -51,7 +51,7 @@ CACHED_DEPENDENCIES = [
     # TODO(https://github.com/NVIDIA-NeMo/RL/issues/2111): upgrade to core_cu13 when we move to CUDA 13 base container
     "transformer-engine[pytorch,core_cu12]",
     # VCS dependency - must match pyproject.toml [tool.uv.sources]
-    "nvidia-resiliency-ext @ git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@63154570cea17f8805a7fd15cc3b8cc2919ba575",
+    "nvidia-resiliency-ext @ git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@15a851565a4ce846c04431ecb0cf09903ab4837e",
     "tqdm",
     "einops~=0.8",
     "tensorstore~=0.1,!=0.1.46,!=0.1.72",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,10 @@
 #     docker buildx build -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
 #
 #   Self-contained build (specific git ref):
-#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push .
 #
 #   Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
-#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push https://github.com/NVIDIA-NeMo/RL.git
 #
 #   Local NeMo RL source override:
 #     docker buildx build --build-context nemo-rl=. -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .

--- a/docker/Dockerfile.ngc_pytorch
+++ b/docker/Dockerfile.ngc_pytorch
@@ -3,8 +3,8 @@
 #
 # Usage:
 # Self-contained build (default: builds from main): docker buildx build -f docker/Dockerfile.ngc_pytorch --tag <registry>/nemo-rl:latest --push .
-# Self-contained build (specific git ref): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
-# Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+# Self-contained build (specific git ref): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push .
+# Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push https://github.com/NVIDIA-NeMo/RL.git
 # Local NeMo RL source override: docker buildx build --build-context nemo-rl=. -f docker/Dockerfile.ngc_pytorch --tag <registry>/nemo-rl:latest --push .
 #
 # If installing new dependencies in the container, then use "uv pip install new-dependency"

--- a/docs/about/algorithms/index.md
+++ b/docs/about/algorithms/index.md
@@ -7,12 +7,12 @@ NeMo RL supports multiple training algorithms for post-training large language m
 | Algorithms | Single Node | Multi-node |
 |------------|-------------|------------|
 | [GRPO](grpo.md) | [GRPO Single Node](grpo.md#grpo-single-node) | [GRPO Multi-node](grpo.md#grpo-multi-node): [GRPO Qwen2.5-32B](grpo.md#grpo-qwen25-32b), [GRPO Multi-Turn](grpo.md#grpo-multi-turn) |
-|DAPO (dapo.md)| similar to GRPO example| similar to GRPO example|
 | [DAPO](dapo.md) | [DAPO Single Node](dapo.md#dapo-single-node) | [DAPO Multi-node](dapo.md#dapo-multi-node) |
 | [On-policy Distillation](on-policy-distillation.md) | [Distillation Single Node](on-policy-distillation.md#on-policy-distillation-single-node) | [Distillation Multi-node](on-policy-distillation.md#on-policy-distillation-multi-node) |
 | [Supervised Fine-Tuning (SFT)](sft.md) | [SFT Single Node](sft.md#sft-single-node) | [SFT Multi-node](sft.md#sft-multi-node) |
 | [DPO](dpo.md) | [DPO Single Node](dpo.md#dpo-single-node) | [DPO Multi-node](dpo.md#dpo-multi-node) |
 | [RM](rm.md) | [RM Single Node](rm.md#rm-single-node) | [RM Multi-node](rm.md#rm-multi-node) |
+
 On-policy distillation is also supported in the PyTorch DTensor path.
 ```{toctree}
 :maxdepth: 2

--- a/docs/about/model-support.md
+++ b/docs/about/model-support.md
@@ -2,7 +2,7 @@
 
 ## Broad coverage for 🤗Hugging Face models via [NeMo AutoModel](https://github.com/NVIDIA-NeMo/Automodel)
 
-NeMo-RL support 🤗Hugging Face models from the following classes
+NeMo-RL supports 🤗Hugging Face models from the following classes
 - LLMs ([AutoModelForCausalLM](https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForCausalLM))
 - VLMs ([AutoModelForImageTextToText](https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForImageTextToText))
 

--- a/docs/about/performance-summary.md
+++ b/docs/about/performance-summary.md
@@ -3,7 +3,7 @@
 
 As part of the NVIDIA NeMo Framework, NeMo RL, provides optimal performance for reinforcement learning on generative AI models by incorporating the latest optimizations - such as refit optimizations, mixed-precision training, and off-policy training.
 
-This page provides performance benchmarks for LLMs and VLMs using NeMo RL across different GPU systems and configurations. The recipes to reproduce these runs, in yaml file form, can be found under [this folder](https://github.com/NVIDIA-NeMo/RL/tree/r0.5.0/examples/configs/recipes/llm/performance).
+This page provides performance benchmarks for LLMs and VLMs using NeMo RL across different GPU systems and configurations. The recipes to reproduce these runs, in yaml file form, can be found under [this folder](https://github.com/NVIDIA-NeMo/RL/tree/r0.6.0/examples/configs/recipes/llm/performance).
 
 ## Nomenclature
 

--- a/docs/about/performance-summary.md
+++ b/docs/about/performance-summary.md
@@ -1,7 +1,7 @@
 
 # Performance
 
-As part of the NVIDIA NeMo Framework, NeMo RL, provides optimal performance for reinforcement learning on generative AI models by incorporating the latest optimizations - such as refit optimizations, mixed-precision training, and off-policy training.
+As part of the NVIDIA NeMo Framework, NeMo RL provides optimal performance for reinforcement learning on generative AI models by incorporating the latest optimizations - such as refit optimizations, mixed-precision training, and off-policy training.
 
 This page provides performance benchmarks for LLMs and VLMs using NeMo RL across different GPU systems and configurations. The recipes to reproduce these runs, in yaml file form, can be found under [this folder](https://github.com/NVIDIA-NeMo/RL/tree/r0.6.0/examples/configs/recipes/llm/performance).
 
@@ -16,13 +16,13 @@ This page provides performance benchmarks for LLMs and VLMs using NeMo RL across
 - **EP**: Expert Parallel Size
 - **T-**: Training related
 - **G-**: Generation related
-- **Training backend**: NeMo RL have two training backends: Megatron and PyTorch DTensor. This performance summary currently only shows number from Megatron backend.
+- **Training backend**: NeMo RL has two training backends: Megatron and PyTorch DTensor. This performance summary currently only shows numbers from the Megatron backend.
 
 ## Performance Metrics
 
 Since reinforcement learning consists of training, generation and transition between the two, performance measurement also reflects this. Specifically, we track the following metrics:
 - **Step time**: Time for each step, which includes training, generation, policy logprobs, and refit time.
-- **Tokens/sec/GPU**: The rate at the tokens are processed by a stage (such as training, generation, or refitting) on a single GPU:
+- **Tokens/sec/GPU**: The rate at which the tokens are processed by a stage (such as training, generation, or refitting) on a single GPU:
 
     $$
     \text{Tokens/sec/GPU} = \frac{\text{Total Tokens Processed}}{\text{Time for Stage} \times \text{Number of GPUs}}
@@ -98,4 +98,4 @@ The performance data includes:
 Note:
 
 * All Mixture-of-expert (MoE) model training uses token drop-less. 
-* The following metrics are extracted from the average of 5 steps: G-Average Seq len, Tokens/sec/gpu, Total Step time(s). Because of the averaging, the numbers in table does not completely match the equation stated in Performance Metrics above but the difference is small.
+* The following metrics are extracted from the average of 5 steps: G-Average Seq len, Tokens/sec/gpu, Total Step time(s). Because of the averaging, the numbers in the table do not completely match the equation stated in Performance Metrics above but the difference is small.

--- a/docs/about/performance-summary.md
+++ b/docs/about/performance-summary.md
@@ -43,27 +43,25 @@ The performance data includes:
 
 ---
 
-## Nemo RL v0.5
+## Nemo RL v0.6
 
 ### H100 BF16 Benchmarks
-* GRPO Dataset: [OpenMathInstruct-2](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2); DAPO dataset: [DAPOMath17k](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17k)
+* GRPO Dataset: [OpenMathInstruct-2](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2); DAPO dataset: [DAPOMath17k](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17k); SWE dataset: refer to [Nemotron super-v3 documentation - stage 2.2](https://github.com/NVIDIA-NeMo/RL/blob/super-v3/docs/guides/nemotron-3-super.md#stage-22---swe-2-64-nodes)
 * System: DGX-H100
 * Precision: Training BF16, Generation BF16
 * Training Backend: Megatron-core.
 
 | Algorithm | Model     |On/Off policy|T-Max Sequence Length|G-Average Seq len|#-GPUs|G-GBS|T-GBS|Generation [TP,PP]|Training [TP,CP,EP,PP,VPP]|Tokens / sec / GPU|Total Step time(s)|
 |---------  |-------    |--------     |-----                |-----            |------|---- |---- |----              |----                      |---               |---|
-| GRPO      |LLAMA3.1_8B|On policy    |4,096                |1,019            |16    |2,048|512  |[1,1]             |[1,1,1,1,1,2,n/a]         |1,581             | 92.8|
-| GRPO      |LLAMA3.1_8B|1-step Off   |4,096                |1,123            |16    |2,048|512  |[1,1]             |[1,1,1,1,1,1,n/a]         |2,478             | 64.8|
-| GRPO      |DeepSeek V3|On policy    |1,536                |744              |256   |512  |512  |[32,1]            |[1,1,16,16,n/a]           |12.7              | 134|
-| GRPO      |DeepSeek V3|1-step Off   |1,536                |738              |512   |512  |512  |[32,1]            |[1,1,16,16,n/a]           |13.1              | 64.9|
-| DAPO      |DeepSeek V3|On policy    |1,536                |974              |512   |512  |512  |[64,1]            |[8,4,32,8,n/a]            |2.45              | 458|
-| GRPO      |Qwen3-235B |On policy    |8,192                |5,700            |128   |512  |512  |[16,1]            |[2,2,16,8,n/a]            |54.1              | 431|
-| GRPO      |Qwen3-235B |1-step Off   |8,192                |5,707            |256   |512  |512  |[8,1]             |[4,1,16,8,n/a]            |58.7              | 203|
-| GRPO      |Qwen3-30B3A|On policy    |4,096                |3,196            |32    |2,048|512  |[2,1]             |[1,1,8,1,n/a]             |1066               | 198|
-| GRPO      |Qwen3-30B3A|1-step Off   |4,096                |3,201            |32    |2,048|512  |[2,1]             |[1,1,8,2,n/a]             |1391               | 154|
-| GRPO      |Qwen3-32B  |On policy    |4,096                |3,251            |32    |2,048|512  |[4,1]             |[4,1,1,4,n/a]             |571               | 376|
-| GRPO      |Qwen3-32B  |1-step Off   |4,096                |3,252            |64    |2,048|512  |[4,1]             |[4,1,1,4,n/a]             |538               | 200|
+| GRPO      |DeepSeek V3|On policy    |1,536                |701              |256   |512  |512  |[32,1]            |[1,1,16,16,n/a]           |12.1              | 134|
+| GRPO      |DeepSeek V3|On policy    |1,536                |697              |512   |512  |512  |[32,1]            |[1,1,16,16,n/a]           |7.24              | 111|
+| GRPO      |DeepSeek V3|1-step Off   |1,536                |710              |512   |512  |512  |[32,1]            |[1,1,16,16,n/a]           |12.8              | 64.1|
+| GRPO      |Qwen3-235B |On policy    |8,192                |5,698            |128   |512  |512  |[16,1]            |[2,2,16,8,n/a]            |58.9              | 395|
+| GRPO      |Qwen3-235B |On policy    |8,192                |5,713            |256   |512  |512  |[16,1]            |[2,2,16,8,n/a]            |37.4              | 312|
+| GRPO      |Qwen3-235B |1-step Off   |8,192                |5,721            |256   |512  |512  |[8,1]             |[4,1,16,8,n/a]            |58.7              | 231|
+| GRPO      |Qwen3-30B3A|On policy    |4,096                |3,203            |32    |2,048|512  |[2,1]             |[1,1,8,1,n/a]             |1102               | 192|
+| GRPO      |Qwen3-30B3A|1-step Off   |4,096                |3,201            |32    |2,048|512  |[2,1]             |[1,1,8,2,n/a]             |1414               | 152|
+| GRPO      |Qwen3-30B3A|8-step Off   |4,096                |3,206            |192   |2,048|512  |[2,1]             |[1,1,8,1,n/a]             |1025               | 34.5|
 
 ### H100 FP8 Benchmarks
 * GRPO Dataset: [OpenMathInstruct-2](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2)
@@ -73,8 +71,7 @@ The performance data includes:
 
 | Algorithm | Model     |On/Off policy|T-Max Sequence Length|G-Average Seq len|#-GPUs|G-GBS|T-GBS|Generation [TP,PP]|Training [TP,CP,EP,PP,VPP]|Tokens / sec / GPU|Total Step time(s)|
 |---------  |-------    |--------     |-----                |-----            |------|---- |---- |----              |----                      |---               |---|
-| GRPO      |LLAMA3.1_8B|1-step Off   |4,096                |1,128            |16    |2,048|512  |[1,1]             |[1,1,1,1,1,1,n/a]         |3,052             | 53.0|
-| GRPO      |DeepSeek V3|1-step Off   |1,536                |761              |512   |512  |512  |[16,1]            |[1,1,16,16,n/a]           |14.1              | 67.6|
+| GRPO      |DeepSeek V3|1-step Off   |1,536                |721              |512   |512  |512  |[16,1]            |[1,1,16,16,n/a]           |14.1              | 59.2|
 
 ### GB200 BF16 Benchmarks
 * GRPO Dataset: [OpenMathInstruct-2](https://huggingface.co/datasets/nvidia/OpenMathInstruct-2)
@@ -84,18 +81,18 @@ The performance data includes:
 
 | Algorithm | Model     |On/Off policy|T-Max Sequence Length|G-Average Seq len|#-GPUs|G-GBS|T-GBS|Generation [TP,PP]|Training [TP,CP,EP,PP,VPP]|Tokens / sec / GPU|Total Step time(s)|
 |---------  |-------    |--------     |-----                |-----            |------|---- |---- |----              |----                      |---               |---|
-| GRPO      |LLAMA3.1_8B|On policy    |4,096                |1,066            |8     |2,048|512  |[1,1]             |[1,1,1,1,1,1,n/a]         |3,359             | 91.0|
-| GRPO      |LLAMA3.1_8B|1-step Off   |4,096                |1,107            |8     |2,048|512  |[1,1]             |[1,1,1,1,1,1,n/a]         |4,463             | 71.1|
-| GRPO      |DeepSeek V3|On policy    |1,536                |996              |128   |512  |512  |[32,1]            |[1,1,16,8,n/a]            |34.3              | 128|
-| GRPO      |DeepSeek V3|1-step Off   |1,536                |994              |256   |512  |512  |[16,1]            |[1,1,16,8,n/a]            |31.7              | 64.5|
-| GRPO      |Qwen3-235B |On policy    |8,192                |5,711            |64    |512  |512  |[8,1]            |[2,2,16,4,n/a]            |140              | 332|
-| GRPO      |Qwen3-235B |1-step Off   |8,192                |5,711            |128   |512  |512  |[8,1]             |[4,1,16,4,n/a]            |87.9              | 268|
-| GRPO      |Qwen3-30B3A|On policy    |4,096                |3,198            |16    |2,048|512  |[1,1]             |[1,1,16,1,n/a]             |1,822               | 232|
-| GRPO      |Qwen3-30B3A|1-step Off   |4,096                |3,204            |32    |2,048|512  |[1,1]             |[1,1,16,1,n/a]             |1,558               | 136|
-| GRPO      |Qwen3-32B  |On policy    |4,096                |3,253            |16    |2,048|512  |[1,1]             |[2,1,1,1,n/a]             |1,127              | 381|
-| GRPO      |Qwen3-32B  |1-step Off   |4,096                |3,258            |32    |2,048|512  |[1,1]             |[2,1,1,1,n/a]             |1,025               | 210|
+| GRPO      |DeepSeek V3|On policy    |1,536                |711              |128   |512  |512  |[32,1]            |[1,1,16,8,n/a]            |30.2              | 108|
+| GRPO      |DeepSeek V3|On policy    |1,536                |700              |256   |512  |512  |[32,1]            |[1,1,16,8,n/a]            |16.4              | 98.7|
+| GRPO      |DeepSeek V3|1-step Off   |1,536                |708              |256   |512  |512  |[16,1]            |[1,1,16,8,n/a]            |26.7              | 61.7|
+| GRPO      |Qwen3-235B |On policy    |8,192                |5,709            |64    |512  |512  |[8,1]            |[2,2,16,4,n/a]            |163              | 286|
+| GRPO      |Qwen3-235B |On policy    |8,192                |5,693            |128   |512  |512  |[8,1]            |[2,2,16,4,n/a]            |67.4              | 345|
+| GRPO      |Qwen3-235B |1-step Off   |8,192                |5,705            |128   |512  |512  |[8,1]             |[4,1,16,4,n/a]            |85.5              | 278|
+| GRPO      |Qwen3-30B3A|On policy    |4,096                |3,199            |16    |2,048|512  |[1,1]             |[1,1,16,1,n/a]             |1,910               | 221|
+| GRPO      |Qwen3-30B3A|1-step Off   |4,096                |3,197            |16    |2,048|512  |[1,1]             |[1,1,16,1,n/a]             |1,406               | 301|
+| SWE       |Nemotron-3-Nano-30B-A3B|1-step Off   |131,072  |31,599           |128   |512  |512  |[8,1]             |[8,8,8,1,n/a]             |37.5               | 430|
 
 Note:
 
 * All Mixture-of-expert (MoE) model training uses token drop-less. 
 * The following metrics are extracted from the average of 5 steps: G-Average Seq len, Tokens/sec/gpu, Total Step time(s). Because of the averaging, the numbers in the table do not completely match the equation stated in Performance Metrics above but the difference is small.
+* There was a change in pretrained checkpoint (see [docs/guides/deepseek.md](https://github.com/NVIDIA-NeMo/RL/blob/r0.6.0/docs/guides/deepseek.md)) for DeepSeek V3 leading to lower Average Seq len. The reported throughput is not comparable across versions. Please use equivalent checkpoints for comparison. For example, using the newer checkpoint `DeepSeek V3 on-policy GRPO #-GPUs: 128` v0.5.0 performs at `26.1 Tokens / sec / GPU` compared to v0.6.0 at `30.2 Tokens / sec / GPU`.

--- a/docs/broken_links_false_positives.json
+++ b/docs/broken_links_false_positives.json
@@ -1,2 +1,4 @@
 {"uri": "https://docs.nvidia.com/nsight-systems/UserGuide/index.html#viewing-multiple-reports-in-the-same-timeline"}
 {"uri": "https://platform.openai.com/docs/guides/function-calling"}
+{"uri": "https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForCausalLM"}
+{"uri": "https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForImageTextToText"}

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -33,7 +33,7 @@ The first node is always the head node, so we need to port forward the dashboard
 #   on the login node is likely taken by someone else.
 ssh -L $LOCAL_PORT:localhost:$DASHBOARD_PORT -N node-12
 
-# Example chosing a port other than 8265 for the LOCAL_PORT
+# Example choosing a port other than 8265 for the LOCAL_PORT
 ssh -L 52640:localhost:8265 -N node-12
 ```
 

--- a/docs/design-docs/training-backends.md
+++ b/docs/design-docs/training-backends.md
@@ -35,12 +35,8 @@ _Note_: When using Megatron, the optimizer and learning rate schedule are config
 ### DTensor Backend
 To enable DTensor (FSDP2) training:
 
-1. Set `policy.dtensor_config.enabled=True`.
+1. Set `policy.dtensor_cfg.enabled=True`.
 2. Refer to [examples/configs/grpo_math_1B.yaml](../../examples/configs/grpo_math_1B.yaml) for a configuration example.
-
-## Backend Priority
-
-**Megatron takes precedence over DTensor.** If both backends are enabled simultaneously (`policy.megatron_cfg.enabled=True` and `policy.dtensor_config.enabled=True`), the Megatron backend will be used.
 
 ## Configuration Examples
 
@@ -72,7 +68,7 @@ export HF_HOME="/shared/nfs/huggingface"
 
 ### Best Practices ###
 
-- **Mount in checkpoint directory**: If you are using Docker, make sure the Megatron checkpoint path is covered by `-v`/`--mount`. Similarly, if you are using SLURM+pyxis, ensure `--container-mounts` includes this path.
+- **Mount the checkpoint directory**: If you are using Docker, make sure the Megatron checkpoint path is covered by `-v`/`--mount`. Similarly, if you are using SLURM+pyxis, ensure `--container-mounts` includes this path.
 - **Use shared storage**: Ensure the checkpoint directory is accessible from all nodes (e.g., NFS, shared filesystem).
 - **Prefer HF_HOME**: If you already have `HF_HOME` mounted across nodes, this reduces the number of environment variables to manage.
 - **Sufficient space**: Ensure adequate disk space for the converted model checkpoints.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,14 +14,14 @@ docker buildx build -f docker/Dockerfile \
 
 # Self-contained build (specific git ref):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.3.0 \
-    --tag <registry>/nemo-rl:r0.3.0 \
+    --build-arg NRL_GIT_REF=r0.6.0 \
+    --tag <registry>/nemo-rl:r0.6.0 \
     --push .
 
 # Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.3.0 \
-    --tag <registry>/nemo-rl:r0.3.0 \
+    --build-arg NRL_GIT_REF=r0.6.0 \
+    --tag <registry>/nemo-rl:r0.6.0 \
     --push https://github.com/NVIDIA-NeMo/RL.git
 
 # Local NeMo RL source override:

--- a/docs/fp8.md
+++ b/docs/fp8.md
@@ -93,4 +93,4 @@ The above results are from Llama-3.1-8B-Instruct GRPO experiments. You can run t
 * For FP8: `examples/configs/grpo_math_8B_megatron_fp8.yaml`
 
 In the experiment in this figure, enabling FP8 rollout and training gives 15%-25% decrease in step time, and the validation accuracy curves match up to 1000 steps.
-Efforts are ongoing to performs longer runs and further optimize performance.
+Efforts are ongoing to perform longer runs and further optimize performance.

--- a/docs/guides/ft-launcher-guide.md
+++ b/docs/guides/ft-launcher-guide.md
@@ -1,6 +1,6 @@
 # Fault Tolerance Launcher Guide
 
-The `ft_launcher` is provided by `nvidia-resiliency-ext` (included in NeMo RL dependencies) and enables automatic fault tolerance and recovery for distributed training runs.
+The `ft_launcher` is provided by `nvidia-resiliency-ext` (available via the `nvrx` optional extra, e.g. `uv run --extra nvrx ft_launcher ...`) and enables automatic fault tolerance and recovery for distributed training runs.
 
 ## Key Arguments
 
@@ -14,7 +14,7 @@ The `ft_launcher` is provided by `nvidia-resiliency-ext` (included in NeMo RL de
 ## Basic Usage
 
 ```bash
-uv run ft_launcher \
+uv run --extra nvrx ft_launcher \
     --ft-cfg-path examples/ft_launcher/ft_config.yaml \
     --ft-rank-heartbeat-timeout 450 \
     --ft-initial-rank-heartbeat-timeout 1200 \

--- a/docs/guides/muon-optimizer.md
+++ b/docs/guides/muon-optimizer.md
@@ -11,7 +11,7 @@ This guide explains how to use the Muon optimizer with NeMo RL for training larg
 Muon is only supported with the **Megatron backend**. Ensure you have:
 
 1. Megatron submodules initialized: `git submodule update --init --recursive`
-2. Megatron backend enabled in your configuration: `policy.megatron_cfg.enabled=True`
+2. Megatron backend enabled in your configuration: `policy.megatron_cfg.enabled=true`
 
 ## Basic Usage
 
@@ -24,15 +24,16 @@ uv run examples/run_sft.py \
     ++policy.megatron_cfg.optimizer.optimizer=dist_muon \
     ++policy.megatron_cfg.optimizer.muon_scale_mode=spectral \
     ++policy.megatron_cfg.optimizer.muon_momentum=0.9 \
-    ++policy.megatron_cfg.optimizer.muon_use_nesterov=False \
+    ++policy.megatron_cfg.optimizer.muon_nesterov=false \
     ++policy.megatron_cfg.optimizer.muon_extra_scale_factor=0.5 \
     policy.megatron_cfg.optimizer.use_precision_aware_optimizer=false \
-    policy.megatron_cfg.optimizer.use_distributed_optimizer=false
+    policy.megatron_cfg.optimizer.use_distributed_optimizer=false \
+    policy.megatron_cfg.distributed_data_parallel_config.overlap_param_gather=false \
 ```
 
-For a full list of Muon-related arguments and a description of each, please refer to the [Megatron documentation](https://github.com/terrykong/Megatron-LM/blob/25a62edf77b5130f888328ca8119d6a76117cf23/megatron/core/optimizer/optimizer_config.py#L128-L150). 
+For a full list of Muon-related arguments and a description of each, please refer to the [Megatron documentation](https://github.com/NVIDIA/Megatron-LM/blob/7928a84e86a79a783d70968660e067d2ab492f23/megatron/core/optimizer/optimizer_config.py#L259-L290). 
 
-_NOTE_: precision_aware_optimizer and distributed_optimizer are not supported with Muon and should be disabled.
+_NOTE_: precision_aware_optimizer, distributed_optimizer and overlap_param_gather are not supported with Muon and should be disabled.
 
 ## Example YAML Configuration
 
@@ -53,7 +54,7 @@ policy:
       
       # Muon-specific settings
       muon_momentum: 0.95
-      muon_use_nesterov: false
+      muon_nesterov: false
       muon_scale_mode: "spectral"
       muon_fp32_matmul_prec: "medium"
       muon_num_ns_steps: 5
@@ -74,6 +75,9 @@ policy:
       weight_decay_incr_style: "constant"
       start_weight_decay: 0.1
       end_weight_decay: 0.1
+    
+    distributed_data_parallel_config:
+      overlap_param_gather: false
 ```
 
 ## Experimental Results
@@ -96,28 +100,28 @@ uv run examples/run_sft.py \
   ++policy.megatron_cfg.optimizer.optimizer=dist_muon \
   ++policy.megatron_cfg.optimizer.muon_scale_mode=spectral \
   ++policy.megatron_cfg.optimizer.muon_momentum=0.9 \
-  ++policy.megatron_cfg.optimizer.muon_use_nesterov=False \
+  ++policy.megatron_cfg.optimizer.muon_nesterov=false \
   ++policy.megatron_cfg.optimizer.muon_extra_scale_factor=0.2 \
   policy.megatron_cfg.optimizer.use_precision_aware_optimizer=false \
   ++policy.megatron_cfg.optimizer.lr=2e-5 \
-  policy.megatron_cfg.optimizer.use_distributed_optimizer=False \
-  cluster.num_nodes=4 \
+  policy.megatron_cfg.optimizer.use_distributed_optimizer=false \
+  policy.megatron_cfg.distributed_data_parallel_config.overlap_param_gather=false \
+  cluster.num_nodes=16 \
   cluster.gpus_per_node=8 \
   policy.megatron_cfg.pipeline_model_parallel_size=8 \
-  policy.megatron_cfg.sequence_parallel=True \
+  policy.megatron_cfg.sequence_parallel=true \
   policy.megatron_cfg.expert_model_parallel_size=8 \
   policy.megatron_cfg.tensor_model_parallel_size=8 \
-  policy.sequence_packing.enabled=True \
+  policy.sequence_packing.enabled=true \
   policy.model_name=Qwen/Qwen3-235B-A22B \
   policy.tokenizer.name=Qwen/Qwen3-235B-A22B \
-  checkpointing.enabled=True \
-  cluster.num_nodes=16 \
+  checkpointing.enabled=true \
   policy.megatron_cfg.num_layers_in_first_pipeline_stage=11 \
   policy.megatron_cfg.num_layers_in_last_pipeline_stage=11
 ```
 
 
-Here is a comparison of Muon vs Adam for DAPO with Qwen3.5-7B:
+Here is a comparison of Muon vs Adam for DAPO with Qwen2.5-7B:
 
 <p align="center">
 <img src="../assets/muon-dapo-reward.png" alt="Muon vs Adam DAPO Train Reward" height="300">
@@ -134,11 +138,12 @@ uv run examples/run_grpo_math.py \
   ++policy.megatron_cfg.optimizer.optimizer=dist_muon \
   ++policy.megatron_cfg.optimizer.muon_scale_mode=spectral \
   ++policy.megatron_cfg.optimizer.muon_momentum=0.9 \
-  ++policy.megatron_cfg.optimizer.muon_use_nesterov=False \
+  ++policy.megatron_cfg.optimizer.muon_nesterov=false \
   ++policy.megatron_cfg.optimizer.muon_extra_scale_factor=0.5 \
   policy.megatron_cfg.optimizer.use_precision_aware_optimizer=false \
-  policy.megatron_cfg.optimizer.use_distributed_optimizer=False \
+  policy.megatron_cfg.optimizer.use_distributed_optimizer=false \
+  policy.megatron_cfg.distributed_data_parallel_config.overlap_param_gather=false \
   cluster.num_nodes=16 cluster.gpus_per_node=8 \
-  policy.sequence_packing.enabled=True \
+  policy.sequence_packing.enabled=true \
   ~checkpointing.model_save_format
 ```

--- a/docs/guides/yarn-long-context.md
+++ b/docs/guides/yarn-long-context.md
@@ -1,0 +1,101 @@
+# YaRN Long-Context Training
+
+[**YaRN** (Yet another RoPE extensioN)](https://arxiv.org/abs/2309.00071) extends a model's usable context window beyond the length it was pretrained on by rescaling RoPE frequencies. NeMo RL supports YaRN RoPE scaling for SFT, GRPO, DPO, RM, and distillation workflows, letting you fine-tune or RL-train models at sequence lengths much larger than their original pretraining context.
+
+## Requirements
+
+YaRN is only supported with the **Megatron backend**. The DTensor (Automodel) backend will raise an assertion error if `rope_scaling.rope_type=yarn` is set. Make sure:
+
+1. Megatron submodules are initialized: `git submodule update --init --recursive`
+2. Megatron backend is enabled: `policy.megatron_cfg.enabled=True` and `policy.dtensor_cfg.enabled=False`
+
+## Enablement
+
+YaRN is configured through `policy.hf_config_overrides.rope_scaling`. All YaRN fields are required — NeMo RL validates that none are missing before training starts.
+
+```yaml
+policy:
+  max_total_sequence_length: 65536
+  megatron_cfg:
+    enabled: true
+  dtensor_cfg:
+    enabled: false
+  hf_config_overrides:
+    rope_scaling:
+      rope_type: yarn
+      rope_theta: 1000000
+      factor: 1.6
+      original_max_position_embeddings: 40960
+      truncate: true
+      beta_fast: 32
+      beta_slow: 1
+      mscale: 1
+      mscale_all_dim: 0
+```
+
+### Required Fields
+
+| Field | Description |
+| --- | --- |
+| `rope_type` | Must be `yarn` to enable YaRN. |
+| `rope_theta` | RoPE base frequency used when recomputing scaled frequencies. |
+| `factor` | Scaling factor — typically `max_total_sequence_length / original_max_position_embeddings`. |
+| `original_max_position_embeddings` | The model's original pretraining context length. |
+| `truncate` | Whether to truncate out-of-range positions. |
+| `beta_fast` / `beta_slow` | YaRN interpolation thresholds on the fast and slow RoPE dimensions. |
+| `mscale` / `mscale_all_dim` | Attention temperature scaling terms used by YaRN. |
+
+You can also compute `factor` directly from other config values using the `div:` interpolation helper:
+
+```yaml
+factor: ${div:${policy.max_total_sequence_length},${policy.hf_config_overrides.rope_scaling.original_max_position_embeddings}}
+```
+
+> [!NOTE]
+> YaRN only takes effect when `max_total_sequence_length` exceeds `original_max_position_embeddings`. If the two are equal, YaRN is a no-op.
+
+## How Conversion Works
+
+When `hf_config_overrides` are present, NeMo RL's Megatron setup:
+
+1. Validates that every required YaRN field is specified.
+2. Computes a stable hash over `hf_config_overrides` and appends it to the converted-checkpoint directory name (`<model>__hfovr_<hash>`). Different override sets therefore produce separate cached checkpoints and will not collide.
+3. Re-imports the HF model into Megatron format if no cached checkpoint at that path exists.
+
+The same `hf_config_overrides` are also propagated to vLLM during generation, so the rollout engine applies the identical YaRN settings as the trainer.
+
+## Forcing a Fresh Conversion
+
+If you change yarn parameters in `hf_config_overrides` after a conversion has been cached (for example, adjusting the YaRN `factor`), set:
+
+```yaml
+policy:
+  megatron_cfg:
+    force_reconvert_from_hf: true  # Default: false
+```
+
+This re-runs the HF → Megatron conversion and overwrites the cached checkpoint. It is equivalent to deleting the cached directory and rerunning. See also the [Training Backends design doc](../design-docs/training-backends.md#force-reconvert) for background on the checkpoint cache.
+
+## Example Recipes
+
+Two end-to-end YaRN recipes ship with NeMo RL:
+
+- **SFT, 64K context**: [`examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml`](../../examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml) — Qwen3-0.6B fine-tuned to a 64K sequence length on Nemotron-Cascade-2-SFT-Math using `factor: 1.6` (64K / 40960).
+- **GRPO, 256K context**: [`examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml`](../../examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml) — Qwen2.5-1.5B trained at 256K sequence length with `factor` derived from `max_total_sequence_length / original_max_position_embeddings`.
+
+Launch them the same way as any other recipe:
+
+```bash
+uv run examples/run_sft.py \
+    --config examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml
+
+uv run examples/run_grpo_math.py \
+    --config examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml
+```
+
+## Practical Tips
+
+- **Set context parallelism appropriately.** Long sequences typically require `policy.megatron_cfg.context_parallel_size > 1`. The 256K recipe uses `context_parallel_size: 32`; the 64K recipe uses `8`.
+- **Check `make_sequence_length_divisible_by`.** Long-context recipes usually need a larger divisor (e.g. `64` at 256K) so sequences align with CP/TP shapes.
+- **Keep override configs identical across trainer and generator.** Because `hf_config_overrides` flows into both Megatron and vLLM, editing only one side will cause mismatched RoPE behavior.
+- **Reconvert after changing overrides.** Cached checkpoints are keyed by override hash, so a new hash produces a new cache entry — but if you deliberately mutate an existing cache path, use `force_reconvert_from_hf: true`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,13 @@ Configure offline and online Eagle3 draft-model workflows to accelerate rollout 
 Learn how to add support for new model architectures in NeMo RL.
 :::
 
+:::{grid-item-card} {octicon}`arrow-both` YaRN Long-Context Training
+:link: guides/yarn-long-context
+:link-type: doc
+
+Extend a model's context window with YaRN RoPE scaling on the Megatron backend for SFT, GRPO, and other workflows.
+:::
+
 ::::
 
 ## Advanced Topics
@@ -227,6 +234,7 @@ guides/deepseek.md
 model-quirks.md
 guides/async-grpo.md
 guides/eagle3-speculative-decoding.md
+guides/yarn-long-context.md
 guides/muon-optimizer.md
 guides/dtensor-tp-accuracy.md
 guides/ft-launcher-guide.md

--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -22,7 +22,7 @@ export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"
 
 Set the `NRL_NSYS_PROFILE_STEP_RANGE` environment variable to control which training steps the profiler captures. Its
 format is colon separated integers representing `start:stop`, where `start` is inclusive and `stop` is exclusive
-(same as slice syntax `arr[start:stop]`). Note that the `start` is 1-index, so `NRL_NSYS_PROFILE_STEP_RANGE=0:10` would error.
+(same as slice syntax `arr[start:stop]`). Note that the `start` is 1-indexed, so `NRL_NSYS_PROFILE_STEP_RANGE=0:10` would error.
 
 ```bash
 export NRL_NSYS_PROFILE_STEP_RANGE=3:5

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,7 +55,6 @@ Limitations and tips:
 - The remote-aware selection uses a conservative static import map (no dynamic import resolution). If a test loads code dynamically that isn’t visible via imports, you may need to run it explicitly once to seed the map.
 - The helper is test-only and does not alter library behavior. It activates automatically when you pass `--testmon`.
 
-Refreshing remote-selection artifacts
 ### Refreshing Remote-Selection Artifacts
 If you change test layout or significantly refactor imports, the remote-selection artifacts may become stale.
 To rebuild them, delete the following files at the repo root and re-run with `--testmon` to seed again:
@@ -68,9 +67,7 @@ rm .nrl_remote_map.json .nrl_remote_state.json
 
 ### Run Unit Tests in a Hermetic Environment
 
-For environments lacking necessary dependencies (e.g., `gcc`, `nvcc`)
-or where environmental configuration may be problematic, tests can be run
-in Docker with this script:
+For environments lacking necessary dependencies (e.g., `gcc`, `nvcc`) or where environmental configuration may be problematic, tests can be run in Docker with this script:
 
 ```sh
 CONTAINER=... bash tests/run_unit_in_docker.sh
@@ -155,7 +152,6 @@ Functional tests are located under `tests/functional/`.
 uv run bash tests/functional/sft.sh
 ```
 
-At the end of each functional test, the metric checks will be printed as well as
 At the end of each functional test, the metric checks will be printed as well as whether they pass or fail. Here is an example:
 
 ```text
@@ -169,8 +165,6 @@ At the end of each functional test, the metric checks will be printed as well as
 
 ### Run Functional Tests in a Hermetic Environment
 
-For environments lacking necessary dependencies (e.g., `gcc`, `nvcc`)
-or where environmental configuration may be problematic, tests can be run
 For environments lacking necessary dependencies (e.g., `gcc`, `nvcc`) or where environmental configuration may be problematic, tests can be run in Docker with this script:
 
 ```sh

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,14 @@
         "url": "https://docs.nvidia.com/nemo/rl/nightly/"
     },
     {
-        "name": "0.5.0 (latest)",
-        "version": "0.5.0",
+        "name": "0.6.0 (latest)",
+        "version": "0.6.0",
         "url": "https://docs.nvidia.com/nemo/rl/latest/",
         "preferred": true
+    },
+    {
+        "version": "0.5.0",
+        "url": "https://docs.nvidia.com/nemo/rl/0.5.0/"
     },
     {
         "version": "0.4.0",

--- a/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-32n4g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-32n4g-megatron.yaml
@@ -6,6 +6,9 @@ policy:
     # DeepEP is supported for Ampere, Hopper, and Blackwell (B200/B300) GPUs
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
+  generation:
+    vllm_cfg:
+      gpu_memory_utilization: 0.3
 checkpointing:
   checkpoint_dir: results/grpo-dapomath17k-dsv3-32n4g-megatron
 logger:

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -2,8 +2,6 @@ defaults: ./grpo-deepseek-v3-32n8g.yaml
 checkpointing:
   checkpoint_dir: results/grpo-deepseek-v3-32n4g
 policy:
-  sequence_packing:
-    enabled: false
   megatron_cfg:
     pipeline_model_parallel_size: 8
     num_layers_in_first_pipeline_stage: 7

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -8,6 +8,9 @@ policy:
     pipeline_model_parallel_size: 8
     num_layers_in_first_pipeline_stage: 7
     num_layers_in_last_pipeline_stage: 6
+  generation:
+    vllm_cfg:
+      gpu_memory_utilization: 0.3
 logger:
   log_dir: logs/grpo-deepseek-v3-32n4g
   wandb:

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
@@ -15,6 +15,8 @@ policy:
   logprob_batch_size: 1
   max_total_sequence_length: 1536
   make_sequence_length_divisible_by: 1
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   megatron_cfg:

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
@@ -2,8 +2,6 @@ defaults: ./grpo-deepseek-v3-64n8g-async-1off.yaml
 checkpointing:
   checkpoint_dir: results/grpo-deepseek-v3-64n4g-async-1off
 policy:
-  sequence_packing:
-    enabled: false
   megatron_cfg:
     pipeline_model_parallel_size: 8
     num_layers_in_first_pipeline_stage: 7

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g.yaml
@@ -1,0 +1,12 @@
+defaults: ./grpo-deepseek-v3-32n4g.yaml
+checkpointing:
+  checkpoint_dir: results/grpo-deepseek-v3-64n4g
+logger:
+  log_dir: logs/grpo-deepseek-v3-64n4g
+  wandb:
+    name: grpo-deepseek-v3-64n4g
+policy:
+  megatron_cfg:
+    expert_model_parallel_size: 32
+cluster:
+  num_nodes: 64

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n8g.yaml
@@ -1,0 +1,12 @@
+defaults: ./grpo-deepseek-v3-32n8g.yaml
+checkpointing:
+  checkpoint_dir: results/grpo-deepseek-v3-64n8g
+logger:
+  log_dir: logs/grpo-deepseek-v3-64n8g
+  wandb:
+    name: grpo-deepseek-v3-64n8g
+policy:
+  megatron_cfg:
+    expert_model_parallel_size: 32
+cluster:
+  num_nodes: 64

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n4g.yaml
@@ -9,6 +9,7 @@ policy:
   generation:
     vllm_cfg:
       tensor_parallel_size: 8
+      gpu_memory_utilization: 0.4
 logger:
   log_dir: logs/grpo-qwen3-235b-16n4g
   wandb:

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n4g.yaml
@@ -1,0 +1,13 @@
+defaults: ./grpo-qwen3-235b-16n4g.yaml
+checkpointing:
+  checkpoint_dir: results/grpo-qwen3-235b-32n4g
+logger:
+  log_dir: logs/grpo-qwen3-235b-32n4g
+  wandb:
+    name: grpo-qwen3-235b-32n4g
+policy:
+  generation:
+    vllm_cfg:
+      gpu_memory_utilization: 0.6
+cluster:
+  num_nodes: 32

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n8g.yaml
@@ -1,0 +1,9 @@
+defaults: ./grpo-qwen3-235b-16n8g.yaml
+checkpointing:
+  checkpoint_dir: results/grpo-qwen3-235b-32n8g
+logger:
+  log_dir: logs/grpo-qwen3-235b-32n8g
+  wandb:
+    name: grpo-qwen3-235b-32n8g
+cluster:
+  num_nodes: 32

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.yaml
@@ -12,13 +12,13 @@ policy:
   megatron_cfg:
     tensor_model_parallel_size: 1
     pipeline_model_parallel_size: 1
-    expert_model_parallel_size: 16
+    expert_model_parallel_size: 8
     sequence_parallel: false
   generation:
     colocated:
       enabled: false
       resources:
-        num_nodes: 4
+        num_nodes: 2
         gpus_per_node: 4
     vllm_cfg:
       async_engine: true
@@ -30,4 +30,4 @@ logger:
     name: grpo-qwen3-30ba3b-8n4g-async-1off
 cluster:
   gpus_per_node: 4
-  num_nodes: 8
+  num_nodes: 4

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -8,6 +8,7 @@ checkpointing:
 policy:
   model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
+  logprob_batch_size: 4
   max_total_sequence_length: 4096
   dtensor_cfg:
     enabled: false

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -8,7 +8,7 @@ checkpointing:
 policy:
   model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
-  logprob_batch_size: 4
+  logprob_batch_size: 2
   max_total_sequence_length: 4096
   dtensor_cfg:
     enabled: false

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
@@ -8,6 +8,7 @@ checkpointing:
 policy:
   model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
+  logprob_batch_size: 4
   max_total_sequence_length: 4096
   dtensor_cfg:
     enabled: false

--- a/nemo_rl/algorithms/async_utils.py
+++ b/nemo_rl/algorithms/async_utils.py
@@ -28,6 +28,9 @@ from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
 )
 from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.models.generation.vllm.lfs import (
+    build_async_cross_dp_group_ids,
+)
 
 TokenizerType = PreTrainedTokenizerBase
 
@@ -50,7 +53,18 @@ class ReplayBuffer:
         self.target_weight_versions = []  # it is the weight-version of the trainer where this trajectory will be used.
 
         self.last_target_weight_already_generated = -1
+        self.fatal_error: str | None = None
         self._lock = _threading.Lock()
+
+    def _raise_if_failed(self) -> None:
+        if self.fatal_error is not None:
+            raise RuntimeError(self.fatal_error)
+
+    def set_fatal_error(self, error: str) -> None:
+        """Publish a generation failure to every trainer-side buffer poll."""
+        with self._lock:
+            if self.fatal_error is None:
+                self.fatal_error = str(error)
 
     def push_with_wait_signal(
         self,
@@ -66,6 +80,7 @@ class ReplayBuffer:
             target_weight_version: version of the model weights this trajectory is intended for training
         """
         with self._lock:
+            self._raise_if_failed()
             if len(self.trajectories) >= self.max_size:
                 return "full"
 
@@ -83,6 +98,7 @@ class ReplayBuffer:
 
     def get_debug_info(self) -> dict:
         """Get debug information about buffer state."""
+        self._raise_if_failed()
         return {
             "total_trajectories": len(self.trajectories),
             "trajectory_versions": self.trajectory_versions,
@@ -92,11 +108,13 @@ class ReplayBuffer:
 
     def get_last_target_weight_already_generated(self) -> int:
         with self._lock:
+            self._raise_if_failed()
             return self.last_target_weight_already_generated
 
     def get_existing_target_weights(self) -> set[int]:
         """Get set of target weight versions that already have trajectories."""
         with self._lock:
+            self._raise_if_failed()
             return set(self.target_weight_versions)
 
     def sample(
@@ -116,6 +134,7 @@ class ReplayBuffer:
             Dictionary with 'trajectories' and 'avg_trajectory_age' keys, or None if insufficient data
         """
         with self._lock:
+            self._raise_if_failed()
             if not self.trajectories:
                 return None
 
@@ -225,6 +244,7 @@ class ReplayBuffer:
     def size(self) -> int:
         """Return current buffer size."""
         with self._lock:
+            self._raise_if_failed()
             return len(self.trajectories)
 
     def clear(self) -> None:
@@ -290,6 +310,22 @@ class AsyncTrajectoryCollector:
         self._generation_check_lock: _threading.Lock = _threading.Lock()
         # Track which target weights are currently being generated (globally)
         self._generating_targets: set[int] = set()
+
+    def _publish_fatal_error(self, error: BaseException) -> None:
+        """Stop collection and make the trainer's next buffer poll fail."""
+        message = f"Async trajectory generation failed: {error!r}"
+        self.running = False
+        # Wake every possible collection wait so its background thread exits.
+        self._manual_pause_cleared.set()
+        self._refit_pause_cleared.set()
+        self._generation_limit_cleared.set()
+        try:
+            ray.get(self.replay_buffer.set_fatal_error.remote(message))
+        except Exception as publish_error:
+            print(
+                f"❌ Failed to publish collector fatal error: {publish_error}",
+                flush=True,
+            )
 
     def _calculate_target_weights(self, generation_weight_version: int) -> list[int]:
         """Calculate target weight versions for given generation weight version.
@@ -450,7 +486,19 @@ class AsyncTrajectoryCollector:
 
     def _process_batch(self, batch: BatchedDataDict[DatumSpec]) -> None:
         """Process a single batch and generate for one target weight."""
+        cross_dp_session = None
+        launched_cross_dp_participants = 0
+        launched_workers = 0
+        reserved_inflight_tokens = 0
+        target_weight = None
         try:
+            # Do not reserve a target, semaphore tokens, or dispatcher slots
+            # while a refit has already paused new generations.
+            if not self._refit_pause_cleared.is_set() and self.running:
+                self._refit_pause_cleared.wait()
+                if not self.running:
+                    return
+
             generation_weight_version = self.current_weight_version
             num_generations = self.master_config["grpo"]["num_generations_per_prompt"]
             num_prompts = batch.size
@@ -469,6 +517,42 @@ class AsyncTrajectoryCollector:
             print(
                 f"🎯 Generating for target weight {target_weight} from generation_weight_version {generation_weight_version}"
             )
+
+            if getattr(
+                self.policy_generation, "cross_dp_scheduler_enabled", False
+            ):
+                from nemo_rl.algorithms.grpo import _should_use_nemo_gym
+
+                if _should_use_nemo_gym(self.master_config):
+                    raise RuntimeError(
+                        "Cross-DP middleware scheduling is not implemented for "
+                        "NeMo-Gym rollouts"
+                    )
+                # Open one catalog before any prompt-group thread starts.  The
+                # contiguous A0,A1,... input order can therefore not hide B/C
+                # groups from the first probe wave.
+                all_group_ids = build_async_cross_dp_group_ids(
+                    batch, num_generations=num_generations
+                )
+                participant_indices = [
+                    prompt_idx
+                    for prompt_idx in range(num_prompts)
+                    for _ in range(num_generations)
+                ]
+                # Reserve every prompt-group thread before the dispatcher can
+                # assign this session. Otherwise a catalog for threads blocked
+                # on the semaphore could occupy all DP slots while older
+                # threads wait for a later-turn lease.
+                for _ in range(num_prompts):
+                    self._inflight_sema.acquire()
+                    reserved_inflight_tokens += 1
+                cross_dp_session = (
+                    self.policy_generation.open_cross_dp_session_sync(
+                        all_group_ids,
+                        participant_count=num_prompts,
+                        participant_indices=participant_indices,
+                    )
+                )
 
             # Generate for all prompts in this batch for the target weight
             for prompt_idx in range(num_prompts):
@@ -489,8 +573,25 @@ class AsyncTrajectoryCollector:
 
                 single_prompt_batch = batch.slice(prompt_idx, prompt_idx + 1)
                 repeated_batch = single_prompt_batch.repeat_interleave(num_generations)
+                prompt_cross_dp_session = None
+                if cross_dp_session is not None:
+                    start = prompt_idx * num_generations
+                    end = start + num_generations
+                    prompt_cross_dp_session = {
+                        "session_id": cross_dp_session["session_id"],
+                        "request_ids": cross_dp_session["request_ids"][start:end],
+                        "group_ids": cross_dp_session["group_ids"][start:end],
+                        "request_participant_ids": cross_dp_session[
+                            "request_participant_ids"
+                        ][start:end],
+                        "participant_id": cross_dp_session["participant_ids"][
+                            prompt_idx
+                        ],
+                    }
 
-                self._inflight_sema.acquire()
+                if cross_dp_session is None:
+                    self._inflight_sema.acquire()
+                    reserved_inflight_tokens += 1
                 worker = _threading.Thread(
                     target=self._run_prompt_group_worker,
                     args=(
@@ -498,12 +599,24 @@ class AsyncTrajectoryCollector:
                         generation_weight_version,
                         target_weight,
                         prompt_idx,
+                        prompt_cross_dp_session,
                     ),
                     daemon=True,
                 )
                 with self._threads_lock:
                     self._inflight_threads.add(worker)
-                worker.start()
+                try:
+                    worker.start()
+                except BaseException:
+                    with self._threads_lock:
+                        self._inflight_threads.discard(worker)
+                    raise
+                launched_workers += 1
+                # Every successfully started worker releases exactly one token
+                # in its finally block, regardless of scheduling mode.
+                reserved_inflight_tokens -= 1
+                if prompt_cross_dp_session is not None:
+                    launched_cross_dp_participants += 1
 
             self._cleanup_finished_threads()
 
@@ -512,6 +625,29 @@ class AsyncTrajectoryCollector:
             import traceback
 
             traceback.print_exc()
+            if cross_dp_session is not None:
+                for participant_index in range(
+                    launched_cross_dp_participants, num_prompts
+                ):
+                    try:
+                        self.policy_generation.close_cross_dp_session_participant_sync(
+                            cross_dp_session["session_id"],
+                            cross_dp_session["participant_ids"][participant_index],
+                        )
+                    except Exception:
+                        traceback.print_exc()
+            for _ in range(reserved_inflight_tokens):
+                self._inflight_sema.release()
+            # _get_next_target_for_generation reserves before validation and
+            # dispatcher setup. With no worker to own that reservation, this
+            # exception path must release it itself.
+            if launched_workers == 0 and target_weight is not None:
+                with self._generation_check_lock:
+                    self._generating_targets.discard(target_weight)
+            if getattr(
+                self.policy_generation, "cross_dp_scheduler_enabled", False
+            ):
+                self._publish_fatal_error(e)
 
     def get_weight_version(self) -> int:
         return self.current_weight_version
@@ -640,7 +776,9 @@ class AsyncTrajectoryCollector:
         generation_weight_version: int,
         target_weight_version: int,
         prompt_idx: int,
+        cross_dp_session: dict[str, Any] | None = None,
     ) -> None:
+        cross_dp_session_handed_off = False
         try:
             # Import here to avoid circular dependency
             from nemo_rl.algorithms.grpo import _should_use_nemo_gym
@@ -665,6 +803,7 @@ class AsyncTrajectoryCollector:
                 final_batch = nemo_gym_rollout_result.final_batch
                 rollout_metrics = nemo_gym_rollout_result.rollout_metrics
             else:
+                cross_dp_session_handed_off = cross_dp_session is not None
                 final_batch, rollout_metrics = run_async_multi_turn_rollout(
                     policy_generation=self.policy_generation,
                     input_batch=repeated_batch,
@@ -675,6 +814,7 @@ class AsyncTrajectoryCollector:
                     ],
                     max_rollout_turns=self.master_config["grpo"]["max_rollout_turns"],
                     greedy=False,
+                    cross_dp_session=cross_dp_session,
                 )
 
             # Move to CPU and push to buffer (avoid blocking on GC/push)
@@ -731,7 +871,20 @@ class AsyncTrajectoryCollector:
             import traceback
 
             traceback.print_exc()
+            if cross_dp_session is not None:
+                self._publish_fatal_error(e)
         finally:
+            if cross_dp_session is not None and not cross_dp_session_handed_off:
+                try:
+                    self.policy_generation.close_cross_dp_session_participant_sync(
+                        cross_dp_session["session_id"],
+                        cross_dp_session["participant_id"],
+                    )
+                except Exception:
+                    import traceback
+
+                    traceback.print_exc()
+
             # Clean up reservation in case of error (if not already cleaned up)
             with self._generation_check_lock:
                 if target_weight_version in self._generating_targets:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import json
 import os
+import random
+import shutil
 import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -180,6 +183,8 @@ class GRPOSaveState(TypedDict):
     val_reward: NotRequired[
         float
     ]  # Optional field - may not be present during training
+    preserve_checkpoint: NotRequired[bool]
+    completed_epoch: NotRequired[int]
 
 
 def _default_grpo_save_state() -> GRPOSaveState:
@@ -303,6 +308,38 @@ def setup(
         )
 
     # Load train dataset
+    cohort_size = data_config.get("train_prompt_cohort_size")
+    if cohort_size is not None:
+        if data_config["use_multiple_dataloader"]:
+            raise ValueError(
+                "data.train_prompt_cohort_size is only supported with one dataloader"
+            )
+        cohort_size = int(cohort_size)
+        if cohort_size < dataloader_batch_size:
+            raise ValueError(
+                "data.train_prompt_cohort_size must be at least one dataloader "
+                f"batch ({dataloader_batch_size}), got {cohort_size}"
+            )
+        if cohort_size > len(dataset):
+            raise ValueError(
+                "data.train_prompt_cohort_size exceeds the training dataset: "
+                f"{cohort_size} > {len(dataset)}"
+            )
+        cohort_seed = int(
+            data_config.get("train_prompt_cohort_seed", grpo_config["seed"])
+        )
+        cohort_indices = random.Random(cohort_seed).sample(
+            range(len(dataset)), cohort_size
+        )
+        # Subset forwards the original dataset index into __getitem__, so the
+        # resulting DatumSpec.idx remains a stable prompt identity across epochs.
+        dataset = torch.utils.data.Subset(dataset, cohort_indices)
+        print(
+            "  ✓ Fixed real-prompt training cohort enabled: "
+            f"size={cohort_size} seed={cohort_seed}",
+            flush=True,
+        )
+
     def init_train_dataloader(dataset, suffix: str = ""):
         dataloader = StatefulDataLoader(
             dataset,
@@ -1566,6 +1603,48 @@ def grpo_train(
                             greedy=False,
                         )
                     policy_generation.finish_generation()
+                    # Persist history_lfs observations independently of the
+                    # best-effort trajectory logger. A checkpoint copies this
+                    # exact step-aligned state for causal recovery.
+                    _scheduler_snapshot_for_step = None
+                    _cross_dp_history_path = os.environ.get(
+                        "NRL_VLLM_GROUP_HISTORY_PATH"
+                    )
+                    if policy_generation is not None and (
+                        _cross_dp_history_path
+                        or os.environ.get("NRL_DUMP_ROLLOUT_LENGTHS")
+                    ):
+                        _snapshot_fn = getattr(
+                            policy_generation,
+                            "get_cross_dp_scheduler_snapshot",
+                            None,
+                        )
+                        if _snapshot_fn is not None:
+                            _scheduler_snapshot_for_step = _snapshot_fn()
+                    if _cross_dp_history_path:
+                        if _scheduler_snapshot_for_step is None:
+                            raise RuntimeError(
+                                "NRL_VLLM_GROUP_HISTORY_PATH requires an active "
+                                "cross-DP scheduler"
+                            )
+                        _history_payload = {
+                            "step": int(total_steps + 1),
+                            "group_history": _scheduler_snapshot_for_step.get(
+                                "group_history", {}
+                            ),
+                        }
+                        os.makedirs(
+                            os.path.dirname(
+                                os.path.abspath(_cross_dp_history_path)
+                            ),
+                            exist_ok=True,
+                        )
+                        _history_tmp = (
+                            f"{_cross_dp_history_path}.tmp.{os.getpid()}"
+                        )
+                        with open(_history_tmp, "w") as _history_file:
+                            json.dump(_history_payload, _history_file)
+                        os.replace(_history_tmp, _cross_dp_history_path)
                     # Collect generation logger metrics for performance reporting after each generation step
                     # inflight batch sizes and num pending samples are collected from each worker
                     if policy_generation is not None:
@@ -1717,6 +1796,84 @@ def grpo_train(
                             "sample_mask": repeated_batch["loss_multiplier"],
                         }
                     )
+                    # Env-gated per-step rollout length dump. Records
+                    # per-(prompt, sample) generation lengths grouped by prompt (batch is
+                    # repeat_interleave(G), so every G contiguous rows are one prompt group)
+                    # so we can measure whether the intra-group length similarity persists as
+                    # the policy weights update. Best-effort; never breaks training.
+                    _rollout_length_dump = os.environ.get("NRL_DUMP_ROLLOUT_LENGTHS")
+                    if _rollout_length_dump:
+                        try:
+                            import json as _json
+
+                            _gen_len = (
+                                flat_messages["token_loss_mask"]
+                                .sum(dim=1)
+                                .to(torch.int64)
+                                .tolist()
+                            )
+                            _rec = {
+                                "step": int(total_steps + 1),
+                                "G": int(
+                                    master_config["grpo"]["num_generations_per_prompt"]
+                                ),
+                                "cap": int(
+                                    master_config["policy"]["max_total_sequence_length"]
+                                ),
+                                "gen_len": _gen_len,
+                                "prompt_len": repeated_batch["length"]
+                                .to(torch.int64)
+                                .tolist(),
+                                "reward": repeated_batch["total_reward"]
+                                .to(torch.float32)
+                                .tolist(),
+                                # Stable identity from the underlying real dataset.
+                                # It is repeated G times in exactly the same order as
+                                # gen_len, enabling strictly causal cross-step history.
+                                "prompt_id": [
+                                    int(_v.item() if hasattr(_v, "item") else _v)
+                                    for _v in repeated_batch["idx"]
+                                ],
+                            }
+                            _scheduler_snapshot = _scheduler_snapshot_for_step
+                            if _scheduler_snapshot is not None:
+                                _assignments = _scheduler_snapshot.get(
+                                    "assignment_history", []
+                                )
+                                _session_id = (
+                                    _assignments[-1]["session_id"]
+                                    if _assignments
+                                    else None
+                                )
+                                _rec["scheduler_mode"] = _scheduler_snapshot.get(
+                                    "mode"
+                                )
+                                _rec["scheduler_assignments"] = [
+                                    _item
+                                    for _item in _assignments
+                                    if _item.get("session_id") == _session_id
+                                ]
+                                _rec["scheduler_history_updates"] = [
+                                    _item
+                                    for _item in _scheduler_snapshot.get(
+                                        "history_update_history", []
+                                    )
+                                    if _item.get("session_id") == _session_id
+                                ]
+                            os.makedirs(
+                                os.path.dirname(os.path.abspath(_rollout_length_dump)),
+                                exist_ok=True,
+                            )
+                            with open(_rollout_length_dump, "a") as _f:
+                                _f.write(_json.dumps(_rec) + "\n")
+                            print(
+                                f"[length dump] step {total_steps + 1}: "
+                                f"{len(_gen_len)} samples -> {_rollout_length_dump}",
+                                flush=True,
+                            )
+                        except Exception as _e:  # noqa: BLE001 - best-effort profiling
+                            print(f"[length dump] skipped: {_e}", flush=True)
+
                     # this will be mini-batched inside the policy, so maintain the packed multimodal structure
                     # This is also used to populate part of the downstream logprob calculation data
                     extra_multimodal_data = flat_messages.get_multimodal_dict(
@@ -1967,6 +2124,18 @@ def grpo_train(
                     grpo_save_state["total_steps"] = total_steps + 1
                     grpo_save_state["current_epoch"] = current_epoch
                     grpo_save_state["total_valid_tokens"] = total_valid_tokens
+                    is_epoch_end = (
+                        not master_config["data"]["use_multiple_dataloader"]
+                        and current_step + 1 == len(wrapped_dataloader)
+                    )
+                    # Epoch-boundary checkpoints are semantic experiment
+                    # artifacts, while timeout checkpoints are rolling recovery
+                    # points. CheckpointManager keeps the former permanently.
+                    grpo_save_state["preserve_checkpoint"] = is_epoch_end
+                    if is_epoch_end:
+                        grpo_save_state["completed_epoch"] = current_epoch + 1
+                    else:
+                        grpo_save_state.pop("completed_epoch", None)
                     if val_metrics is not None:
                         grpo_save_state["val_reward"] = val_metrics["accuracy"]
                     elif "val_reward" in grpo_save_state:
@@ -2040,6 +2209,22 @@ def grpo_train(
                             torch.save(
                                 wrapped_dataloader.state_dict(),
                                 os.path.join(checkpoint_path, "train_dataloader.pt"),
+                            )
+                        cross_dp_history_path = os.environ.get(
+                            "NRL_VLLM_GROUP_HISTORY_PATH"
+                        )
+                        if cross_dp_history_path:
+                            if not os.path.exists(cross_dp_history_path):
+                                raise FileNotFoundError(
+                                    "Cross-DP history file is missing at checkpoint "
+                                    f"time: {cross_dp_history_path}"
+                                )
+                            shutil.copyfile(
+                                cross_dp_history_path,
+                                os.path.join(
+                                    checkpoint_path,
+                                    "cross_dp_group_history.json",
+                                ),
                             )
                         checkpointer.finalize_checkpoint(checkpoint_path)
 

--- a/nemo_rl/data/__init__.py
+++ b/nemo_rl/data/__init__.py
@@ -31,6 +31,12 @@ class ResponseDatasetConfig(TypedDict):
     split_validation_size: NotRequired[float]
     # Seed for train/validation split when split_validation_size > 0
     seed: NotRequired[int]
+    # DAPO-Math-17k was accidentally published with roughly 100 copies of
+    # each prompt. These options expose the cleaned, prompt-unique view used
+    # for multi-epoch experiments.
+    deduplicate_prompts: NotRequired[bool]
+    drop_conflicting_rewards: NotRequired[bool]
+    expected_num_prompts: NotRequired[int]
 
 
 class PreferenceDatasetConfig(TypedDict):
@@ -62,6 +68,11 @@ class DataConfig(TypedDict):
     use_multiple_dataloader: NotRequired[bool]
     num_prompts_per_dataloader: NotRequired[int]
     custom_dataloader: NotRequired[str]
+    # Optional deterministic subset of real training prompts. Repeating this
+    # cohort across epochs is useful for measuring how the same prompts change
+    # as the policy is updated.
+    train_prompt_cohort_size: NotRequired[int | None]
+    train_prompt_cohort_seed: NotRequired[int]
     # dataset configs
     train: ResponseDatasetConfig | PreferenceDatasetConfig | list[ResponseDatasetConfig]
     validation: NotRequired[

--- a/nemo_rl/data/datasets/response_datasets/dapo_math.py
+++ b/nemo_rl/data/datasets/response_datasets/dapo_math.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import Any
 
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 
 from nemo_rl.data.datasets.raw_dataset import RawDataset
 
@@ -22,11 +23,31 @@ from nemo_rl.data.datasets.raw_dataset import RawDataset
 class DAPOMath17KDataset(RawDataset):
     """Simple wrapper around the DAPO Math 17K dataset with train split."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(
+        self,
+        deduplicate_prompts: bool = False,
+        drop_conflicting_rewards: bool = True,
+        expected_num_prompts: int | None = None,
+        **kwargs,
+    ) -> None:
         self.task_name = "DAPOMath17K"
 
         # load from huggingface
         self.dataset = load_dataset("BytedTsinghua-SIA/DAPO-Math-17k", split="train")
+
+        if deduplicate_prompts:
+            self.dataset = _select_unique_dapo_prompts(
+                self.dataset,
+                drop_conflicting_rewards=drop_conflicting_rewards,
+            )
+        if (
+            expected_num_prompts is not None
+            and len(self.dataset) != expected_num_prompts
+        ):
+            raise ValueError(
+                "Unexpected DAPO prompt count after preprocessing: "
+                f"expected {expected_num_prompts}, got {len(self.dataset)}"
+            )
 
         # format the dataset
         self.dataset = self.dataset.map(
@@ -63,3 +84,60 @@ class DAPOMathAIME2024Dataset(DAPOMath17KDataset):
             self.format_data,
             remove_columns=self.dataset.column_names,
         )
+
+
+def _select_unique_dapo_prompts(
+    dataset: Dataset,
+    *,
+    drop_conflicting_rewards: bool,
+) -> Dataset:
+    """Return the first row for each prompt, optionally dropping conflicts.
+
+    The hosted DAPO-Math-17k parquet contains about 100 accidental repetitions.
+    A small number of identical prompts are also paired with different reward
+    models. Iterating Arrow record batches avoids materializing the 1.79M-row
+    dataset as a pandas DataFrame while preserving deterministic source order.
+    """
+
+    first_index_by_prompt: dict[str, int] = {}
+    reward_key_by_prompt: dict[str, str] = {}
+    conflicting_prompts: set[str] = set()
+    row_index = 0
+
+    for batch in dataset.iter(batch_size=10_000):
+        prompts = batch["prompt"]
+        reward_models = batch["reward_model"]
+        for prompt_messages, reward_model in zip(
+            prompts, reward_models, strict=True
+        ):
+            prompt = prompt_messages[0]["content"]
+            reward_key = json.dumps(
+                reward_model,
+                sort_keys=True,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            if prompt not in first_index_by_prompt:
+                first_index_by_prompt[prompt] = row_index
+                reward_key_by_prompt[prompt] = reward_key
+            elif reward_key_by_prompt[prompt] != reward_key:
+                conflicting_prompts.add(prompt)
+            row_index += 1
+
+    selected_indices = [
+        index
+        for prompt, index in first_index_by_prompt.items()
+        if not drop_conflicting_rewards or prompt not in conflicting_prompts
+    ]
+    print(
+        "  ✓ DAPO prompt deduplication: "
+        f"{len(dataset)} rows -> {len(first_index_by_prompt)} unique prompts"
+        + (
+            f" -> {len(selected_indices)} after dropping "
+            f"{len(conflicting_prompts)} reward conflicts"
+            if drop_conflicting_rewards
+            else ""
+        ),
+        flush=True,
+    )
+    return dataset.select(selected_indices)

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -19,7 +19,9 @@ import asyncio
 import copy
 import json
 import math
+import os
 import statistics
+import time
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -229,6 +231,14 @@ async def generate_responses_async(
             )
         except Exception as e:
             print(f"Error occurred while extracting gen_leader_worker_idx: {e}")
+    if "gen_dp_shard_idx" in generation_outputs:
+        value = generation_outputs["gen_dp_shard_idx"][0]
+        try:
+            gen_metrics["gen_dp_shard_idx"] = (
+                int(value[0]) if isinstance(value, list) else int(value)
+            )
+        except Exception as e:
+            print(f"Error occurred while extracting gen_dp_shard_idx: {e}")
 
     # Add response_truncated to gen_metrics for use by caller
     if response_truncated is not None:
@@ -603,6 +613,8 @@ async def async_generate_response_for_sample_turn(
     tokenizer: TokenizerType,
     max_seq_len: int,
     greedy: bool = False,
+    lfs_group: int | None = None,
+    cross_dp_request: dict[str, str] | None = None,
 ) -> tuple[list[dict], torch.Tensor, torch.Tensor, dict[str, float]]:
     """Generate a response for a single sample's turn using async generation.
 
@@ -636,6 +648,22 @@ async def async_generate_response_for_sample_turn(
             "stop_strings": [sample_stop_strings],
         }
     )
+    # Carry the prompt-group id to the engine-level LFS scheduler.
+    if lfs_group is not None:
+        generation_input_data["lfs_group"] = torch.tensor([lfs_group])
+    if cross_dp_request is not None:
+        generation_input_data["_cross_dp_session_id"] = [
+            cross_dp_request["session_id"]
+        ]
+        generation_input_data["_cross_dp_participant_id"] = [
+            cross_dp_request["participant_id"]
+        ]
+        generation_input_data["_cross_dp_request_id"] = [
+            cross_dp_request["request_id"]
+        ]
+        generation_input_data["_cross_dp_group_id"] = [
+            cross_dp_request["group_id"]
+        ]
 
     # Create a dummy batch for generate_responses_async
     dummy_batch = BatchedDataDict[DatumSpec](
@@ -672,6 +700,7 @@ async def run_sample_multi_turn_rollout(
     max_seq_len: int,
     max_rollout_turns: int = 999999,
     greedy: bool = False,
+    cross_dp_request: dict[str, str] | None = None,
 ) -> tuple[dict, dict[str, Any]]:
     """Run a multi-turn rollout for a single sample.
 
@@ -717,6 +746,7 @@ async def run_sample_multi_turn_rollout(
     turn_total_tokens = []
     # Track per-turn per-worker token accounting if available
     per_worker_token_counts = {}  # worker_idx -> token_count
+    per_dp_token_counts = {}  # dp_shard_idx -> token_count
 
     for turn in range(max_rollout_turns):
         if terminated or truncated:
@@ -725,6 +755,22 @@ async def run_sample_multi_turn_rollout(
         turn_count += 1
 
         # Generate response for this sample using async generation
+        lfs_group_size = (
+            os.environ.get("NRL_VLLM_LFS_SCHED_G")
+            if os.environ.get("NRL_VLLM_LFS_SCHED") == "1"
+            and cross_dp_request is None
+            else None
+        )
+        lfs_group = (
+            sample_idx // int(lfs_group_size) if lfs_group_size else None
+        )
+        turn_cross_dp_request = None
+        if cross_dp_request is not None:
+            turn_cross_dp_request = dict(cross_dp_request)
+            if turn > 0:
+                turn_cross_dp_request["request_id"] = (
+                    f"{cross_dp_request['request_id']}:turn:{turn}"
+                )
         try:
             (
                 updated_message_log,
@@ -738,6 +784,8 @@ async def run_sample_multi_turn_rollout(
                 tokenizer,
                 max_seq_len,
                 greedy=greedy,
+                lfs_group=lfs_group,
+                cross_dp_request=turn_cross_dp_request,
             )
             current_message_log = updated_message_log
 
@@ -759,9 +807,19 @@ async def run_sample_multi_turn_rollout(
                 per_worker_token_counts[worker_idx] = (
                     per_worker_token_counts.get(worker_idx, 0) + gen_token_count
                 )
+            if "gen_dp_shard_idx" in gen_metrics:
+                dp_idx = int(gen_metrics["gen_dp_shard_idx"])
+                per_dp_token_counts[dp_idx] = (
+                    per_dp_token_counts.get(dp_idx, 0) + gen_token_count
+                )
 
         except Exception as e:
             print(f"Error generating response for sample {sample_idx}: {e}")
+            if cross_dp_request is not None:
+                # A dispatcher failure affects global admission state. Returning
+                # a partial trajectory would make async-GRPO buffer invalid
+                # training data and hide the real scheduling failure.
+                raise
             break
 
         # Create single-sample batch for environment interaction
@@ -833,7 +891,10 @@ async def run_sample_multi_turn_rollout(
         "task_name": task_name,
         "total_reward": torch.tensor(total_reward),
         "stop_strings": current_stop_strings,
-        "idx": sample_idx,
+        # Preserve the dataset identity supplied by the caller. sample_idx is
+        # only the position inside this rollout batch; replacing idx with it
+        # breaks prompt-group identity after repeat_interleave(G).
+        "idx": initial_sample_state.get("idx", sample_idx),
     }
     if multi_reward_seen:
         for j in range(len(reward_acc_list)):
@@ -854,6 +915,7 @@ async def run_sample_multi_turn_rollout(
         "turn_total_tokens": turn_total_tokens,
         # Pass-through per-worker per-turn accounting for aggregation at batch level
         "per_worker_token_counts": per_worker_token_counts,
+        "per_dp_token_counts": per_dp_token_counts,
     }
 
     return final_sample_state, sample_metrics
@@ -867,6 +929,7 @@ def run_async_multi_turn_rollout(
     max_seq_len: int,
     max_rollout_turns: int = 999999,
     greedy: bool = False,
+    cross_dp_session: dict[str, Any] | None = None,
 ) -> tuple[BatchedDataDict[DatumSpec], dict[str, Any]]:
     """Run multi-turn rollouts with sample-level processing.
 
@@ -888,9 +951,27 @@ def run_async_multi_turn_rollout(
             - Dictionary of rollout metrics
     """
 
-    async def _async_rollout_implementation():
-        """Internal async implementation."""
+    async def _async_rollout_with_session(
+        scheduling_session: dict[str, Any] | None,
+    ):
+        """Run one rollout after its optional scheduling session is open."""
         batch_size = len(input_batch["message_log"])
+
+        if scheduling_session is not None:
+            request_ids = scheduling_session["request_ids"]
+            group_ids = scheduling_session["group_ids"]
+            request_participant_ids = scheduling_session["request_participant_ids"]
+            if (
+                len(request_ids) != batch_size
+                or len(group_ids) != batch_size
+                or len(request_participant_ids) != batch_size
+            ):
+                raise ValueError(
+                    "Cross-DP session size does not match rollout batch: "
+                    f"requests={len(request_ids)} groups={len(group_ids)} "
+                    f"participants={len(request_participant_ids)} "
+                    f"batch={batch_size}"
+                )
 
         # Prepare initial states for each sample
         sample_initial_states = []
@@ -902,6 +983,15 @@ def run_async_multi_turn_rollout(
                 "stop_strings": input_batch.get("stop_strings", [None] * batch_size)[i],
                 "idx": input_batch.get("idx", list(range(batch_size)))[i],
             }
+            if scheduling_session is not None:
+                sample_state["cross_dp_request"] = {
+                    "session_id": scheduling_session["session_id"],
+                    "participant_id": scheduling_session[
+                        "request_participant_ids"
+                    ][i],
+                    "request_id": scheduling_session["request_ids"][i],
+                    "group_id": scheduling_session["group_ids"][i],
+                }
             sample_initial_states.append(sample_state)
 
         # Run all samples concurrently
@@ -917,19 +1007,63 @@ def run_async_multi_turn_rollout(
                     max_seq_len=max_seq_len,
                     max_rollout_turns=max_rollout_turns,
                     greedy=greedy,
+                    cross_dp_request=sample_state.get("cross_dp_request"),
                 )
                 return result
             except Exception as e:
                 raise RuntimeError(f"Error in sample {i} rollout: {e}") from e
 
-        # Create tasks for all samples and run them concurrently
+        # Submit every sample immediately. NRL_ROLLOUT_TIMING=1 records per-sample
+        # completion times for engine-scheduler A/B comparisons without imposing a
+        # separate client-side admission limit.
+        timing_enabled = os.environ.get("NRL_ROLLOUT_TIMING") == "1"
+        rollout_start = time.monotonic()
+        finish_times: list[float | None] = [None] * len(sample_initial_states)
+
+        async def timed_rollout(sample_index: int, sample_state: dict):
+            result = await run_single_sample_with_error_handling(
+                sample_index, sample_state
+            )
+            if timing_enabled:
+                finish_times[sample_index] = time.monotonic() - rollout_start
+            return result
+
         sample_tasks = [
-            run_single_sample_with_error_handling(i, sample_state)
+            asyncio.create_task(timed_rollout(i, sample_state))
             for i, sample_state in enumerate(sample_initial_states)
         ]
-
-        # Execute all sample rollouts concurrently
-        sample_results = await asyncio.gather(*sample_tasks, return_exceptions=False)
+        try:
+            sample_results = await asyncio.gather(
+                *sample_tasks, return_exceptions=False
+            )
+        except BaseException:
+            # Drain every sibling before the outer session finally closes its
+            # participant. Each task then gets a chance to cancel or resolve
+            # its dispatcher lease in _async_generate_base.
+            for task in sample_tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*sample_tasks, return_exceptions=True)
+            raise
+        if timing_enabled:
+            completed_finish_times = sorted(
+                finish_time for finish_time in finish_times if finish_time is not None
+            )
+            request_count = len(completed_finish_times)
+            makespan = time.monotonic() - rollout_start
+            p90_index = max(0, math.ceil(0.9 * request_count) - 1)
+            p90 = (
+                completed_finish_times[p90_index] if request_count else makespan
+            )
+            print(
+                "[ROLLOUT-TIMING "
+                f"lfs_sched={os.environ.get('NRL_VLLM_LFS_SCHED', '0')} "
+                "cross_dp_sched="
+                f"{os.environ.get('NRL_VLLM_CROSS_DP_SCHED', 'off')}] "
+                f"makespan={makespan:.1f}s "
+                f"tail_last10pct={makespan - p90:.1f}s N={request_count}",
+                flush=True,
+            )
 
         # Process results
         final_sample_states = []
@@ -1036,6 +1170,14 @@ def run_async_multi_turn_rollout(
                 for k, v in m["per_worker_token_counts"].items():
                     per_worker_token_counts[k] = per_worker_token_counts.get(k, 0) + v
             rollout_metrics["per_worker_token_counts"] = per_worker_token_counts
+        if "per_dp_token_counts" in all_sample_metrics[0]:
+            per_dp_token_counts = {}
+            for metrics in all_sample_metrics:
+                for dp_idx, token_count in metrics["per_dp_token_counts"].items():
+                    per_dp_token_counts[dp_idx] = (
+                        per_dp_token_counts.get(dp_idx, 0) + token_count
+                    )
+            rollout_metrics["per_dp_token_counts"] = per_dp_token_counts
 
         # Collect ISL, OSL, and ISL+OSL metrics for all samples
         rollout_metrics["histogram/gen_tokens_length"] = [
@@ -1049,6 +1191,68 @@ def run_async_multi_turn_rollout(
         ]
 
         return final_batch, rollout_metrics
+
+    async def _async_rollout_implementation():
+        """Open/close one middleware session around the complete rollout."""
+        scheduling_session = cross_dp_session
+        primary_error: BaseException | None = None
+        try:
+            cross_dp_enabled = bool(
+                getattr(policy_generation, "cross_dp_scheduler_enabled", False)
+            )
+            if scheduling_session is not None and not cross_dp_enabled:
+                raise RuntimeError(
+                    "A cross-DP rollout session was supplied to a generation "
+                    "backend without cross-DP scheduling enabled"
+                )
+            if cross_dp_enabled and scheduling_session is None:
+                batch_size = len(input_batch["message_log"])
+                if "idx" in input_batch:
+                    raw_group_ids = input_batch["idx"]
+                    group_ids = [
+                        str(value.item() if hasattr(value, "item") else value)
+                        for value in raw_group_ids
+                    ]
+                else:
+                    group_size = int(
+                        os.environ.get("NRL_VLLM_LFS_SCHED_G", "1")
+                    )
+                    if group_size <= 0:
+                        raise ValueError(
+                            "NRL_VLLM_LFS_SCHED_G must be positive when cross-DP "
+                            f"scheduling is enabled, got {group_size}"
+                        )
+                    group_ids = [
+                        str(index // group_size)
+                        for index in range(batch_size)
+                    ]
+                scheduling_session = (
+                    await policy_generation.open_cross_dp_session(
+                        group_ids, participant_count=1
+                    )
+                )
+                scheduling_session["participant_id"] = scheduling_session[
+                    "participant_ids"
+                ][0]
+            return await _async_rollout_with_session(scheduling_session)
+        except BaseException as error:
+            primary_error = error
+            raise
+        finally:
+            if scheduling_session is not None:
+                try:
+                    await policy_generation.close_cross_dp_session_participant(
+                        scheduling_session["session_id"],
+                        scheduling_session["participant_id"],
+                    )
+                except Exception as close_error:
+                    if primary_error is None:
+                        raise
+                    print(
+                        "Failed to close cross-DP rollout participant after "
+                        f"{primary_error!r}: {close_error}",
+                        flush=True,
+                    )
 
     return asyncio.run(_async_rollout_implementation())
 

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -39,6 +39,9 @@ class VllmSpecificArgs(TypedDict):
     # Miscellaneous top level vLLM HTTP server arguments.
     # A filepath that can be imported to register a vLLM tool parser
     tool_parser_plugin: NotRequired[str]
+    # Capture exact per-scheduler-step batch composition from vLLM's MFU debug
+    # stats. This is a read-only benchmark/debugging facility.
+    enable_vllm_step_trace: NotRequired[bool]
 
 
 class VllmConfig(GenerationConfig):

--- a/nemo_rl/models/generation/vllm/forced_sequence_logits_processor.py
+++ b/nemo_rl/models/generation/vllm/forced_sequence_logits_processor.py
@@ -1,0 +1,85 @@
+"""Benchmark-only exact token-sequence replay for vLLM 0.17."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import (
+    AdapterLogitsProcessor,
+    RequestLogitsProcessor,
+)
+
+
+class _ForcedSequence:
+    def __init__(self, token_ids: list[int]) -> None:
+        self.token_ids = token_ids
+
+    def __call__(
+        self, output_ids: list[int], logits: torch.Tensor
+    ) -> torch.Tensor:
+        position = len(output_ids)
+        if position >= len(self.token_ids):
+            raise RuntimeError(
+                "forced-sequence processor called beyond recorded sequence: "
+                f"position={position}, length={len(self.token_ids)}"
+            )
+        target = self.token_ids[position]
+        if target >= logits.numel():
+            raise RuntimeError(
+                f"forced token {target} is outside logits size {logits.numel()}"
+            )
+        value = logits[target].clone()
+        logits[:] = float("-inf")
+        logits[target] = value
+        return logits
+
+
+class ForcedSequenceLogitsProcessor(AdapterLogitsProcessor):
+    """Force each request to emit its recorded output token IDs."""
+
+    ARGUMENT = "nrl_forced_token_ids"
+
+    @classmethod
+    def validate_params(cls, params: SamplingParams) -> None:
+        value: Any = params.extra_args and params.extra_args.get(cls.ARGUMENT)
+        if os.environ.get("NRL_FORCED_SEQUENCE_AUDIT") == "1":
+            print(
+                "[FORCED-SEQUENCE-AUDIT] validate_params "
+                f"has_value={value is not None} "
+                f"length={len(value) if isinstance(value, list) else None}",
+                flush=True,
+            )
+        if value is None:
+            return
+        if (
+            not isinstance(value, list)
+            or not value
+            or any(type(token_id) is not int or token_id < 0 for token_id in value)
+        ):
+            raise ValueError(
+                f"{cls.ARGUMENT} must be a non-empty list of non-negative ints"
+            )
+        if params.max_tokens != len(value):
+            raise ValueError(
+                f"{cls.ARGUMENT} length ({len(value)}) must equal max_tokens "
+                f"({params.max_tokens})"
+            )
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def new_req_logits_processor(
+        self, params: SamplingParams
+    ) -> Optional[RequestLogitsProcessor]:
+        self.validate_params(params)
+        value = params.extra_args and params.extra_args.get(self.ARGUMENT)
+        if os.environ.get("NRL_FORCED_SEQUENCE_AUDIT") == "1":
+            print(
+                "[FORCED-SEQUENCE-AUDIT] new_req_logits_processor "
+                f"has_value={value is not None}",
+                flush=True,
+            )
+        return None if value is None else _ForcedSequence(list(value))

--- a/nemo_rl/models/generation/vllm/inflight_profiler.py
+++ b/nemo_rl/models/generation/vllm/inflight_profiler.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live in-flight rollout batch profiler for vLLM generation.
+
+At a fixed cadence *during* a ``generate()`` call this samples the in-process
+vLLM V1 scheduler's running queue, capturing the per-data-parallel-rank in-flight
+batch composition: the number of running sequences (batch size) and the context
+length of every running sequence (prompt + tokens generated so far). Sampling
+each data-parallel replica concurrently over the same wall-clock window gives the
+"global" view of how each worker's batch and context lengths evolve over time
+(batch decay, straggler tails, KV pressure) for rollout performance analysis.
+
+Enabled via ``NRL_PROFILE_INFLIGHT=1``. It reads vLLM internals directly, which
+requires the in-process EngineCore (``VLLM_ENABLE_V1_MULTIPROCESSING=0``, which
+NeMo-RL sets by default) so the scheduler's ``running`` queue is reachable from
+the worker process. If the scheduler cannot be located it degrades to a no-op
+(after logging once) rather than failing generation.
+"""
+
+import os
+import threading
+import time
+from typing import Any, Callable, Optional
+
+
+def inflight_profiling_enabled() -> bool:
+    """Whether to sample the in-flight rollout batch (NRL_PROFILE_INFLIGHT)."""
+    return os.environ.get("NRL_PROFILE_INFLIGHT", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def inflight_interval_s() -> float:
+    """Sampling cadence in seconds (NRL_PROFILE_INFLIGHT_INTERVAL, default 0.5)."""
+    raw = os.environ.get("NRL_PROFILE_INFLIGHT_INTERVAL", "0.5")
+    try:
+        # Floor the interval so a typo cannot spin the sampler thread.
+        return max(0.02, float(raw))
+    except ValueError:
+        return 0.5
+
+
+def inflight_output_dir() -> str:
+    """Directory the driver writes the timeline JSONL to (NRL_PROFILE_INFLIGHT_DIR)."""
+    return os.environ.get("NRL_PROFILE_INFLIGHT_DIR", "dp_inflight_profiles")
+
+
+def find_vllm_scheduler(llm: Any) -> Optional[Any]:
+    """Locate the in-process vLLM V1 scheduler from a ``vllm.LLM`` instance.
+
+    Navigates ``LLM -> LLMEngine -> EngineCoreClient -> EngineCore -> scheduler``.
+    With multiprocessing disabled the client is an ``InprocClient`` whose
+    ``.engine_core`` is the in-process ``EngineCore`` holding the scheduler; the
+    extra candidates make this robust to minor vLLM version differences. Returns
+    the scheduler (which exposes ``running: list[Request]``) or None if it is not
+    reachable (e.g. EngineCore lives in a separate process).
+    """
+    if llm is None:
+        return None
+    engine = getattr(llm, "llm_engine", None)
+    candidates = []
+    if engine is not None:
+        engine_core_client = getattr(engine, "engine_core", None)
+        if engine_core_client is not None:
+            # InprocClient.engine_core is the in-process EngineCore.
+            candidates.append(getattr(engine_core_client, "engine_core", None))
+            candidates.append(engine_core_client)
+        candidates.append(engine)
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        scheduler = getattr(candidate, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "running"):
+            return scheduler
+    return None
+
+
+def read_scheduler_sample(scheduler: Any) -> Optional[dict[str, Any]]:
+    """Snapshot the running queue of an in-process vLLM scheduler (sync engine).
+
+    Returns ``{batch_size, waiting, ctx_lens, prompt_lens, gen_lens}`` for the
+    currently-running requests, or None if the scheduler is unavailable. Used as
+    the ``sample_fn`` for the synchronous engine, where the scheduler lives in the
+    worker process. (The async engine runs its scheduler out-of-process, so it
+    uses a front-end streaming sample source instead — see the async worker.)
+    """
+    if scheduler is None:
+        return None
+    # list(...) over a CPython list is atomic under the GIL, so this is safe
+    # against the engine thread mutating scheduler.running concurrently.
+    try:
+        running = list(getattr(scheduler, "running", []))
+    except Exception:
+        return None
+
+    ctx_lens: list[int] = []
+    prompt_lens: list[int] = []
+    gen_lens: list[int] = []
+    for request in running:
+        try:
+            # Request.num_tokens == len(all_token_ids): prompt + generated so far.
+            ctx_lens.append(int(request.num_tokens))
+            prompt_lens.append(int(getattr(request, "num_prompt_tokens", 0)))
+            gen_lens.append(int(getattr(request, "num_output_tokens", 0)))
+        except Exception:
+            continue
+    try:
+        waiting = len(getattr(scheduler, "waiting", []) or [])
+    except Exception:
+        waiting = -1
+    return {
+        "batch_size": len(running),
+        "waiting": waiting,
+        "ctx_lens": ctx_lens,
+        "prompt_lens": prompt_lens,
+        "gen_lens": gen_lens,
+    }
+
+
+class InflightProfiler:
+    """Background sampler of a vLLM scheduler's running queue for one DP replica.
+
+    The owning worker calls :meth:`mark_call_start` / :meth:`mark_call_end` around
+    each ``generate()`` so samples are scoped to a single generation call (relative
+    timestamps reset each call), and the driver pulls the buffer with
+    :meth:`snapshot` afterwards. A daemon thread does the sampling so it runs while
+    the synchronous ``llm.generate()`` blocks the main thread.
+    """
+
+    # Hard cap so a pathologically long generation cannot grow the buffer without
+    # bound; at the default 0.5s cadence this is far more than any real rollout.
+    _MAX_SAMPLES_PER_CALL = 100_000
+
+    def __init__(
+        self,
+        sample_fn: Callable[[], Optional[dict[str, Any]]],
+        dp_label: str,
+        interval_s: float,
+    ):
+        # sample_fn returns {batch_size, waiting, ctx_lens, prompt_lens, gen_lens}
+        # for the current in-flight set, or None if the source is unavailable.
+        # Sync engine reads the in-process scheduler; async engine reads a live
+        # dict maintained from the streamed RequestOutputs (scheduler is remote).
+        self._sample_fn = sample_fn
+        self._dp_label = dp_label
+        self._interval_s = interval_s
+        self._lock = threading.Lock()
+        self._buffer: list[dict[str, Any]] = []
+        self._active = False
+        self._t0 = 0.0
+        self._thread: Optional[threading.Thread] = None
+        self._sample_missing_warned = False
+
+    def start(self) -> None:
+        """Launch the daemon sampling thread (idempotent)."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._loop, name="nrl-inflight-profiler", daemon=True
+        )
+        self._thread.start()
+
+    def mark_call_start(self) -> None:
+        """Begin a new generation window: clear the buffer and start sampling."""
+        with self._lock:
+            self._buffer = []
+            self._t0 = time.monotonic()
+            self._active = True
+
+    def mark_call_end(self) -> None:
+        """Stop sampling; take one final sample to capture the decode tail."""
+        self._sample_once()
+        with self._lock:
+            self._active = False
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return a copy of the samples collected for the last generation window."""
+        with self._lock:
+            return list(self._buffer)
+
+    def _loop(self) -> None:
+        while True:
+            if self._active:
+                self._sample_once()
+            time.sleep(self._interval_s)
+
+    def _sample_once(self) -> None:
+        try:
+            data = self._sample_fn()
+        except Exception:
+            data = None
+        if data is None:
+            if not self._sample_missing_warned:
+                self._sample_missing_warned = True
+                print(
+                    f"[INFLIGHT-PROFILER] sample source unavailable for "
+                    f"{self._dp_label}; the in-flight timeline will be empty.",
+                    flush=True,
+                )
+            return
+
+        sample = {
+            "t": round(time.monotonic() - self._t0, 4),
+            "batch_size": data.get("batch_size", 0),
+            "waiting": data.get("waiting", -1),
+            "ctx_lens": data.get("ctx_lens", []),
+            "prompt_lens": data.get("prompt_lens", []),
+            "gen_lens": data.get("gen_lens", []),
+        }
+        with self._lock:
+            if self._active and len(self._buffer) < self._MAX_SAMPLES_PER_CALL:
+                self._buffer.append(sample)

--- a/nemo_rl/models/generation/vllm/lfs/__init__.py
+++ b/nemo_rl/models/generation/vllm/lfs/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Length-aware (LFS) admission scheduling for vLLM rollouts."""
+
+from nemo_rl.models.generation.vllm.lfs.groups import build_async_cross_dp_group_ids
+from nemo_rl.models.generation.vllm.lfs.modes import (
+    LFS_ADMISSION_FAIRNESS_SEMANTICS,
+    CrossDpMode,
+    DpSelectionMode,
+)
+from nemo_rl.models.generation.vllm.lfs.scheduler import CrossDpSchedulerState
+
+__all__ = [
+    "LFS_ADMISSION_FAIRNESS_SEMANTICS",
+    "CrossDpMode",
+    "CrossDpSchedulerState",
+    "DpSelectionMode",
+    "build_async_cross_dp_group_ids",
+]

--- a/nemo_rl/models/generation/vllm/lfs/concurrency.py
+++ b/nemo_rl/models/generation/vllm/lfs/concurrency.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Concurrency limits that guarantee the configured KV cache can fit."""
+
+from typing import Any
+
+
+def get_engine_kv_cache_shape(engine: Any) -> tuple[int, int]:
+    """Read initialized vLLM KV token capacity and block size.
+
+    vLLM's sync and async front ends expose the same cache config at
+    different object paths. Only an initialized config has a positive
+    ``num_gpu_blocks``; returning the actual value lets benchmarks validate
+    TP-dependent concurrency without relying on a TP=1 estimate.
+    """
+    candidate_paths = (
+        ("vllm_config", "cache_config"),
+        ("llm_engine", "vllm_config", "cache_config"),
+        ("llm_engine", "cache_config"),
+        ("engine_core", "vllm_config", "cache_config"),
+    )
+    for path in candidate_paths:
+        candidate = engine
+        try:
+            for attribute in path:
+                candidate = getattr(candidate, attribute)
+            num_gpu_blocks = int(candidate.num_gpu_blocks)
+            block_size = int(candidate.block_size)
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if num_gpu_blocks > 0 and block_size > 0:
+            return num_gpu_blocks * block_size, block_size
+    raise RuntimeError("could not read initialized vLLM KV cache capacity")
+
+
+def max_concurrency_without_preemption(
+    *,
+    kv_cache_tokens: int,
+    max_sequence_length: int,
+    block_size: int,
+    reserve_blocks_per_sequence: int = 0,
+) -> int:
+    """Return a block-aligned concurrency cap that fits the KV cache.
+
+    The calculation assumes every live request reaches ``max_sequence_length``.
+    This is intentionally more conservative than using an observed mean length:
+    the result is suitable for experiments that must exclude KV-capacity-driven
+    preemption.
+
+    Args:
+        kv_cache_tokens: Total token slots in the GPU KV cache.
+        max_sequence_length: Maximum prompt-plus-output length per request.
+        block_size: Number of token slots in one KV cache block.
+        reserve_blocks_per_sequence: Extra blocks reserved per live request for
+            scheduler lookahead or an explicit safety margin.
+
+    Returns:
+        The largest positive number of concurrent requests that fits.
+
+    Raises:
+        ValueError: If an input is invalid or one maximum-length request cannot
+            fit in the cache.
+    """
+    if kv_cache_tokens <= 0:
+        raise ValueError("kv_cache_tokens must be positive")
+    if max_sequence_length <= 0:
+        raise ValueError("max_sequence_length must be positive")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if reserve_blocks_per_sequence < 0:
+        raise ValueError("reserve_blocks_per_sequence must be non-negative")
+
+    available_blocks = kv_cache_tokens // block_size
+    sequence_blocks = (
+        (max_sequence_length + block_size - 1) // block_size
+        + reserve_blocks_per_sequence
+    )
+    concurrency = available_blocks // sequence_blocks
+    if concurrency < 1:
+        raise ValueError(
+            "KV cache cannot fit one maximum-length request: "
+            f"available_blocks={available_blocks}, sequence_blocks={sequence_blocks}"
+        )
+    return concurrency

--- a/nemo_rl/models/generation/vllm/lfs/diagnostics.py
+++ b/nemo_rl/models/generation/vllm/lfs/diagnostics.py
@@ -1,0 +1,677 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only introspection for the cross-DP admission scheduler.
+
+Everything here explains a decision after the fact: the snapshot the
+dispatcher publishes, and the per-assignment counterfactual answering "what
+would plain FCFS have picked instead?".  None of it feeds back into
+admission, so it stays outside the scheduler's state machine.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nemo_rl.models.generation.vllm.lfs.modes import (
+    EXPLICIT_PROBE_SELECTION_SEMANTICS,
+    LFS_ADMISSION_FAIRNESS_POLICY,
+    LFS_ADMISSION_FAIRNESS_SEMANTICS,
+    ONLINE_LFS_MODES,
+    PREFERRED_DP_PINNING_SEMANTICS,
+    PROBE_LFS_MODES,
+    STATIC_ADMISSION_COST_SEMANTICS,
+)
+from nemo_rl.models.generation.vllm.lfs.state import Request
+
+def build_snapshot(state) -> dict[str, Any]:
+    return {
+        "mode": state.mode,
+        "dp_selection_mode": state.dp_selection_mode,
+        "preferred_dp_pinning_semantics": (
+            PREFERRED_DP_PINNING_SEMANTICS
+        ),
+        "lfs_admission_fairness": {
+            "policy": LFS_ADMISSION_FAIRNESS_POLICY,
+            "semantics": LFS_ADMISSION_FAIRNESS_SEMANTICS,
+            "interval": state.lfs_admission_fairness_interval,
+            "ordinary_admission_opportunity_count": (
+                state.ordinary_admission_opportunities
+            ),
+            "due_count": state.admission_fairness_due_count,
+            "selected_count": state.admission_fairness_selected_count,
+            "override_count": state.admission_fairness_override_count,
+            "noop_count": state.admission_fairness_noop_count,
+            "no_candidate_count": (
+                state.admission_fairness_no_candidate_count
+            ),
+        },
+        "dp_size": state.dp_size,
+        "max_num_seqs_per_dp": state.max_num_seqs_per_dp,
+        "lookahead_per_dp": state.lookahead_per_dp,
+        "admission_limit_per_dp": state.admission_limit_per_dp,
+        "global_admission_limit": state.global_admission_limit,
+        "max_total_inflight_observed": (
+            state.max_total_inflight_observed
+        ),
+        "max_inflight_observed_by_dp": list(
+            state.max_inflight_observed_by_dp
+        ),
+        "inflight_high_watermark_semantics": (
+            "Exact dispatcher state after every occupancy-increasing "
+            "assignment since actor construction; completions and "
+            "rollbacks can only decrease occupancy."
+        ),
+        "fatal_error": state.fatal_error,
+        "dp_inflight": [sorted(items) for items in state.dp_inflight],
+        "dp_static_admission_cost": [
+            sum(items.values()) for items in state.dp_inflight
+        ],
+        "dp_load_accounting_semantics": (
+            STATIC_ADMISSION_COST_SEMANTICS
+        ),
+        "pending": state._pending_request_count,
+        "pending_preferred_dp": (
+            state._pending_preferred_dp_request_count
+        ),
+        "pending_counter_matches_request_states": (
+            state._pending_request_count
+            == sum(
+                request.status == "pending"
+                for request in state.requests.values()
+            )
+        ),
+        "pending_preferred_dp_counter_matches_request_states": (
+            state._pending_preferred_dp_request_count
+            == sum(
+                request.status == "pending"
+                and request.preferred_dp_idx is not None
+                for request in state.requests.values()
+            )
+        ),
+        "inflight_group_index_matches_dp_inflight": (
+            {
+                request_id
+                for inflight in state.dp_inflight
+                for request_id in inflight
+            }
+            == {
+                request_id
+                for request_ids in state._inflight_by_group.values()
+                for request_id in request_ids
+            }
+        ),
+        "sessions": {
+            session_id: {
+                "open_participants": sorted(session.open_participants),
+                "estimates": dict(session.estimates),
+                "failed_error": session.failed_error,
+                "dp_placement_mode": session.dp_placement_mode,
+                "probe_selection_semantics": (
+                    session.probe_selection_semantics
+                ),
+                "designated_probe_request_ids": dict(
+                    session.designated_probe_request_ids
+                ),
+                "group_catalog_ordinals": dict(
+                    session.group_catalog_ordinals
+                ),
+                "last_group_admission_sequences": dict(
+                    session.last_group_admission_sequences
+                ),
+                "ordinary_admission_opportunity_count": (
+                    session.ordinary_admission_opportunities
+                ),
+                "admission_fairness_due_count": (
+                    session.admission_fairness_due_count
+                ),
+                "admission_fairness_selected_count": (
+                    session.admission_fairness_selected_count
+                ),
+                "admission_fairness_override_count": (
+                    session.admission_fairness_override_count
+                ),
+                "admission_fairness_noop_count": (
+                    session.admission_fairness_noop_count
+                ),
+                "admission_fairness_no_candidate_count": (
+                    session.admission_fairness_no_candidate_count
+                ),
+            }
+            for session_id, session in state.sessions.items()
+        },
+        "assignment_history": list(state.assignment_history),
+        "group_history": {
+            group_id: {
+                "mean": total / count,
+                "sum": total,
+                "count": count,
+            }
+            for group_id, (total, count) in state.group_history.items()
+            if count > 0
+        },
+        "history_update_history": list(state.history_update_history),
+        "estimate_rebase_history": list(state.estimate_rebase_history),
+    }
+
+def diagnostic_group_front(
+    state, group_key: tuple[str, str]
+) -> Request | None:
+    request_ids = state._diagnostic_pending_by_group.get(group_key)
+    if request_ids is None:
+        return None
+    while request_ids:
+        request = state.requests.get(request_ids[0])
+        if request is None or request.status != "pending":
+            request_ids.popleft()
+            continue
+        session = state.sessions.get(request.session_id)
+        if session is None or session.failed_error is not None:
+            request_ids.popleft()
+            continue
+        return request
+    return None
+
+def diagnostic_policy_group_front(
+    state, group_key: tuple[str, str]
+) -> Request | None:
+    """Reconstruct a policy front without consulting the policy queue.
+
+    The diagnostic index intentionally preserves catalog order so it can
+    reconstruct an FCFS counterfactual. Explicit probe designation is the
+    one mode-specific within-group reorder, so reconstruct that choice
+    from the immutable session manifest instead of reading
+    ``_pending_by_group`` (the queue whose behavior is being checked).
+    """
+
+    catalog_front = diagnostic_group_front(state, group_key)
+    if catalog_front is None:
+        return None
+    if state.mode not in PROBE_LFS_MODES:
+        return catalog_front
+    session = state.sessions[catalog_front.session_id]
+    if (
+        session.probe_selection_semantics
+        != EXPLICIT_PROBE_SELECTION_SEMANTICS
+        or catalog_front.group_id in session.probed_groups
+    ):
+        return catalog_front
+    designated_request_id = session.designated_probe_request_ids.get(
+        catalog_front.group_id
+    )
+    designated_request = state.requests.get(
+        designated_request_id
+    )
+    if (
+        designated_request is not None
+        and designated_request.status == "pending"
+        and designated_request.session_id == catalog_front.session_id
+        and designated_request.group_id == catalog_front.group_id
+    ):
+        return designated_request
+    # A cancelled or definitively failed designated request is replaced by
+    # the first remaining catalog request, matching
+    # _prioritize_designated_probes().
+    return catalog_front
+
+def pending_choice_diagnostics(state) -> dict[str, Any]:
+    """Describe whether policy priority can still change admission order."""
+
+    catalog_group_fronts: dict[tuple[str, str], Request] = {}
+    policy_group_fronts: dict[tuple[str, str], Request] = {}
+    for group_key in list(state._diagnostic_pending_by_group):
+        catalog_request = diagnostic_group_front(state, group_key)
+        if catalog_request is None:
+            state._diagnostic_pending_by_group.pop(group_key, None)
+            continue
+        policy_request = diagnostic_policy_group_front(state, group_key)
+        if policy_request is None:
+            raise AssertionError(
+                "policy diagnostic lost a group with a catalog front"
+            )
+        catalog_group_fronts[group_key] = catalog_request
+        policy_group_fronts[group_key] = policy_request
+    if not catalog_group_fronts:
+        if state._pending_request_count != 0:
+            raise AssertionError(
+                "pending request counter is nonzero without any pending "
+                "group front"
+            )
+        return {
+            "pending_request_count_before_assignment": 0,
+            "pending_group_count_before_assignment": 0,
+            "pending_unprobed_group_count_before_assignment": 0,
+            "pending_unknown_group_count_before_assignment": 0,
+            "pending_finite_group_count_before_assignment": 0,
+            "pending_finite_estimate_min": None,
+            "pending_finite_estimate_max": None,
+            "policy_active_priority_tier": None,
+            "policy_eligible_session_ids": [],
+            "policy_eligible_pending_groups": [],
+            "policy_eligible_pending_finite_group_count": 0,
+            "policy_eligible_pending_finite_estimate_min": None,
+            "policy_eligible_pending_finite_estimate_max": None,
+            "policy_priority_class_count_before_assignment": 0,
+            "policy_expected_request_id": None,
+            "policy_expected_group_id": None,
+            "policy_expected_priority_key": None,
+            "base_policy_expected_request_id": None,
+            "base_policy_expected_group_id": None,
+            "base_policy_expected_priority_key": None,
+            "ordinary_admission_opportunity": False,
+            "ordinary_admission_ordinal": None,
+            "admission_fairness_interval": (
+                state.lfs_admission_fairness_interval
+            ),
+            "admission_fairness_policy": (
+                LFS_ADMISSION_FAIRNESS_POLICY
+            ),
+            "admission_fairness_semantics": (
+                LFS_ADMISSION_FAIRNESS_SEMANTICS
+            ),
+            "admission_fairness_due": False,
+            "admission_fairness_eligible_pending_groups": [],
+            "admission_fairness_candidate_count": 0,
+            "admission_fairness_expected_request_id": None,
+            "admission_fairness_expected_group_id": None,
+            "admission_fairness_expected_priority_key": None,
+            "admission_fairness_selected": False,
+            "admission_fairness_changed_base_choice": False,
+            "admission_fairness_due_but_no_candidate": False,
+            "admission_selection_reason": None,
+            "fcfs_front_request_id": None,
+        }
+
+    fcfs_front = min(
+        catalog_group_fronts.values(),
+        key=lambda request: (
+            state.sessions[request.session_id].arrival_seq,
+            request.arrival_seq,
+        ),
+    )
+
+    oldest_session_arrival_seq = min(
+        state.sessions[request.session_id].arrival_seq
+        for request in policy_group_fronts.values()
+    )
+    oldest_session_fronts = [
+        request
+        for request in policy_group_fronts.values()
+        if state.sessions[request.session_id].arrival_seq
+        == oldest_session_arrival_seq
+    ]
+    if state.mode in (
+        "lfs",
+        "predicted_lfs",
+        "history_lfs",
+        "oracle_probe_lfs",
+    ):
+        policy_active_priority_tier = min(
+            state._lfs_key(request)[1]
+            for request in oldest_session_fronts
+        )
+        policy_eligible_fronts = [
+            request
+            for request in oldest_session_fronts
+            if state._lfs_key(request)[1]
+            == policy_active_priority_tier
+        ]
+    else:
+        policy_active_priority_tier = None
+        policy_eligible_fronts = oldest_session_fronts
+    base_policy_expected_front = (
+        min(policy_eligible_fronts, key=state._lfs_key)
+        if state.mode in ONLINE_LFS_MODES
+        else None
+    )
+    ordinary_admission_opportunity = (
+        state.mode in ONLINE_LFS_MODES
+        and policy_active_priority_tier == 2
+    )
+    fairness_session = (
+        state.sessions[oldest_session_fronts[0].session_id]
+        if ordinary_admission_opportunity
+        else None
+    )
+    ordinary_admission_ordinal = (
+        fairness_session.ordinary_admission_opportunities + 1
+        if fairness_session is not None
+        else None
+    )
+    admission_fairness_due = bool(
+        ordinary_admission_ordinal is not None
+        and state.lfs_admission_fairness_interval > 0
+        and ordinary_admission_ordinal
+        % state.lfs_admission_fairness_interval
+        == 0
+    )
+    admission_fairness_eligible_fronts = (
+        [
+            request
+            for request in policy_eligible_fronts
+            if not state._inflight_by_group.get(
+                (request.session_id, request.group_id)
+            )
+        ]
+        if admission_fairness_due
+        else []
+    )
+    admission_fairness_expected_front = (
+        min(
+            admission_fairness_eligible_fronts,
+            key=state._admission_fairness_key,
+        )
+        if admission_fairness_eligible_fronts
+        else None
+    )
+    admission_fairness_selected = bool(
+        admission_fairness_due
+        and admission_fairness_expected_front is not None
+    )
+    policy_expected_front = (
+        admission_fairness_expected_front
+        if admission_fairness_selected
+        else base_policy_expected_front
+    )
+    admission_fairness_changed_base_choice = bool(
+        admission_fairness_selected
+        and admission_fairness_expected_front is not None
+        and base_policy_expected_front is not None
+        and admission_fairness_expected_front.request_id
+        != base_policy_expected_front.request_id
+    )
+    admission_fairness_due_but_no_candidate = bool(
+        admission_fairness_due
+        and admission_fairness_expected_front is None
+    )
+    if state.mode not in ONLINE_LFS_MODES:
+        admission_selection_reason = None
+    elif policy_active_priority_tier == 0:
+        admission_selection_reason = "probe_priority"
+    elif admission_fairness_due_but_no_candidate:
+        admission_selection_reason = "fairness_no_candidate_fallback"
+    elif admission_fairness_selected:
+        admission_selection_reason = (
+            "fairness_override"
+            if admission_fairness_changed_base_choice
+            else "fairness_noop"
+        )
+    else:
+        admission_selection_reason = "base_lfs"
+
+    unprobed_count = 0
+    unknown_count = 0
+    finite_estimates: list[int] = []
+    priority_classes: set[tuple[int, float, int]] = set()
+    for request in policy_group_fronts.values():
+        session = state.sessions[request.session_id]
+        estimate = session.estimates.get(request.group_id)
+        if state.mode in ONLINE_LFS_MODES:
+            if (
+                estimate is None
+                and request.group_id not in session.probed_groups
+            ):
+                unprobed_count += 1
+                priority_classes.add((0, 0.0, 0))
+            elif estimate is None:
+                unknown_count += 1
+                priority_classes.add(
+                    (
+                        2,
+                        -float(request.fallback_cost),
+                        session.unknown_admissions.get(
+                            request.group_id, 0
+                        ),
+                    )
+                )
+            else:
+                finite_estimates.append(int(estimate))
+                priority_classes.add(
+                    (
+                        2,
+                        -float(max(1, estimate)),
+                        session.unknown_admissions.get(
+                            request.group_id, 0
+                        ),
+                    )
+                )
+        elif estimate is not None:
+            finite_estimates.append(int(estimate))
+
+    eligible_finite_estimates = [
+        int(estimate)
+        for request in policy_eligible_fronts
+        if (
+            estimate := state.sessions[
+                request.session_id
+            ].estimates.get(request.group_id)
+        )
+        is not None
+    ]
+    policy_eligible_pending_groups = []
+    for request in sorted(
+        policy_eligible_fronts,
+        key=lambda item: (
+            state.sessions[item.session_id].arrival_seq,
+            item.arrival_seq,
+        ),
+    ):
+        request_session = state.sessions[request.session_id]
+        request_estimate = request_session.estimates.get(request.group_id)
+        effective_estimate = (
+            request.fallback_cost
+            if request_estimate is None
+            else max(1, request_estimate)
+        )
+        policy_eligible_pending_groups.append(
+            {
+                "session_id": request.session_id,
+                "session_arrival_seq": request_session.arrival_seq,
+                "group_id": request.group_id,
+                "request_id": request.request_id,
+                "request_arrival_seq": request.arrival_seq,
+                "fallback_cost": request.fallback_cost,
+                "estimate": request_estimate,
+                "effective_estimate": effective_estimate,
+                "unknown_admission_count": (
+                    request_session.unknown_admissions.get(
+                        request.group_id, 0
+                    )
+                ),
+                "group_catalog_ordinal": (
+                    request_session.group_catalog_ordinals[
+                        request.group_id
+                    ]
+                ),
+                "last_group_admission_sequence": (
+                    request_session.last_group_admission_sequences.get(
+                        request.group_id, -1
+                    )
+                ),
+                "group_inflight_count": len(
+                    state._inflight_by_group.get(
+                        (request.session_id, request.group_id), set()
+                    )
+                ),
+                "policy_priority_key": list(state._lfs_key(request)),
+            }
+        )
+
+    admission_fairness_eligible_pending_groups = []
+    for request in sorted(
+        admission_fairness_eligible_fronts,
+        key=lambda item: (
+            state.sessions[item.session_id].arrival_seq,
+            state.sessions[item.session_id].group_catalog_ordinals[
+                item.group_id
+            ],
+            item.arrival_seq,
+        ),
+    ):
+        request_session = state.sessions[request.session_id]
+        admission_fairness_eligible_pending_groups.append(
+            {
+                "session_id": request.session_id,
+                "session_arrival_seq": request_session.arrival_seq,
+                "group_id": request.group_id,
+                "request_id": request.request_id,
+                "request_arrival_seq": request.arrival_seq,
+                "group_catalog_ordinal": (
+                    request_session.group_catalog_ordinals[
+                        request.group_id
+                    ]
+                ),
+                "last_group_admission_sequence": (
+                    request_session.last_group_admission_sequences.get(
+                        request.group_id, -1
+                    )
+                ),
+                "group_inflight_count": 0,
+                "policy_priority_key": list(
+                    state._lfs_key(request)
+                ),
+                "admission_fairness_priority_key": list(
+                    state._admission_fairness_key(request)
+                ),
+            }
+        )
+
+    return {
+        "pending_request_count_before_assignment": (
+            state._pending_request_count
+        ),
+        "pending_group_count_before_assignment": len(
+            policy_group_fronts
+        ),
+        "pending_unprobed_group_count_before_assignment": (
+            unprobed_count
+        ),
+        "pending_unknown_group_count_before_assignment": unknown_count,
+        "pending_finite_group_count_before_assignment": len(
+            finite_estimates
+        ),
+        "pending_finite_estimate_min": (
+            min(finite_estimates) if finite_estimates else None
+        ),
+        "pending_finite_estimate_max": (
+            max(finite_estimates) if finite_estimates else None
+        ),
+        "policy_active_priority_tier": (
+            policy_active_priority_tier
+        ),
+        "policy_eligible_session_ids": sorted(
+            {request.session_id for request in policy_eligible_fronts}
+        ),
+        "policy_eligible_pending_groups": (
+            policy_eligible_pending_groups
+        ),
+        "policy_eligible_pending_finite_group_count": len(
+            eligible_finite_estimates
+        ),
+        "policy_eligible_pending_finite_estimate_min": (
+            min(eligible_finite_estimates)
+            if eligible_finite_estimates
+            else None
+        ),
+        "policy_eligible_pending_finite_estimate_max": (
+            max(eligible_finite_estimates)
+            if eligible_finite_estimates
+            else None
+        ),
+        "policy_priority_class_count_before_assignment": (
+            len(priority_classes)
+            if state.mode in ONLINE_LFS_MODES
+            else None
+        ),
+        "policy_expected_request_id": (
+            policy_expected_front.request_id
+            if policy_expected_front is not None
+            else None
+        ),
+        "policy_expected_group_id": (
+            policy_expected_front.group_id
+            if policy_expected_front is not None
+            else None
+        ),
+        "policy_expected_priority_key": (
+            list(state._lfs_key(policy_expected_front))
+            if policy_expected_front is not None
+            else None
+        ),
+        "base_policy_expected_request_id": (
+            base_policy_expected_front.request_id
+            if base_policy_expected_front is not None
+            else None
+        ),
+        "base_policy_expected_group_id": (
+            base_policy_expected_front.group_id
+            if base_policy_expected_front is not None
+            else None
+        ),
+        "base_policy_expected_priority_key": (
+            list(state._lfs_key(base_policy_expected_front))
+            if base_policy_expected_front is not None
+            else None
+        ),
+        "ordinary_admission_opportunity": (
+            ordinary_admission_opportunity
+        ),
+        "ordinary_admission_ordinal": ordinary_admission_ordinal,
+        "admission_fairness_interval": (
+            state.lfs_admission_fairness_interval
+        ),
+        "admission_fairness_policy": (
+            LFS_ADMISSION_FAIRNESS_POLICY
+        ),
+        "admission_fairness_semantics": (
+            LFS_ADMISSION_FAIRNESS_SEMANTICS
+        ),
+        "admission_fairness_due": admission_fairness_due,
+        "admission_fairness_eligible_pending_groups": (
+            admission_fairness_eligible_pending_groups
+        ),
+        "admission_fairness_candidate_count": len(
+            admission_fairness_eligible_pending_groups
+        ),
+        "admission_fairness_expected_request_id": (
+            admission_fairness_expected_front.request_id
+            if admission_fairness_expected_front is not None
+            else None
+        ),
+        "admission_fairness_expected_group_id": (
+            admission_fairness_expected_front.group_id
+            if admission_fairness_expected_front is not None
+            else None
+        ),
+        "admission_fairness_expected_priority_key": (
+            list(
+                state._admission_fairness_key(
+                    admission_fairness_expected_front
+                )
+            )
+            if admission_fairness_expected_front is not None
+            else None
+        ),
+        "admission_fairness_selected": (
+            admission_fairness_selected
+        ),
+        "admission_fairness_changed_base_choice": (
+            admission_fairness_changed_base_choice
+        ),
+        "admission_fairness_due_but_no_candidate": (
+            admission_fairness_due_but_no_candidate
+        ),
+        "admission_selection_reason": admission_selection_reason,
+        "fcfs_front_request_id": fcfs_front.request_id,
+    }

--- a/nemo_rl/models/generation/vllm/lfs/dispatcher.py
+++ b/nemo_rl/models/generation/vllm/lfs/dispatcher.py
@@ -1,0 +1,573 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray concurrency boundary for the pure cross-DP scheduler state machine."""
+
+import asyncio
+import os
+import time
+from collections import deque
+from typing import Any
+
+import ray
+
+from nemo_rl.models.generation.vllm.lfs.scheduler import (
+    CrossDpMode,
+    CrossDpSchedulerState,
+    DpSelectionMode,
+)
+
+
+@ray.remote(num_cpus=0, max_concurrency=100000)
+class CrossDpDispatcherActor:  # pragma: no cover - exercised in Ray integration tests
+    """Share one scheduler safely across event loops, threads, and Ray actors."""
+
+    def __init__(
+        self,
+        dp_size: int,
+        max_num_seqs_per_dp: int,
+        mode: CrossDpMode,
+        trace: bool = False,
+        initial_group_history: dict[str, Any] | None = None,
+        lookahead_per_dp: int = 0,
+        global_admission_limit: int | None = None,
+        dp_selection_mode: DpSelectionMode = "inflight_count",
+        lfs_admission_fairness_interval: int = 0,
+    ) -> None:
+        self.state = CrossDpSchedulerState(
+            dp_size,
+            max_num_seqs_per_dp,
+            mode,
+            lookahead_per_dp=lookahead_per_dp,
+            global_admission_limit=global_admission_limit,
+            dp_selection_mode=dp_selection_mode,
+            lfs_admission_fairness_interval=(
+                lfs_admission_fairness_interval
+            ),
+        )
+        if initial_group_history:
+            self.state.restore_group_history(initial_group_history)
+        self.trace = trace
+        self._waiters: dict[str, asyncio.Future] = {}
+        # Leave ample async-actor call slots for complete/cancel/close RPCs.
+        # Above this limit we fail explicitly instead of risking actor starvation.
+        self._max_waiters = 90000
+        self._completion_history: list[dict[str, Any]] = []
+        # A scheduler assignment reserves capacity, but it is not yet an engine
+        # submission. Release at most one lease at a time on each DP and wait
+        # until that DP worker confirms that vLLM's add_request() completed
+        # before releasing the next one. Creating a Ray worker proxy is not a
+        # sufficient boundary: separately scheduled proxy calls can reach an
+        # async worker out of order. Independent DP ranks still launch in
+        # parallel because each DP owns a separate gate.
+        self._launch_queues_by_dp: list[deque[str]] = [
+            deque() for _ in range(dp_size)
+        ]
+        self._launch_outstanding_by_dp: list[str | None] = [None] * dp_size
+        self._engine_frontend_ack_history: list[dict[str, Any]] = []
+
+    async def open_session(
+        self,
+        session_id: str,
+        request_catalog: list[dict[str, Any]],
+        participant_ids: list[str],
+    ) -> None:
+        self.state.open_session(session_id, request_catalog, participant_ids)
+        self._after_state_change()
+
+    async def acquire(
+        self,
+        session_id: str,
+        participant_id: str,
+        request_id: str,
+        group_id: str,
+        fallback_cost: int,
+    ) -> dict[str, Any]:
+        self.state.prepare_acquire(
+            session_id, participant_id, request_id, group_id, fallback_cost
+        )
+        self._after_state_change()
+
+        if request_id in self._waiters:
+            raise RuntimeError(f"request {request_id!r} already has a pending acquire")
+        if len(self._waiters) >= self._max_waiters:
+            self.state.cancel_unsubmitted(request_id)
+            self._after_state_change()
+            raise RuntimeError(
+                "Cross-DP dispatcher waiter limit exceeded; split the rollout "
+                f"or raise the actor limit (current={self._max_waiters})"
+            )
+
+        future = asyncio.get_running_loop().create_future()
+        self._waiters[request_id] = future
+        self._drain_launch_gates()
+        try:
+            return await future
+        except asyncio.CancelledError:
+            self.state.cancel_unsubmitted(request_id)
+            self._clear_launch_outstanding(request_id)
+            self._after_state_change()
+            raise
+        finally:
+            self._waiters.pop(request_id, None)
+
+    async def confirm_engine_frontend_submitted(
+        self,
+        request_id: str,
+        assignment_sequence: int,
+        dp_assignment_ordinal: int,
+        session_dp_assignment_ordinal: int,
+        client_reported_at_unix_s: float | None = None,
+        client_reported_at_monotonic_s: float | None = None,
+        client_hostname: str | None = None,
+    ) -> None:
+        """Acknowledge that vLLM accepted the leased request on its DP worker."""
+        received_at_unix_s = time.time()
+        received_at_monotonic_s = time.monotonic()
+        request = self.state.requests.get(request_id)
+        if request is None:
+            raise KeyError(f"unknown cross-DP request {request_id!r}")
+        if request.status != "started":
+            raise RuntimeError(
+                f"request {request_id!r} acknowledged engine submission from "
+                f"invalid status {request.status!r}"
+            )
+        if request.assignment_sequence != int(assignment_sequence):
+            raise RuntimeError(
+                f"request {request_id!r} assignment sequence mismatch: "
+                f"{request.assignment_sequence} != {assignment_sequence}"
+            )
+        if request.dp_assignment_ordinal != int(dp_assignment_ordinal):
+            raise RuntimeError(
+                f"request {request_id!r} DP assignment ordinal mismatch: "
+                f"{request.dp_assignment_ordinal} != {dp_assignment_ordinal}"
+            )
+        if request.session_dp_assignment_ordinal != int(
+            session_dp_assignment_ordinal
+        ):
+            raise RuntimeError(
+                f"request {request_id!r} session DP assignment ordinal "
+                f"mismatch: {request.session_dp_assignment_ordinal} != "
+                f"{session_dp_assignment_ordinal}"
+            )
+        assert request.dp_idx is not None
+        dp_idx = request.dp_idx
+        if self._launch_outstanding_by_dp[dp_idx] != request_id:
+            raise RuntimeError(
+                f"request {request_id!r} is not the outstanding launch on "
+                f"DP {dp_idx}: {self._launch_outstanding_by_dp[dp_idx]!r}"
+            )
+
+        self._record_engine_frontend_ack(
+            request_id=request_id,
+            dp_idx=dp_idx,
+            assignment_sequence=int(assignment_sequence),
+            dp_assignment_ordinal=int(dp_assignment_ordinal),
+            session_dp_assignment_ordinal=int(session_dp_assignment_ordinal),
+            source="engine_frontend_submitted",
+            client_reported_at_unix_s=client_reported_at_unix_s,
+            client_reported_at_monotonic_s=client_reported_at_monotonic_s,
+            client_hostname=client_hostname,
+            dispatcher_received_at_unix_s=received_at_unix_s,
+            dispatcher_received_at_monotonic_s=received_at_monotonic_s,
+        )
+        self._launch_outstanding_by_dp[dp_idx] = None
+        self._drain_launch_gates()
+
+    async def complete(
+        self,
+        request_id: str,
+        actual_length: int,
+        client_reported_at_unix_s: float | None = None,
+        client_reported_at_monotonic_s: float | None = None,
+        client_hostname: str | None = None,
+    ) -> None:
+        received_at_unix_s = time.time()
+        received_at_monotonic_s = time.monotonic()
+        dispatcher_hostname = os.uname().nodename
+        request = self.state.requests.get(request_id)
+        session_id = request.session_id if request is not None else None
+        dp_idx = request.dp_idx if request is not None else None
+        self._ack_launch_from_terminal_transition(request_id, source="completion")
+        self.state.complete(request_id, actual_length)
+        events = self._after_state_change(
+            trigger_completion={
+                "request_id": request_id,
+                "client_reported_at_unix_s": client_reported_at_unix_s,
+                "client_reported_at_monotonic_s": (
+                    client_reported_at_monotonic_s
+                ),
+                "client_hostname": client_hostname,
+                "dispatcher_received_at_unix_s": received_at_unix_s,
+                "dispatcher_received_at_monotonic_s": (
+                    received_at_monotonic_s
+                ),
+            }
+        )
+        completed_at_unix_s = time.time()
+        completed_at_monotonic_s = time.monotonic()
+        self._completion_history.append(
+            {
+                "request_id": request_id,
+                "session_id": session_id,
+                "dp_idx": dp_idx,
+                "actual_length": actual_length,
+                "client_reported_at_unix_s": client_reported_at_unix_s,
+                "client_reported_at_monotonic_s": (
+                    client_reported_at_monotonic_s
+                ),
+                "client_hostname": client_hostname,
+                "dispatcher_received_at_unix_s": received_at_unix_s,
+                "dispatcher_received_at_monotonic_s": (
+                    received_at_monotonic_s
+                ),
+                "dispatcher_completed_at_unix_s": completed_at_unix_s,
+                "dispatcher_completed_at_monotonic_s": (
+                    completed_at_monotonic_s
+                ),
+                "dispatcher_hostname": dispatcher_hostname,
+                "client_to_dispatcher_rpc_s": (
+                    received_at_monotonic_s
+                    - client_reported_at_monotonic_s
+                    if client_reported_at_monotonic_s is not None
+                    and client_hostname == dispatcher_hostname
+                    else None
+                ),
+                "client_to_dispatcher_rpc_wall_s": (
+                    received_at_unix_s - client_reported_at_unix_s
+                    if client_reported_at_unix_s is not None
+                    else None
+                ),
+                "dispatcher_complete_service_s": (
+                    completed_at_monotonic_s - received_at_monotonic_s
+                ),
+                "refill_assignment_sequences": [
+                    int(event["sequence"]) for event in events
+                ],
+            }
+        )
+        if len(self._completion_history) > 12000:
+            del self._completion_history[:2000]
+
+    async def cancel_unsubmitted(self, request_id: str) -> None:
+        self.state.cancel_unsubmitted(request_id)
+        self._clear_launch_outstanding(request_id)
+        self._after_state_change()
+        self._reject_waiter(
+            request_id, f"cross-DP request {request_id!r} was cancelled"
+        )
+
+    async def fail_terminated(self, request_id: str, error: str) -> None:
+        self._ack_launch_from_terminal_transition(
+            request_id, source="terminated_failure"
+        )
+        self.state.fail_terminated(request_id, error)
+        self._after_state_change()
+
+    async def fail_unknown(self, request_id: str, error: str) -> None:
+        self.state.fail_unknown(request_id, error)
+        self._clear_launch_outstanding(request_id)
+        self._after_state_change()
+        assert self.state.fatal_error is not None
+        for waiting_request_id in list(self._waiters):
+            self._reject_waiter(waiting_request_id, self.state.fatal_error)
+
+    async def close_participant(
+        self, session_id: str, participant_id: str
+    ) -> None:
+        session = self.state.sessions.get(session_id)
+        request_ids = (
+            list(session.participant_requests.get(participant_id, set()))
+            if session is not None
+            else []
+        )
+        # Once a lease has been returned, absence of the frontend ACK does not
+        # prove that the request is still unsubmitted: add_request() may already
+        # have returned on the worker while its ACK RPC is in flight. Releasing
+        # such a slot could over-admit the engine. Participant close in this
+        # window therefore makes remote state unknown and must fail fast while
+        # retaining the scheduler capacity reservation.
+        outstanding_request_ids = {
+            request_id
+            for request_id in self._launch_outstanding_by_dp
+            if request_id is not None
+        }
+        unknown_request_ids = []
+        for request_id in request_ids:
+            if request_id not in outstanding_request_ids:
+                continue
+            request = self.state.requests.get(request_id)
+            if request is None or request.status != "started":
+                continue
+            self.state.fail_unknown(
+                request_id,
+                "participant closed after lease return but before the "
+                "engine-frontend acknowledgement was observed",
+            )
+            self._clear_launch_outstanding(request_id)
+            unknown_request_ids.append(request_id)
+        self.state.close_participant(session_id, participant_id)
+        self._after_state_change()
+        if unknown_request_ids:
+            assert self.state.fatal_error is not None
+            for waiting_request_id in list(self._waiters):
+                self._reject_waiter(
+                    waiting_request_id, self.state.fatal_error
+                )
+        for request_id in request_ids:
+            request = self.state.requests.get(request_id)
+            if request is None or request.status == "cancelled":
+                self._reject_waiter(
+                    request_id,
+                    f"cross-DP request {request_id!r} was cancelled",
+                )
+
+    async def snapshot(self) -> dict[str, Any]:
+        snapshot = self.state.snapshot()
+        snapshot["completion_history"] = list(self._completion_history)
+        snapshot["launch_queues_by_dp"] = [
+            list(items) for items in self._launch_queues_by_dp
+        ]
+        snapshot["launch_outstanding_by_dp"] = list(
+            self._launch_outstanding_by_dp
+        )
+        snapshot["engine_frontend_ack_history"] = list(
+            self._engine_frontend_ack_history
+        )
+        # Keep the old key for result readers written before the acknowledgement
+        # boundary moved from driver-side proxy creation to engine submission.
+        # Events retain their truthful new source value.
+        snapshot["worker_proxy_ack_history"] = list(
+            self._engine_frontend_ack_history
+        )
+        return snapshot
+
+    def _after_state_change(
+        self,
+        trigger_completion: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        events = self.state.drain_new_assignment_events()
+        for event in events:
+            # The state and actor share this event object.  Adding the timestamp
+            # here therefore makes admission/drain timing visible in snapshots
+            # without putting a clock dependency in the pure scheduler tests.
+            event["assigned_at_monotonic_s"] = time.monotonic()
+            # Ray may place this zero-CPU actor on a different host from the
+            # benchmark driver.  A remote monotonic clock cannot safely be
+            # subtracted from the driver's monotonic clock, so also expose a
+            # common wall-clock timestamp for cross-process timeline alignment.
+            event["assigned_at_unix_s"] = time.time()
+            dispatcher_hostname = os.uname().nodename
+            event["dispatcher_hostname"] = dispatcher_hostname
+            if trigger_completion is not None:
+                event["trigger_completion_request_id"] = trigger_completion[
+                    "request_id"
+                ]
+                event["trigger_client_reported_at_unix_s"] = (
+                    trigger_completion["client_reported_at_unix_s"]
+                )
+                event["trigger_client_reported_at_monotonic_s"] = (
+                    trigger_completion["client_reported_at_monotonic_s"]
+                )
+                event["trigger_client_hostname"] = trigger_completion[
+                    "client_hostname"
+                ]
+                event["trigger_dispatcher_received_at_unix_s"] = (
+                    trigger_completion["dispatcher_received_at_unix_s"]
+                )
+                event["trigger_dispatcher_received_at_monotonic_s"] = (
+                    trigger_completion["dispatcher_received_at_monotonic_s"]
+                )
+                if (
+                    trigger_completion["client_reported_at_monotonic_s"]
+                    is not None
+                    and trigger_completion["client_hostname"]
+                    == dispatcher_hostname
+                ):
+                    event["client_completion_to_refill_assignment_s"] = (
+                        event["assigned_at_monotonic_s"]
+                        - trigger_completion[
+                            "client_reported_at_monotonic_s"
+                        ]
+                    )
+                event["dispatcher_receive_to_refill_assignment_s"] = (
+                    event["assigned_at_monotonic_s"]
+                    - trigger_completion[
+                        "dispatcher_received_at_monotonic_s"
+                    ]
+                )
+            request_id = event["request_id"]
+            dp_idx = int(event["dp_idx"])
+            self._launch_queues_by_dp[dp_idx].append(request_id)
+            if self.trace:
+                self._trace_assignment(event)
+        self._drain_launch_gates()
+        return events
+
+    def _drain_launch_gates(self) -> None:
+        if self.state.fatal_error is not None:
+            return
+        terminal_statuses = {
+            "cancelled",
+            "completed",
+            "failed_terminal",
+            "failed_unknown",
+        }
+        for dp_idx, queue in enumerate(self._launch_queues_by_dp):
+            if self._launch_outstanding_by_dp[dp_idx] is not None:
+                continue
+            while queue:
+                request_id = queue[0]
+                request = self.state.requests.get(request_id)
+                if request is None or request.status in terminal_statuses:
+                    queue.popleft()
+                    continue
+                if request.status == "pending":
+                    raise AssertionError(
+                        f"queued launch {request_id!r} on DP {dp_idx} reverted "
+                        "to pending"
+                    )
+                if request.status == "started":
+                    raise AssertionError(
+                        f"queued launch {request_id!r} on DP {dp_idx} was "
+                        "already claimed"
+                    )
+                if request.status != "assigned" or request.dp_idx != dp_idx:
+                    raise AssertionError(
+                        f"queued launch {request_id!r} has state "
+                        f"status={request.status!r}, dp_idx={request.dp_idx!r}; "
+                        f"expected assigned on DP {dp_idx}"
+                    )
+
+                future = self._waiters.get(request_id)
+                if future is None or future.done():
+                    break
+                lease = self.state.claim_if_assigned(request_id)
+                if lease is None:
+                    raise AssertionError(
+                        f"launch queue head {request_id!r} lost its assignment"
+                    )
+                queue.popleft()
+                self._launch_outstanding_by_dp[dp_idx] = request_id
+                future.set_result(lease)
+                break
+
+    def _clear_launch_outstanding(self, request_id: str) -> None:
+        for dp_idx, outstanding in enumerate(self._launch_outstanding_by_dp):
+            if outstanding == request_id:
+                self._launch_outstanding_by_dp[dp_idx] = None
+                return
+
+    def _ack_launch_from_terminal_transition(
+        self, request_id: str, *, source: str
+    ) -> None:
+        for dp_idx, outstanding in enumerate(self._launch_outstanding_by_dp):
+            if outstanding != request_id:
+                continue
+            request = self.state.requests.get(request_id)
+            if request is None:
+                raise AssertionError(
+                    f"outstanding launch {request_id!r} has no scheduler request"
+                )
+            assert request.assignment_sequence is not None
+            assert request.dp_assignment_ordinal is not None
+            assert request.session_dp_assignment_ordinal is not None
+            now_unix_s = time.time()
+            now_monotonic_s = time.monotonic()
+            self._record_engine_frontend_ack(
+                request_id=request_id,
+                dp_idx=dp_idx,
+                assignment_sequence=request.assignment_sequence,
+                dp_assignment_ordinal=request.dp_assignment_ordinal,
+                session_dp_assignment_ordinal=(
+                    request.session_dp_assignment_ordinal
+                ),
+                source=source,
+                client_reported_at_unix_s=None,
+                client_reported_at_monotonic_s=None,
+                client_hostname=None,
+                dispatcher_received_at_unix_s=now_unix_s,
+                dispatcher_received_at_monotonic_s=now_monotonic_s,
+            )
+            self._launch_outstanding_by_dp[dp_idx] = None
+            self._drain_launch_gates()
+            return
+
+    def _record_engine_frontend_ack(
+        self,
+        *,
+        request_id: str,
+        dp_idx: int,
+        assignment_sequence: int,
+        dp_assignment_ordinal: int,
+        session_dp_assignment_ordinal: int,
+        source: str,
+        client_reported_at_unix_s: float | None,
+        client_reported_at_monotonic_s: float | None,
+        client_hostname: str | None,
+        dispatcher_received_at_unix_s: float,
+        dispatcher_received_at_monotonic_s: float,
+    ) -> None:
+        request = self.state.requests.get(request_id)
+        self._engine_frontend_ack_history.append(
+            {
+                "request_id": request_id,
+                "session_id": (
+                    request.session_id if request is not None else None
+                ),
+                "dp_idx": dp_idx,
+                "assignment_sequence": assignment_sequence,
+                "dp_assignment_ordinal": dp_assignment_ordinal,
+                "session_dp_assignment_ordinal": (
+                    session_dp_assignment_ordinal
+                ),
+                "source": source,
+                "client_reported_at_unix_s": client_reported_at_unix_s,
+                "client_reported_at_monotonic_s": (
+                    client_reported_at_monotonic_s
+                ),
+                "client_hostname": client_hostname,
+                "dispatcher_received_at_unix_s": dispatcher_received_at_unix_s,
+                "dispatcher_received_at_monotonic_s": (
+                    dispatcher_received_at_monotonic_s
+                ),
+                "dispatcher_hostname": os.uname().nodename,
+                "client_to_dispatcher_rpc_s": (
+                    dispatcher_received_at_monotonic_s
+                    - client_reported_at_monotonic_s
+                    if client_reported_at_monotonic_s is not None
+                    and client_hostname == os.uname().nodename
+                    else None
+                ),
+            }
+        )
+        if len(self._engine_frontend_ack_history) > 12000:
+            del self._engine_frontend_ack_history[:2000]
+
+    def _reject_waiter(self, request_id: str, error: str) -> None:
+        future = self._waiters.get(request_id)
+        if future is not None and not future.done():
+            future.set_exception(RuntimeError(error))
+
+    @staticmethod
+    def _trace_assignment(event: dict[str, Any]) -> None:
+        print(
+            "[CROSS-DP-SCHED] "
+            f"t={time.monotonic():.6f} seq={event['sequence']} "
+            f"session={event['session_id']} request={event['request_id']} "
+            f"group={event['group_id']} tier={event['tier']} "
+            f"estimate={event['estimate']} dp={event['dp_idx']} "
+            f"inflight={event['dp_inflight']}",
+            flush=True,
+        )

--- a/nemo_rl/models/generation/vllm/lfs/engine_schedulers.py
+++ b/nemo_rl/models/generation/vllm/lfs/engine_schedulers.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Group-aware waiting-queue ordering for vLLM's V1 scheduler.
+
+This policy takes the probe/group-length idea only as far as reordering whole
+requests already sitting in one engine's waiting queue. It does not split requests into generation chunks,
+re-enqueue them by cumulative generated progress, migrate their KV cache across
+instances, or implement a long-term underserved-group fairness rule.
+Each request carries its group id in ``Request.priority``.
+
+Use this scheduler with vLLM's scheduling policy left at ``fcfs``. The group id
+occupies the priority field, so vLLM's priority heap must not also reorder it.
+"""
+
+from collections import deque
+from collections.abc import Iterable, Iterator
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.request_queue import RequestQueue
+from vllm.v1.request import Request
+
+
+class OracleLengthRequestQueue(RequestQueue):
+    """Order waiting requests by their known output length, longest first.
+
+    This queue is an experiment-only upper bound. The benchmark passes the
+    forced output length through ``Request.priority``; production requests do
+    not know this value before generation.
+    """
+
+    def __init__(self) -> None:
+        self._by_length: dict[int, deque[Request]] = {}
+        self._size = 0
+
+    @staticmethod
+    def _length(request: Request) -> int:
+        return int(request.priority)
+
+    def _best_length(self) -> int:
+        try:
+            return max(
+                length for length, requests in self._by_length.items() if requests
+            )
+        except ValueError as error:
+            raise IndexError("empty queue") from error
+
+    def add_request(self, request: Request) -> None:
+        self._by_length.setdefault(self._length(request), deque()).append(request)
+        self._size += 1
+
+    def pop_request(self) -> Request:
+        request = self._by_length[self._best_length()].popleft()
+        self._size -= 1
+        return request
+
+    def peek_request(self) -> Request:
+        return self._by_length[self._best_length()][0]
+
+    def prepend_request(self, request: Request) -> None:
+        self._by_length.setdefault(self._length(request), deque()).appendleft(request)
+        self._size += 1
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.prepend_request(request)
+
+    def remove_request(self, request: Request) -> None:
+        self._by_length[self._length(request)].remove(request)
+        self._size -= 1
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        requests_to_remove = requests if isinstance(requests, set) else set(requests)
+        for length, length_requests in self._by_length.items():
+            kept = deque(
+                request
+                for request in length_requests
+                if request not in requests_to_remove
+            )
+            self._size -= len(length_requests) - len(kept)
+            self._by_length[length] = kept
+
+    def __bool__(self) -> bool:
+        return self._size > 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    def __iter__(self) -> Iterator[Request]:
+        for length in sorted(self._by_length, reverse=True):
+            yield from self._by_length[length]
+
+
+class ProbeLfsRequestQueue(RequestQueue):
+    """Order whole waiting requests by an online group-length estimate.
+
+    If the probes do not fill the first batch, requests from still-unknown
+    groups fill the remaining slots round-robin. This avoids draining one
+    group merely because its requests arrived first. The round robin applies
+    only while a group is unknown; it is not a persistent fairness rule.
+    """
+
+    def __init__(self, group_estimates: dict[int, int]) -> None:
+        self._group_estimates = group_estimates
+        self._by_group: dict[int, deque[Request]] = {}
+        self._probed_groups: set[int] = set()
+        self._probe_request_ids: dict[int, str] = {}
+        self._unknown_admission_counts: dict[int, int] = {}
+        self._unknown_request_ids: set[str] = set()
+        self._size = 0
+
+    def _group_key(self, group_id: int, front: Request) -> tuple[int, float, float]:
+        estimate = self._group_estimates.get(group_id)
+        if estimate is None:
+            if group_id not in self._probed_groups:
+                # Before normal LFS admission, launch one request from every
+                # group so each group has an online length probe in flight.
+                return (0, 0.0, front.arrival_time)
+            # A probed group with no completed request is still unknown and
+            # remains ahead of groups with finite estimates. Among unknown
+            # groups, admit the fewest-sampled group first so spare slots in
+            # the first batch are filled round-robin.
+            return (
+                1,
+                float(self._unknown_admission_counts.get(group_id, 0)),
+                front.arrival_time,
+            )
+        return (2, -float(estimate), front.arrival_time)
+
+    def _best_group(self) -> int:
+        best_group = None
+        best_key = None
+        for group_id, requests in self._by_group.items():
+            if not requests:
+                continue
+            key = self._group_key(group_id, requests[0])
+            if best_key is None or key < best_key:
+                best_group = group_id
+                best_key = key
+        if best_group is None:
+            raise IndexError("empty queue")
+        return best_group
+
+    def add_request(self, request: Request) -> None:
+        self._by_group.setdefault(request.priority, deque()).append(request)
+        self._size += 1
+
+    def pop_request(self) -> Request:
+        group_id = self._best_group()
+        request = self._by_group[group_id].popleft()
+        if group_id not in self._group_estimates:
+            self._probed_groups.add(group_id)
+            self._probe_request_ids.setdefault(group_id, request.request_id)
+            self._unknown_admission_counts[group_id] = (
+                self._unknown_admission_counts.get(group_id, 0) + 1
+            )
+            self._unknown_request_ids.add(request.request_id)
+        self._size -= 1
+        return request
+
+    def peek_request(self) -> Request:
+        return self._by_group[self._best_group()][0]
+
+    def prepend_request(self, request: Request) -> None:
+        group_id = request.priority
+        if (
+            group_id not in self._group_estimates
+            and request.request_id in self._unknown_request_ids
+        ):
+            self._unknown_request_ids.remove(request.request_id)
+            self._unknown_admission_counts[group_id] -= 1
+        if (
+            group_id not in self._group_estimates
+            and self._probe_request_ids.get(group_id) == request.request_id
+        ):
+            # A scheduler skip or preemption did not successfully keep this
+            # probe running. Restore the group to the unprobed tier.
+            self._probed_groups.discard(group_id)
+            del self._probe_request_ids[group_id]
+        self._by_group.setdefault(request.priority, deque()).appendleft(request)
+        self._size += 1
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.prepend_request(request)
+
+    def remove_request(self, request: Request) -> None:
+        self._by_group[request.priority].remove(request)
+        self._size -= 1
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        requests_to_remove = requests if isinstance(requests, set) else set(requests)
+        for group_id, group_requests in self._by_group.items():
+            kept = deque(
+                request
+                for request in group_requests
+                if request not in requests_to_remove
+            )
+            self._size -= len(group_requests) - len(kept)
+            self._by_group[group_id] = kept
+
+    def __bool__(self) -> bool:
+        return self._size > 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    def __iter__(self) -> Iterator[Request]:
+        groups = sorted(
+            (group_id for group_id, requests in self._by_group.items() if requests),
+            key=lambda group_id: self._group_key(
+                group_id, self._by_group[group_id][0]
+            ),
+        )
+        for group_id in groups:
+            yield from self._by_group[group_id]
+
+
+class ProbeLfsScheduler(AsyncScheduler):
+    """Experimental async scheduler with group-LFS waiting admission.
+
+    vLLM selects ``AsyncScheduler`` automatically only when no custom
+    ``scheduler_cls`` is supplied. Inheriting it here preserves the default
+    schedule/execute overlap when this policy is installed as a custom
+    scheduler.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._group_estimates: dict[int, int] = {}
+        self.waiting = ProbeLfsRequestQueue(self._group_estimates)
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int]
+    ) -> tuple[list[int], bool]:
+        result = super()._update_request_with_output(request, new_token_ids)
+        _, stopped = result
+        if stopped:
+            group_id = request.priority
+            output_length = request.num_output_tokens
+            if output_length > self._group_estimates.get(group_id, 0):
+                self._group_estimates[group_id] = output_length
+        return result
+
+
+class OracleLengthScheduler(AsyncScheduler):
+    """Experiment-only async scheduler that knows exact output lengths."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.waiting = OracleLengthRequestQueue()

--- a/nemo_rl/models/generation/vllm/lfs/groups.py
+++ b/nemo_rl/models/generation/vllm/lfs/groups.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable cross-DP group identity for async rollouts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+def build_async_cross_dp_group_ids(
+    batch: Any, *, num_generations: int
+) -> list[str]:
+    """Build one stable cross-DP group key per generated trajectory.
+
+    Dataset ``idx`` values are stable across async dataloader batches, whereas
+    a prompt's position inside a batch is not. Reusing batch-local positions
+    would therefore merge unrelated prompts in ``history_lfs``.
+    """
+
+    if num_generations <= 0:
+        raise ValueError("num_generations must be positive")
+    if "idx" in batch:
+        raw_group_ids = batch["idx"]
+        if len(raw_group_ids) != batch.size:
+            raise ValueError(
+                "batch idx count does not match prompt count: "
+                f"idx={len(raw_group_ids)} prompts={batch.size}"
+            )
+        prompt_group_ids = [
+            str(value.item() if hasattr(value, "item") else value)
+            for value in raw_group_ids
+        ]
+    else:
+        # Retain the pre-existing fallback for custom datasets without ``idx``.
+        # Such datasets cannot provide cross-batch history identity.
+        prompt_group_ids = [str(prompt_idx) for prompt_idx in range(batch.size)]
+    return [
+        group_id
+        for group_id in prompt_group_ids
+        for _ in range(num_generations)
+    ]

--- a/nemo_rl/models/generation/vllm/lfs/modes.py
+++ b/nemo_rl/models/generation/vllm/lfs/modes.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vocabulary for cross-DP admission: policy modes and the prose that pins
+down what each recorded field actually means.
+
+The semantics strings are part of the result contract — analysis code asserts
+on them — so they live next to the modes they describe rather than inline in
+the scheduler.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+CrossDpMode = Literal[
+    "fcfs",
+    "lfs",
+    "predicted_lfs",
+    "history_lfs",
+    "oracle_probe_lfs",
+    "exact_length_lpt",
+]
+PROBE_LFS_MODES = ("lfs", "oracle_probe_lfs")
+ONLINE_LFS_MODES = ("lfs", "predicted_lfs", "oracle_probe_lfs")
+DpSelectionMode = Literal["static_cost", "inflight_count"]
+
+STATIC_ADMISSION_COST_SEMANTICS = (
+    "Piecewise-static estimated total generation cost. It may be rebased "
+    "when a same-group request completes, is never decremented for generated "
+    "progress, and is not remaining work."
+)
+EXPLICIT_PROBE_SELECTION_SEMANTICS = "explicit_catalog_flag-v1"
+IMPLICIT_PROBE_SELECTION_SEMANTICS = "implicit_first_pending-v1"
+SCHEDULER_SELECTED_DP_PLACEMENT = "scheduler_selected"
+PREFERRED_DP_PINNED_PLACEMENT = "preferred_dp_pinned"
+PREFERRED_DP_PINNING_SEMANTICS = (
+    "Exact-length diagnostic only: every request in the bounded first-turn "
+    "session catalog has an immutable preferred DP. Later dynamically "
+    "discovered requests are rejected because they have no routing manifest."
+)
+LFS_ADMISSION_FAIRNESS_POLICY = (
+    "prose-inspired-idle-group-admission-age-v1"
+)
+LFS_ADMISSION_FAIRNESS_SEMANTICS = (
+    "Exploratory admission-age safeguard inspired by the reference paper's "
+    "prose-only underserved-group note. It is not that paper's Algorithm 2 "
+    "and is not chunk-level shortest-attained-service scheduling. Every Nth "
+    "ordinary admission opportunity, after no probe-tier candidate remains "
+    "in the oldest session, selects the pending zero-inflight group with the "
+    "oldest dispatcher admission; stable ties use catalog-group and front-"
+    "request arrival order. A due opportunity with no eligible group falls "
+    "back to ordinary LFS without carrying credit."
+)

--- a/nemo_rl/models/generation/vllm/lfs/prompt_groups.py
+++ b/nemo_rl/models/generation/vllm/lfs/prompt_groups.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prompt construction helpers for length-scheduling experiments."""
+
+
+def make_request_unique_prompts(
+    prompt_lengths: list[int], common_token_id: int = 1000
+) -> list[dict[str, list[int]]]:
+    """Build fixed-length prompts whose first token is unique per request.
+
+    A request-specific first token makes every prompt diverge before the first
+    KV-cache block, preventing automatic prefix caching from sharing prompt KV
+    state between requests while keeping the remaining token content fixed.
+    """
+    prompts = []
+    for request_index, prompt_length in enumerate(prompt_lengths):
+        if prompt_length < 1:
+            raise ValueError("prompt lengths must be positive")
+        prompt_token_ids = [common_token_id] * prompt_length
+        prompt_token_ids[0] = common_token_id + request_index
+        prompts.append({"prompt_token_ids": prompt_token_ids})
+    return prompts

--- a/nemo_rl/models/generation/vllm/lfs/scheduler.py
+++ b/nemo_rl/models/generation/vllm/lfs/scheduler.py
@@ -1,0 +1,1702 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global probe/LFS admission for async vLLM data-parallel engines.
+
+The vLLM schedulers only see one data-parallel engine.  This module owns the
+small middleware queue immediately above them: it picks both the next request
+and its DP rank, while each engine keeps its vanilla FCFS scheduler.
+
+``CrossDpSchedulerState`` is deliberately free of Ray and asyncio so the
+ordering and capacity invariants stay deterministically testable.  Its Ray
+wrapper lives in :mod:`dispatcher`.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import deque
+from typing import Any
+
+from nemo_rl.models.generation.vllm.lfs.diagnostics import build_snapshot, pending_choice_diagnostics
+from nemo_rl.models.generation.vllm.lfs.modes import (
+    EXPLICIT_PROBE_SELECTION_SEMANTICS,
+    IMPLICIT_PROBE_SELECTION_SEMANTICS,
+    LFS_ADMISSION_FAIRNESS_POLICY,
+    ONLINE_LFS_MODES,
+    PREFERRED_DP_PINNED_PLACEMENT,
+    PROBE_LFS_MODES,
+    SCHEDULER_SELECTED_DP_PLACEMENT,
+    STATIC_ADMISSION_COST_SEMANTICS,
+    CrossDpMode,
+    DpSelectionMode,
+)
+from nemo_rl.models.generation.vllm.lfs.state import Request, Session
+from nemo_rl.models.generation.vllm.lfs.validation import (
+    inspect_catalog,
+    resolve_global_admission_limit,
+    validate_scheduler_config,
+)
+
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+
+
+
+
+
+
+class CrossDpSchedulerState:
+    """Pure state machine for bounded global FCFS or probe-based LFS.
+
+    A rollout opens a session with its complete first-turn request catalog.
+    Opening the session is what makes those requests schedulable; therefore a
+    group-contiguous caller cannot accidentally fill the first wave before the
+    other prompt groups are visible.
+    """
+
+    def __init__(
+        self,
+        dp_size: int,
+        max_num_seqs_per_dp: int,
+        mode: CrossDpMode,
+        lookahead_per_dp: int = 0,
+        global_admission_limit: int | None = None,
+        dp_selection_mode: DpSelectionMode = "inflight_count",
+        lfs_admission_fairness_interval: int = 0,
+    ):
+        validate_scheduler_config(
+            dp_size=dp_size,
+            max_num_seqs_per_dp=max_num_seqs_per_dp,
+            mode=mode,
+            lookahead_per_dp=lookahead_per_dp,
+            dp_selection_mode=dp_selection_mode,
+            lfs_admission_fairness_interval=lfs_admission_fairness_interval,
+        )
+
+        self.dp_size = dp_size
+        self.max_num_seqs_per_dp = max_num_seqs_per_dp
+        self.lookahead_per_dp = lookahead_per_dp
+        self.admission_limit_per_dp = max_num_seqs_per_dp + lookahead_per_dp
+        self.global_admission_limit = resolve_global_admission_limit(
+            dp_size=dp_size,
+            admission_limit_per_dp=self.admission_limit_per_dp,
+            requested=global_admission_limit,
+        )
+        self.mode = mode
+        self.dp_selection_mode = dp_selection_mode
+        self.lfs_admission_fairness_interval = int(
+            lfs_admission_fairness_interval
+        )
+
+        self.sessions: dict[str, Session] = {}
+        self.requests: dict[str, Request] = {}
+        self.dp_inflight: list[dict[str, int]] = [dict() for _ in range(dp_size)]
+        self._inflight_by_group: dict[tuple[str, str], set[str]] = {}
+        self._pending_request_count = 0
+        self._pending_preferred_dp_request_count = 0
+        self.assignment_history: list[dict[str, Any]] = []
+        # Persistent across rollout sessions. history_lfs snapshots these means
+        # when a new session opens; observations from the current session are
+        # committed only when it closes, preventing current-step leakage/probes.
+        self.group_history: dict[str, tuple[int, int]] = {}
+        self.history_update_history: list[dict[str, Any]] = []
+        self.estimate_rebase_history: list[dict[str, Any]] = []
+        self._pending_fcfs: deque[str] = deque()
+        self._pending_exact_length: list[tuple[int, int, str]] = []
+        self._pending_by_group: dict[tuple[str, str], deque[str]] = {}
+        # A scheduler-independent group index keeps diagnostics O(groups)
+        # instead of rescanning every catalog request on every assignment.
+        self._diagnostic_pending_by_group: dict[
+            tuple[str, str], deque[str]
+        ] = {}
+        self._group_heap: list[
+            tuple[tuple[int, int, float, int, int], int, tuple[str, str]]
+        ] = []
+        self._group_versions: dict[tuple[str, str], int] = {}
+        self._new_assignment_events: deque[dict[str, Any]] = deque()
+        self._cancel_tombstones: dict[str, None] = {}
+        self._max_cancel_tombstones = 100000
+        self._closed_session_ids: set[str] = set()
+        self._closed_session_order: deque[str] = deque()
+        self._max_closed_session_tombstones = 10000
+
+        self._arrival_seq = 0
+        self._assignment_seq = 0
+        self._dp_assignment_ordinals = [0] * dp_size
+        self._session_seq = 0
+        self._dp_tiebreak = 0
+        # Exact dispatcher-side high-water marks. Engine gauges are sampled
+        # independently on each DP rank, so summing last-observed gauge values
+        # cannot prove a global admission limit during a cross-DP handoff.
+        # Every increase in dispatcher occupancy happens in _pump(), making
+        # these cumulative watermarks a lossless capacity-safety witness.
+        self.max_total_inflight_observed = 0
+        self.max_inflight_observed_by_dp = [0] * dp_size
+        self.ordinary_admission_opportunities = 0
+        self.admission_fairness_due_count = 0
+        self.admission_fairness_selected_count = 0
+        self.admission_fairness_override_count = 0
+        self.admission_fairness_noop_count = 0
+        self.admission_fairness_no_candidate_count = 0
+        self.fatal_error: str | None = None
+
+    @property
+    def total_capacity(self) -> int:
+        return self.global_admission_limit
+
+    def restore_group_history(self, history: dict[str, Any]) -> None:
+        """Restore completed-session means before opening any new session."""
+        if self.mode != "history_lfs":
+            raise ValueError("group history can only be restored for history_lfs")
+        if self.sessions or self.requests:
+            raise RuntimeError("group history must be restored before opening a session")
+
+        restored: dict[str, tuple[int, int]] = {}
+        for group_id, value in history.items():
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"group history entry {group_id!r} must be an object"
+                )
+            total = int(value["sum"])
+            count = int(value["count"])
+            if total < 0 or count <= 0:
+                raise ValueError(
+                    f"invalid group history entry {group_id!r}: "
+                    f"sum={total}, count={count}"
+                )
+            restored[str(group_id)] = (total, count)
+        self.group_history = restored
+
+    def open_session(
+        self,
+        session_id: str,
+        request_catalog: list[dict[str, Any]],
+        participant_ids: list[str] | None = None,
+    ) -> None:
+        if self.fatal_error is not None:
+            raise RuntimeError(self.fatal_error)
+        if not session_id:
+            raise ValueError("session_id must be non-empty")
+        if session_id in self.sessions:
+            raise ValueError(f"session {session_id!r} already exists")
+        if session_id in self._closed_session_ids:
+            raise ValueError(f"session {session_id!r} was already closed")
+        if participant_ids is None:
+            participant_ids = [f"{session_id}:participant:0"]
+        if not participant_ids or len(set(participant_ids)) != len(participant_ids):
+            raise ValueError("participant_ids must be non-empty and unique")
+        if not request_catalog:
+            raise ValueError("request_catalog must contain at least one request")
+        (
+            dp_placement_mode,
+            probe_selection_semantics,
+            designated_probe_request_ids,
+        ) = inspect_catalog(
+            request_catalog, mode=self.mode, dp_size=self.dp_size
+        )
+
+        session = Session(
+            session_id=session_id,
+            arrival_seq=self._session_seq,
+            open_participants=set(participant_ids),
+            participant_requests={item: set() for item in participant_ids},
+            dp_assignment_ordinals=[0] * self.dp_size,
+            probe_selection_semantics=probe_selection_semantics,
+            designated_probe_request_ids=designated_probe_request_ids,
+            dp_placement_mode=dp_placement_mode,
+        )
+        if self.mode == "history_lfs":
+            catalog_groups = {str(item["group_id"]) for item in request_catalog}
+            session.estimates = {
+                group_id: max(1, round(total / count))
+                for group_id, (total, count) in self.group_history.items()
+                if count > 0 and group_id in catalog_groups
+            }
+        elif self.mode == "oracle_probe_lfs":
+            # Benchmark-only diagnostic: retain exact group maxima out of band.
+            # They become visible to scheduling only after that group's probe
+            # completes. Faster ordinary requests admitted by the unknown
+            # round-robin fill cannot reveal the out-of-band value early.
+            for item in request_catalog:
+                group_id = str(item["group_id"])
+                request_cost = int(item["oracle_cost"])
+                if request_cost <= 0:
+                    raise ValueError(
+                        f"oracle_cost must be positive, got {request_cost}"
+                    )
+                session.oracle_estimates[group_id] = max(
+                    request_cost, session.oracle_estimates.get(group_id, 0)
+                )
+        elif self.mode == "predicted_lfs":
+            for item in request_catalog:
+                group_id = str(item["group_id"])
+                predicted_cost = int(item["predicted_cost"])
+                if predicted_cost <= 0:
+                    raise ValueError(
+                        f"predicted_cost must be positive, got {predicted_cost}"
+                    )
+                previous = session.estimates.setdefault(group_id, predicted_cost)
+                if previous != predicted_cost:
+                    raise ValueError(
+                        "predicted_cost must be identical within a prompt group: "
+                        f"group={group_id!r}, {previous} != {predicted_cost}"
+                    )
+        self._session_seq += 1
+        self.sessions[session_id] = session
+        try:
+            for item in request_catalog:
+                self._add_request(
+                    session=session,
+                    participant_id=str(item.get("participant_id", participant_ids[0])),
+                    request_id=str(item["request_id"]),
+                    group_id=str(item["group_id"]),
+                    fallback_cost=int(item["fallback_cost"]),
+                    is_designated_probe=bool(
+                        item.get("is_designated_probe", False)
+                    ),
+                    preferred_dp_idx=item.get("preferred_dp_idx"),
+                )
+            self._prioritize_designated_probes(session)
+        except Exception:
+            for request_id in session.request_ids:
+                request = self.requests.pop(request_id, None)
+                if request is not None and request.status == "pending":
+                    self._decrement_pending_count(request)
+            for group_key in [
+                key
+                for key in self._diagnostic_pending_by_group
+                if key[0] == session_id
+            ]:
+                self._diagnostic_pending_by_group.pop(group_key, None)
+                self._pending_by_group.pop(group_key, None)
+                self._group_versions.pop(group_key, None)
+            del self.sessions[session_id]
+            raise
+
+        self._pump()
+
+    def acquire(
+        self,
+        session_id: str,
+        participant_id: str,
+        request_id: str,
+        group_id: str,
+        fallback_cost: int,
+    ) -> dict[str, Any] | None:
+        """Claim an assigned lease, or return ``None`` while it is pending."""
+        self.prepare_acquire(
+            session_id,
+            participant_id,
+            request_id,
+            group_id,
+            fallback_cost,
+        )
+        request = self.requests[request_id]
+        if request.status == "assigned":
+            return self._claim(request)
+        if request.status == "pending":
+            return None
+        raise AssertionError(
+            f"prepared request {request_id!r} has unexpected status "
+            f"{request.status!r}"
+        )
+
+    def prepare_acquire(
+        self,
+        session_id: str,
+        participant_id: str,
+        request_id: str,
+        group_id: str,
+        fallback_cost: int,
+    ) -> None:
+        """Register and validate an acquire without claiming its lease.
+
+        The Ray dispatcher uses this split phase so preassigned requests can be
+        released to each DP worker strictly in assignment order.  Keeping the
+        request in ``assigned`` (rather than ``started``) also lets participant
+        close and client cancellation reclaim capacity until the target worker
+        begins the causal vLLM frontend-submission path.
+        """
+        session = self._require_session(session_id)
+        if self.fatal_error is not None:
+            raise RuntimeError(self.fatal_error)
+        if session.failed_error is not None:
+            raise RuntimeError(session.failed_error)
+        if participant_id not in session.open_participants:
+            raise RuntimeError(
+                f"participant {participant_id!r} is closed in session {session_id!r}"
+            )
+
+        request = self.requests.get(request_id)
+        if request is None:
+            # Later multi-turn requests are not known when the first-turn
+            # catalog is opened.  They join the same prompt-group estimate.
+            request = self._add_request(
+                session=session,
+                participant_id=participant_id,
+                request_id=request_id,
+                group_id=group_id,
+                fallback_cost=fallback_cost,
+            )
+            self._pump()
+        else:
+            if request.session_id != session_id:
+                raise ValueError(
+                    f"request {request_id!r} belongs to session "
+                    f"{request.session_id!r}, not {session_id!r}"
+                )
+            if request.participant_id != participant_id:
+                raise ValueError(
+                    f"request {request_id!r} participant mismatch: "
+                    f"{request.participant_id!r} != {participant_id!r}"
+                )
+            if request.group_id != str(group_id):
+                raise ValueError(
+                    f"request {request_id!r} group mismatch: "
+                    f"{request.group_id!r} != {group_id!r}"
+                )
+
+        if request.status in ("assigned", "pending"):
+            return
+        if request.status == "started":
+            raise RuntimeError(f"request {request_id!r} already acquired its lease")
+        raise RuntimeError(
+            f"request {request_id!r} cannot acquire from status {request.status!r}"
+        )
+
+    def claim_if_assigned(self, request_id: str) -> dict[str, Any] | None:
+        request = self.requests.get(request_id)
+        if request is None or request.status != "assigned":
+            return None
+        return self._claim(request)
+
+    def drain_new_assignment_events(self) -> list[dict[str, Any]]:
+        events = list(self._new_assignment_events)
+        self._new_assignment_events.clear()
+        return events
+
+    def complete(self, request_id: str, actual_length: int) -> None:
+        request = self._require_request(request_id)
+        if request.status == "completed":
+            return
+        if request.status != "started":
+            raise RuntimeError(
+                f"request {request_id!r} completed from invalid status "
+                f"{request.status!r}"
+            )
+        if actual_length < 0:
+            raise ValueError(f"actual_length must be non-negative, got {actual_length}")
+
+        self._release_dp(request)
+        request.status = "completed"
+        session = self._require_session(request.session_id)
+        if self.mode in ONLINE_LFS_MODES:
+            previous_estimate = session.estimates.get(request.group_id)
+            # Round-robin fill may place additional unknown members of a group
+            # beside its probe.  A faster ordinary member must not reveal a
+            # group estimate before the actual probe completes.  Once the
+            # probe has established the first finite estimate, later
+            # completions may continue to refine ordinary/predicted LFS.
+            if (
+                session.probe_selection_semantics
+                == EXPLICIT_PROBE_SELECTION_SEMANTICS
+            ):
+                designated_request_id = (
+                    session.designated_probe_request_ids.get(request.group_id)
+                )
+                designated_request = (
+                    self.requests.get(designated_request_id)
+                    if designated_request_id is not None
+                    else None
+                )
+                is_observable_probe_completion = (
+                    request.is_designated_probe
+                    or (
+                        # More than one unresolved group member can already be
+                        # in flight when the designated probe definitively
+                        # leaves.  The next such observation is the only
+                        # available replacement even when it was originally
+                        # admitted through the unknown round-robin tier.
+                        request.unknown_admission
+                        and designated_request is not None
+                        and designated_request.status
+                        in ("cancelled", "failed_terminal")
+                    )
+                )
+            else:
+                is_observable_probe_completion = request.probe_admission
+            reveals_first_probe_estimate = (
+                previous_estimate is not None
+                or self.mode == "predicted_lfs"
+                or is_observable_probe_completion
+            )
+            if reveals_first_probe_estimate:
+                if self.mode == "oracle_probe_lfs":
+                    session.estimates[request.group_id] = (
+                        session.oracle_estimates[request.group_id]
+                    )
+                else:
+                    session.estimates[request.group_id] = max(
+                        actual_length,
+                        session.estimates.get(request.group_id, 0),
+                    )
+                self._rebase_inflight_group_estimate(
+                    session_id=request.session_id,
+                    group_id=request.group_id,
+                    estimate=session.estimates[request.group_id],
+                    previous_estimate=previous_estimate,
+                    completed_request_id=request_id,
+                )
+                self._refresh_group((request.session_id, request.group_id))
+        elif self.mode == "history_lfs":
+            session.completed_lengths.setdefault(request.group_id, []).append(
+                actual_length
+            )
+        self._pump()
+        self._maybe_drop_session(session)
+
+    def cancel_unsubmitted(self, request_id: str) -> None:
+        """Cancel a pending lease or one known not to have reached a worker."""
+        request = self.requests.get(request_id)
+        if request is None:
+            self._cancel_tombstones[request_id] = None
+            while len(self._cancel_tombstones) > self._max_cancel_tombstones:
+                oldest = next(iter(self._cancel_tombstones))
+                del self._cancel_tombstones[oldest]
+            return
+        if request.status in ("cancelled", "completed"):
+            return
+        if request.status in ("assigned", "started"):
+            self._rollback_unknown_admission(request)
+            self._release_dp(request)
+        elif request.status == "pending":
+            self._decrement_pending_count(request)
+        else:
+            raise RuntimeError(
+                f"request {request_id!r} cannot be cancelled from "
+                f"status {request.status!r}"
+            )
+        request.status = "cancelled"
+        session = self._require_session(request.session_id)
+        self._pump()
+        self._maybe_drop_session(session)
+
+    def fail_terminated(self, request_id: str, error: str) -> None:
+        """Release a request after the worker RPC definitively terminated."""
+        request = self._require_request(request_id)
+        if request.status in ("failed_terminal", "completed"):
+            return
+        if request.status != "started":
+            raise RuntimeError(
+                f"submitted request {request_id!r} failed from invalid status "
+                f"{request.status!r}"
+            )
+        session = self._require_session(request.session_id)
+        self._rollback_unknown_admission(request)
+        self._release_dp(request)
+        request.status = "failed_terminal"
+        self._pump()
+        self._maybe_drop_session(session)
+
+    def fail_unknown(self, request_id: str, error: str) -> None:
+        """Fail-fast globally when the submitted RPC may still be running.
+
+        We neither release nor reuse the uncertain DP slot.  More importantly,
+        every subsequent open/acquire fails immediately instead of silently
+        hanging or running with a permanently reduced capacity.
+        """
+        request = self._require_request(request_id)
+        if request.status in ("failed_unknown", "completed"):
+            return
+        if request.status != "started":
+            raise RuntimeError(
+                f"submitted request {request_id!r} failed from invalid status "
+                f"{request.status!r}"
+            )
+        request.status = "failed_unknown"
+        self.fatal_error = (
+            "cross-DP dispatcher remote state became unknown after request "
+            f"{request_id!r}: {error}"
+        )
+        for other in self.requests.values():
+            if other.status == "pending":
+                self._decrement_pending_count(other)
+                other.status = "cancelled"
+            elif other.status == "assigned" and not other.lease_started:
+                self._rollback_unknown_admission(other)
+                self._release_dp(other)
+                other.status = "cancelled"
+
+    def close_participant(self, session_id: str, participant_id: str) -> None:
+        session = self.sessions.get(session_id)
+        if session is None:
+            if session_id in self._closed_session_ids:
+                return
+            raise KeyError(f"unknown cross-DP session {session_id!r}")
+        if participant_id not in session.participant_requests:
+            raise KeyError(
+                f"unknown participant {participant_id!r} in cross-DP session "
+                f"{session_id!r}"
+            )
+        if participant_id not in session.open_participants:
+            return
+        session.open_participants.remove(participant_id)
+
+        # Release this participant's requests immediately. Waiting for the last
+        # prompt thread can deadlock the remaining participants behind slots
+        # reserved by a thread that already exited.
+        for request_id in list(session.participant_requests[participant_id]):
+            request = self.requests[request_id]
+            if request.status == "pending":
+                self._decrement_pending_count(request)
+                request.status = "cancelled"
+            elif request.status == "assigned" and not request.lease_started:
+                self._rollback_unknown_admission(request)
+                self._release_dp(request)
+                request.status = "cancelled"
+
+        if not session.open_participants:
+            # Defensive cleanup for catalog entries whose owner never started.
+            for request_id in list(session.request_ids):
+                request = self.requests[request_id]
+                if request.status == "pending":
+                    self._decrement_pending_count(request)
+                    request.status = "cancelled"
+                elif request.status == "assigned" and not request.lease_started:
+                    self._rollback_unknown_admission(request)
+                    self._release_dp(request)
+                    request.status = "cancelled"
+        self._pump()
+        self._maybe_drop_session(session)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Publish the dispatcher-visible view of sessions, DPs and history."""
+        return build_snapshot(self)
+
+    def _add_request(
+        self,
+        session: Session,
+        participant_id: str,
+        request_id: str,
+        group_id: str,
+        fallback_cost: int,
+        is_designated_probe: bool = False,
+        preferred_dp_idx: int | None = None,
+    ) -> Request:
+        if not request_id:
+            raise ValueError("request_id must be non-empty")
+        if request_id in self.requests:
+            raise ValueError(f"request {request_id!r} already exists")
+        if participant_id not in session.open_participants:
+            raise ValueError(
+                f"unknown participant {participant_id!r} for session "
+                f"{session.session_id!r}"
+            )
+        if fallback_cost <= 0:
+            raise ValueError(f"fallback_cost must be positive, got {fallback_cost}")
+        if (
+            session.dp_placement_mode == PREFERRED_DP_PINNED_PLACEMENT
+            and preferred_dp_idx is None
+        ):
+            raise ValueError(
+                "preferred-DP pinning is limited to the bounded first-turn "
+                "request catalog; later requests without preferred_dp_idx "
+                "cannot join a pinned session"
+            )
+
+        request = Request(
+            session_id=session.session_id,
+            participant_id=participant_id,
+            request_id=request_id,
+            group_id=str(group_id),
+            arrival_seq=self._arrival_seq,
+            fallback_cost=fallback_cost,
+            is_designated_probe=is_designated_probe,
+            preferred_dp_idx=preferred_dp_idx,
+        )
+        self._arrival_seq += 1
+        self.requests[request_id] = request
+        session.request_ids.add(request_id)
+        session.participant_requests[participant_id].add(request_id)
+        session.group_catalog_ordinals.setdefault(
+            request.group_id, len(session.group_catalog_ordinals)
+        )
+        if request_id in self._cancel_tombstones:
+            self._cancel_tombstones.pop(request_id)
+            request.status = "cancelled"
+        else:
+            group_key = (session.session_id, request.group_id)
+            self._pending_request_count += 1
+            if request.preferred_dp_idx is not None:
+                self._pending_preferred_dp_request_count += 1
+            self._diagnostic_pending_by_group.setdefault(
+                group_key, deque()
+            ).append(request_id)
+            if self.mode == "fcfs":
+                self._pending_fcfs.append(request_id)
+            elif self.mode == "exact_length_lpt":
+                # Experiment-only exact-output-length LPT order. This is a
+                # diagnostic reference for whole-request ordering, not a
+                # makespan oracle: service time also depends on context and
+                # batch state.
+                heapq.heappush(
+                    self._pending_exact_length,
+                    (
+                        -request.fallback_cost,
+                        request.arrival_seq,
+                        request_id,
+                    ),
+                )
+            else:
+                request_ids = self._pending_by_group.setdefault(
+                    group_key, deque()
+                )
+                was_empty = not request_ids
+                request_ids.append(request_id)
+                if was_empty:
+                    self._refresh_group(group_key)
+        return request
+
+    def _prioritize_designated_probes(self, session: Session) -> None:
+        """Move explicit probes only within the LFS policy's group queues."""
+        if (
+            self.mode not in PROBE_LFS_MODES
+            or session.probe_selection_semantics
+            != EXPLICIT_PROBE_SELECTION_SEMANTICS
+        ):
+            return
+        for group_id, request_id in session.designated_probe_request_ids.items():
+            group_key = (session.session_id, group_id)
+            pending = self._pending_by_group.get(group_key)
+            if pending is None or request_id not in pending:
+                # A pre-open cancellation tombstone can remove the designated
+                # request. The first remaining request becomes an explicitly
+                # observable replacement probe when capacity is assigned.
+                self._refresh_group(group_key)
+                continue
+            pending.remove(request_id)
+            pending.appendleft(request_id)
+            self._refresh_group(group_key)
+
+    def _pump(self) -> None:
+        """Assign pending requests until capacity or the pending queue runs out."""
+        if self.fatal_error is not None:
+            return
+        while self._admit_one():
+            pass
+
+    def _admit_one(self) -> bool:
+        """Assign at most one request; return False when the loop must stop."""
+        # _select_dp() advances the cyclic tie-break. Do not call it when there
+        # is no request to assign: completion and participant-close paths both
+        # pump after the last request, and those no-op pumps must not perturb
+        # placement in the next session.
+        if self._pending_request_count == 0:
+            return False
+        if (
+            sum(len(inflight) for inflight in self.dp_inflight)
+            >= self.global_admission_limit
+        ):
+            return False
+
+        capacity = self._capacity_view()
+        choice_diagnostics = pending_choice_diagnostics(self)
+        selection = self._select_request_and_dp(capacity, choice_diagnostics)
+        if selection is None:
+            return False
+        request, dp_idx, dp_placement_mode = selection
+
+        session = self._require_session(request.session_id)
+        tier, estimate, predicted_length = self._plan_admission(session, request)
+        self._record_fairness(session, request, choice_diagnostics)
+        self._commit_assignment(session, request, dp_idx, predicted_length)
+        self._append_assignment_event(
+            session,
+            request,
+            dp_idx=dp_idx,
+            dp_placement_mode=dp_placement_mode,
+            tier=tier,
+            estimate=estimate,
+            predicted_length=predicted_length,
+            capacity=capacity,
+            choice_diagnostics=choice_diagnostics,
+        )
+        return True
+
+    def _capacity_view(self) -> dict[str, Any]:
+        """Per-DP occupancy plus both one-step DP-selection counterfactuals.
+
+        The counterfactuals are recorded, never acted on: they answer "would
+        the other selector have chosen a different rank in this exact state?".
+        """
+        candidate_dp_indices = [
+            candidate_dp_idx
+            for candidate_dp_idx, inflight in enumerate(self.dp_inflight)
+            if len(inflight) < self.admission_limit_per_dp
+        ]
+        static_cost_before_assignment = [
+            sum(inflight.values()) for inflight in self.dp_inflight
+        ]
+        inflight_count_before_assignment = [
+            len(inflight) for inflight in self.dp_inflight
+        ]
+        dp_tiebreak_before_assignment = self._dp_tiebreak
+        selected_by_static_cost = (
+            min(
+                candidate_dp_indices,
+                key=lambda candidate_dp_idx: (
+                    static_cost_before_assignment[candidate_dp_idx],
+                    inflight_count_before_assignment[candidate_dp_idx],
+                    (
+                        candidate_dp_idx
+                        - dp_tiebreak_before_assignment
+                    )
+                    % self.dp_size,
+                ),
+            )
+            if candidate_dp_indices
+            else None
+        )
+        selected_by_inflight_count = (
+            min(
+                candidate_dp_indices,
+                key=lambda candidate_dp_idx: (
+                    len(self.dp_inflight[candidate_dp_idx]),
+                    (
+                        candidate_dp_idx
+                        - dp_tiebreak_before_assignment
+                    )
+                    % self.dp_size,
+                ),
+            )
+            if candidate_dp_indices
+            else None
+        )
+        return {
+            "candidate_dp_indices": candidate_dp_indices,
+            "static_cost_before_assignment": static_cost_before_assignment,
+            "inflight_count_before_assignment": inflight_count_before_assignment,
+            "dp_tiebreak_before_assignment": dp_tiebreak_before_assignment,
+            "selected_by_static_cost": selected_by_static_cost,
+            "selected_by_inflight_count": selected_by_inflight_count,
+        }
+
+    def _select_request_and_dp(
+        self, capacity: dict[str, Any], choice_diagnostics: dict[str, Any]
+    ) -> tuple[Request, int, str] | None:
+        """Pick the next request and its DP rank, or None to stop pumping."""
+        candidate_dp_indices = capacity["candidate_dp_indices"]
+        if (
+            self.mode == "exact_length_lpt"
+            and self._pending_preferred_dp_request_count > 0
+        ):
+            request = self._pop_exact_length_request_for_available_dp(
+                candidate_dp_indices
+            )
+            if request is None:
+                return
+            if request.preferred_dp_idx is None:
+                dp_idx = self._select_dp()
+                if dp_idx is None:
+                    raise AssertionError(
+                        "an unpinned exact-length request was selected "
+                        "without an available DP"
+                    )
+                dp_placement_mode = SCHEDULER_SELECTED_DP_PLACEMENT
+            else:
+                dp_idx = request.preferred_dp_idx
+                if dp_idx not in candidate_dp_indices:
+                    raise AssertionError(
+                        "a pinned exact-length request was selected for "
+                        f"unavailable DP {dp_idx}"
+                    )
+                self._dp_tiebreak = (dp_idx + 1) % self.dp_size
+                dp_placement_mode = PREFERRED_DP_PINNED_PLACEMENT
+        else:
+            # Preserve the pre-pinning ordering and cyclic tie-break
+            # behavior exactly when no pinned request is pending.
+            dp_idx = self._select_dp()
+            if dp_idx is None:
+                return
+            request = self._pop_request()
+            if request is None:
+                return
+            dp_placement_mode = SCHEDULER_SELECTED_DP_PLACEMENT
+        if (
+            self.mode in ONLINE_LFS_MODES
+            and choice_diagnostics["policy_expected_request_id"]
+            != request.request_id
+        ):
+            raise AssertionError(
+                "LFS heap selection disagrees with the independently "
+                "reconstructed policy key: selected="
+                f"{request.request_id!r}, expected="
+                f"{choice_diagnostics['policy_expected_request_id']!r}"
+            )
+
+        return request, dp_idx, dp_placement_mode
+
+    def _plan_admission(
+        self, session: Session, request: Request
+    ) -> tuple[str, int | None, int]:
+        """Classify the admission tier and settle the static admission cost.
+
+        Order matters: the tier reads ``probed_groups`` before the cost branch
+        below inserts this group into it.
+        """
+        estimate = (
+            session.estimates.get(request.group_id)
+            if self.mode in (*ONLINE_LFS_MODES, "history_lfs")
+            else None
+        )
+        estimate = (
+            session.estimates.get(request.group_id)
+            if self.mode in (*ONLINE_LFS_MODES, "history_lfs")
+            else None
+        )
+        tier = "fcfs"
+        if self.mode in ONLINE_LFS_MODES:
+            if estimate is None and request.group_id not in session.probed_groups:
+                tier = "probe"
+            elif estimate is None:
+                tier = "unknown_rr"
+            else:
+                tier = (
+                    "oracle_probe_lfs"
+                    if self.mode == "oracle_probe_lfs"
+                    else self.mode
+                )
+        elif self.mode == "history_lfs":
+            tier = "history_lfs" if estimate is not None else "cold_start_fcfs"
+        elif self.mode == "exact_length_lpt":
+            tier = "exact_length_lpt"
+
+        if self.mode == "fcfs":
+            predicted_length = request.fallback_cost
+            request.probe_admission = False
+            request.unknown_admission = False
+        elif self.mode == "history_lfs":
+            predicted_length = (
+                request.fallback_cost if estimate is None else max(1, estimate)
+            )
+            request.probe_admission = False
+            request.unknown_admission = False
+        elif self.mode == "exact_length_lpt":
+            predicted_length = request.fallback_cost
+            request.probe_admission = False
+            request.unknown_admission = False
+        elif estimate is None:
+            predicted_length = request.fallback_cost
+            request.probe_admission = (
+                request.group_id not in session.probed_groups
+            )
+            request.unknown_admission = True
+            session.probed_groups.add(request.group_id)
+            session.unknown_admissions[request.group_id] = (
+                session.unknown_admissions.get(request.group_id, 0) + 1
+            )
+        else:
+            predicted_length = max(1, estimate)
+            request.probe_admission = False
+            request.unknown_admission = False
+
+        return tier, estimate, predicted_length
+
+    def _record_fairness(
+        self,
+        session: Session,
+        request: Request,
+        choice_diagnostics: dict[str, Any],
+    ) -> None:
+        """Fold this admission opportunity into the fairness counters."""
+        ordinary_admission_opportunity = bool(
+            choice_diagnostics["ordinary_admission_opportunity"]
+        )
+        if ordinary_admission_opportunity:
+            ordinary_admission_ordinal = int(
+                choice_diagnostics["ordinary_admission_ordinal"]
+            )
+            if (
+                ordinary_admission_ordinal
+                != session.ordinary_admission_opportunities + 1
+            ):
+                raise AssertionError(
+                    "ordinary admission ordinal disagrees with session "
+                    "counter"
+                )
+            session.ordinary_admission_opportunities += 1
+            self.ordinary_admission_opportunities += 1
+            request.ordinary_admission_ordinal = (
+                ordinary_admission_ordinal
+            )
+            if choice_diagnostics["admission_fairness_due"]:
+                session.admission_fairness_due_count += 1
+                self.admission_fairness_due_count += 1
+                if choice_diagnostics["admission_fairness_selected"]:
+                    session.admission_fairness_selected_count += 1
+                    self.admission_fairness_selected_count += 1
+                    if choice_diagnostics[
+                        "admission_fairness_changed_base_choice"
+                    ]:
+                        session.admission_fairness_override_count += 1
+                        self.admission_fairness_override_count += 1
+                    else:
+                        session.admission_fairness_noop_count += 1
+                        self.admission_fairness_noop_count += 1
+                else:
+                    if not choice_diagnostics[
+                        "admission_fairness_due_but_no_candidate"
+                    ]:
+                        raise AssertionError(
+                            "due admission-fairness opportunity was "
+                            "neither selected nor candidate-empty"
+                        )
+                    session.admission_fairness_no_candidate_count += 1
+                    self.admission_fairness_no_candidate_count += 1
+        else:
+            request.ordinary_admission_ordinal = None
+
+        request.admission_fairness_selected = bool(
+            choice_diagnostics["admission_fairness_selected"]
+        )
+        request.admission_selection_reason = choice_diagnostics[
+            "admission_selection_reason"
+        ]
+        if self.mode in ONLINE_LFS_MODES:
+            session.last_group_admission_sequences[
+                request.group_id
+            ] = self._assignment_seq
+
+        if self.mode in (*ONLINE_LFS_MODES, "history_lfs"):
+            self._refresh_group((request.session_id, request.group_id))
+
+
+    def _commit_assignment(
+        self,
+        session: Session,
+        request: Request,
+        dp_idx: int,
+        predicted_length: int,
+    ) -> None:
+        """Move the request into ``assigned`` and charge it to its DP rank."""
+        request.status = "assigned"
+        request.dp_idx = dp_idx
+        request.predicted_length = predicted_length
+        request.assignment_sequence = self._assignment_seq
+        request.dp_assignment_ordinal = self._dp_assignment_ordinals[dp_idx]
+        request.session_dp_assignment_ordinal = (
+            session.dp_assignment_ordinals[dp_idx]
+        )
+        self.dp_inflight[dp_idx][request.request_id] = predicted_length
+        self._inflight_by_group.setdefault(
+            (request.session_id, request.group_id), set()
+        ).add(request.request_id)
+        inflight_counts_after_assignment = [
+            len(items) for items in self.dp_inflight
+        ]
+        self.max_total_inflight_observed = max(
+            self.max_total_inflight_observed,
+            sum(inflight_counts_after_assignment),
+        )
+        self.max_inflight_observed_by_dp = [
+            max(previous, current)
+            for previous, current in zip(
+                self.max_inflight_observed_by_dp,
+                inflight_counts_after_assignment,
+                strict=True,
+            )
+        ]
+
+    def _append_assignment_event(
+        self,
+        session: Session,
+        request: Request,
+        *,
+        dp_idx: int,
+        dp_placement_mode: str,
+        tier: str,
+        estimate: int | None,
+        predicted_length: int,
+        capacity: dict[str, Any],
+        choice_diagnostics: dict[str, Any],
+    ) -> None:
+        """Record the full provenance of one assignment for downstream analysis."""
+        candidate_dp_indices = capacity["candidate_dp_indices"]
+        static_cost_before_assignment = capacity["static_cost_before_assignment"]
+        inflight_count_before_assignment = capacity[
+            "inflight_count_before_assignment"
+        ]
+        dp_tiebreak_before_assignment = capacity["dp_tiebreak_before_assignment"]
+        selected_by_static_cost = capacity["selected_by_static_cost"]
+        selected_by_inflight_count = capacity["selected_by_inflight_count"]
+        inflight_counts_after_assignment = [
+            len(items) for items in self.dp_inflight
+        ]
+        event = {
+            "sequence": self._assignment_seq,
+            "dp_assignment_ordinal": request.dp_assignment_ordinal,
+            "session_dp_assignment_ordinal": (
+                request.session_dp_assignment_ordinal
+            ),
+            "session_id": request.session_id,
+            "request_id": request.request_id,
+            "group_id": request.group_id,
+            "dp_idx": dp_idx,
+            "preferred_dp_idx": request.preferred_dp_idx,
+            "dp_placement_mode": dp_placement_mode,
+            "dp_selection_mode": self.dp_selection_mode,
+            "tier": tier,
+            "is_designated_probe": request.is_designated_probe,
+            "probe_replacement": (
+                tier == "probe"
+                and request.group_id
+                in session.designated_probe_request_ids
+                and session.designated_probe_request_ids[
+                    request.group_id
+                ]
+                != request.request_id
+            ),
+            "probe_selection_semantics": (
+                session.probe_selection_semantics
+            ),
+            "estimate": estimate,
+            "static_admission_cost": predicted_length,
+            "predicted_length": predicted_length,
+            "candidate_dp_count": len(candidate_dp_indices),
+            "candidate_dp_indices": candidate_dp_indices,
+            "dp_static_admission_cost_before_assignment": (
+                static_cost_before_assignment
+            ),
+            "dp_inflight_count_before_assignment": (
+                inflight_count_before_assignment
+            ),
+            "dp_tiebreak_before_assignment": (
+                dp_tiebreak_before_assignment
+            ),
+            "dp_selected_by_static_admission_cost": (
+                selected_by_static_cost
+            ),
+            "dp_selected_by_inflight_count": (
+                selected_by_inflight_count
+            ),
+            "dp_selected_without_static_admission_cost": (
+                selected_by_inflight_count
+            ),
+            "static_admission_cost_affected_dp_selection": (
+                selected_by_static_cost != selected_by_inflight_count
+            ),
+            "dp_selector_applied": (
+                dp_placement_mode == SCHEDULER_SELECTED_DP_PLACEMENT
+            ),
+            "preferred_dp_pin_honored": (
+                dp_idx == request.preferred_dp_idx
+                if dp_placement_mode
+                == PREFERRED_DP_PINNED_PLACEMENT
+                else None
+            ),
+            "dp_selection_matches_declared_mode": (
+                dp_placement_mode
+                == SCHEDULER_SELECTED_DP_PLACEMENT
+                and dp_idx
+                == (
+                    selected_by_static_cost
+                    if self.dp_selection_mode == "static_cost"
+                    else selected_by_inflight_count
+                )
+            ),
+            "dp_selection_counterfactual_semantics": (
+                "Static-cost and inflight-count one-step counterfactuals "
+                "hold the observed candidate set, in-flight state, and "
+                "cyclic tie-break fixed; they do not model alternative "
+                "scheduling trajectories."
+            ),
+            "dp_load_accounting_semantics": (
+                STATIC_ADMISSION_COST_SEMANTICS
+            ),
+            **choice_diagnostics,
+            "ordinary_admission_opportunity_count_after_assignment": (
+                session.ordinary_admission_opportunities
+            ),
+            "admission_fairness_due_count_after_assignment": (
+                session.admission_fairness_due_count
+            ),
+            "admission_fairness_selected_count_after_assignment": (
+                session.admission_fairness_selected_count
+            ),
+            "admission_fairness_override_count_after_assignment": (
+                session.admission_fairness_override_count
+            ),
+            "admission_fairness_noop_count_after_assignment": (
+                session.admission_fairness_noop_count
+            ),
+            "admission_fairness_no_candidate_count_after_assignment": (
+                session.admission_fairness_no_candidate_count
+            ),
+            "selected_differs_from_fcfs_front": (
+                choice_diagnostics["fcfs_front_request_id"]
+                != request.request_id
+            ),
+            "dp_inflight": inflight_counts_after_assignment,
+        }
+        self.assignment_history.append(event)
+        self._new_assignment_events.append(event)
+        self._assignment_seq += 1
+        self._dp_assignment_ordinals[dp_idx] += 1
+        session.dp_assignment_ordinals[dp_idx] += 1
+        if len(self.assignment_history) > 12000:
+            del self.assignment_history[:2000]
+
+    def _pop_request(self) -> Request | None:
+        if self.mode == "fcfs":
+            while self._pending_fcfs:
+                request_id = self._pending_fcfs.popleft()
+                request = self.requests.get(request_id)
+                if request is None or request.status != "pending":
+                    continue
+                session = self.sessions.get(request.session_id)
+                if session is None or session.failed_error is not None:
+                    continue
+                self._decrement_pending_count(request)
+                return request
+            return None
+        if self.mode == "exact_length_lpt":
+            while self._pending_exact_length:
+                _, _, request_id = heapq.heappop(self._pending_exact_length)
+                request = self.requests.get(request_id)
+                if request is None or request.status != "pending":
+                    continue
+                session = self.sessions.get(request.session_id)
+                if session is None or session.failed_error is not None:
+                    continue
+                self._decrement_pending_count(request)
+                return request
+            return None
+
+        fairness_group_key = self._fairness_group_key_if_due()
+        if fairness_group_key is not None:
+            request = self._group_front(fairness_group_key)
+            if request is None:
+                raise AssertionError(
+                    "admission-fairness winner lost its pending group front"
+                )
+            self._pending_by_group[fairness_group_key].popleft()
+            self._decrement_pending_count(request)
+            return request
+
+        while self._group_heap:
+            key, version, group_key = heapq.heappop(self._group_heap)
+            if self._group_versions.get(group_key) != version:
+                continue
+            request = self._group_front(group_key)
+            if request is None:
+                self._pending_by_group.pop(group_key, None)
+                self._group_versions.pop(group_key, None)
+                continue
+            current_key = self._lfs_key(request)
+            if current_key != key:
+                self._refresh_group(group_key)
+                continue
+            self._pending_by_group[group_key].popleft()
+            self._decrement_pending_count(request)
+            return request
+        return None
+
+    def _pop_exact_length_request_for_available_dp(
+        self, candidate_dp_indices: list[int]
+    ) -> Request | None:
+        """Pop the longest exact request whose pinned DP can accept it.
+
+        A temporarily full pinned DP must not head-of-line block work assigned
+        to another DP. Skipped heap entries are restored unchanged, preserving
+        their exact-LPT priority as soon as their target DP has capacity.
+        The scan is O(pending) per refill and is intentionally confined to the
+        bounded, benchmark-only first-turn diagnostic described by
+        ``PREFERRED_DP_PINNING_SEMANTICS``.
+        """
+
+        candidate_dp_set = set(candidate_dp_indices)
+        skipped: list[tuple[int, int, str]] = []
+        selected: Request | None = None
+        while self._pending_exact_length:
+            item = heapq.heappop(self._pending_exact_length)
+            request = self.requests.get(item[2])
+            if request is None or request.status != "pending":
+                continue
+            session = self.sessions.get(request.session_id)
+            if session is None or session.failed_error is not None:
+                continue
+            if (
+                request.preferred_dp_idx is not None
+                and request.preferred_dp_idx not in candidate_dp_set
+            ):
+                skipped.append(item)
+                continue
+            self._decrement_pending_count(request)
+            selected = request
+            break
+        for item in skipped:
+            heapq.heappush(self._pending_exact_length, item)
+        return selected
+
+    def _fairness_group_key_if_due(self) -> tuple[str, str] | None:
+        """Select from the policy queue without consulting diagnostic state."""
+
+        if (
+            self.lfs_admission_fairness_interval <= 0
+            or self.mode not in ONLINE_LFS_MODES
+        ):
+            return None
+        group_fronts: dict[tuple[str, str], Request] = {}
+        for group_key in list(self._pending_by_group):
+            request = self._group_front(group_key)
+            if request is not None:
+                group_fronts[group_key] = request
+        if not group_fronts:
+            return None
+
+        oldest_session_arrival_seq = min(
+            self.sessions[request.session_id].arrival_seq
+            for request in group_fronts.values()
+        )
+        oldest_session_fronts = [
+            request
+            for request in group_fronts.values()
+            if self.sessions[request.session_id].arrival_seq
+            == oldest_session_arrival_seq
+        ]
+        active_tier = min(
+            self._lfs_key(request)[1]
+            for request in oldest_session_fronts
+        )
+        if active_tier != 2:
+            return None
+        session = self.sessions[oldest_session_fronts[0].session_id]
+        next_ordinary_ordinal = (
+            session.ordinary_admission_opportunities + 1
+        )
+        if (
+            next_ordinary_ordinal
+            % self.lfs_admission_fairness_interval
+            != 0
+        ):
+            return None
+
+        candidates = [
+            request
+            for request in oldest_session_fronts
+            if self._lfs_key(request)[1] == 2
+            and not self._inflight_by_group.get(
+                (request.session_id, request.group_id)
+            )
+        ]
+        if not candidates:
+            return None
+        winner = min(candidates, key=self._admission_fairness_key)
+        return (winner.session_id, winner.group_id)
+
+    def _admission_fairness_key(
+        self, request: Request
+    ) -> tuple[int, int, int]:
+        session = self.sessions[request.session_id]
+        return (
+            session.last_group_admission_sequences.get(
+                request.group_id, -1
+            ),
+            session.group_catalog_ordinals[request.group_id],
+            request.arrival_seq,
+        )
+
+    def _decrement_pending_count(self, request: Request) -> None:
+        if request.status != "pending":
+            raise AssertionError(
+                f"request {request.request_id!r} is not pending"
+            )
+        if self._pending_request_count <= 0:
+            raise AssertionError("pending request count underflow")
+        self._pending_request_count -= 1
+        if request.preferred_dp_idx is not None:
+            if self._pending_preferred_dp_request_count <= 0:
+                raise AssertionError(
+                    "pending preferred-DP request count underflow"
+                )
+            self._pending_preferred_dp_request_count -= 1
+
+    def _lfs_key(
+        self, request: Request
+    ) -> tuple[int, int, float, int, int]:
+        session = self.sessions[request.session_id]
+        estimate = session.estimates.get(request.group_id)
+        if self.mode == "history_lfs":
+            # No current-session probe. Known prompts use the mean of completed
+            # rollouts from earlier sessions; unseen prompts retain FCFS order.
+            return (
+                session.arrival_seq,
+                0 if estimate is not None else 1,
+                -float(estimate) if estimate is not None else 0.0,
+                0,
+                request.arrival_seq,
+            )
+        if estimate is None and request.group_id not in session.probed_groups:
+            return (session.arrival_seq, 0, 0.0, 0, request.arrival_seq)
+
+        # Algorithm 2 gives an unresolved group the numerical generation-length
+        # upper bound, then orders all ordinary candidates by that estimate.
+        # Keep the existing admission count as a stable round-robin tie-break
+        # so G < capacity still fills across groups after the probe wave.
+        effective_estimate = (
+            request.fallback_cost
+            if estimate is None
+            else max(1, estimate)
+        )
+        return (
+            session.arrival_seq,
+            2,
+            -float(effective_estimate),
+            session.unknown_admissions.get(request.group_id, 0),
+            request.arrival_seq,
+        )
+
+    def _group_front(self, group_key: tuple[str, str]) -> Request | None:
+        request_ids = self._pending_by_group.get(group_key)
+        if request_ids is None:
+            return None
+        while request_ids:
+            request = self.requests.get(request_ids[0])
+            if request is None or request.status != "pending":
+                request_ids.popleft()
+                continue
+            session = self.sessions.get(request.session_id)
+            if session is None or session.failed_error is not None:
+                request_ids.popleft()
+                continue
+            return request
+        return None
+
+    def _refresh_group(self, group_key: tuple[str, str]) -> None:
+        if self.mode not in (*ONLINE_LFS_MODES, "history_lfs"):
+            return
+        version = self._group_versions.get(group_key, 0) + 1
+        self._group_versions[group_key] = version
+        request = self._group_front(group_key)
+        if request is not None:
+            heapq.heappush(
+                self._group_heap, (self._lfs_key(request), version, group_key)
+            )
+
+    def _select_dp(self) -> int | None:
+        candidates = [
+            dp_idx
+            for dp_idx, inflight in enumerate(self.dp_inflight)
+            if len(inflight) < self.admission_limit_per_dp
+        ]
+        if not candidates:
+            return None
+
+        def static_cost_key(dp_idx: int) -> tuple[int, int, int]:
+            cyclic_distance = (dp_idx - self._dp_tiebreak) % self.dp_size
+            return (
+                sum(self.dp_inflight[dp_idx].values()),
+                len(self.dp_inflight[dp_idx]),
+                cyclic_distance,
+            )
+
+        def inflight_count_key(dp_idx: int) -> tuple[int, int]:
+            cyclic_distance = (dp_idx - self._dp_tiebreak) % self.dp_size
+            return (
+                len(self.dp_inflight[dp_idx]),
+                cyclic_distance,
+            )
+
+        if self.dp_selection_mode == "static_cost":
+            selected = min(candidates, key=static_cost_key)
+        else:
+            # Causal control: length estimates and static admission costs are
+            # deliberately absent from both the key and its tie-break.
+            selected = min(candidates, key=inflight_count_key)
+        self._dp_tiebreak = (selected + 1) % self.dp_size
+        return selected
+
+    def _claim(self, request: Request) -> dict[str, Any]:
+        assert request.dp_idx is not None
+        assert request.predicted_length is not None
+        assert request.assignment_sequence is not None
+        assert request.dp_assignment_ordinal is not None
+        assert request.session_dp_assignment_ordinal is not None
+        request.status = "started"
+        request.lease_started = True
+        return {
+            "request_id": request.request_id,
+            "dp_idx": request.dp_idx,
+            "predicted_length": request.predicted_length,
+            "assignment_sequence": request.assignment_sequence,
+            "dp_assignment_ordinal": request.dp_assignment_ordinal,
+            "session_dp_assignment_ordinal": (
+                request.session_dp_assignment_ordinal
+            ),
+        }
+
+    def _release_dp(self, request: Request) -> None:
+        if request.dp_idx is None:
+            return
+        if request.request_id not in self.dp_inflight[request.dp_idx]:
+            raise AssertionError(
+                f"request {request.request_id!r} missing from DP "
+                f"{request.dp_idx} inflight set"
+            )
+        del self.dp_inflight[request.dp_idx][request.request_id]
+        group_key = (request.session_id, request.group_id)
+        inflight_group = self._inflight_by_group.get(group_key)
+        if (
+            inflight_group is None
+            or request.request_id not in inflight_group
+        ):
+            raise AssertionError(
+                f"request {request.request_id!r} missing from in-flight "
+                f"group index {group_key!r}"
+            )
+        inflight_group.remove(request.request_id)
+        if not inflight_group:
+            del self._inflight_by_group[group_key]
+        request.dp_idx = None
+        request.predicted_length = None
+
+    def _rollback_unknown_admission(self, request: Request) -> None:
+        if not request.unknown_admission:
+            return
+        session = self._require_session(request.session_id)
+        if request.group_id not in session.estimates:
+            count = session.unknown_admissions.get(request.group_id, 0)
+            if count <= 0:
+                raise AssertionError(
+                    f"unknown admission count underflow for group {request.group_id!r}"
+                )
+            if count == 1:
+                del session.unknown_admissions[request.group_id]
+            else:
+                session.unknown_admissions[request.group_id] = count - 1
+            if count == 1:
+                session.probed_groups.discard(request.group_id)
+            self._refresh_group((request.session_id, request.group_id))
+        request.unknown_admission = False
+        request.probe_admission = False
+
+    def _rebase_inflight_group_estimate(
+        self,
+        *,
+        session_id: str,
+        group_id: str,
+        estimate: int,
+        previous_estimate: int | None,
+        completed_request_id: str,
+    ) -> None:
+        """Replace stale upper-bound costs after a group estimate arrives."""
+
+        new_cost = max(1, int(estimate))
+        group_key = (session_id, group_id)
+        inflight_request_ids = sorted(
+            self._inflight_by_group.get(group_key, set())
+        )
+        touched: list[dict[str, int | str | bool]] = []
+        changed: list[dict[str, int | str | bool]] = []
+        for request_id in inflight_request_ids:
+            request = self._require_request(request_id)
+            if (
+                request.status not in ("assigned", "started")
+                or request.dp_idx is None
+            ):
+                raise AssertionError(
+                    f"in-flight group index contains non-live request "
+                    f"{request_id!r} in status {request.status!r}"
+                )
+            old_cost = self.dp_inflight[request.dp_idx].get(
+                request.request_id
+            )
+            if old_cost is None:
+                raise AssertionError(
+                    f"in-flight request {request.request_id!r} is missing "
+                    f"from DP {request.dp_idx}"
+                )
+            self.dp_inflight[request.dp_idx][request.request_id] = new_cost
+            request.predicted_length = new_cost
+            item: dict[str, int | str | bool] = {
+                "request_id": request.request_id,
+                "dp_idx": request.dp_idx,
+                "status_at_rebase": request.status,
+                "old_static_admission_cost": old_cost,
+                "new_static_admission_cost": new_cost,
+                "cost_changed": old_cost != new_cost,
+            }
+            touched.append(item)
+            if old_cost != new_cost:
+                changed.append(item)
+        if previous_estimate is None:
+            estimate_transition = "first_finite_estimate"
+        elif new_cost > int(previous_estimate):
+            estimate_transition = "increased"
+        elif new_cost < int(previous_estimate):
+            estimate_transition = "decreased"
+        else:
+            estimate_transition = "unchanged"
+        pending_request_ids = sorted(
+            request_id
+            for request_id in self._pending_by_group.get(
+                group_key, ()
+            )
+            if (
+                (request := self.requests.get(request_id)) is not None
+                and request.status == "pending"
+            )
+        )
+        completed_request = self._require_request(completed_request_id)
+        session = self._require_session(session_id)
+        self.estimate_rebase_history.append(
+            {
+                "session_id": session_id,
+                "group_id": group_id,
+                "estimate": new_cost,
+                "previous_estimate": previous_estimate,
+                "first_finite_estimate": previous_estimate is None,
+                "estimate_transition": estimate_transition,
+                "completed_request_id": completed_request_id,
+                "completed_request_is_designated_probe": (
+                    completed_request.is_designated_probe
+                ),
+                "completed_request_is_probe_admission": (
+                    completed_request.probe_admission
+                ),
+                "completed_request_is_unknown_admission": (
+                    completed_request.unknown_admission
+                ),
+                "probe_selection_semantics": (
+                    session.probe_selection_semantics
+                ),
+                "designated_probe_request_id": (
+                    session.designated_probe_request_ids.get(group_id)
+                ),
+                "designated_probe_request_status": (
+                    self.requests[
+                        session.designated_probe_request_ids[group_id]
+                    ].status
+                    if group_id in session.designated_probe_request_ids
+                    else None
+                ),
+                "completed_request_was_admission_fairness_selected": (
+                    completed_request.admission_fairness_selected
+                ),
+                "completed_request_ordinary_admission_ordinal": (
+                    completed_request.ordinary_admission_ordinal
+                ),
+                "completed_request_admission_selection_reason": (
+                    completed_request.admission_selection_reason
+                ),
+                "pending_request_ids": pending_request_ids,
+                "inflight_request_ids": inflight_request_ids,
+                "touched_request_count": len(touched),
+                "changed_request_count": len(changed),
+                "no_op_request_count": len(touched) - len(changed),
+                "touched_requests": touched,
+                "changed_requests": changed,
+                "load_accounting_semantics": (
+                    STATIC_ADMISSION_COST_SEMANTICS
+                ),
+            }
+        )
+        if len(self.estimate_rebase_history) > 12000:
+            del self.estimate_rebase_history[:2000]
+
+    def _maybe_drop_session(self, session: Session) -> None:
+        if session.open_participants:
+            return
+        terminal = {"completed", "cancelled", "failed_terminal"}
+        if any(
+            self.requests[item].status not in terminal
+            for item in session.request_ids
+        ):
+            return
+        if self.mode == "history_lfs":
+            for group_id, lengths in session.completed_lengths.items():
+                if not lengths:
+                    continue
+                old_total, old_count = self.group_history.get(group_id, (0, 0))
+                new_total = old_total + sum(lengths)
+                new_count = old_count + len(lengths)
+                self.group_history[group_id] = (new_total, new_count)
+                self.history_update_history.append(
+                    {
+                        "session_id": session.session_id,
+                        "group_id": group_id,
+                        "prediction": (
+                            old_total / old_count if old_count else None
+                        ),
+                        "current_group_mean": sum(lengths) / len(lengths),
+                        "history_count_before": old_count,
+                        "history_mean_after": new_total / new_count,
+                    }
+                )
+            if len(self.history_update_history) > 12000:
+                del self.history_update_history[:2000]
+        for request_id in session.request_ids:
+            del self.requests[request_id]
+        for group_key in [
+            key for key in self._pending_by_group if key[0] == session.session_id
+        ]:
+            self._pending_by_group.pop(group_key, None)
+            self._group_versions.pop(group_key, None)
+        for group_key in [
+            key
+            for key in self._diagnostic_pending_by_group
+            if key[0] == session.session_id
+        ]:
+            self._diagnostic_pending_by_group.pop(group_key, None)
+        if any(
+            group_key[0] == session.session_id
+            for group_key in self._inflight_by_group
+        ):
+            raise AssertionError(
+                f"session {session.session_id!r} closed with indexed "
+                "in-flight requests"
+            )
+        del self.sessions[session.session_id]
+        self._closed_session_ids.add(session.session_id)
+        self._closed_session_order.append(session.session_id)
+        while len(self._closed_session_order) > self._max_closed_session_tombstones:
+            expired = self._closed_session_order.popleft()
+            self._closed_session_ids.discard(expired)
+
+    def _require_session(self, session_id: str) -> Session:
+        try:
+            return self.sessions[session_id]
+        except KeyError as error:
+            raise KeyError(f"unknown cross-DP session {session_id!r}") from error
+
+    def _require_request(self, request_id: str) -> Request:
+        try:
+            return self.requests[request_id]
+        except KeyError as error:
+            raise KeyError(f"unknown cross-DP request {request_id!r}") from error

--- a/nemo_rl/models/generation/vllm/lfs/state.py
+++ b/nemo_rl/models/generation/vllm/lfs/state.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-flight bookkeeping for one admission session.
+
+``Request`` is a single trajectory the dispatcher may hand to a DP rank;
+``Session`` is the bounded first-turn catalog a rollout opens in one shot.
+Both are plain records: every transition lives in :mod:`scheduler`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from nemo_rl.models.generation.vllm.lfs.modes import (
+    IMPLICIT_PROBE_SELECTION_SEMANTICS,
+    SCHEDULER_SELECTED_DP_PLACEMENT,
+)
+
+@dataclass
+class Request:
+    session_id: str
+    participant_id: str
+    request_id: str
+    group_id: str
+    arrival_seq: int
+    fallback_cost: int
+    status: str = "pending"
+    dp_idx: int | None = None
+    preferred_dp_idx: int | None = None
+    predicted_length: int | None = None
+    assignment_sequence: int | None = None
+    dp_assignment_ordinal: int | None = None
+    session_dp_assignment_ordinal: int | None = None
+    lease_started: bool = False
+    unknown_admission: bool = False
+    probe_admission: bool = False
+    is_designated_probe: bool = False
+    admission_fairness_selected: bool = False
+    ordinary_admission_ordinal: int | None = None
+    admission_selection_reason: str | None = None
+
+
+@dataclass
+class Session:
+    session_id: str
+    arrival_seq: int
+    open_participants: set[str]
+    request_ids: set[str] = field(default_factory=set)
+    participant_requests: dict[str, set[str]] = field(default_factory=dict)
+    estimates: dict[str, int] = field(default_factory=dict)
+    probed_groups: set[str] = field(default_factory=set)
+    unknown_admissions: dict[str, int] = field(default_factory=dict)
+    failed_error: str | None = None
+    completed_lengths: dict[str, list[int]] = field(default_factory=dict)
+    dp_assignment_ordinals: list[int] = field(default_factory=list)
+    # Benchmark-only truth, kept separate from estimates so the ordinary
+    # probe/unknown exploration wave remains unchanged.
+    oracle_estimates: dict[str, int] = field(default_factory=dict)
+    probe_selection_semantics: str = IMPLICIT_PROBE_SELECTION_SEMANTICS
+    designated_probe_request_ids: dict[str, str] = field(default_factory=dict)
+    group_catalog_ordinals: dict[str, int] = field(default_factory=dict)
+    last_group_admission_sequences: dict[str, int] = field(default_factory=dict)
+    ordinary_admission_opportunities: int = 0
+    admission_fairness_due_count: int = 0
+    admission_fairness_selected_count: int = 0
+    admission_fairness_override_count: int = 0
+    admission_fairness_noop_count: int = 0
+    admission_fairness_no_candidate_count: int = 0
+    dp_placement_mode: str = SCHEDULER_SELECTED_DP_PLACEMENT

--- a/nemo_rl/models/generation/vllm/lfs/validation.py
+++ b/nemo_rl/models/generation/vllm/lfs/validation.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Input validation for the cross-DP scheduler.
+
+These are pure argument checks with no scheduler state, kept apart so the
+state machine itself reads as transitions rather than as a wall of guards.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nemo_rl.models.generation.vllm.lfs.modes import (
+    EXPLICIT_PROBE_SELECTION_SEMANTICS,
+    IMPLICIT_PROBE_SELECTION_SEMANTICS,
+    ONLINE_LFS_MODES,
+    PREFERRED_DP_PINNED_PLACEMENT,
+    SCHEDULER_SELECTED_DP_PLACEMENT,
+)
+
+
+def validate_scheduler_config(
+    *,
+    dp_size: int,
+    max_num_seqs_per_dp: int,
+    mode: str,
+    lookahead_per_dp: int,
+    dp_selection_mode: str,
+    lfs_admission_fairness_interval: int,
+) -> None:
+    """Reject a scheduler configuration that could never be honoured."""
+    if dp_size <= 0:
+        raise ValueError(f"dp_size must be positive, got {dp_size}")
+    if max_num_seqs_per_dp <= 0:
+        raise ValueError(
+            "max_num_seqs_per_dp must be positive, "
+            f"got {max_num_seqs_per_dp}"
+        )
+    if lookahead_per_dp < 0:
+        raise ValueError(
+            f"lookahead_per_dp must be non-negative, got {lookahead_per_dp}"
+        )
+    if mode not in (
+        "fcfs",
+        "lfs",
+        "predicted_lfs",
+        "history_lfs",
+        "oracle_probe_lfs",
+        "exact_length_lpt",
+    ):
+        raise ValueError(
+            "mode must be 'fcfs', 'lfs', 'predicted_lfs', 'history_lfs', "
+            "'oracle_probe_lfs', or 'exact_length_lpt', "
+            f"got {mode!r}"
+        )
+    if dp_selection_mode not in ("static_cost", "inflight_count"):
+        raise ValueError(
+            "dp_selection_mode must be 'static_cost' or "
+            f"'inflight_count', got {dp_selection_mode!r}"
+        )
+    if (
+        type(lfs_admission_fairness_interval) is not int
+        or lfs_admission_fairness_interval < 0
+    ):
+        raise ValueError(
+            "lfs_admission_fairness_interval must be a non-negative "
+            f"integer, got {lfs_admission_fairness_interval!r}"
+        )
+    if (
+        lfs_admission_fairness_interval > 0
+        and mode not in ONLINE_LFS_MODES
+    ):
+        raise ValueError(
+            "lfs_admission_fairness_interval is only supported for "
+            f"lfs/predicted_lfs/oracle_probe_lfs, got mode={mode!r}"
+        )
+
+
+def resolve_global_admission_limit(
+    *, dp_size: int, admission_limit_per_dp: int, requested: int | None
+) -> int:
+    """Default the global cap to the aggregate per-DP cap, and bound it."""
+    aggregate_admission_limit = dp_size * admission_limit_per_dp
+    if requested is None:
+        return aggregate_admission_limit
+    if not 0 < requested <= aggregate_admission_limit:
+        raise ValueError(
+            "global_admission_limit must be in [1, "
+            f"{aggregate_admission_limit}], got "
+            f"{requested}"
+        )
+    return requested
+
+
+def inspect_catalog(
+    request_catalog: list[dict[str, Any]], *, mode: str, dp_size: int
+) -> tuple[str, str, dict[str, str]]:
+    """Validate a first-turn catalog and read its placement/probe conventions.
+
+    Returns ``(dp_placement_mode, probe_selection_semantics,
+    designated_probe_request_ids)``.
+    """
+    self = _ConfigView(mode=mode, dp_size=dp_size)
+
+    preferred_dp_marker_presence = [
+        "preferred_dp_idx" in item for item in request_catalog
+    ]
+    dp_placement_mode = SCHEDULER_SELECTED_DP_PLACEMENT
+    if any(preferred_dp_marker_presence):
+        if not all(preferred_dp_marker_presence):
+            raise ValueError(
+                "preferred_dp_idx must be present on every catalog request "
+                "when exact-length DP pinning is used"
+            )
+        if self.mode != "exact_length_lpt":
+            raise ValueError(
+                "preferred_dp_idx is only supported for "
+                f"exact_length_lpt, got mode={self.mode!r}"
+            )
+        invalid_preferred_dp_indices = [
+            (str(item.get("request_id")), item["preferred_dp_idx"])
+            for item in request_catalog
+            if type(item["preferred_dp_idx"]) is not int
+            or not 0 <= item["preferred_dp_idx"] < self.dp_size
+        ]
+        if invalid_preferred_dp_indices:
+            raise ValueError(
+                "preferred_dp_idx must be an int (not bool) in "
+                f"[0, {self.dp_size}); invalid requests="
+                f"{invalid_preferred_dp_indices}"
+            )
+        dp_placement_mode = PREFERRED_DP_PINNED_PLACEMENT
+
+    marker_presence = [
+        "is_designated_probe" in item for item in request_catalog
+    ]
+    designated_probe_request_ids: dict[str, str] = {}
+    probe_selection_semantics = IMPLICIT_PROBE_SELECTION_SEMANTICS
+    if any(marker_presence):
+        if not all(marker_presence):
+            raise ValueError(
+                "is_designated_probe must be present on every catalog "
+                "request when explicit probe designation is used"
+            )
+        invalid_markers = [
+            str(item.get("request_id"))
+            for item in request_catalog
+            if type(item["is_designated_probe"]) is not bool
+        ]
+        if invalid_markers:
+            raise ValueError(
+                "is_designated_probe must be a bool for every catalog "
+                f"request; invalid request_ids={invalid_markers}"
+            )
+        designated_counts: dict[str, int] = {}
+        for item in request_catalog:
+            group_id = str(item["group_id"])
+            designated_counts.setdefault(group_id, 0)
+            if item["is_designated_probe"]:
+                designated_counts[group_id] += 1
+                designated_probe_request_ids[group_id] = str(
+                    item["request_id"]
+                )
+        invalid_groups = {
+            group_id: count
+            for group_id, count in designated_counts.items()
+            if count != 1
+        }
+        if invalid_groups:
+            raise ValueError(
+                "explicit probe designation requires exactly one "
+                "is_designated_probe request per group; "
+                f"invalid_groups={invalid_groups}"
+            )
+        probe_selection_semantics = EXPLICIT_PROBE_SELECTION_SEMANTICS
+    return (
+        dp_placement_mode,
+        probe_selection_semantics,
+        designated_probe_request_ids,
+    )
+
+
+class _ConfigView:
+    """Minimal stand-in so the moved checks keep reading ``self.mode``."""
+
+    __slots__ = ("mode", "dp_size")
+
+    def __init__(self, *, mode: str, dp_size: int) -> None:
+        self.mode = mode
+        self.dp_size = dp_size

--- a/nemo_rl/models/generation/vllm/model_step_gpu_profiler.py
+++ b/nemo_rl/models/generation/vllm/model_step_gpu_profiler.py
@@ -1,0 +1,724 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic GPU profiling over an exact model-step interval.
+
+The controller is deliberately independent of vLLM types. It replaces one
+``model_runner.execute_model`` attribute on a specific instance and counts calls
+from zero after :meth:`arm` returns. The capture interval is half open:
+``[start_step, stop_step)``.
+
+The start boundary synchronizes the current CUDA device and starts the profiler
+immediately before the first included call. After the final included call
+returns, the controller closes its NVTX range, synchronizes the device, stops
+the profiler, and restores the exact original callable topology before
+returning. Therefore no excluded model step can enter the CUDA-profiler range.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import os
+import socket
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+
+MODEL_STEP_GPU_PROFILER_PROOF_SCHEMA_VERSION = 1
+MODEL_STEP_NVTX_RANGE_PREFIX = "NRL_MODEL_STEP"
+
+
+class ModelStepGpuProfilerError(RuntimeError):
+    """Base error for deterministic model-step profiling."""
+
+
+class ModelStepGpuProfilerContractError(ModelStepGpuProfilerError):
+    """Raised when the requested profiling contract cannot be proven."""
+
+
+def _callable_identity(value: Any) -> dict[str, Any]:
+    """Return a JSON-safe identity for a callable without using its repr."""
+    underlying = getattr(value, "__func__", value)
+    bound_self = getattr(value, "__self__", None)
+    try:
+        signature = str(inspect.signature(value))
+    except (TypeError, ValueError):
+        signature = None
+    return {
+        "callable_object_id": id(value),
+        "underlying_callable_id": id(underlying),
+        "bound_self_id": None if bound_self is None else id(bound_self),
+        "module": getattr(underlying, "__module__", None),
+        "qualname": getattr(underlying, "__qualname__", None),
+        "signature": signature,
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "is_coroutine_function": inspect.iscoroutinefunction(value),
+    }
+
+
+def _same_callable(left: Any, right: Any) -> bool:
+    """Compare bound methods by function and owner, otherwise by identity."""
+    left_function = getattr(left, "__func__", None)
+    right_function = getattr(right, "__func__", None)
+    if left_function is not None or right_function is not None:
+        return (
+            left_function is right_function
+            and getattr(left, "__self__", None)
+            is getattr(right, "__self__", None)
+        )
+    return left is right
+
+
+class DeterministicModelStepGpuProfiler:
+    """One-shot exact-step CUDA-profiler controller for a model-runner instance.
+
+    The controller is intentionally one-shot. Re-arming it, including after a
+    completed capture, invalidates its proof and raises. A failure while armed
+    poisons the installed wrapper so later model execution cannot silently
+    continue outside the requested profiling contract.
+    """
+
+    _CALL_NAMES = (
+        "wrapper_install",
+        "wrapper_restore",
+        "execute_model",
+        "cuda_synchronize",
+        "profiler_start",
+        "profiler_stop",
+        "nvtx_range_push",
+        "nvtx_range_pop",
+    )
+    _WRAPPER_CONTROLLER_ATTRIBUTE = "__nrl_model_step_gpu_profiler_controller__"
+
+    def __init__(
+        self,
+        model_runner: Any,
+        *,
+        torch_module: Any = torch,
+        hostname_fn: Callable[[], str] = socket.gethostname,
+        pid_fn: Callable[[], int] = os.getpid,
+    ) -> None:
+        """Create an unarmed controller without changing ``model_runner``."""
+        self._model_runner = model_runner
+        self._torch = torch_module
+        self._hostname = str(hostname_fn())
+        self._pid = int(pid_fn())
+        self._lock = threading.RLock()
+
+        self._state = "new"
+        self._start_step: int | None = None
+        self._stop_step: int | None = None
+        self._device_proof: dict[str, Any] | None = None
+        self._original_execute_model: Callable[..., Any] | None = None
+        self._wrapper: Callable[..., Any] | None = None
+        self._original_was_instance_attribute: bool | None = None
+        self._original_instance_attribute: Any = None
+        self._wrapper_installed = False
+        self._original_restored = False
+        self._execute_in_progress = False
+        self._profiler_may_be_active = False
+        self._nvtx_range_open = False
+
+        self._observed_model_step_count = 0
+        self._completed_execute_model_count = 0
+        self._completed_captured_model_step_count = 0
+        self._last_observed_model_step_ordinal: int | None = None
+        self._profiler_started_before_model_step_ordinal: int | None = None
+        self._profiler_stopped_after_model_step_ordinal: int | None = None
+        self._call_counts = {
+            name: {"attempted": 0, "succeeded": 0}
+            for name in self._CALL_NAMES
+        }
+        self._errors: list[dict[str, Any]] = []
+
+    def arm(self, start_step: int, stop_step: int) -> None:
+        """Install the wrapper for zero-based ``[start_step, stop_step)``.
+
+        The first call to the wrapped ``execute_model`` after this method
+        returns has ordinal zero. Bounds must be plain integers satisfying
+        ``0 <= start_step < stop_step``.
+        """
+        with self._lock:
+            if self._state != "new":
+                error = ModelStepGpuProfilerContractError(
+                    f"controller is one-shot and cannot be armed from state {self._state!r}"
+                )
+                self._record_error_locked("arm", None, "double_arm", error)
+                self._fail_closed_locked()
+                raise error
+
+            try:
+                self._validate_bounds(start_step, stop_step)
+                original = getattr(self._model_runner, "execute_model")
+                if not callable(original):
+                    raise ModelStepGpuProfilerContractError(
+                        "model_runner.execute_model must be callable"
+                    )
+                if inspect.iscoroutinefunction(original):
+                    raise ModelStepGpuProfilerContractError(
+                        "async execute_model callables are not supported"
+                    )
+                if getattr(
+                    original,
+                    self._WRAPPER_CONTROLLER_ATTRIBUTE,
+                    None,
+                ) is not None:
+                    raise ModelStepGpuProfilerContractError(
+                        "model_runner.execute_model is already controlled by a "
+                        "model-step profiler"
+                    )
+                runner_dict = getattr(self._model_runner, "__dict__", None)
+                if not isinstance(runner_dict, dict):
+                    raise ModelStepGpuProfilerContractError(
+                        "model_runner.__dict__ must be a real dict so exact "
+                        "execute_model attribute restoration can be proven"
+                    )
+                self._device_proof = self._read_device_proof()
+            except BaseException as error:
+                self._record_error_locked("arm", None, "validation", error)
+                self._state = "failed"
+                raise
+
+            self._start_step = start_step
+            self._stop_step = stop_step
+            self._original_execute_model = original
+            self._original_was_instance_attribute = "execute_model" in runner_dict
+            if self._original_was_instance_attribute:
+                self._original_instance_attribute = runner_dict["execute_model"]
+
+            @functools.wraps(original)
+            def wrapped_execute_model(*args: Any, **kwargs: Any) -> Any:
+                return self._execute_model(*args, **kwargs)
+
+            setattr(
+                wrapped_execute_model,
+                self._WRAPPER_CONTROLLER_ATTRIBUTE,
+                self,
+            )
+            self._wrapper = wrapped_execute_model
+            try:
+                self._invoke_locked(
+                    "wrapper_install",
+                    None,
+                    "arm",
+                    lambda: setattr(
+                        self._model_runner,
+                        "execute_model",
+                        wrapped_execute_model,
+                    ),
+                )
+                if (
+                    getattr(self._model_runner, "execute_model")
+                    is not wrapped_execute_model
+                ):
+                    raise ModelStepGpuProfilerContractError(
+                        "installed execute_model wrapper identity did not match"
+                    )
+            except BaseException as error:
+                if not self._errors or self._errors[-1]["error"] != str(error):
+                    self._record_error_locked(
+                        "wrapper_install",
+                        None,
+                        "identity_verification",
+                        error,
+                    )
+                self._state = "failed"
+                self._best_effort_restore_after_install_failure_locked()
+                raise
+
+            self._wrapper_installed = True
+            self._state = "armed"
+
+    def require_complete(self) -> dict[str, Any]:
+        """Return the proof or fail closed and stop an incomplete capture."""
+        with self._lock:
+            if self._is_complete_locked():
+                return self._snapshot_locked()
+            error = ModelStepGpuProfilerContractError(
+                "model-step profiling did not complete its exact target range"
+            )
+            self._record_error_locked(
+                "require_complete",
+                self._last_observed_model_step_ordinal,
+                "incomplete_capture",
+                error,
+            )
+            self._fail_closed_locked()
+            raise error
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-safe proof snapshot without changing controller state."""
+        with self._lock:
+            return self._snapshot_locked()
+
+    @staticmethod
+    def _validate_bounds(start_step: int, stop_step: int) -> None:
+        if (
+            isinstance(start_step, bool)
+            or isinstance(stop_step, bool)
+            or not isinstance(start_step, int)
+            or not isinstance(stop_step, int)
+        ):
+            raise ModelStepGpuProfilerContractError(
+                "model-step bounds must be plain integers"
+            )
+        if start_step < 0 or stop_step <= start_step:
+            raise ModelStepGpuProfilerContractError(
+                "model-step bounds must satisfy 0 <= start_step < stop_step"
+            )
+
+    def _read_device_proof(self) -> dict[str, Any]:
+        cuda = getattr(self._torch, "cuda", None)
+        if cuda is None or not callable(
+            getattr(cuda, "current_device", None)
+        ):
+            raise ModelStepGpuProfilerContractError(
+                "torch.cuda.current_device is unavailable"
+            )
+        current_device = cuda.current_device()
+        runner_device = getattr(self._model_runner, "device", None)
+        return {
+            "cuda_current_device": current_device,
+            "model_runner_device": (
+                None if runner_device is None else str(runner_device)
+            ),
+        }
+
+    def _execute_model(self, *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            if self._state == "failed":
+                raise ModelStepGpuProfilerContractError(
+                    "model-step profiler is in failed state"
+                )
+            if self._state not in ("armed", "capturing"):
+                error = ModelStepGpuProfilerContractError(
+                    f"wrapped execute_model called from invalid state {self._state!r}"
+                )
+                self._record_error_locked(
+                    "execute_model",
+                    self._last_observed_model_step_ordinal,
+                    "invalid_state",
+                    error,
+                )
+                self._fail_closed_locked()
+                raise error
+            if self._execute_in_progress:
+                error = ModelStepGpuProfilerContractError(
+                    "concurrent or re-entrant execute_model calls are unsupported"
+                )
+                self._record_error_locked(
+                    "execute_model",
+                    self._last_observed_model_step_ordinal,
+                    "concurrent_execute",
+                    error,
+                )
+                self._fail_closed_locked()
+                raise error
+
+            ordinal = self._observed_model_step_count
+            self._observed_model_step_count += 1
+            self._last_observed_model_step_ordinal = ordinal
+            self._execute_in_progress = True
+            try:
+                return self._execute_model_locked(ordinal, *args, **kwargs)
+            except BaseException:
+                self._fail_closed_locked()
+                raise
+            finally:
+                self._execute_in_progress = False
+
+    def _execute_model_locked(
+        self,
+        ordinal: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        assert self._start_step is not None
+        assert self._stop_step is not None
+        assert self._original_execute_model is not None
+
+        included = self._start_step <= ordinal < self._stop_step
+        if ordinal == self._start_step:
+            self._invoke_locked(
+                "cuda_synchronize",
+                ordinal,
+                "start_boundary",
+                self._torch.cuda.synchronize,
+            )
+            self._profiler_may_be_active = True
+            self._invoke_locked(
+                "profiler_start",
+                ordinal,
+                "start_boundary",
+                self._torch.cuda.profiler.start,
+            )
+            self._profiler_started_before_model_step_ordinal = ordinal
+            self._state = "capturing"
+        elif ordinal > self._start_step and self._state != "capturing":
+            error = ModelStepGpuProfilerContractError(
+                "capture start boundary was not observed exactly once"
+            )
+            self._record_error_locked(
+                "execute_model",
+                ordinal,
+                "missed_start_boundary",
+                error,
+            )
+            raise error
+
+        if included:
+            self._invoke_locked(
+                "nvtx_range_push",
+                ordinal,
+                "captured_model_step",
+                lambda: self._torch.cuda.nvtx.range_push(
+                    f"{MODEL_STEP_NVTX_RANGE_PREFIX}:{ordinal}"
+                ),
+            )
+            self._nvtx_range_open = True
+
+        result = self._invoke_locked(
+            "execute_model",
+            ordinal,
+            "model_step",
+            lambda: self._original_execute_model(*args, **kwargs),
+        )
+        if inspect.isawaitable(result):
+            error = ModelStepGpuProfilerContractError(
+                "execute_model returned an awaitable; exact synchronous "
+                "boundaries cannot be proven"
+            )
+            self._record_error_locked(
+                "execute_model",
+                ordinal,
+                "awaitable_result",
+                error,
+            )
+            close = getattr(result, "close", None)
+            if callable(close):
+                close()
+            raise error
+
+        self._completed_execute_model_count += 1
+        if included:
+            self._invoke_locked(
+                "nvtx_range_pop",
+                ordinal,
+                "captured_model_step",
+                self._torch.cuda.nvtx.range_pop,
+            )
+            self._nvtx_range_open = False
+            self._completed_captured_model_step_count += 1
+
+        if ordinal + 1 == self._stop_step:
+            self._invoke_locked(
+                "cuda_synchronize",
+                ordinal,
+                "stop_boundary",
+                self._torch.cuda.synchronize,
+            )
+            self._invoke_locked(
+                "profiler_stop",
+                ordinal,
+                "stop_boundary",
+                self._torch.cuda.profiler.stop,
+            )
+            self._profiler_may_be_active = False
+            self._profiler_stopped_after_model_step_ordinal = ordinal
+            self._restore_original_locked()
+            self._state = "completed"
+
+        return result
+
+    def _invoke_locked(
+        self,
+        call_name: str,
+        ordinal: int | None,
+        phase: str,
+        function: Callable[[], Any],
+    ) -> Any:
+        counts = self._call_counts[call_name]
+        counts["attempted"] += 1
+        try:
+            result = function()
+        except BaseException as error:
+            self._record_error_locked(call_name, ordinal, phase, error)
+            raise
+        counts["succeeded"] += 1
+        return result
+
+    def _restore_original_locked(self) -> None:
+        assert self._original_execute_model is not None
+        try:
+            if self._original_was_instance_attribute is False:
+                self._invoke_locked(
+                    "wrapper_restore",
+                    self._last_observed_model_step_ordinal,
+                    "completed_capture",
+                    lambda: delattr(self._model_runner, "execute_model"),
+                )
+            else:
+                restore_value = (
+                    self._original_instance_attribute
+                    if self._original_was_instance_attribute
+                    else self._original_execute_model
+                )
+                self._invoke_locked(
+                    "wrapper_restore",
+                    self._last_observed_model_step_ordinal,
+                    "completed_capture",
+                    lambda: setattr(
+                        self._model_runner,
+                        "execute_model",
+                        restore_value,
+                    ),
+                )
+            current = getattr(self._model_runner, "execute_model")
+            if not _same_callable(current, self._original_execute_model):
+                raise ModelStepGpuProfilerContractError(
+                    "restored execute_model callable identity did not match"
+                )
+        except BaseException as error:
+            if not self._errors or self._errors[-1]["error"] != str(error):
+                self._record_error_locked(
+                    "wrapper_restore",
+                    self._last_observed_model_step_ordinal,
+                    "identity_verification",
+                    error,
+                )
+            raise
+        self._wrapper_installed = False
+        self._original_restored = True
+
+    def _best_effort_restore_after_install_failure_locked(self) -> None:
+        if self._original_execute_model is None:
+            return
+        try:
+            if self._original_was_instance_attribute is False:
+                delattr(self._model_runner, "execute_model")
+            else:
+                restore_value = (
+                    self._original_instance_attribute
+                    if self._original_was_instance_attribute
+                    else self._original_execute_model
+                )
+                setattr(self._model_runner, "execute_model", restore_value)
+        except BaseException as error:
+            self._record_error_locked(
+                "wrapper_restore",
+                None,
+                "install_failure_cleanup",
+                error,
+            )
+
+    def _fail_closed_locked(self) -> None:
+        self._state = "failed"
+        if self._nvtx_range_open:
+            try:
+                self._invoke_locked(
+                    "nvtx_range_pop",
+                    self._last_observed_model_step_ordinal,
+                    "failure_cleanup",
+                    self._torch.cuda.nvtx.range_pop,
+                )
+            except BaseException:
+                pass
+            self._nvtx_range_open = False
+        if self._profiler_may_be_active:
+            try:
+                self._invoke_locked(
+                    "cuda_synchronize",
+                    self._last_observed_model_step_ordinal,
+                    "failure_cleanup",
+                    self._torch.cuda.synchronize,
+                )
+            except BaseException:
+                pass
+            try:
+                self._invoke_locked(
+                    "profiler_stop",
+                    self._last_observed_model_step_ordinal,
+                    "failure_cleanup",
+                    self._torch.cuda.profiler.stop,
+                )
+            except BaseException:
+                pass
+            self._profiler_may_be_active = False
+
+    def _record_error_locked(
+        self,
+        operation: str,
+        ordinal: int | None,
+        phase: str,
+        error: BaseException,
+    ) -> None:
+        self._errors.append(
+            {
+                "operation": operation,
+                "phase": phase,
+                "model_step_ordinal": ordinal,
+                "error_type": type(error).__name__,
+                "error": str(error),
+            }
+        )
+
+    def _is_complete_locked(self) -> bool:
+        if self._start_step is None or self._stop_step is None:
+            return False
+        return (
+            self._state == "completed"
+            and not self._errors
+            and self._observed_model_step_count == self._stop_step
+            and self._completed_execute_model_count == self._stop_step
+            and self._completed_captured_model_step_count
+            == self._stop_step - self._start_step
+            and self._profiler_started_before_model_step_ordinal
+            == self._start_step
+            and self._profiler_stopped_after_model_step_ordinal
+            == self._stop_step - 1
+            and self._call_counts["profiler_start"]
+            == {"attempted": 1, "succeeded": 1}
+            and self._call_counts["profiler_stop"]
+            == {"attempted": 1, "succeeded": 1}
+            and self._call_counts["wrapper_install"]
+            == {"attempted": 1, "succeeded": 1}
+            and self._call_counts["wrapper_restore"]
+            == {"attempted": 1, "succeeded": 1}
+            and not self._wrapper_installed
+            and self._original_restored
+        )
+
+    def _snapshot_locked(self) -> dict[str, Any]:
+        original_identity = (
+            None
+            if self._original_execute_model is None
+            else _callable_identity(self._original_execute_model)
+        )
+        wrapper_identity = (
+            None
+            if self._wrapper is None
+            else _callable_identity(self._wrapper)
+        )
+        try:
+            current_callable = getattr(
+                self._model_runner,
+                "execute_model",
+                None,
+            )
+            current_identity = (
+                None
+                if current_callable is None
+                else _callable_identity(current_callable)
+            )
+            current_matches_original = (
+                self._original_execute_model is not None
+                and _same_callable(
+                    current_callable,
+                    self._original_execute_model,
+                )
+            )
+            current_matches_wrapper = (
+                self._wrapper is not None
+                and current_callable is self._wrapper
+            )
+        except BaseException:
+            current_identity = None
+            current_matches_original = False
+            current_matches_wrapper = False
+
+        start_step = self._start_step
+        stop_step = self._stop_step
+        expected_captured_count = (
+            None
+            if start_step is None or stop_step is None
+            else stop_step - start_step
+        )
+        return {
+            "schema_version": MODEL_STEP_GPU_PROFILER_PROOF_SCHEMA_VERSION,
+            "hostname": self._hostname,
+            "pid": self._pid,
+            "device": (
+                None
+                if self._device_proof is None
+                else dict(self._device_proof)
+            ),
+            "range": {
+                "semantics": "[start_inclusive, stop_exclusive)",
+                "ordinal_origin": (
+                    "first model_runner.execute_model call after arm returns"
+                ),
+                "start_step": start_step,
+                "stop_step": stop_step,
+                "expected_captured_model_step_count": (
+                    expected_captured_count
+                ),
+                "nvtx_range_name_format": (
+                    f"{MODEL_STEP_NVTX_RANGE_PREFIX}:<zero_based_ordinal>"
+                ),
+            },
+            "calls": {
+                name: dict(counts)
+                for name, counts in self._call_counts.items()
+            },
+            "observed_model_step_count": self._observed_model_step_count,
+            "completed_execute_model_count": (
+                self._completed_execute_model_count
+            ),
+            "completed_captured_model_step_count": (
+                self._completed_captured_model_step_count
+            ),
+            "last_observed_model_step_ordinal": (
+                self._last_observed_model_step_ordinal
+            ),
+            "capture_boundaries": {
+                "profiler_started_before_model_step_ordinal": (
+                    self._profiler_started_before_model_step_ordinal
+                ),
+                "profiler_stopped_after_model_step_ordinal": (
+                    self._profiler_stopped_after_model_step_ordinal
+                ),
+            },
+            "completion": {
+                "complete": self._is_complete_locked(),
+                "state": self._state,
+                "profiler_may_be_active": self._profiler_may_be_active,
+                "nvtx_range_open": self._nvtx_range_open,
+            },
+            "callable_identity": {
+                "model_runner_type": (
+                    f"{type(self._model_runner).__module__}."
+                    f"{type(self._model_runner).__qualname__}"
+                ),
+                "original_was_instance_attribute": (
+                    self._original_was_instance_attribute
+                ),
+                "original_execute_model": original_identity,
+                "installed_wrapper": wrapper_identity,
+                "current_execute_model": current_identity,
+                "installed_exactly_once": (
+                    self._call_counts["wrapper_install"]
+                    == {"attempted": 1, "succeeded": 1}
+                ),
+                "wrapper_currently_installed": current_matches_wrapper,
+                "original_callable_restored": (
+                    self._original_restored
+                    and current_matches_original
+                ),
+            },
+            "errors": [dict(error) for error in self._errors],
+        }

--- a/nemo_rl/models/generation/vllm/nested_runtime_env.py
+++ b/nemo_rl/models/generation/vllm/nested_runtime_env.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Fail-closed runtime-environment contract for nested vLLM Ray workers."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+import os
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+NESTED_RUNTIME_ENV_JSON_ENV = "NRL_VLLM_NESTED_RUNTIME_ENV_JSON"
+NESTED_RUNTIME_ENV_SHA256_ENV = (
+    "NRL_VLLM_NESTED_RUNTIME_ENV_SHA256"
+)
+RUNTIME_ENV_CONTRACT_SHA256_ENV = (
+    "NRL_VLLM_RUNTIME_ENV_CONTRACT_SHA256"
+)
+NESTED_RUNTIME_ENV_SCHEMA = "nemo_rl.vllm_nested_runtime_env.v1"
+
+_RUNTIME_ENV_REQUIRED_KEYS = frozenset({"py_executable", "env_vars"})
+_RUNTIME_ENV_OPTIONAL_KEYS = frozenset({"nsight"})
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+class NestedRuntimeEnvContractError(RuntimeError):
+    """Raised when the nested-worker runtime contract is invalid."""
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _normalize_string_mapping(
+    value: object,
+    *,
+    field_name: str,
+) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise NestedRuntimeEnvContractError(
+            f"{field_name} must be a mapping"
+        )
+
+    normalized: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key:
+            raise NestedRuntimeEnvContractError(
+                f"{field_name} keys must be non-empty strings"
+            )
+        if not isinstance(item, str):
+            raise NestedRuntimeEnvContractError(
+                f"{field_name}[{key!r}] must be a string"
+            )
+        normalized[key] = item
+    return normalized
+
+
+def _normalize_runtime_env(
+    runtime_env: object,
+    *,
+    allow_contract_hash: bool,
+) -> dict[str, Any]:
+    if not isinstance(runtime_env, Mapping):
+        raise NestedRuntimeEnvContractError(
+            "nested runtime_env must be a mapping"
+        )
+
+    keys = set(runtime_env)
+    if not all(isinstance(key, str) for key in keys):
+        raise NestedRuntimeEnvContractError(
+            "nested runtime_env keys must be strings"
+        )
+    allowed_keys = _RUNTIME_ENV_REQUIRED_KEYS | _RUNTIME_ENV_OPTIONAL_KEYS
+    if keys - allowed_keys:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime_env has unsupported keys: "
+            f"{sorted(keys - allowed_keys)!r}"
+        )
+    missing_keys = _RUNTIME_ENV_REQUIRED_KEYS - keys
+    if missing_keys:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime_env is missing required keys: "
+            f"{sorted(missing_keys)!r}"
+        )
+
+    python_executable = runtime_env["py_executable"]
+    if not isinstance(python_executable, str) or not python_executable:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime_env py_executable must be a non-empty string"
+        )
+
+    env_vars = _normalize_string_mapping(
+        runtime_env["env_vars"],
+        field_name="nested runtime_env env_vars",
+    )
+    contract_hash = env_vars.get(RUNTIME_ENV_CONTRACT_SHA256_ENV)
+    if contract_hash is not None:
+        if not allow_contract_hash:
+            raise NestedRuntimeEnvContractError(
+                "nested runtime_env input must not contain the reserved "
+                f"{RUNTIME_ENV_CONTRACT_SHA256_ENV} variable"
+            )
+        if _SHA256_PATTERN.fullmatch(contract_hash) is None:
+            raise NestedRuntimeEnvContractError(
+                f"{RUNTIME_ENV_CONTRACT_SHA256_ENV} must be a lowercase "
+                "SHA-256 digest"
+            )
+
+    normalized: dict[str, Any] = {
+        "py_executable": python_executable,
+        "env_vars": env_vars,
+    }
+    if "nsight" in runtime_env:
+        normalized["nsight"] = _normalize_string_mapping(
+            runtime_env["nsight"],
+            field_name="nested runtime_env nsight",
+        )
+    return normalized
+
+
+def _contract_envelope(
+    runtime_env: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema": NESTED_RUNTIME_ENV_SCHEMA,
+        "runtime_env": runtime_env,
+    }
+
+
+def _with_contract_hash(
+    runtime_env: Mapping[str, Any],
+    digest: str,
+) -> dict[str, Any]:
+    desired = copy.deepcopy(dict(runtime_env))
+    desired["env_vars"][RUNTIME_ENV_CONTRACT_SHA256_ENV] = digest
+    return desired
+
+
+def export_nested_runtime_env_contract(
+    runtime_env: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Export a canonical contract and return its worker runtime environment.
+
+    The serialized contract intentionally excludes its own digest. The
+    returned runtime environment includes that digest as a reserved
+    environment variable so each nested worker can prove which contract it
+    received.
+    """
+
+    normalized = _normalize_runtime_env(
+        runtime_env,
+        allow_contract_hash=False,
+    )
+    serialized = _canonical_json(_contract_envelope(normalized))
+    digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    os.environ[NESTED_RUNTIME_ENV_JSON_ENV] = serialized
+    os.environ[NESTED_RUNTIME_ENV_SHA256_ENV] = digest
+    return _with_contract_hash(normalized, digest), digest
+
+
+def _reject_duplicate_json_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise NestedRuntimeEnvContractError(
+                f"nested runtime contract contains duplicate key {key!r}"
+            )
+        result[key] = value
+    return result
+
+
+def load_nested_runtime_env_contract() -> tuple[dict[str, Any], str]:
+    """Load and authenticate the contract exported by the parent process."""
+
+    serialized = os.environ.get(NESTED_RUNTIME_ENV_JSON_ENV)
+    expected_digest = os.environ.get(NESTED_RUNTIME_ENV_SHA256_ENV)
+    if serialized is None or expected_digest is None:
+        missing = [
+            name
+            for name, value in (
+                (NESTED_RUNTIME_ENV_JSON_ENV, serialized),
+                (NESTED_RUNTIME_ENV_SHA256_ENV, expected_digest),
+            )
+            if value is None
+        ]
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract is missing required environment "
+            f"variables: {missing!r}"
+        )
+    if _SHA256_PATTERN.fullmatch(expected_digest) is None:
+        raise NestedRuntimeEnvContractError(
+            f"{NESTED_RUNTIME_ENV_SHA256_ENV} must be a lowercase "
+            "SHA-256 digest"
+        )
+
+    try:
+        envelope = json.loads(
+            serialized,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except NestedRuntimeEnvContractError:
+        raise
+    except (TypeError, ValueError) as error:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract is not valid JSON"
+        ) from error
+
+    if not isinstance(envelope, Mapping):
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract envelope must be a mapping"
+        )
+    if set(envelope) != {"schema", "runtime_env"}:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract envelope must contain exactly "
+            "'schema' and 'runtime_env'"
+        )
+    if envelope["schema"] != NESTED_RUNTIME_ENV_SCHEMA:
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract has an unsupported schema"
+        )
+
+    normalized = _normalize_runtime_env(
+        envelope["runtime_env"],
+        allow_contract_hash=False,
+    )
+    canonical = _canonical_json(_contract_envelope(normalized))
+    if not hmac.compare_digest(serialized, canonical):
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract JSON is not canonical"
+        )
+
+    actual_digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    if not hmac.compare_digest(actual_digest, expected_digest):
+        raise NestedRuntimeEnvContractError(
+            "nested runtime contract SHA-256 mismatch"
+        )
+    return _with_contract_hash(normalized, actual_digest), actual_digest
+
+
+def _merge_string_mapping(
+    existing: object,
+    desired: object,
+    *,
+    field_name: str,
+) -> dict[str, str]:
+    merged = _normalize_string_mapping(existing, field_name=field_name)
+    desired_mapping = _normalize_string_mapping(
+        desired,
+        field_name=field_name,
+    )
+    for key, value in desired_mapping.items():
+        if key in merged and merged[key] != value:
+            raise NestedRuntimeEnvContractError(
+                f"{field_name}[{key!r}] conflicts with the nested "
+                "runtime contract"
+            )
+        merged[key] = value
+    return merged
+
+
+def merge_nested_runtime_env(
+    existing: Mapping[str, Any] | None,
+    desired: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge the authenticated worker settings without overwriting conflicts."""
+
+    normalized_desired = _normalize_runtime_env(
+        desired,
+        allow_contract_hash=True,
+    )
+    if existing is None:
+        return copy.deepcopy(normalized_desired)
+    if not isinstance(existing, Mapping):
+        raise NestedRuntimeEnvContractError(
+            "existing Ray runtime_env must be a mapping or None"
+        )
+
+    merged = copy.deepcopy(dict(existing))
+    for key, desired_value in normalized_desired.items():
+        if key not in merged:
+            merged[key] = copy.deepcopy(desired_value)
+            continue
+        if key in {"env_vars", "nsight"}:
+            merged[key] = _merge_string_mapping(
+                merged[key],
+                desired_value,
+                field_name=f"Ray runtime_env {key}",
+            )
+            continue
+        if merged[key] != desired_value:
+            raise NestedRuntimeEnvContractError(
+                f"Ray runtime_env {key!r} conflicts with the nested "
+                "runtime contract"
+            )
+    return merged

--- a/nemo_rl/models/generation/vllm/ray_executor.py
+++ b/nemo_rl/models/generation/vllm/ray_executor.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""vLLM Ray executor that propagates NeMo RL's nested runtime contract."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import ray._private.ray_constants as ray_constants
+from vllm.v1.executor.ray_executor import RayDistributedExecutor
+
+from nemo_rl.models.generation.vllm.nested_runtime_env import (
+    NestedRuntimeEnvContractError,
+    load_nested_runtime_env_contract,
+    merge_nested_runtime_env,
+)
+
+
+_RAY_ENABLE_UV_RUN_RUNTIME_ENV = "RAY_ENABLE_UV_RUN_RUNTIME_ENV"
+
+
+class NemoRayDistributedExecutor(RayDistributedExecutor):
+    """Inject the authenticated runtime environment into vLLM Ray workers."""
+
+    def _init_workers_ray(
+        self,
+        placement_group: Any,
+        **ray_remote_kwargs: Any,
+    ) -> Any:
+        if os.environ.get(_RAY_ENABLE_UV_RUN_RUNTIME_ENV) != "0":
+            raise NestedRuntimeEnvContractError(
+                f"{_RAY_ENABLE_UV_RUN_RUNTIME_ENV} must equal '0' in "
+                "vLLM's EngineCore process"
+            )
+        if (
+            ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV is not False
+        ):
+            raise NestedRuntimeEnvContractError(
+                "Ray imported with RAY_ENABLE_UV_RUN_RUNTIME_ENV enabled; "
+                "the nested worker executable cannot be guaranteed"
+            )
+
+        desired_runtime_env, _ = load_nested_runtime_env_contract()
+        ray_remote_kwargs["runtime_env"] = merge_nested_runtime_env(
+            ray_remote_kwargs.get("runtime_env"),
+            desired_runtime_env,
+        )
+        return super()._init_workers_ray(
+            placement_group,
+            **ray_remote_kwargs,
+        )

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -37,6 +37,20 @@ except ImportError:
     )
 
 
+def fix_gpt_oss_export_transpose(key: str, weight: torch.Tensor) -> torch.Tensor:
+    """Apply GPT-OSS down_proj transpose fix to the weight.
+
+    This is a workaround for the issue that the down_proj layout is not the same across different frameworks.
+        - HF needs [in, out] layout.
+        - Megatron needs [in, out] layout.
+        - vLLM needs [out, in] layout.
+    See https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3271 for more details.
+    """
+    if key.endswith("mlp.experts.down_proj"):
+        weight = weight.transpose(-2, -1).contiguous()
+    return weight
+
+
 class VllmInternalWorkerExtension:
     def init_collective(
         self,
@@ -199,20 +213,30 @@ class VllmInternalWorkerExtension:
                     shape, dtype = self.state_dict_info[key]  # pyrefly
                     if isinstance(shape, list):
                         shape = torch.Size(shape)
+
+                    # Get the weight from the buffer
                     size_in_bytes = dtype.itemsize * shape.numel()
-                    weights.append(
-                        (
-                            key,
-                            buffer[offset : offset + size_in_bytes]
-                            .view(dtype=dtype)
-                            .view(shape),
-                        )
+                    weight = (
+                        buffer[offset : offset + size_in_bytes]
+                        .view(dtype=dtype)
+                        .view(shape)
                     )
+                    # apply gpt-oss transpose fix
+                    if (
+                        "GptOssForCausalLM"
+                        in self.model_runner.vllm_config.model_config.architectures
+                    ):
+                        weight = fix_gpt_oss_export_transpose(key, weight)
+                    weights.append((key, weight))
+
+                    # Move offset to the next weight
                     aligned_size = calculate_aligned_size(size_in_bytes)
                     offset += aligned_size
+
                 assert offset == used_bytes, (
                     "Offset is not equal to used bytes, usually indicate inaccurate info like keys or cached dtype in state_dict_info"
                 )
+
                 # Load weights into the model
                 from nemo_rl.models.generation.vllm.quantization import fp8
 
@@ -275,6 +299,15 @@ class VllmInternalWorkerExtension:
                 None
             """
             from nemo_rl.models.generation.vllm.quantization import fp8
+
+            # apply gpt-oss transpose fix
+            if (
+                "GptOssForCausalLM"
+                in self.model_runner.vllm_config.model_config.architectures
+            ):
+                for idx, (key, weight) in enumerate(weights):
+                    weight = fix_gpt_oss_export_transpose(key, weight)
+                    weights[idx] = (key, weight)
 
             policy_weights, draft_weights = self._split_policy_and_draft_weights(
                 weights

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -207,6 +207,7 @@ class VllmInternalWorkerExtension:
                 ipc_handle, list_keys, used_bytes = payload
                 buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, self.device.index)
 
+                weight = None
                 weights = []
                 offset = 0
                 for key in list_keys:
@@ -258,7 +259,8 @@ class VllmInternalWorkerExtension:
                 # copied the data, Python may not garbage collect these view objects immediately.
                 # If sender reuses the buffer before GC runs, old views would read corrupted data.
                 # Explicit del ensures immediate cleanup before sending ACK.
-                del weights, policy_weights, draft_weights, buffer
+                del weight, weights, policy_weights, draft_weights, buffer
+                weight = None
                 weights = None
                 policy_weights = None
                 draft_weights = None

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import os
+import sys
 import traceback
 from typing import Any
 
@@ -37,6 +39,69 @@ except ImportError:
     )
 
 
+_RUNTIME_ENV_PROOF_ENV_NAMES = (
+    "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+    "NCCL_CUMEM_ENABLE",
+    "NCCL_NVLS_ENABLE",
+    "NRL_VLLM_RUNTIME_ENV_CONTRACT_SHA256",
+    "PYTHONPATH",
+    "NRL_VLLM_PROPAGATE_PYTHONPATH",
+    "NRL_FORCED_SEQUENCE_AUDIT",
+    "NRL_VLLM_INNER_NSYS_MODE",
+)
+
+
+def _sanitize_ray_runtime_env(raw_runtime_env: object) -> dict[str, Any]:
+    """Return only the non-secret fields used to prove the worker contract."""
+    if not isinstance(raw_runtime_env, dict):
+        return {}
+
+    sanitized_runtime_env: dict[str, Any] = {}
+    py_executable = raw_runtime_env.get("py_executable")
+    if isinstance(py_executable, str):
+        sanitized_runtime_env["py_executable"] = py_executable
+
+    # Ray's public runtime_env input is named ``nsight``, but RuntimeEnv stores
+    # and serializes it as ``_nsight``. Accept the public spelling as well for
+    # forward/backward compatibility, while refusing an ambiguous proof.
+    public_nsight_present = "nsight" in raw_runtime_env
+    internal_nsight_present = "_nsight" in raw_runtime_env
+    if (
+        public_nsight_present
+        and internal_nsight_present
+        and raw_runtime_env["nsight"] != raw_runtime_env["_nsight"]
+    ):
+        raise RuntimeError(
+            "Ray runtime_env contains conflicting 'nsight' and '_nsight' "
+            "configurations"
+        )
+    raw_nsight = (
+        raw_runtime_env["_nsight"]
+        if internal_nsight_present
+        else raw_runtime_env.get("nsight")
+    )
+    if raw_nsight is not None:
+        if not isinstance(raw_nsight, dict):
+            raise RuntimeError(
+                "Ray runtime_env Nsight configuration must be a mapping"
+            )
+        sanitized_runtime_env["nsight"] = dict(raw_nsight)
+
+    raw_runtime_env_vars = raw_runtime_env.get("env_vars")
+    if isinstance(raw_runtime_env_vars, dict):
+        sanitized_runtime_env_vars = {
+            name: value
+            for name in _RUNTIME_ENV_PROOF_ENV_NAMES
+            if isinstance(
+                (value := raw_runtime_env_vars.get(name)),
+                str,
+            )
+        }
+        if sanitized_runtime_env_vars:
+            sanitized_runtime_env["env_vars"] = sanitized_runtime_env_vars
+    return sanitized_runtime_env
+
+
 def fix_gpt_oss_export_transpose(key: str, weight: torch.Tensor) -> torch.Tensor:
     """Apply GPT-OSS down_proj transpose fix to the weight.
 
@@ -52,6 +117,153 @@ def fix_gpt_oss_export_transpose(key: str, weight: torch.Tensor) -> torch.Tensor
 
 
 class VllmInternalWorkerExtension:
+    def report_runtime_environment(self) -> dict[str, Any]:
+        """Report a sanitized proof of the nested Ray worker environment."""
+        import ray
+        from ray._private import ray_constants
+
+        selected_env = {
+            name: value
+            for name in _RUNTIME_ENV_PROOF_ENV_NAMES
+            if (value := os.environ.get(name)) is not None
+        }
+
+        runtime_context = ray.get_runtime_context()
+        sanitized_runtime_env = _sanitize_ray_runtime_env(
+            runtime_context.runtime_env
+        )
+
+        def _runtime_context_id(method_name: str) -> str | None:
+            method = getattr(runtime_context, method_name, None)
+            if not callable(method):
+                return None
+            try:
+                identifier = method()
+            except Exception:  # pragma: no cover - depends on Ray context
+                return None
+            if identifier is None:
+                return None
+            return str(identifier)
+
+        return {
+            "python_executable": sys.executable,
+            "worker_module_file": __file__,
+            "hostname": os.uname().nodename,
+            "pid": os.getpid(),
+            "selected_env": selected_env,
+            "ray_enable_uv_import_constant": getattr(
+                ray_constants,
+                "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+                None,
+            ),
+            "ray_runtime_env": sanitized_runtime_env,
+            "actor_id": _runtime_context_id("get_actor_id"),
+            "node_id": _runtime_context_id("get_node_id"),
+        }
+
+    def arm_model_step_gpu_profile(
+        self,
+        start_step: int,
+        stop_step: int,
+    ) -> dict[str, Any]:
+        """Arm one exact, one-shot model-step capture on this TP worker.
+
+        This method is called through vLLM ``collective_rpc`` so every tensor
+        parallel rank installs its own wrapper before the frontend submits any
+        request. Pipeline parallelism is deliberately rejected: one ordinal
+        must identify the same complete model step on every captured worker.
+        """
+        from nemo_rl.models.generation.vllm.model_step_gpu_profiler import (
+            DeterministicModelStepGpuProfiler,
+        )
+
+        if hasattr(self, "_nrl_model_step_gpu_profiler"):
+            raise RuntimeError(
+                "the model-step GPU profiler is one-shot per nested worker"
+            )
+        parallel_config = getattr(self, "parallel_config", None)
+        pipeline_parallel_size = getattr(
+            parallel_config,
+            "pipeline_parallel_size",
+            None,
+        )
+        tensor_parallel_size = getattr(
+            parallel_config,
+            "tensor_parallel_size",
+            None,
+        )
+        if pipeline_parallel_size != 1:
+            raise RuntimeError(
+                "exact model-step profiling requires pipeline_parallel_size=1; "
+                f"observed {pipeline_parallel_size!r}"
+            )
+        model_runner = getattr(self, "model_runner", None)
+        if model_runner is None:
+            raise RuntimeError("nested vLLM worker has no model_runner")
+
+        controller = DeterministicModelStepGpuProfiler(model_runner)
+        # Store before arming so a partial collective failure can never permit
+        # a second controller to be installed in this worker process.
+        self._nrl_model_step_gpu_profiler = controller
+        controller.arm(start_step, stop_step)
+        return self._model_step_gpu_profile_proof(
+            controller.snapshot(),
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+        )
+
+    def get_model_step_gpu_profile(self) -> dict[str, Any]:
+        """Require completion and return this TP worker's exact-range proof."""
+        controller = getattr(
+            self,
+            "_nrl_model_step_gpu_profiler",
+            None,
+        )
+        if controller is None:
+            raise RuntimeError("model-step GPU profiler was not armed")
+        parallel_config = getattr(self, "parallel_config", None)
+        return self._model_step_gpu_profile_proof(
+            controller.require_complete(),
+            tensor_parallel_size=getattr(
+                parallel_config,
+                "tensor_parallel_size",
+                None,
+            ),
+            pipeline_parallel_size=getattr(
+                parallel_config,
+                "pipeline_parallel_size",
+                None,
+            ),
+        )
+
+    @staticmethod
+    def _model_step_gpu_profile_proof(
+        proof: dict[str, Any],
+        *,
+        tensor_parallel_size: Any,
+        pipeline_parallel_size: Any,
+    ) -> dict[str, Any]:
+        """Attach distributed identity without mutating controller proof."""
+        if (
+            not torch.distributed.is_available()
+            or not torch.distributed.is_initialized()
+        ):
+            raise RuntimeError(
+                "exact model-step profiling requires initialized torch.distributed"
+            )
+        return {
+            **proof,
+            "distributed": {
+                "rank": torch.distributed.get_rank(),
+                "world_size": torch.distributed.get_world_size(),
+                "tensor_parallel_size": tensor_parallel_size,
+                "pipeline_parallel_size": pipeline_parallel_size,
+                "cuda_visible_devices": os.environ.get(
+                    "CUDA_VISIBLE_DEVICES"
+                ),
+            },
+        }
+
     def init_collective(
         self,
         rank_prefix: int,

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import asyncio
+import copy
+import json
 import os
+import time
+import uuid
 import warnings
 from collections import defaultdict
 from typing import (
@@ -26,6 +30,7 @@ from typing import (
 import numpy as np
 import ray
 from ray.util.placement_group import PlacementGroup
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict, SlicedDataDict
 from nemo_rl.distributed.named_sharding import NamedSharding
@@ -37,10 +42,31 @@ from nemo_rl.models.generation.interfaces import (
     GenerationOutputSpec,
 )
 from nemo_rl.models.generation.vllm.config import VllmConfig
+from nemo_rl.models.generation.vllm.lfs.dispatcher import (
+    CrossDpDispatcherActor,
+)
+from nemo_rl.models.generation.vllm.inflight_profiler import (
+    inflight_interval_s,
+    inflight_output_dir,
+    inflight_profiling_enabled,
+)
 from nemo_rl.models.generation.vllm.utils import (
     aggregate_spec_decode_counters,
     compute_spec_decode_metrics,
 )
+
+
+def _dp_batch_stats_enabled() -> bool:
+    """Whether to emit per-data-parallel-rank rollout batch/load stats.
+
+    Controlled by the NRL_LOG_DP_BATCH_STATS env var (off by default so there
+    is zero overhead in normal runs). Set to 1/true/yes to enable.
+    """
+    return os.environ.get("NRL_LOG_DP_BATCH_STATS", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 class VllmGeneration(GenerationInterface):
@@ -54,6 +80,9 @@ class VllmGeneration(GenerationInterface):
         """Initialize a vLLM policy with distributed workers."""
         # Store config
         self.cfg = config
+        self._cross_dp_dispatcher = None
+        self._cross_dp_dp_selection_mode: str | None = None
+        self._cross_dp_lfs_admission_fairness_interval: int | None = None
         self.tp_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
         self.pp_size = self.cfg["vllm_cfg"]["pipeline_parallel_size"]
         self.ep_size = self.cfg["vllm_cfg"]["expert_parallel_size"]
@@ -166,6 +195,36 @@ class VllmGeneration(GenerationInterface):
         if self.ep_size > self.tp_size:
             env_vars["VLLM_DP_SIZE"] = str(self.vllm_dp_size)
 
+        # vLLM only populates DebugPerfStats when both the engine observability
+        # option and this environment gate are enabled. The worker sets the
+        # engine option and installs the read-only StatLogger.
+        if self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False):
+            env_vars["VLLM_DEBUG_MFU_METRICS"] = "1"
+
+        # Benchmark-only source-tree development can opt in to propagating the
+        # driver's PYTHONPATH into the isolated NeMo worker. Ray otherwise
+        # constructs the actor environment only from ``env_vars`` here, so a
+        # worker may silently import the image-installed NeMo package instead
+        # of the source tree used by the driver.
+        if os.environ.get("NRL_VLLM_PROPAGATE_PYTHONPATH") == "1":
+            pythonpath = os.environ.get("PYTHONPATH")
+            if not pythonpath:
+                raise RuntimeError(
+                    "NRL_VLLM_PROPAGATE_PYTHONPATH=1 requires PYTHONPATH"
+                )
+            env_vars["PYTHONPATH"] = pythonpath
+            env_vars["NRL_VLLM_PROPAGATE_PYTHONPATH"] = "1"
+            if os.environ.get("NRL_FORCED_SEQUENCE_AUDIT") == "1":
+                env_vars["NRL_FORCED_SEQUENCE_AUDIT"] = "1"
+
+        # Propagate the in-flight rollout profiler toggle (and cadence) to the
+        # worker actors so they start their scheduler samplers. The driver writes
+        # the collected per-DP timeline to JSONL after each generate() call.
+        self._inflight_profiling = inflight_profiling_enabled()
+        if self._inflight_profiling:
+            env_vars["NRL_PROFILE_INFLIGHT"] = "1"
+            env_vars["NRL_PROFILE_INFLIGHT_INTERVAL"] = str(inflight_interval_s())
+
         # Check if we need parallelism-aware worker group creation
         if self.model_parallel_size > 1:
             # For parallelism, create node-aware worker groups
@@ -205,10 +264,192 @@ class VllmGeneration(GenerationInterface):
         # Used to track the round-robin selection of worker groups for generate_async
         self.current_generate_dp_shard_idx = 0
 
-        # Save the device uuids for the workers
+        # Optional middleware scheduler shared by every serialized copy of this
+        # generation object.  Keeping the mutable queue in a Ray actor makes it
+        # safe across repeated asyncio.run() calls and async-GRPO's OS threads.
+        cross_dp_mode = os.environ.get("NRL_VLLM_CROSS_DP_SCHED", "").strip().lower()
+        if cross_dp_mode in ("", "0", "off", "none"):
+            cross_dp_mode = ""
+        elif cross_dp_mode not in (
+            "fcfs",
+            "lfs",
+            "predicted_lfs",
+            "history_lfs",
+            "oracle_probe_lfs",
+            "exact_length_lpt",
+        ):
+            raise ValueError(
+                "NRL_VLLM_CROSS_DP_SCHED must be one of "
+                "off/fcfs/lfs/predicted_lfs/history_lfs/oracle_probe_lfs/"
+                "exact_length_lpt, "
+                f"got {cross_dp_mode!r}"
+            )
+
+        self._cross_dp_scheduler_mode = cross_dp_mode or None
+
+        # Report devices before creating the optional dispatcher actor so a
+        # constructor failure cannot orphan that actor.
         self.device_uuids = self._report_device_id()
 
+        if self._cross_dp_scheduler_mode is not None:
+            if not self.cfg["vllm_cfg"]["async_engine"]:
+                raise ValueError(
+                    "Cross-DP scheduling requires policy.generation.vllm_cfg."
+                    "async_engine=true"
+                )
+            if os.environ.get("NRL_VLLM_LFS_SCHED") == "1":
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_SCHED and the engine-local "
+                    "NRL_VLLM_LFS_SCHED cannot be enabled together. Cross-DP "
+                    "scheduling requires vanilla FCFS inside each vLLM engine."
+                )
+
+            configured_cap = self.cfg.get("vllm_kwargs", {}).get("max_num_seqs")
+            max_num_seqs = os.environ.get("NRL_VLLM_MAX_NUM_SEQS", configured_cap)
+            if max_num_seqs is None:
+                raise ValueError(
+                    "Cross-DP scheduling needs an explicit per-engine capacity. "
+                    "Set NRL_VLLM_MAX_NUM_SEQS or "
+                    "policy.generation.vllm_kwargs.max_num_seqs."
+                )
+            max_num_seqs = int(max_num_seqs)
+            if max_num_seqs <= 0:
+                raise ValueError(
+                    f"max_num_seqs must be positive, got {max_num_seqs}"
+                )
+            cross_dp_lookahead = int(
+                os.environ.get("NRL_VLLM_CROSS_DP_LOOKAHEAD", "0")
+            )
+            if cross_dp_lookahead < 0:
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_LOOKAHEAD must be non-negative, "
+                    f"got {cross_dp_lookahead}"
+                )
+            aggregate_admission_limit = self.worker_group.dp_size * (
+                max_num_seqs + cross_dp_lookahead
+            )
+            cross_dp_global_admission_limit = int(
+                os.environ.get(
+                    "NRL_VLLM_CROSS_DP_GLOBAL_ADMISSION_LIMIT",
+                    str(aggregate_admission_limit),
+                )
+            )
+            if not (
+                0
+                < cross_dp_global_admission_limit
+                <= aggregate_admission_limit
+            ):
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_GLOBAL_ADMISSION_LIMIT must be in "
+                    f"[1, {aggregate_admission_limit}], got "
+                    f"{cross_dp_global_admission_limit}"
+                )
+            cross_dp_dp_selection_mode = os.environ.get(
+                "NRL_VLLM_CROSS_DP_DP_SELECTION_MODE",
+                "inflight_count",
+            ).strip().lower()
+            if cross_dp_dp_selection_mode not in (
+                "static_cost",
+                "inflight_count",
+            ):
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_DP_SELECTION_MODE must be "
+                    "'static_cost' or 'inflight_count', got "
+                    f"{cross_dp_dp_selection_mode!r}"
+                )
+            self._cross_dp_dp_selection_mode = cross_dp_dp_selection_mode
+            cross_dp_lfs_admission_fairness_interval = int(
+                os.environ.get(
+                    "NRL_VLLM_CROSS_DP_LFS_ADMISSION_FAIRNESS_INTERVAL",
+                    "0",
+                )
+            )
+            if cross_dp_lfs_admission_fairness_interval < 0:
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_LFS_ADMISSION_FAIRNESS_INTERVAL "
+                    "must be non-negative, got "
+                    f"{cross_dp_lfs_admission_fairness_interval}"
+                )
+            if (
+                cross_dp_lfs_admission_fairness_interval > 0
+                and self._cross_dp_scheduler_mode
+                not in ("lfs", "predicted_lfs", "oracle_probe_lfs")
+            ):
+                raise ValueError(
+                    "NRL_VLLM_CROSS_DP_LFS_ADMISSION_FAIRNESS_INTERVAL "
+                    "is only supported with lfs/predicted_lfs/"
+                    "oracle_probe_lfs, got "
+                    f"{self._cross_dp_scheduler_mode!r}"
+                )
+            self._cross_dp_lfs_admission_fairness_interval = (
+                cross_dp_lfs_admission_fairness_interval
+            )
+
+            trace = os.environ.get("NRL_VLLM_CROSS_DP_TRACE", "0").lower() in (
+                "1",
+                "true",
+                "yes",
+            )
+            initial_group_history = None
+            history_path = os.environ.get("NRL_VLLM_GROUP_HISTORY_PATH")
+            if (
+                self._cross_dp_scheduler_mode == "history_lfs"
+                and history_path
+                and os.path.exists(history_path)
+            ):
+                with open(history_path, encoding="utf-8") as history_file:
+                    history_payload = json.load(history_file)
+                initial_group_history = history_payload.get(
+                    "group_history", history_payload
+                )
+                print(
+                    "[CROSS-DP-SCHED] restoring "
+                    f"{len(initial_group_history)} prompt histories from "
+                    f"{history_path}",
+                    flush=True,
+                )
+            # Dispatcher and VllmGeneration exchange latency/audit timestamps
+            # in the driver's monotonic clock domain. Pin the zero-CPU actor to
+            # this node so a multi-node Ray cluster cannot place it elsewhere.
+            self._cross_dp_dispatcher = CrossDpDispatcherActor.options(
+                scheduling_strategy=NodeAffinitySchedulingStrategy(
+                    node_id=ray.get_runtime_context().get_node_id(),
+                    soft=False,
+                )
+            ).remote(
+                self.worker_group.dp_size,
+                max_num_seqs,
+                self._cross_dp_scheduler_mode,
+                trace,
+                initial_group_history,
+                cross_dp_lookahead,
+                cross_dp_global_admission_limit,
+                cross_dp_dp_selection_mode,
+                cross_dp_lfs_admission_fairness_interval,
+            )
+            print(
+                "[CROSS-DP-SCHED] enabled "
+                f"mode={self._cross_dp_scheduler_mode} "
+                f"dp_size={self.worker_group.dp_size} "
+                f"max_num_seqs_per_dp={max_num_seqs} "
+                f"lookahead_per_dp={cross_dp_lookahead} "
+                "global_admission_limit="
+                f"{cross_dp_global_admission_limit} "
+                f"dp_selection_mode={cross_dp_dp_selection_mode} "
+                "lfs_admission_fairness_interval="
+                f"{cross_dp_lfs_admission_fairness_interval}",
+                flush=True,
+            )
+
         self._step_metrics_snapshot: dict[str | tuple[str, int], float] | None = None
+
+        # Monotonic counter used to label each generate() call when
+        # NRL_LOG_DP_BATCH_STATS is enabled (see _log_dp_batch_stats).
+        self._dp_stats_call_idx = 0
+
+        # Separate counter labelling each generate() call in the in-flight
+        # timeline JSONL (see _dump_inflight_timeline).
+        self._inflight_call_idx = 0
 
     def _get_tied_worker_bundle_indices(
         self, cluster: RayVirtualCluster
@@ -462,6 +703,156 @@ class VllmGeneration(GenerationInterface):
         # this function should co-work with lm_policy, so we should wait for all futures to complete outside
         return futures
 
+    def _log_dp_batch_stats(
+        self,
+        sharded_data: list[SlicedDataDict],
+        results: list[BatchedDataDict[GenerationOutputSpec]],
+        wall_time_s: float,
+        phase: str = "generate",
+    ) -> None:
+        """Log per-data-parallel-rank batch sizes / token load and a global summary.
+
+        Intended for rollout performance analysis: it surfaces how the work is
+        distributed across the ``dp_size`` data-parallel vLLM replicas so DP load
+        imbalance and stragglers are easy to spot. ``sharded_data[i]`` and
+        ``results[i]`` both correspond to data-parallel rank ``i`` (the worker
+        group preserves DP order), so the stats are attributed per DP rank.
+
+        All lines are prefixed with ``[DP-BATCH-STATS]`` for easy grepping out of
+        the driver log. Enabled via NRL_LOG_DP_BATCH_STATS (see
+        :func:`_dp_batch_stats_enabled`); a no-op overhead-wise when disabled
+        because it is only called from the guarded path.
+        """
+        call_idx = self._dp_stats_call_idx
+        self._dp_stats_call_idx += 1
+
+        dp_size = len(sharded_data)
+        in_seqs = np.zeros(dp_size, dtype=np.int64)
+        in_tokens = np.zeros(dp_size, dtype=np.int64)
+        gen_tokens = np.zeros(dp_size, dtype=np.int64)
+        gen_max = np.zeros(dp_size, dtype=np.int64)
+        truncated = np.zeros(dp_size, dtype=np.int64)
+
+        for i in range(dp_size):
+            shard = sharded_data[i]
+            in_seqs[i] = len(shard["input_ids"])
+            if "input_lengths" in shard and len(shard["input_lengths"]) > 0:
+                in_tokens[i] = int(shard["input_lengths"].sum().item())
+
+            res = results[i] if i < len(results) else None
+            if res is None:
+                continue
+            gen_len = res.get("generation_lengths")
+            if gen_len is not None and len(gen_len) > 0:
+                gen_tokens[i] = int(gen_len.sum().item())
+                gen_max[i] = int(gen_len.max().item())
+            trunc = res.get("truncated")
+            if trunc is not None and len(trunc) > 0:
+                truncated[i] = int(trunc.sum().item())
+
+        def _summ(arr: np.ndarray) -> str:
+            return (
+                f"min={int(arr.min())} max={int(arr.max())} "
+                f"mean={arr.mean():.1f} std={arr.std():.1f}"
+            )
+
+        mean_gen = gen_tokens.mean()
+        # Imbalance > 1 means the busiest DP does more decode work than the
+        # average; the step is gated by this straggler.
+        imbalance = float(gen_tokens.max() / mean_gen) if mean_gen > 0 else float("nan")
+        straggler_dp = int(gen_tokens.argmax())
+
+        lines = [
+            f"[DP-BATCH-STATS] call={call_idx} phase={phase} dp_size={dp_size} "
+            f"wall={wall_time_s:.2f}s total_in_seqs={int(in_seqs.sum())} "
+            f"total_gen_tokens={int(gen_tokens.sum())}",
+            f"[DP-BATCH-STATS]   in_seqs   : {_summ(in_seqs)}",
+            f"[DP-BATCH-STATS]   in_tokens : {_summ(in_tokens)}",
+            f"[DP-BATCH-STATS]   gen_tokens: {_summ(gen_tokens)} "
+            f"imbalance(max/mean)={imbalance:.2f} straggler_dp={straggler_dp}",
+            f"[DP-BATCH-STATS]   gen_len   : {_summ(gen_max)} (max = decode steps gating each dp)",
+            f"[DP-BATCH-STATS]   truncated : total={int(truncated.sum())} "
+            f"max_per_dp={int(truncated.max())}",
+        ]
+        detail = " ".join(
+            f"[dp{i}:seq={int(in_seqs[i])},in_tok={int(in_tokens[i])},"
+            f"gen_tok={int(gen_tokens[i])},gen_max={int(gen_max[i])},"
+            f"trunc={int(truncated[i])}]"
+            for i in range(dp_size)
+        )
+        lines.append(f"[DP-BATCH-STATS]   dp_detail: {detail}")
+        print("\n".join(lines), flush=True)
+
+    def _dump_inflight_timeline(self) -> None:
+        """Collect the per-DP in-flight batch timeline and append it to JSONL.
+
+        Pulls each data-parallel leader's samples (captured live by its
+        :class:`InflightProfiler` during the generate() that just finished) and
+        writes one JSON line per sample, tagged with the generate-call index and
+        DP rank, into ``NRL_PROFILE_INFLIGHT_DIR/inflight_timeline.jsonl``. Lines
+        from the same ``call`` across all ``dp`` ranks share a wall-clock window,
+        so grouping by ``call`` and overlaying ``dp`` gives the global view of how
+        each worker's batch size / context lengths evolve over time. Best-effort:
+        never raises into the generation path.
+        """
+        call_idx = self._inflight_call_idx
+        self._inflight_call_idx += 1
+
+        futures: list[ray.ObjectRef] = []
+        dp_indices: list[int] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "get_inflight_timeline", worker_idx=worker_idx
+                )
+            )
+            dp_indices.append(dp_idx)
+
+        try:
+            results = ray.get(futures)
+        except Exception as e:
+            print(
+                f"[INFLIGHT-PROFILER] call={call_idx}: failed to collect timelines: {e}",
+                flush=True,
+            )
+            return
+
+        out_dir = inflight_output_dir()
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(out_dir, "inflight_timeline.jsonl")
+
+        n_samples = 0
+        with open(path, "a") as f:
+            for dp_idx, samples in zip(dp_indices, results):
+                if not samples:
+                    continue
+                for sample in samples:
+                    ctx_lens = sample.get("ctx_lens") or []
+                    n = len(ctx_lens)
+                    record = {
+                        "call": call_idx,
+                        "dp": dp_idx,
+                        "t": sample.get("t"),
+                        "batch_size": sample.get("batch_size"),
+                        "waiting": sample.get("waiting"),
+                        "ctx_min": min(ctx_lens) if n else 0,
+                        "ctx_max": max(ctx_lens) if n else 0,
+                        "ctx_mean": (sum(ctx_lens) / n) if n else 0.0,
+                        "ctx_sum": sum(ctx_lens),
+                        "ctx_lens": ctx_lens,
+                        "prompt_lens": sample.get("prompt_lens"),
+                        "gen_lens": sample.get("gen_lens"),
+                    }
+                    f.write(json.dumps(record) + "\n")
+                    n_samples += 1
+
+        print(
+            f"[INFLIGHT-PROFILER] call={call_idx}: wrote {n_samples} samples "
+            f"across {len(dp_indices)} dp ranks -> {path}",
+            flush=True,
+        )
+
     def generate(
         self, data: BatchedDataDict[GenerationDatumSpec], greedy: bool = False
     ) -> BatchedDataDict[GenerationOutputSpec]:
@@ -478,6 +869,10 @@ class VllmGeneration(GenerationInterface):
         sharded_data: list[SlicedDataDict] = data.shard_by_batch_size(
             dp_size, allow_uneven_shards=True
         )
+
+        log_dp_stats = _dp_batch_stats_enabled()
+        gen_start_time = time.perf_counter() if log_dp_stats else 0.0
+
         future_bundle = self.worker_group.run_all_workers_sharded_data(
             "generate",
             data=sharded_data,
@@ -489,6 +884,17 @@ class VllmGeneration(GenerationInterface):
 
         # Get results from the workers, respecting tied worker groups (only one result per tied worker group)
         results = self.worker_group.get_all_worker_results(future_bundle)
+
+        if log_dp_stats:
+            self._log_dp_batch_stats(
+                sharded_data,
+                results,
+                time.perf_counter() - gen_start_time,
+                phase="generate",
+            )
+
+        if self._inflight_profiling:
+            self._dump_inflight_timeline()
 
         # Combine results from all tied worker groups
         combined: BatchedDataDict[GenerationOutputSpec] = BatchedDataDict.from_batches(
@@ -556,6 +962,281 @@ class VllmGeneration(GenerationInterface):
 
         return combined
 
+    @property
+    def cross_dp_scheduler_enabled(self) -> bool:
+        return self._cross_dp_dispatcher is not None
+
+    @property
+    def cross_dp_scheduler_mode(self) -> str | None:
+        return self._cross_dp_scheduler_mode
+
+    @property
+    def cross_dp_dp_selection_mode(self) -> str | None:
+        return self._cross_dp_dp_selection_mode
+
+    @property
+    def cross_dp_lfs_admission_fairness_interval(self) -> int | None:
+        return self._cross_dp_lfs_admission_fairness_interval
+
+    def _build_cross_dp_session(
+        self,
+        group_ids: list[str | int],
+        participant_count: int,
+        participant_indices: list[int] | None,
+        request_costs: list[int] | None,
+        predicted_group_costs: list[int] | None = None,
+        designated_probe_flags: list[bool] | None = None,
+        preferred_dp_indices: list[int] | None = None,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        if self._cross_dp_dispatcher is None:
+            raise RuntimeError("Cross-DP scheduling is not enabled")
+        if not group_ids:
+            raise ValueError("A cross-DP session requires at least one request")
+        if participant_count <= 0:
+            raise ValueError("participant_count must be positive")
+        if participant_indices is None:
+            if participant_count != 1:
+                raise ValueError(
+                    "participant_indices are required when participant_count > 1"
+                )
+            participant_indices = [0] * len(group_ids)
+        if len(participant_indices) != len(group_ids) or any(
+            index < 0 or index >= participant_count for index in participant_indices
+        ):
+            raise ValueError(
+                "participant_indices must align with group_ids and fall within "
+                f"[0, {participant_count})"
+            )
+        if request_costs is not None:
+            if len(request_costs) != len(group_ids):
+                raise ValueError("request_costs must align with group_ids")
+            if any(int(cost) <= 0 for cost in request_costs):
+                raise ValueError("request_costs must all be positive")
+            if self._cross_dp_scheduler_mode not in (
+                "exact_length_lpt",
+                "oracle_probe_lfs",
+            ):
+                raise ValueError(
+                    "request_costs are benchmark-only exact-length metadata "
+                    "and require NRL_VLLM_CROSS_DP_SCHED=exact_length_lpt "
+                    "or oracle_probe_lfs"
+                )
+        elif self._cross_dp_scheduler_mode == "oracle_probe_lfs":
+            raise ValueError(
+                "oracle_probe_lfs requires explicit benchmark request_costs"
+            )
+        if predicted_group_costs is not None:
+            if self._cross_dp_scheduler_mode != "predicted_lfs":
+                raise ValueError(
+                    "predicted_group_costs require "
+                    "NRL_VLLM_CROSS_DP_SCHED=predicted_lfs"
+                )
+            if len(predicted_group_costs) != len(group_ids):
+                raise ValueError(
+                    "predicted_group_costs must align with group_ids"
+                )
+            if any(int(cost) <= 0 for cost in predicted_group_costs):
+                raise ValueError(
+                    "predicted_group_costs must all be positive"
+                )
+        elif self._cross_dp_scheduler_mode == "predicted_lfs":
+            raise ValueError(
+                "predicted_lfs requires explicit predicted_group_costs"
+            )
+        if preferred_dp_indices is not None:
+            if self._cross_dp_scheduler_mode != "exact_length_lpt":
+                raise ValueError(
+                    "preferred_dp_indices require "
+                    "NRL_VLLM_CROSS_DP_SCHED=exact_length_lpt"
+                )
+            if request_costs is None:
+                raise ValueError(
+                    "preferred_dp_indices require explicit exact-length "
+                    "request_costs"
+                )
+            if len(preferred_dp_indices) != len(group_ids):
+                raise ValueError(
+                    "preferred_dp_indices must align with group_ids"
+                )
+            dp_size = int(self.dp_size)
+            invalid_preferred_dp_indices = [
+                value
+                for value in preferred_dp_indices
+                if type(value) is not int or not 0 <= value < dp_size
+            ]
+            if invalid_preferred_dp_indices:
+                raise ValueError(
+                    "preferred_dp_indices must contain only ints (not bool) "
+                    f"in [0, {dp_size}); invalid values="
+                    f"{invalid_preferred_dp_indices}"
+                )
+        if designated_probe_flags is not None:
+            if len(designated_probe_flags) != len(group_ids):
+                raise ValueError(
+                    "designated_probe_flags must align with group_ids"
+                )
+            if any(type(flag) is not bool for flag in designated_probe_flags):
+                raise ValueError(
+                    "designated_probe_flags must contain only bool values"
+                )
+            designated_counts: dict[str, int] = {}
+            for group_id, is_designated_probe in zip(
+                group_ids, designated_probe_flags, strict=True
+            ):
+                normalized_group = str(group_id)
+                designated_counts.setdefault(normalized_group, 0)
+                designated_counts[normalized_group] += int(
+                    is_designated_probe
+                )
+            invalid_groups = {
+                group_id: count
+                for group_id, count in designated_counts.items()
+                if count != 1
+            }
+            if invalid_groups:
+                raise ValueError(
+                    "designated_probe_flags must select exactly one request "
+                    f"per group; invalid_groups={invalid_groups}"
+                )
+
+        session_id = uuid.uuid4().hex
+        request_ids = [f"{session_id}:{index}" for index in range(len(group_ids))]
+        participant_ids = [
+            f"{session_id}:participant:{index}"
+            for index in range(participant_count)
+        ]
+        request_participant_ids = [
+            participant_ids[index] for index in participant_indices
+        ]
+        normalized_groups = [str(group_id) for group_id in group_ids]
+        fallback_costs = (
+            [int(cost) for cost in request_costs]
+            if (
+                request_costs is not None
+                and self._cross_dp_scheduler_mode == "exact_length_lpt"
+            )
+            else [max(1, int(self.cfg["max_new_tokens"]))] * len(group_ids)
+        )
+        request_catalog = []
+        for index, (
+            request_id,
+            group_id,
+            participant_id,
+            fallback_cost,
+        ) in enumerate(
+            zip(
+                request_ids,
+                normalized_groups,
+                request_participant_ids,
+                fallback_costs,
+                strict=True,
+            )
+        ):
+            item = {
+                "request_id": request_id,
+                "group_id": group_id,
+                "participant_id": participant_id,
+                "fallback_cost": fallback_cost,
+            }
+            if self._cross_dp_scheduler_mode == "oracle_probe_lfs":
+                assert request_costs is not None
+                item["oracle_cost"] = int(request_costs[index])
+            if self._cross_dp_scheduler_mode == "predicted_lfs":
+                assert predicted_group_costs is not None
+                item["predicted_cost"] = int(predicted_group_costs[index])
+            if designated_probe_flags is not None:
+                item["is_designated_probe"] = designated_probe_flags[index]
+            if preferred_dp_indices is not None:
+                item["preferred_dp_idx"] = preferred_dp_indices[index]
+            request_catalog.append(item)
+        session = {
+            "session_id": session_id,
+            "request_ids": request_ids,
+            "group_ids": normalized_groups,
+            "participant_ids": participant_ids,
+            "request_participant_ids": request_participant_ids,
+        }
+        return session, request_catalog
+
+    async def open_cross_dp_session(
+        self,
+        group_ids: list[str | int],
+        participant_count: int = 1,
+        participant_indices: list[int] | None = None,
+        request_costs: list[int] | None = None,
+        predicted_group_costs: list[int] | None = None,
+        designated_probe_flags: list[bool] | None = None,
+        preferred_dp_indices: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Open a globally visible rollout session without blocking its event loop."""
+        session, request_catalog = self._build_cross_dp_session(
+            group_ids,
+            participant_count,
+            participant_indices,
+            request_costs,
+            predicted_group_costs,
+            designated_probe_flags,
+            preferred_dp_indices,
+        )
+        assert self._cross_dp_dispatcher is not None
+        await self._cross_dp_dispatcher.open_session.remote(
+            session["session_id"], request_catalog, session["participant_ids"]
+        )
+        return session
+
+    def open_cross_dp_session_sync(
+        self,
+        group_ids: list[str | int],
+        participant_count: int = 1,
+        participant_indices: list[int] | None = None,
+        request_costs: list[int] | None = None,
+        predicted_group_costs: list[int] | None = None,
+        designated_probe_flags: list[bool] | None = None,
+        preferred_dp_indices: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Synchronous session opener for async-GRPO's collector actor."""
+        session, request_catalog = self._build_cross_dp_session(
+            group_ids,
+            participant_count,
+            participant_indices,
+            request_costs,
+            predicted_group_costs,
+            designated_probe_flags,
+            preferred_dp_indices,
+        )
+        assert self._cross_dp_dispatcher is not None
+        ray.get(
+            self._cross_dp_dispatcher.open_session.remote(
+                session["session_id"], request_catalog, session["participant_ids"]
+            )
+        )
+        return session
+
+    async def close_cross_dp_session_participant(
+        self, session_id: str, participant_id: str
+    ) -> None:
+        if self._cross_dp_dispatcher is None:
+            return
+        await self._cross_dp_dispatcher.close_participant.remote(
+            session_id, participant_id
+        )
+
+    def close_cross_dp_session_participant_sync(
+        self, session_id: str, participant_id: str
+    ) -> None:
+        if self._cross_dp_dispatcher is None:
+            return
+        ray.get(
+            self._cross_dp_dispatcher.close_participant.remote(
+                session_id, participant_id
+            )
+        )
+
+    def get_cross_dp_scheduler_snapshot(self) -> dict[str, Any] | None:
+        if self._cross_dp_dispatcher is None:
+            return None
+        return ray.get(self._cross_dp_dispatcher.snapshot.remote())
+
     async def _async_generate_base(
         self,
         data: BatchedDataDict[GenerationDatumSpec],
@@ -587,102 +1268,266 @@ class VllmGeneration(GenerationInterface):
         if not data_validation_fn(data):
             return
 
-        # Determine the leader worker for the current data parallel shard
-        leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
-            self.current_generate_dp_shard_idx
+        metadata_keys = (
+            "_cross_dp_session_id",
+            "_cross_dp_participant_id",
+            "_cross_dp_request_id",
+            "_cross_dp_group_id",
         )
+        present_metadata = [key in data for key in metadata_keys]
+        if any(present_metadata) and not all(present_metadata):
+            raise ValueError(
+                "Cross-DP request metadata must contain all of "
+                f"{metadata_keys}, got keys {list(data.keys())}"
+            )
+        if all(present_metadata) and method_name != "generate_async":
+            raise NotImplementedError(
+                "Cross-DP scheduling currently supports token generation only; "
+                "generate_text_async does not report generation_lengths needed "
+                "to release and update the middleware lease"
+            )
 
-        # Run the async method on the selected leader worker
-        worker_gen_proxy = self.worker_group.run_single_worker_single_data(
-            method_name=method_name,
-            worker_idx=leader_worker_idx,
-            data=data,
-            greedy=greedy,
-        )
-
-        # Increment the round-robin worker group index
-        self.current_generate_dp_shard_idx += 1
-        self.current_generate_dp_shard_idx %= self.worker_group.dp_size
-
-        # Create a queue to collect sample results from the worker as they complete
-        result_queue = asyncio.Queue()
-        finished = False
-
-        async def consume_worker_generator(worker_idx, worker_gen):
-            """Consume a single worker generator and put sample results in the queue."""
-            nonlocal finished
-            worker_name = f"Worker-{worker_idx}"
-            try:
-                async for sample_result_ref in worker_gen:
-                    sample_result = await sample_result_ref
-                    # sample_result is a tuple: (original_idx, BatchedDataDict)
-                    # Tag the result with worker index for downstream attribution
-                    original_idx, result_batch = sample_result
-                    # Use a length-one list so BatchedDataDict.from_batches can merge without shape errors
-                    result_batch["gen_leader_worker_idx"] = [int(worker_idx)]
-                    sample_result = (original_idx, result_batch)
-                    await result_queue.put(("sample", sample_result))
-            except Exception as e:
-                # Log the error before putting it in the queue for better debugging
-                import traceback
-
-                print(f"Exception in worker {worker_name}")
-                traceback.print_exc()
-                await result_queue.put(("error", e))
-            finally:
-                finished = True
-                await result_queue.put(("worker_done", None))
-
-        # Start the task to consume the worker generator
-        worker_task = asyncio.create_task(
-            consume_worker_generator(leader_worker_idx, worker_gen_proxy)
-        )
-
-        # Yield sample results as they become available from the worker
-        timeout_seconds = float(
-            os.environ.get("NRL_VLLM_ASYNC_TIMEOUT_SECONDS", "600")
-        )  # Default 10 minutes
-
-        while not finished:
-            try:
-                msg_type, item = await asyncio.wait_for(
-                    result_queue.get(), timeout=timeout_seconds
+        def first_metadata_value(key: str) -> str:
+            value = data[key]
+            if len(value) != 1:
+                raise ValueError(
+                    "Cross-DP async dispatch requires singleton request metadata, "
+                    f"but {key} has length {len(value)}"
                 )
-            except asyncio.TimeoutError:
-                print(
-                    f"Timeout waiting for results after {timeout_seconds}s. Worker has not finished."
-                )
-                print(
-                    f"For longer sequences, increase the timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
-                )
-                # Cancel the task
-                if not worker_task.done():
-                    worker_task.cancel()
-                await asyncio.gather(worker_task, return_exceptions=True)
-                raise RuntimeError(
-                    f"Timeout waiting for worker results after {timeout_seconds}s. "
-                    f"For longer sequences, increase timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
-                )
+            item = value[0]
+            if hasattr(item, "item"):
+                item = item.item()
+            return str(item)
 
-            if msg_type == "sample":
-                # Yield individual sample result immediately
-                yield item
-            elif msg_type == "error":
-                # Cancel the task and propagate error
-                if not worker_task.done():
-                    worker_task.cancel()
-                await asyncio.gather(worker_task, return_exceptions=True)
-                raise item
-            elif msg_type == "worker_done":
-                # Worker finished, just continue the loop
-                pass
+        dispatch_request_id: str | None = None
+        worker_submitted = False
+        dispatch_completed = False
+        remote_state_known_finished = False
+        worker_task: asyncio.Task | None = None
+        caught_error: BaseException | None = None
+        lease_received_at_monotonic_s: float | None = None
+        worker_proxy_created_at_monotonic_s: float | None = None
+        cross_dp_assignment_sequence: int | None = None
+        cross_dp_dp_assignment_ordinal: int | None = None
+        cross_dp_session_dp_assignment_ordinal: int | None = None
+        cross_dp_frontend_submission: dict[str, Any] | None = None
+
+        try:
+            if all(present_metadata):
+                if self._cross_dp_dispatcher is None:
+                    raise RuntimeError(
+                        "Received cross-DP request metadata, but "
+                        "NRL_VLLM_CROSS_DP_SCHED is disabled"
+                    )
+                session_id = first_metadata_value("_cross_dp_session_id")
+                participant_id = first_metadata_value("_cross_dp_participant_id")
+                dispatch_request_id = first_metadata_value("_cross_dp_request_id")
+                group_id = first_metadata_value("_cross_dp_group_id")
+                lease = await self._cross_dp_dispatcher.acquire.remote(
+                    session_id,
+                    participant_id,
+                    dispatch_request_id,
+                    group_id,
+                    max(1, int(self.cfg["max_new_tokens"])),
+                )
+                lease_received_at_monotonic_s = time.monotonic()
+                dp_shard_idx = int(lease["dp_idx"])
+                cross_dp_assignment_sequence = int(
+                    lease["assignment_sequence"]
+                )
+                cross_dp_dp_assignment_ordinal = int(
+                    lease["dp_assignment_ordinal"]
+                )
+                cross_dp_session_dp_assignment_ordinal = int(
+                    lease["session_dp_assignment_ordinal"]
+                )
+                cross_dp_frontend_submission = {
+                    "dispatcher": self._cross_dp_dispatcher,
+                    "session_id": session_id,
+                    "request_id": dispatch_request_id,
+                    "assignment_sequence": cross_dp_assignment_sequence,
+                    "dp_assignment_ordinal": cross_dp_dp_assignment_ordinal,
+                    "session_dp_assignment_ordinal": (
+                        cross_dp_session_dp_assignment_ordinal
+                    ),
+                }
             else:
-                raise RuntimeError(f"Unexpected message type: {msg_type}")
+                # Preserve vanilla behavior for direct callers that did not
+                # opt into a scheduling session.
+                dp_shard_idx = self.current_generate_dp_shard_idx
+                self.current_generate_dp_shard_idx += 1
+                self.current_generate_dp_shard_idx %= self.worker_group.dp_size
 
-        # Verify the task is actually done
-        assert worker_task.done(), (
-            f"Worker task {leader_worker_idx} should be done but isn't"
-        )
+            leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
+                dp_shard_idx
+            )
+            worker_call_kwargs: dict[str, Any] = {
+                "data": data,
+                "greedy": greedy,
+            }
+            if cross_dp_frontend_submission is not None:
+                worker_call_kwargs["cross_dp_frontend_submission"] = (
+                    cross_dp_frontend_submission
+                )
+            worker_gen_proxy = self.worker_group.run_single_worker_single_data(
+                method_name=method_name,
+                worker_idx=leader_worker_idx,
+                **worker_call_kwargs,
+            )
+            worker_proxy_created_at_monotonic_s = time.monotonic()
+            worker_submitted = True
+
+            result_queue = asyncio.Queue()
+
+            async def consume_worker_generator(worker_idx, worker_gen):
+                """Consume a worker generator and enqueue its single result."""
+                worker_name = f"Worker-{worker_idx}"
+                try:
+                    async for sample_result_ref in worker_gen:
+                        sample_result = await sample_result_ref
+                        original_idx, result_batch = sample_result
+                        result_batch["gen_leader_worker_idx"] = [int(worker_idx)]
+                        result_batch["gen_dp_shard_idx"] = [int(dp_shard_idx)]
+                        if lease_received_at_monotonic_s is not None:
+                            result_batch[
+                                "gen_cross_dp_lease_received_at_monotonic_s"
+                            ] = [lease_received_at_monotonic_s]
+                        if worker_proxy_created_at_monotonic_s is not None:
+                            result_batch[
+                                "gen_worker_proxy_created_at_monotonic_s"
+                            ] = [worker_proxy_created_at_monotonic_s]
+                        if cross_dp_assignment_sequence is not None:
+                            result_batch[
+                                "gen_cross_dp_assignment_sequence"
+                            ] = [cross_dp_assignment_sequence]
+                        if cross_dp_dp_assignment_ordinal is not None:
+                            result_batch[
+                                "gen_cross_dp_dp_assignment_ordinal"
+                            ] = [cross_dp_dp_assignment_ordinal]
+                        if cross_dp_session_dp_assignment_ordinal is not None:
+                            result_batch[
+                                "gen_cross_dp_session_dp_assignment_ordinal"
+                            ] = [cross_dp_session_dp_assignment_ordinal]
+                        await result_queue.put(
+                            ("sample", (original_idx, result_batch))
+                        )
+                except Exception as error:
+                    import traceback
+
+                    print(f"Exception in worker {worker_name}")
+                    traceback.print_exc()
+                    await result_queue.put(("error", error))
+                finally:
+                    await result_queue.put(("worker_done", None))
+
+            worker_task = asyncio.create_task(
+                consume_worker_generator(leader_worker_idx, worker_gen_proxy)
+            )
+            timeout_seconds = float(
+                os.environ.get("NRL_VLLM_ASYNC_TIMEOUT_SECONDS", "600")
+            )
+
+            while True:
+                try:
+                    msg_type, item = await asyncio.wait_for(
+                        result_queue.get(), timeout=timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    print(
+                        f"Timeout waiting for results after {timeout_seconds}s. "
+                        "Worker has not finished."
+                    )
+                    print(
+                        "For longer sequences, increase the timeout by setting: "
+                        "export NRL_VLLM_ASYNC_TIMEOUT_SECONDS="
+                        f"{int(timeout_seconds * 2)}"
+                    )
+                    if not worker_task.done():
+                        worker_task.cancel()
+                    await asyncio.gather(worker_task, return_exceptions=True)
+                    raise RuntimeError(
+                        f"Timeout waiting for worker results after {timeout_seconds}s. "
+                        "For longer sequences, increase timeout by setting: "
+                        "export NRL_VLLM_ASYNC_TIMEOUT_SECONDS="
+                        f"{int(timeout_seconds * 2)}"
+                    )
+
+                if msg_type == "sample":
+                    remote_state_known_finished = True
+                    if dispatch_request_id is not None and not dispatch_completed:
+                        _, result_batch = item
+                        generation_length = int(
+                            result_batch["generation_lengths"][0].item()
+                        )
+                        assert self._cross_dp_dispatcher is not None
+                        # Release/refill before yielding.  Some consumers stop
+                        # the async generator immediately after its first item.
+                        client_reported_at_unix_s = time.time()
+                        client_reported_at_monotonic_s = time.monotonic()
+                        await self._cross_dp_dispatcher.complete.remote(
+                            dispatch_request_id,
+                            generation_length,
+                            client_reported_at_unix_s,
+                            client_reported_at_monotonic_s,
+                            os.uname().nodename,
+                        )
+                        dispatch_completed = True
+                    yield item
+                elif msg_type == "error":
+                    # A Ray async-generator exception does not prove that the
+                    # remote EngineCore request stopped. It may represent an
+                    # actor/transport failure, or an abort that itself failed.
+                    # Keep the state unknown and fail the dispatcher globally
+                    # rather than releasing and reusing a possibly live slot.
+                    if not worker_task.done():
+                        worker_task.cancel()
+                    await asyncio.gather(worker_task, return_exceptions=True)
+                    raise item
+                elif msg_type == "worker_done":
+                    if dispatch_request_id is not None and not dispatch_completed:
+                        remote_state_known_finished = True
+                        raise RuntimeError(
+                            f"Worker {leader_worker_idx} returned no generation result"
+                        )
+                    break
+                else:
+                    raise RuntimeError(f"Unexpected message type: {msg_type}")
+
+            assert worker_task.done(), (
+                f"Worker task {leader_worker_idx} should be done but isn't"
+            )
+        except BaseException as error:
+            caught_error = error
+            raise
+        finally:
+            if worker_task is not None and not worker_task.done():
+                worker_task.cancel()
+                await asyncio.gather(worker_task, return_exceptions=True)
+            if dispatch_request_id is not None and not dispatch_completed:
+                assert self._cross_dp_dispatcher is not None
+                try:
+                    if worker_submitted:
+                        failure_method = (
+                            self._cross_dp_dispatcher.fail_terminated
+                            if remote_state_known_finished
+                            else self._cross_dp_dispatcher.fail_unknown
+                        )
+                        await failure_method.remote(
+                            dispatch_request_id,
+                            repr(caught_error)
+                            if caught_error is not None
+                            else "async generator closed before completion",
+                        )
+                    else:
+                        await self._cross_dp_dispatcher.cancel_unsubmitted.remote(
+                            dispatch_request_id
+                        )
+                except Exception as cleanup_error:
+                    print(
+                        "Failed to clean up cross-DP dispatcher lease "
+                        f"{dispatch_request_id}: {cleanup_error}",
+                        flush=True,
+                    )
 
     async def generate_text_async(
         self, data: BatchedDataDict[GenerationDatumSpec], greedy: bool = False
@@ -783,12 +1628,22 @@ class VllmGeneration(GenerationInterface):
 
     def shutdown(self) -> bool:
         """Shut down all vLLM workers and clean up resources."""
+        result = False
         try:
             # Use the worker group's shutdown method with the worker's cleanup method
-            return self.worker_group.shutdown(cleanup_method="shutdown")
+            result = self.worker_group.shutdown(cleanup_method="shutdown")
         except Exception as e:
             print(f"Error during policy shutdown: {e}")
-            return False
+        finally:
+            dispatcher = getattr(self, "_cross_dp_dispatcher", None)
+            self._cross_dp_dispatcher = None
+            if dispatcher is not None:
+                try:
+                    ray.kill(dispatcher, no_restart=True)
+                except Exception as e:
+                    print(f"Error shutting down cross-DP dispatcher: {e}")
+                    result = False
+        return result
 
     def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
         """Prepare the info for refit."""
@@ -853,13 +1708,69 @@ class VllmGeneration(GenerationInterface):
 
     def start_gpu_profiling(self) -> None:
         """Start GPU profiling."""
-        futures = self.worker_group.run_all_workers_single_data("start_gpu_profiling")
+        method_name = (
+            "start_gpu_profiling_async"
+            if self.cfg["vllm_cfg"]["async_engine"]
+            else "start_gpu_profiling"
+        )
+        futures = self.worker_group.run_all_workers_single_data(method_name)
         ray.get(futures)
 
     def stop_gpu_profiling(self) -> None:
         """Stop GPU profiling."""
-        futures = self.worker_group.run_all_workers_single_data("stop_gpu_profiling")
+        method_name = (
+            "stop_gpu_profiling_async"
+            if self.cfg["vllm_cfg"]["async_engine"]
+            else "stop_gpu_profiling"
+        )
+        futures = self.worker_group.run_all_workers_single_data(method_name)
         ray.get(futures)
+
+    def arm_model_step_gpu_profile(
+        self,
+        start_step: int,
+        stop_step: int,
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Arm an exact model-step range on every TP rank of every DP engine."""
+        if not self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError(
+                "exact model-step GPU profiling requires async vLLM"
+            )
+        futures: list[ray.ObjectRef] = []
+        dp_indices: list[int] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "arm_model_step_gpu_profile_async",
+                    worker_idx=worker_idx,
+                    start_step=start_step,
+                    stop_step=stop_step,
+                )
+            )
+            dp_indices.append(dp_idx)
+        return dict(zip(dp_indices, ray.get(futures), strict=True))
+
+    def get_model_step_gpu_profile(
+        self,
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Require and collect exact-range proofs from all nested TP ranks."""
+        if not self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError(
+                "exact model-step GPU profiling requires async vLLM"
+            )
+        futures: list[ray.ObjectRef] = []
+        dp_indices: list[int] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "get_model_step_gpu_profile_async",
+                    worker_idx=worker_idx,
+                )
+            )
+            dp_indices.append(dp_idx)
+        return dict(zip(dp_indices, ray.get(futures), strict=True))
 
     def get_vllm_logger_metrics(self) -> dict[str, Any]:
         """Collect vLLM logger metrics from vLLM workers (model-owner actors only)."""
@@ -880,11 +1791,18 @@ class VllmGeneration(GenerationInterface):
             dp_indices.append(dp_idx)
 
         results = ray.get(futures)
-        vllm_logger_metrics: dict[str, dict[int, list[Any]]] = {
+        vllm_logger_metrics: dict[str, dict[int, Any]] = {
             "inflight_batch_sizes": {},  # dp_idx -> list[int]
             "num_pending_samples": {},  # dp_idx -> list[int]
             "kv_cache_usage_perc": {},  # dp_idx -> list[float]
             "generation_tokens": {},  # dp_idx -> list[int]
+            "num_preemptions": {},  # dp_idx -> list[int]
+            "metric_samples": {},  # dp_idx -> list[dict[str, Any]]
+            "metric_source_series": {},  # dp_idx -> dict[field, source]
+            "metric_sampler_errors": {},  # dp_idx -> list[dict[str, Any]]
+            "metric_sampler_interval_s": {},  # dp_idx -> float
+            "generation_tokens_baseline": {},  # dp_idx -> int
+            "num_preemptions_baseline": {},  # dp_idx -> int
         }
 
         for dp_idx, stats in zip(dp_indices, results):
@@ -904,27 +1822,179 @@ class VllmGeneration(GenerationInterface):
             generation_tokens = stats.get("generation_tokens")
             if generation_tokens:
                 vllm_logger_metrics["generation_tokens"][dp_idx] = generation_tokens
+            num_preemptions = stats.get("num_preemptions")
+            if num_preemptions:
+                vllm_logger_metrics["num_preemptions"][dp_idx] = num_preemptions
+            metric_samples = stats.get("metric_samples")
+            if metric_samples:
+                vllm_logger_metrics["metric_samples"][dp_idx] = metric_samples
+            vllm_logger_metrics["metric_source_series"][dp_idx] = copy.deepcopy(
+                stats.get("metric_source_series")
+            )
+            vllm_logger_metrics["metric_sampler_errors"][dp_idx] = copy.deepcopy(
+                stats.get("metric_sampler_errors", [])
+            )
+            vllm_logger_metrics["metric_sampler_interval_s"][dp_idx] = float(
+                stats.get("metric_sampler_interval_s", 0.0)
+            )
+            vllm_logger_metrics["generation_tokens_baseline"][dp_idx] = int(
+                stats.get("generation_tokens_baseline", 0)
+            )
+            vllm_logger_metrics["num_preemptions_baseline"][dp_idx] = int(
+                stats.get("num_preemptions_baseline", 0)
+            )
 
         return vllm_logger_metrics
 
-    def clear_vllm_logger_metrics(self) -> None:
+    def get_kv_cache_shapes(self) -> list[dict[str, int]]:
+        """Collect initialized KV cache capacity from every DP engine."""
+        if not self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError("KV cache shape collection requires async vLLM")
+        futures: list[ray.ObjectRef] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "get_kv_cache_shape",
+                    worker_idx=worker_idx,
+                )
+            )
+        return ray.get(futures)
+
+    def clear_vllm_logger_metrics(self) -> dict[int, dict[str, Any]]:
         if not self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
+            return {}
+        if not self.cfg["vllm_cfg"].get("async_engine", False):
+            return {}
+
+        # Record a driver-clock RPC interval for each remote anchor.  A worker's
+        # local monotonic deltas can then be projected onto the driver timeline
+        # without assuming CLOCK_MONOTONIC shares an epoch across physical
+        # nodes.  The half round-trip is retained as alignment uncertainty.
+        pending: dict[ray.ObjectRef, tuple[int, float, float]] = {}
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            sent_monotonic_s = time.monotonic()
+            sent_unix_s = time.time()
+            future = self.worker_group.run_single_worker_single_data(
+                "clear_vllm_logger_metrics",
+                worker_idx=worker_idx,
+            )
+            pending[future] = (dp_idx, sent_monotonic_s, sent_unix_s)
+
+        anchors_by_dp: dict[int, dict[str, Any]] = {}
+        while pending:
+            ready, _ = ray.wait(list(pending), num_returns=1)
+            received_monotonic_s = time.monotonic()
+            received_unix_s = time.time()
+            future = ready[0]
+            dp_idx, sent_monotonic_s, sent_unix_s = pending.pop(future)
+            worker_anchor = ray.get(future)
+            if not isinstance(worker_anchor, dict):
+                raise RuntimeError(
+                    f"DP {dp_idx} did not return a metric measurement anchor"
+                )
+            anchors_by_dp[dp_idx] = {
+                "worker_anchor": worker_anchor,
+                "driver_rpc_sent_monotonic_s": sent_monotonic_s,
+                "driver_rpc_received_monotonic_s": received_monotonic_s,
+                "driver_rpc_midpoint_monotonic_s": (
+                    sent_monotonic_s + received_monotonic_s
+                )
+                / 2.0,
+                "driver_rpc_sent_unix_s": sent_unix_s,
+                "driver_rpc_received_unix_s": received_unix_s,
+                "driver_rpc_round_trip_s": (
+                    received_monotonic_s - sent_monotonic_s
+                ),
+                "driver_alignment_uncertainty_s": (
+                    received_monotonic_s - sent_monotonic_s
+                )
+                / 2.0,
+            }
+        return anchors_by_dp
+
+    def get_vllm_step_trace(self) -> dict[int, dict[str, Any]]:
+        """Collect one exact step-trace snapshot from every DP engine."""
+        if not self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False):
+            return {}
+        if not self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError("vLLM step tracing requires the async engine")
+
+        futures: list[ray.ObjectRef] = []
+        dp_indices: list[int] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "get_vllm_step_trace",
+                    worker_idx=worker_idx,
+                )
+            )
+            dp_indices.append(dp_idx)
+        return dict(zip(dp_indices, ray.get(futures), strict=True))
+
+    def clear_vllm_step_trace(self) -> None:
+        """Open a fresh exact step-trace window on every DP engine."""
+        if not self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False):
             return
         if not self.cfg["vllm_cfg"].get("async_engine", False):
-            return
-        futures = self.worker_group.run_all_workers_single_data(
-            "clear_vllm_logger_metrics",
-            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
-        )
+            raise RuntimeError("vLLM step tracing requires the async engine")
+
+        futures: list[ray.ObjectRef] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "clear_vllm_step_trace",
+                    worker_idx=worker_idx,
+                )
+            )
         ray.get(futures)
+
+    def clear_logger_metrics_with_alignment_anchors(
+        self,
+    ) -> dict[int, dict[str, Any]]:
+        """Clear metrics and return benchmark-only cross-host anchors."""
+        metric_anchors = self.clear_vllm_logger_metrics()
+        self.clear_vllm_step_trace()
+        # Async engine has no blocking generate() to bracket the in-flight
+        # profiler window, so we open a fresh window here (called per training
+        # step before the rollout). The sync engine handles this inside generate().
+        if self._inflight_profiling and self.cfg["vllm_cfg"]["async_engine"]:
+            self._clear_inflight_timeline_workers()
+        return metric_anchors
 
     def clear_logger_metrics(self) -> None:
         """Clear logger metrics for performance reporting."""
-        self.clear_vllm_logger_metrics()
+        self.clear_logger_metrics_with_alignment_anchors()
 
     def get_logger_metrics(self) -> dict[str, Any]:
         """Get logger metrics for performance reporting."""
-        return self.get_vllm_logger_metrics()
+        metrics = self.get_vllm_logger_metrics()
+        # Async counterpart of the sync generate()-time dump: collect the window
+        # opened by clear_logger_metrics() and append it to the timeline JSONL.
+        if self._inflight_profiling and self.cfg["vllm_cfg"]["async_engine"]:
+            self._dump_inflight_timeline()
+        return metrics
+
+    def _clear_inflight_timeline_workers(self) -> None:
+        """Open a fresh in-flight sampling window on each data-parallel leader."""
+        futures: list[ray.ObjectRef] = []
+        for dp_idx in range(self.worker_group.dp_size):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_idx)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    "clear_inflight_timeline", worker_idx=worker_idx
+                )
+            )
+        try:
+            ray.get(futures)
+        except Exception as e:
+            print(
+                f"[INFLIGHT-PROFILER] failed to clear timelines: {e}",
+                flush=True,
+            )
 
     def __del__(self) -> None:
         """Shuts down the worker groups when the object is deleted or is garbage collected.

--- a/nemo_rl/models/generation/vllm/vllm_metric_sampler.py
+++ b/nemo_rl/models/generation/vllm/vllm_metric_sampler.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Low-overhead, auditable sampling of the vLLM metrics used by NeMo RL."""
+
+import math
+from typing import Any
+
+
+# ``vllm.v1.metrics.reader.get_metrics_snapshot`` walks every collector in the
+# process-wide registry and materializes every vLLM histogram bucket.  The
+# rollout profiler only consumes these five series, so sampling the full
+# registry at 4 Hz adds avoidable, highly variable Python work.
+_SAMPLE_NAME_TO_FIELD_AND_TYPE: dict[str, tuple[str, type[int] | type[float]]] = {
+    "vllm:num_requests_running": ("inflight_batch_size", int),
+    "vllm:num_requests_waiting": ("num_pending", int),
+    "vllm:kv_cache_usage_perc": ("kv_cache_usage_perc", float),
+    "vllm:generation_tokens_total": ("generation_tokens", int),
+    "vllm:num_preemptions_total": ("num_preemptions", int),
+}
+
+VLLM_METRIC_SAMPLE_NAMES = frozenset(_SAMPLE_NAME_TO_FIELD_AND_TYPE)
+VLLM_METRIC_FIELDS = frozenset(
+    field for field, _value_type in _SAMPLE_NAME_TO_FIELD_AND_TYPE.values()
+)
+
+
+def read_restricted_vllm_metrics(
+    registry: Any,
+) -> tuple[dict[str, int | float], dict[str, dict[str, Any]]]:
+    """Read exactly the five required vLLM Prometheus series.
+
+    The return value contains JSON-compatible field values plus source
+    metadata that identifies the exact Prometheus family, sample, type, and
+    labels used for each field.
+
+    No full-registry fallback is intentional.  A fallback to ``collect()``
+    would silently restore the expensive behavior this sampler is designed to
+    avoid and would make profiler overhead dependent on unrelated histograms.
+    """
+
+    restricted_registry = getattr(registry, "restricted_registry", None)
+    if not callable(restricted_registry):
+        raise RuntimeError(
+            "The Prometheus registry does not support restricted_registry(); "
+            "refusing to fall back to a full registry scan"
+        )
+
+    values: dict[str, int | float] = {}
+    sources: dict[str, dict[str, Any]] = {}
+    for metric_family in restricted_registry(VLLM_METRIC_SAMPLE_NAMES).collect():
+        for prometheus_sample in metric_family.samples:
+            specification = _SAMPLE_NAME_TO_FIELD_AND_TYPE.get(
+                prometheus_sample.name
+            )
+            if specification is None:
+                continue
+            field, value_type = specification
+            source = {
+                "metric_family_name": str(metric_family.name),
+                "metric_type": str(metric_family.type),
+                "sample_name": str(prometheus_sample.name),
+                "labels": dict(prometheus_sample.labels),
+            }
+            if field in values:
+                raise RuntimeError(
+                    "Multiple Prometheus series matched required vLLM metric "
+                    f"field {field!r}: {sources[field]!r} and {source!r}"
+                )
+            values[field] = value_type(prometheus_sample.value)
+            sources[field] = source
+
+    missing_fields = sorted(VLLM_METRIC_FIELDS.difference(values))
+    if missing_fields:
+        expected_names = sorted(
+            sample_name
+            for sample_name, (field, _value_type) in (
+                _SAMPLE_NAME_TO_FIELD_AND_TYPE.items()
+            )
+            if field in missing_fields
+        )
+        raise RuntimeError(
+            "Required vLLM Prometheus series are missing: "
+            f"fields={missing_fields}, sample_names={expected_names}"
+        )
+    return values, sources
+
+
+def metric_capture_timing(
+    *,
+    interval_s: float,
+    scheduled_at_monotonic_s: float | None,
+    attempted_at_monotonic_s: float,
+    started_at_monotonic_s: float,
+    finished_at_monotonic_s: float,
+) -> dict[str, int | float | None]:
+    """Return diagnostics that separate wake, lock, and capture delays.
+
+    ``attempted`` is recorded when the sampler thread starts a pass, before it
+    acquires the shared metrics lock. ``started`` is recorded immediately after
+    acquiring that lock and before reading Prometheus. ``finished`` is recorded
+    immediately after the registry read.
+
+    ``capture_missed_periods`` counts additional nominal sample deadlines that
+    elapsed from this pass's scheduled deadline through capture completion.  A
+    value of zero means the pass finished before the next deadline.
+    """
+
+    if interval_s <= 0:
+        raise ValueError(f"interval_s must be positive, got {interval_s}")
+    if attempted_at_monotonic_s > started_at_monotonic_s:
+        raise ValueError("capture attempt must not follow capture start")
+    if started_at_monotonic_s > finished_at_monotonic_s:
+        raise ValueError("capture start must not follow capture finish")
+
+    result: dict[str, int | float | None] = {
+        "capture_scheduled_at_monotonic_s": scheduled_at_monotonic_s,
+        "capture_attempted_at_monotonic_s": attempted_at_monotonic_s,
+        "capture_started_at_monotonic_s": started_at_monotonic_s,
+        "capture_finished_at_monotonic_s": finished_at_monotonic_s,
+        "capture_duration_s": (
+            finished_at_monotonic_s - started_at_monotonic_s
+        ),
+        "capture_lock_wait_s": (
+            started_at_monotonic_s - attempted_at_monotonic_s
+        ),
+        "capture_wake_lateness_s": None,
+        "capture_deadline_lateness_s": None,
+        "capture_finish_lateness_s": None,
+        "capture_missed_periods": 0,
+    }
+    if scheduled_at_monotonic_s is None:
+        return result
+
+    result["capture_wake_lateness_s"] = max(
+        0.0, attempted_at_monotonic_s - scheduled_at_monotonic_s
+    )
+    result["capture_deadline_lateness_s"] = max(
+        0.0, started_at_monotonic_s - scheduled_at_monotonic_s
+    )
+    finish_lateness_s = max(
+        0.0, finished_at_monotonic_s - scheduled_at_monotonic_s
+    )
+    result["capture_finish_lateness_s"] = finish_lateness_s
+    result["capture_missed_periods"] = max(
+        0, math.floor(finish_lateness_s / interval_s)
+    )
+    return result

--- a/nemo_rl/models/generation/vllm/vllm_step_trace.py
+++ b/nemo_rl/models/generation/vllm/vllm_step_trace.py
@@ -1,0 +1,1476 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only, per-scheduler-step tracing for the pinned vLLM contract.
+
+The adapter deliberately has no module-level vLLM imports.  Unit tests and
+non-vLLM entry points can therefore import it without initializing vLLM.  The
+custom ``AggregateStatLoggerBase`` subclass is created lazily in the worker.
+
+``frontend_observed_cadence_ns`` is the interval between consecutive
+``StatLogger.record`` callbacks in the AsyncLLM frontend.  It is useful for
+ordering and diagnosing stalls, but it is *not* model execution latency.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import threading
+import time
+from array import array
+from collections import Counter, deque
+from functools import lru_cache
+from typing import Any, Callable
+
+VLLM_STEP_TRACE_SCHEMA_VERSION = 4
+VLLM_STEP_TRACE_AGGREGATION_VERSION = 1
+VLLM_STEP_TRACE_TIMELINE_COLUMN_ENCODING = "python-array-q-v1"
+VLLM_STEP_TRACE_PHASE_CLASSIFIER = "vllm-v0.17.1-mfu-debug"
+VLLM_STEP_TRACE_MODEL_STEP_DISCRIMINATOR = (
+    "mfu_scheduled_work_then_cudagraph_required-v2"
+)
+VLLM_STEP_TRACE_DEFAULT_MAX_RECORDS = 100_000
+VLLM_STEP_TRACE_MAX_RETAINED_ERRORS = 100
+
+_CONTEXT_FIELDS = (
+    "num_prefill_requests",
+    "prefill_num_tokens",
+    "prefill_context_len",
+    "prefill_token_context_product",
+    "num_decode_requests",
+    "decode_num_tokens",
+    "decode_context_len",
+    "decode_token_context_product",
+)
+
+_TIMELINE_COLUMN_PATHS = {
+    "recorded_at_monotonic_ns": ("frontend_recorded_at_monotonic_ns",),
+    "scheduled_request_count": ("scheduled", "request_count"),
+    "scheduled_token_count": ("scheduled", "token_count"),
+    "decode_request_count": ("scheduled", "decode", "request_count"),
+    "decode_token_count": ("scheduled", "decode", "token_count"),
+    "decode_context_len_sum": ("scheduled", "decode", "context_len_sum"),
+    "prefill_request_count": ("scheduled", "prefill", "request_count"),
+    "prefill_token_count": ("scheduled", "prefill", "token_count"),
+    "padding_token_count": ("cudagraph", "padding_tokens"),
+    "estimated_flops_per_gpu": ("estimated_work_per_gpu", "flops"),
+    "estimated_read_bytes_per_gpu": (
+        "estimated_work_per_gpu",
+        "read_bytes",
+    ),
+}
+
+
+class VllmStepTraceContractError(RuntimeError):
+    """The installed vLLM no longer satisfies the pinned trace contract."""
+
+
+def _canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _required_attr(value: Any, name: str, path: str) -> Any:
+    if value is None or not hasattr(value, name):
+        raise VllmStepTraceContractError(f"missing required field {path}.{name}")
+    return getattr(value, name)
+
+
+def _nonnegative_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise VllmStepTraceContractError(
+            f"{path} must be an int, got {type(value).__name__}"
+        )
+    if value < 0:
+        raise VllmStepTraceContractError(f"{path} must be nonnegative, got {value}")
+    return value
+
+
+def _nonnegative_number(value: Any, path: str) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VllmStepTraceContractError(
+            f"{path} must be numeric, got {type(value).__name__}"
+        )
+    if value < 0:
+        raise VllmStepTraceContractError(f"{path} must be nonnegative, got {value}")
+    return value
+
+
+def _integer_breakdown(value: Any, path: str) -> dict[str, int]:
+    if not isinstance(value, dict):
+        raise VllmStepTraceContractError(
+            f"{path} must be a dict, got {type(value).__name__}"
+        )
+    result: dict[str, int] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise VllmStepTraceContractError(
+                f"{path} keys must be strings, got {type(key).__name__}"
+            )
+        result[key] = _nonnegative_int(item, f"{path}[{key!r}]")
+    return result
+
+
+def _optional_iteration_stats(iteration_stats: Any) -> dict[str, Any]:
+    if iteration_stats is None:
+        return {
+            "present": False,
+            "emitted_generation_tokens": None,
+            "emitted_prompt_tokens": None,
+            "computed_prompt_tokens": None,
+            "preempted_requests": None,
+            "finished_requests": None,
+        }
+
+    prompt_token_stats = _required_attr(
+        iteration_stats,
+        "prompt_token_stats",
+        "iteration_stats",
+    )
+    finished_requests = _required_attr(
+        iteration_stats,
+        "finished_requests",
+        "iteration_stats",
+    )
+    if not isinstance(finished_requests, list):
+        raise VllmStepTraceContractError(
+            "iteration_stats.finished_requests must be a list"
+        )
+    return {
+        "present": True,
+        "emitted_generation_tokens": _nonnegative_int(
+            _required_attr(
+                iteration_stats,
+                "num_generation_tokens",
+                "iteration_stats",
+            ),
+            "iteration_stats.num_generation_tokens",
+        ),
+        "emitted_prompt_tokens": _nonnegative_int(
+            _required_attr(prompt_token_stats, "total", "prompt_token_stats"),
+            "iteration_stats.prompt_token_stats.total",
+        ),
+        "computed_prompt_tokens": _nonnegative_int(
+            _required_attr(prompt_token_stats, "computed", "prompt_token_stats"),
+            "iteration_stats.prompt_token_stats.computed",
+        ),
+        "preempted_requests": _nonnegative_int(
+            _required_attr(
+                iteration_stats,
+                "num_preempted_reqs",
+                "iteration_stats",
+            ),
+            "iteration_stats.num_preempted_reqs",
+        ),
+        "finished_requests": len(finished_requests),
+    }
+
+
+def _required_mfu_context(perf_stats: Any) -> tuple[Any, dict[str, int]]:
+    """Return the pinned MFU debug object and its validated context fields."""
+    if perf_stats is None:
+        raise VllmStepTraceContractError(
+            "scheduler_stats.perf_stats is None for a purported model step"
+        )
+    debug_stats = _required_attr(perf_stats, "debug_stats", "perf_stats")
+    if debug_stats is None:
+        raise VllmStepTraceContractError(
+            "perf_stats.debug_stats is None; require "
+            "enable_mfu_metrics=True and VLLM_DEBUG_MFU_METRICS=1"
+        )
+
+    context_breakdown = _required_attr(
+        debug_stats,
+        "context_breakdown",
+        "debug_stats",
+    )
+    if not isinstance(context_breakdown, dict):
+        raise VllmStepTraceContractError(
+            "debug_stats.context_breakdown must be a dict"
+        )
+    missing_context_fields = [
+        field for field in _CONTEXT_FIELDS if field not in context_breakdown
+    ]
+    if missing_context_fields:
+        raise VllmStepTraceContractError(
+            "debug_stats.context_breakdown is missing "
+            f"{missing_context_fields}; observed={sorted(context_breakdown)}"
+        )
+    context = {
+        field: _nonnegative_int(
+            context_breakdown[field],
+            f"debug_stats.context_breakdown[{field!r}]",
+        )
+        for field in _CONTEXT_FIELDS
+    }
+
+    debug_prefill_requests = _nonnegative_int(
+        _required_attr(
+            debug_stats,
+            "num_prefill_requests",
+            "debug_stats",
+        ),
+        "debug_stats.num_prefill_requests",
+    )
+    debug_decode_requests = _nonnegative_int(
+        _required_attr(
+            debug_stats,
+            "num_decode_requests",
+            "debug_stats",
+        ),
+        "debug_stats.num_decode_requests",
+    )
+    if debug_prefill_requests != context["num_prefill_requests"]:
+        raise VllmStepTraceContractError(
+            "prefill request count disagrees between DebugPerfStats and "
+            "context_breakdown"
+        )
+    if debug_decode_requests != context["num_decode_requests"]:
+        raise VllmStepTraceContractError(
+            "decode request count disagrees between DebugPerfStats and "
+            "context_breakdown"
+        )
+    return debug_stats, context
+
+
+def _classify_zero_work_mfu_estimate(
+    perf_stats: Any,
+    debug_stats: Any,
+) -> str:
+    """Validate and classify vLLM's terminal zero-work MFU estimate.
+
+    vLLM 0.17.1 recomputes MFU stats for its terminal cleanup callback.  The
+    context, FLOPs, and writes are zero, but the estimator can still account
+    for a static read-only weight footprint.  This is not a model execution:
+    the callback has no scheduled request/token and no CUDAGraphStat.  Accept
+    only that narrowly observed, internally balanced artifact.
+    """
+    totals = {
+        "num_flops_per_gpu": _nonnegative_int(
+            _required_attr(
+                perf_stats,
+                "num_flops_per_gpu",
+                "perf_stats",
+            ),
+            "perf_stats.num_flops_per_gpu",
+        ),
+        "num_read_bytes_per_gpu": _nonnegative_int(
+            _required_attr(
+                perf_stats,
+                "num_read_bytes_per_gpu",
+                "perf_stats",
+            ),
+            "perf_stats.num_read_bytes_per_gpu",
+        ),
+        "num_write_bytes_per_gpu": _nonnegative_int(
+            _required_attr(
+                perf_stats,
+                "num_write_bytes_per_gpu",
+                "perf_stats",
+            ),
+            "perf_stats.num_write_bytes_per_gpu",
+        ),
+    }
+    breakdowns = {
+        "num_flops_per_gpu_breakdown": _integer_breakdown(
+            _required_attr(
+                debug_stats,
+                "num_flops_per_gpu_breakdown",
+                "debug_stats",
+            ),
+            "debug_stats.num_flops_per_gpu_breakdown",
+        ),
+        "num_read_bytes_per_gpu_breakdown": _integer_breakdown(
+            _required_attr(
+                debug_stats,
+                "num_read_bytes_per_gpu_breakdown",
+                "debug_stats",
+            ),
+            "debug_stats.num_read_bytes_per_gpu_breakdown",
+        ),
+        "num_write_bytes_per_gpu_breakdown": _integer_breakdown(
+            _required_attr(
+                debug_stats,
+                "num_write_bytes_per_gpu_breakdown",
+                "debug_stats",
+            ),
+            "debug_stats.num_write_bytes_per_gpu_breakdown",
+        ),
+    }
+    breakdown_sums = {
+        name: sum(values.values())
+        for name, values in breakdowns.items()
+    }
+    expected_sums = {
+        "num_flops_per_gpu_breakdown": totals["num_flops_per_gpu"],
+        "num_read_bytes_per_gpu_breakdown": totals[
+            "num_read_bytes_per_gpu"
+        ],
+        "num_write_bytes_per_gpu_breakdown": totals[
+            "num_write_bytes_per_gpu"
+        ],
+    }
+    if breakdown_sums != expected_sums:
+        raise VllmStepTraceContractError(
+            "zero-work MFU cleanup totals disagree with breakdowns: "
+            f"totals={totals}, breakdown_sums="
+            f"{breakdown_sums}"
+        )
+    if (
+        totals["num_flops_per_gpu"] != 0
+        or totals["num_write_bytes_per_gpu"] != 0
+    ):
+        raise VllmStepTraceContractError(
+            "zero-work MFU cleanup has compute or write work: "
+            f"totals={totals}, breakdown_sums={breakdown_sums}"
+        )
+    if totals["num_read_bytes_per_gpu"] == 0:
+        return "finished_request_cleanup_zero_scheduled_work"
+    return (
+        "finished_request_cleanup_zero_scheduled_work_"
+        "with_static_read_estimate"
+    )
+
+
+def build_vllm_step_trace_record(
+    scheduler_stats: Any,
+    iteration_stats: Any,
+    *,
+    engine_idx: int,
+    step_index: int,
+    recorded_at_monotonic_ns: int,
+    trace_window_started_monotonic_ns: int,
+    previous_recorded_at_monotonic_ns: int | None,
+) -> dict[str, Any]:
+    """Convert one vLLM scheduler callback into a JSON-serializable record."""
+    perf_stats = _required_attr(scheduler_stats, "perf_stats", "scheduler_stats")
+    debug_stats, context = _required_mfu_context(perf_stats)
+
+    flops_breakdown = _integer_breakdown(
+        _required_attr(
+            debug_stats,
+            "num_flops_per_gpu_breakdown",
+            "debug_stats",
+        ),
+        "debug_stats.num_flops_per_gpu_breakdown",
+    )
+    read_bytes_breakdown = _integer_breakdown(
+        _required_attr(
+            debug_stats,
+            "num_read_bytes_per_gpu_breakdown",
+            "debug_stats",
+        ),
+        "debug_stats.num_read_bytes_per_gpu_breakdown",
+    )
+    write_bytes_breakdown = _integer_breakdown(
+        _required_attr(
+            debug_stats,
+            "num_write_bytes_per_gpu_breakdown",
+            "debug_stats",
+        ),
+        "debug_stats.num_write_bytes_per_gpu_breakdown",
+    )
+    num_flops_per_gpu = _nonnegative_int(
+        _required_attr(perf_stats, "num_flops_per_gpu", "perf_stats"),
+        "perf_stats.num_flops_per_gpu",
+    )
+    num_read_bytes_per_gpu = _nonnegative_int(
+        _required_attr(perf_stats, "num_read_bytes_per_gpu", "perf_stats"),
+        "perf_stats.num_read_bytes_per_gpu",
+    )
+    num_write_bytes_per_gpu = _nonnegative_int(
+        _required_attr(perf_stats, "num_write_bytes_per_gpu", "perf_stats"),
+        "perf_stats.num_write_bytes_per_gpu",
+    )
+    flops_breakdown_sum = sum(flops_breakdown.values())
+    read_bytes_breakdown_sum = sum(read_bytes_breakdown.values())
+    write_bytes_breakdown_sum = sum(write_bytes_breakdown.values())
+
+    prefill_requests = context["num_prefill_requests"]
+    decode_requests = context["num_decode_requests"]
+    prefill_tokens = context["prefill_num_tokens"]
+    decode_tokens = context["decode_num_tokens"]
+    scheduled_requests = prefill_requests + decode_requests
+    scheduled_tokens = prefill_tokens + decode_tokens
+    token_context_product = (
+        context["prefill_token_context_product"]
+        + context["decode_token_context_product"]
+    )
+
+    cudagraph_stats = _required_attr(
+        scheduler_stats,
+        "cudagraph_stats",
+        "scheduler_stats",
+    )
+    if cudagraph_stats is None:
+        raise VllmStepTraceContractError(
+            "scheduler_stats.cudagraph_stats is None; require "
+            "cudagraph_metrics=True"
+        )
+    unpadded_tokens = _nonnegative_int(
+        _required_attr(
+            cudagraph_stats,
+            "num_unpadded_tokens",
+            "cudagraph_stats",
+        ),
+        "cudagraph_stats.num_unpadded_tokens",
+    )
+    padded_tokens = _nonnegative_int(
+        _required_attr(
+            cudagraph_stats,
+            "num_padded_tokens",
+            "cudagraph_stats",
+        ),
+        "cudagraph_stats.num_padded_tokens",
+    )
+    paddings = _nonnegative_int(
+        _required_attr(cudagraph_stats, "num_paddings", "cudagraph_stats"),
+        "cudagraph_stats.num_paddings",
+    )
+    runtime_mode = _required_attr(
+        cudagraph_stats,
+        "runtime_mode",
+        "cudagraph_stats",
+    )
+    if not isinstance(runtime_mode, str):
+        raise VllmStepTraceContractError(
+            "cudagraph_stats.runtime_mode must be a string"
+        )
+    if recorded_at_monotonic_ns < trace_window_started_monotonic_ns:
+        raise VllmStepTraceContractError(
+            "record timestamp precedes trace-window start"
+        )
+    cadence_ns: int | None = None
+    if previous_recorded_at_monotonic_ns is not None:
+        cadence_ns = recorded_at_monotonic_ns - previous_recorded_at_monotonic_ns
+        if cadence_ns < 0:
+            raise VllmStepTraceContractError(
+                "frontend StatLogger record timestamps are not monotonic"
+            )
+
+    return {
+        "schema_version": VLLM_STEP_TRACE_SCHEMA_VERSION,
+        "phase_classifier": VLLM_STEP_TRACE_PHASE_CLASSIFIER,
+        "engine_idx": _nonnegative_int(engine_idx, "engine_idx"),
+        "step_index": _nonnegative_int(step_index, "step_index"),
+        "frontend_recorded_at_monotonic_ns": recorded_at_monotonic_ns,
+        "since_trace_window_start_ns": (
+            recorded_at_monotonic_ns - trace_window_started_monotonic_ns
+        ),
+        "frontend_observed_cadence_ns": cadence_ns,
+        "post_step_scheduler_state": {
+            "running_requests": _nonnegative_int(
+                _required_attr(
+                    scheduler_stats,
+                    "num_running_reqs",
+                    "scheduler_stats",
+                ),
+                "scheduler_stats.num_running_reqs",
+            ),
+            "waiting_requests": _nonnegative_int(
+                _required_attr(
+                    scheduler_stats,
+                    "num_waiting_reqs",
+                    "scheduler_stats",
+                ),
+                "scheduler_stats.num_waiting_reqs",
+            ),
+            "kv_cache_usage": _nonnegative_number(
+                _required_attr(
+                    scheduler_stats,
+                    "kv_cache_usage",
+                    "scheduler_stats",
+                ),
+                "scheduler_stats.kv_cache_usage",
+            ),
+        },
+        "scheduled": {
+            "request_count": scheduled_requests,
+            "token_count": scheduled_tokens,
+            "token_context_product": token_context_product,
+            "prefill": {
+                "request_count": prefill_requests,
+                "token_count": prefill_tokens,
+                "context_len_sum": context["prefill_context_len"],
+                "mean_context_len": (
+                    context["prefill_context_len"] / prefill_requests
+                    if prefill_requests
+                    else None
+                ),
+                "token_context_product": context[
+                    "prefill_token_context_product"
+                ],
+            },
+            "decode": {
+                "request_count": decode_requests,
+                "token_count": decode_tokens,
+                "context_len_sum": context["decode_context_len"],
+                "mean_context_len": (
+                    context["decode_context_len"] / decode_requests
+                    if decode_requests
+                    else None
+                ),
+                "token_context_product": context[
+                    "decode_token_context_product"
+                ],
+            },
+        },
+        "estimated_work_per_gpu": {
+            "flops": num_flops_per_gpu,
+            "read_bytes": num_read_bytes_per_gpu,
+            "write_bytes": num_write_bytes_per_gpu,
+            "flops_breakdown": flops_breakdown,
+            "flops_breakdown_sum": flops_breakdown_sum,
+            "flops_total_matches_breakdown": (
+                num_flops_per_gpu == flops_breakdown_sum
+            ),
+            "read_bytes_breakdown": read_bytes_breakdown,
+            "read_bytes_breakdown_sum": read_bytes_breakdown_sum,
+            "read_bytes_total_matches_breakdown": (
+                num_read_bytes_per_gpu == read_bytes_breakdown_sum
+            ),
+            "write_bytes_breakdown": write_bytes_breakdown,
+            "write_bytes_breakdown_sum": write_bytes_breakdown_sum,
+            "write_bytes_total_matches_breakdown": (
+                num_write_bytes_per_gpu == write_bytes_breakdown_sum
+            ),
+            "mfu_stats_calculation_seconds": _nonnegative_number(
+                _required_attr(debug_stats, "calc_duration", "debug_stats"),
+                "debug_stats.calc_duration",
+            ),
+        },
+        "cudagraph": {
+            "unpadded_tokens": unpadded_tokens,
+            "padded_tokens": padded_tokens,
+            "padding_tokens": paddings,
+            "runtime_mode": runtime_mode,
+            "unpadded_matches_mfu_scheduled_tokens": (
+                unpadded_tokens == scheduled_tokens
+            ),
+            "padded_equals_unpadded_plus_padding": (
+                padded_tokens == unpadded_tokens + paddings
+            ),
+        },
+        "frontend_output": _optional_iteration_stats(iteration_stats),
+    }
+
+
+def _empty_engine_aggregate(engine_idx: int) -> dict[str, Any]:
+    return {
+        "engine_idx": int(engine_idx),
+        "model_step_count": 0,
+        "step_indexes_contiguous": True,
+        "timestamps_are_internally_consistent": True,
+        "record_schema_match_count": 0,
+        "phase_classifier_match_count": 0,
+        "first_records": [],
+        "last_records": deque(maxlen=3),
+        "timeline_columns": {
+            name: array("q") for name in _TIMELINE_COLUMN_PATHS
+        },
+        # Runtime mode is a string in vLLM's CUDAGraphStat and therefore
+        # cannot share the signed-int timeline encoding above.  Retain one
+        # value per model step so an exact selected range can prove whether
+        # CUDA graphs actually ran instead of merely being allowed.
+        "runtime_mode_timeline": [],
+        "distributions": {
+            "scheduled_request_count": Counter(),
+            "scheduled_token_count": Counter(),
+            "decode_request_count": Counter(),
+            "prefill_request_count": Counter(),
+        },
+        "scheduled": {
+            "request_count_sum": 0,
+            "token_count_sum": 0,
+            "decode": {
+                "request_count_sum": 0,
+                "token_count_sum": 0,
+                "context_len_sum": 0,
+                "token_context_product_sum": 0,
+            },
+            "prefill": {
+                "request_count_sum": 0,
+                "token_count_sum": 0,
+                "context_len_sum": 0,
+                "token_context_product_sum": 0,
+            },
+        },
+        "estimated_work_per_gpu": {
+            "flops_sum": 0,
+            "read_bytes_sum": 0,
+            "write_bytes_sum": 0,
+            "mfu_stats_calculation_seconds_sum": 0.0,
+            "flops_breakdown_component_sums": Counter(),
+            "read_bytes_breakdown_component_sums": Counter(),
+            "write_bytes_breakdown_component_sums": Counter(),
+            "flops_total_matches_breakdown_count": 0,
+            "read_bytes_total_matches_breakdown_count": 0,
+            "write_bytes_total_matches_breakdown_count": 0,
+        },
+        "cudagraph": {
+            "unpadded_token_count_sum": 0,
+            "padded_token_count_sum": 0,
+            "padding_token_count_sum": 0,
+            "unpadded_matches_mfu_scheduled_tokens_count": 0,
+            "padded_equals_unpadded_plus_padding_count": 0,
+            "runtime_mode_model_step_counts": Counter(),
+        },
+        "frontend_output": {
+            "present_model_step_count": 0,
+            "emitted_generation_tokens": 0,
+            "emitted_prompt_tokens": 0,
+            "computed_prompt_tokens": 0,
+            "preempted_requests": 0,
+            "finished_requests": 0,
+        },
+    }
+
+
+def _nested_int(record: dict[str, Any], path: tuple[str, ...]) -> int:
+    value: Any = record
+    for key in path:
+        value = value[key]
+    return int(value)
+
+
+def _update_component_sums(
+    target: Counter[str], values: dict[str, int]
+) -> None:
+    target.update({str(key): int(value) for key, value in values.items()})
+
+
+def _aggregate_record(
+    aggregate: dict[str, Any],
+    record: dict[str, Any],
+    *,
+    trace_window_started_monotonic_ns: int,
+) -> None:
+    step_count = int(aggregate["model_step_count"])
+    step_index = int(record["step_index"])
+    aggregate["step_indexes_contiguous"] = bool(
+        aggregate["step_indexes_contiguous"] and step_index == step_count
+    )
+    aggregate["record_schema_match_count"] += int(
+        record.get("schema_version") == VLLM_STEP_TRACE_SCHEMA_VERSION
+    )
+    aggregate["phase_classifier_match_count"] += int(
+        record.get("phase_classifier") == VLLM_STEP_TRACE_PHASE_CLASSIFIER
+    )
+
+    timestamp_ns = int(record["frontend_recorded_at_monotonic_ns"])
+    timestamp_column = aggregate["timeline_columns"][
+        "recorded_at_monotonic_ns"
+    ]
+    previous_timestamp_ns = (
+        int(timestamp_column[-1]) if timestamp_column else None
+    )
+    cadence_ns = record.get("frontend_observed_cadence_ns")
+    timestamp_contract_valid = (
+        int(record["since_trace_window_start_ns"])
+        == timestamp_ns - trace_window_started_monotonic_ns
+        and (
+            previous_timestamp_ns is None
+            and cadence_ns is None
+            or previous_timestamp_ns is not None
+            and cadence_ns is not None
+            and timestamp_ns > previous_timestamp_ns
+            and int(cadence_ns) == timestamp_ns - previous_timestamp_ns
+        )
+    )
+    aggregate["timestamps_are_internally_consistent"] = bool(
+        aggregate["timestamps_are_internally_consistent"]
+        and timestamp_contract_valid
+    )
+
+    for name, path in _TIMELINE_COLUMN_PATHS.items():
+        aggregate["timeline_columns"][name].append(_nested_int(record, path))
+
+    if step_count < 3:
+        aggregate["first_records"].append(record)
+    aggregate["last_records"].append(record)
+
+    scheduled = record["scheduled"]
+    decode = scheduled["decode"]
+    prefill = scheduled["prefill"]
+    distributions = aggregate["distributions"]
+    distributions["scheduled_request_count"].update(
+        [int(scheduled["request_count"])]
+    )
+    distributions["scheduled_token_count"].update(
+        [int(scheduled["token_count"])]
+    )
+    distributions["decode_request_count"].update(
+        [int(decode["request_count"])]
+    )
+    distributions["prefill_request_count"].update(
+        [int(prefill["request_count"])]
+    )
+
+    aggregate_scheduled = aggregate["scheduled"]
+    aggregate_scheduled["request_count_sum"] += int(
+        scheduled["request_count"]
+    )
+    aggregate_scheduled["token_count_sum"] += int(scheduled["token_count"])
+    for phase, values in (("decode", decode), ("prefill", prefill)):
+        phase_aggregate = aggregate_scheduled[phase]
+        phase_aggregate["request_count_sum"] += int(values["request_count"])
+        phase_aggregate["token_count_sum"] += int(values["token_count"])
+        phase_aggregate["context_len_sum"] += int(values["context_len_sum"])
+        phase_aggregate["token_context_product_sum"] += int(
+            values["token_context_product"]
+        )
+
+    estimated = record["estimated_work_per_gpu"]
+    aggregate_estimated = aggregate["estimated_work_per_gpu"]
+    aggregate_estimated["flops_sum"] += int(estimated["flops"])
+    aggregate_estimated["read_bytes_sum"] += int(estimated["read_bytes"])
+    aggregate_estimated["write_bytes_sum"] += int(estimated["write_bytes"])
+    aggregate_estimated["mfu_stats_calculation_seconds_sum"] += float(
+        estimated["mfu_stats_calculation_seconds"]
+    )
+    for field in ("flops", "read_bytes", "write_bytes"):
+        _update_component_sums(
+            aggregate_estimated[f"{field}_breakdown_component_sums"],
+            estimated[f"{field}_breakdown"],
+        )
+        aggregate_estimated[
+            f"{field}_total_matches_breakdown_count"
+        ] += int(estimated[f"{field}_total_matches_breakdown"])
+
+    cudagraph = record["cudagraph"]
+    aggregate_cudagraph = aggregate["cudagraph"]
+    aggregate_cudagraph["unpadded_token_count_sum"] += int(
+        cudagraph["unpadded_tokens"]
+    )
+    aggregate_cudagraph["padded_token_count_sum"] += int(
+        cudagraph["padded_tokens"]
+    )
+    aggregate_cudagraph["padding_token_count_sum"] += int(
+        cudagraph["padding_tokens"]
+    )
+    aggregate_cudagraph[
+        "unpadded_matches_mfu_scheduled_tokens_count"
+    ] += int(cudagraph["unpadded_matches_mfu_scheduled_tokens"])
+    aggregate_cudagraph[
+        "padded_equals_unpadded_plus_padding_count"
+    ] += int(cudagraph["padded_equals_unpadded_plus_padding"])
+    aggregate_cudagraph["runtime_mode_model_step_counts"].update(
+        [str(cudagraph["runtime_mode"])]
+    )
+    aggregate["runtime_mode_timeline"].append(
+        str(cudagraph["runtime_mode"])
+    )
+
+    frontend_output = record["frontend_output"]
+    if frontend_output["present"]:
+        aggregate_frontend = aggregate["frontend_output"]
+        aggregate_frontend["present_model_step_count"] += 1
+        for field in (
+            "emitted_generation_tokens",
+            "emitted_prompt_tokens",
+            "computed_prompt_tokens",
+            "preempted_requests",
+            "finished_requests",
+        ):
+            aggregate_frontend[field] += int(frontend_output[field])
+
+    aggregate["model_step_count"] = step_count + 1
+
+
+def _snapshot_engine_aggregate(
+    aggregate: dict[str, Any],
+) -> dict[str, Any]:
+    step_count = int(aggregate["model_step_count"])
+    return {
+        "engine_idx": int(aggregate["engine_idx"]),
+        "model_step_count": step_count,
+        "first_step_index": 0 if step_count else None,
+        "last_step_index": step_count - 1 if step_count else None,
+        "step_indexes_contiguous": bool(
+            aggregate["step_indexes_contiguous"]
+        ),
+        "timestamps_are_internally_consistent": bool(
+            aggregate["timestamps_are_internally_consistent"]
+        ),
+        "record_schema_match_count": int(
+            aggregate["record_schema_match_count"]
+        ),
+        "phase_classifier_match_count": int(
+            aggregate["phase_classifier_match_count"]
+        ),
+        "first_records": copy.deepcopy(aggregate["first_records"]),
+        "last_records": copy.deepcopy(list(aggregate["last_records"])),
+        "timeline_columns": {
+            name: copy.copy(values)
+            for name, values in aggregate["timeline_columns"].items()
+        },
+        "runtime_mode_timeline": list(
+            aggregate["runtime_mode_timeline"]
+        ),
+        "distributions": {
+            name: dict(values)
+            for name, values in aggregate["distributions"].items()
+        },
+        "scheduled": copy.deepcopy(aggregate["scheduled"]),
+        "estimated_work_per_gpu": {
+            key: (
+                dict(value) if isinstance(value, Counter) else value
+            )
+            for key, value in aggregate["estimated_work_per_gpu"].items()
+        },
+        "cudagraph": {
+            key: (
+                dict(value) if isinstance(value, Counter) else value
+            )
+            for key, value in aggregate["cudagraph"].items()
+        },
+        "frontend_output": copy.deepcopy(aggregate["frontend_output"]),
+    }
+
+
+class VllmStepTraceBuffer:
+    """Thread-safe online aggregate used by the vLLM custom stat logger."""
+
+    def __init__(
+        self,
+        engine_indexes: list[int],
+        *,
+        max_records_per_engine: int = VLLM_STEP_TRACE_DEFAULT_MAX_RECORDS,
+        monotonic_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        if max_records_per_engine <= 0:
+            raise ValueError("max_records_per_engine must be positive")
+        self._engine_indexes = [int(engine_idx) for engine_idx in engine_indexes]
+        self._max_records_per_engine = int(max_records_per_engine)
+        self._monotonic_ns = monotonic_ns
+        self._lock = threading.Lock()
+        self._clear_locked(self._monotonic_ns())
+
+    def _clear_locked(self, started_at_ns: int) -> None:
+        self._window_started_at_ns = started_at_ns
+        self._aggregates: dict[int, dict[str, Any]] = {
+            engine_idx: _empty_engine_aggregate(engine_idx)
+            for engine_idx in self._engine_indexes
+        }
+        self._errors: list[dict[str, Any]] = []
+        self._error_count = 0
+        self._dropped_error_count = 0
+        self._ignored_non_step_callbacks: dict[int, int] = {
+            engine_idx: 0 for engine_idx in self._engine_indexes
+        }
+        self._ignored_non_step_callbacks_by_reason: dict[
+            int, Counter[str]
+        ] = {
+            engine_idx: Counter() for engine_idx in self._engine_indexes
+        }
+        self._ignored_non_step_callbacks_with_frontend_token_activity: dict[
+            int, int
+        ] = {engine_idx: 0 for engine_idx in self._engine_indexes}
+        self._ignored_non_step_callbacks_with_unverifiable_frontend_output: (
+            dict[int, int]
+        ) = {engine_idx: 0 for engine_idx in self._engine_indexes}
+        self._dropped_records: dict[int, int] = {
+            engine_idx: 0 for engine_idx in self._engine_indexes
+        }
+        self._previous_recorded_at_ns: dict[int, int | None] = {
+            engine_idx: None for engine_idx in self._engine_indexes
+        }
+        self._next_step_index: dict[int, int] = {
+            engine_idx: 0 for engine_idx in self._engine_indexes
+        }
+
+    def clear(self) -> None:
+        with self._lock:
+            self._clear_locked(self._monotonic_ns())
+
+    def _ensure_engine(self, engine_idx: int) -> None:
+        if engine_idx in self._aggregates:
+            return
+        self._aggregates[engine_idx] = _empty_engine_aggregate(engine_idx)
+        self._ignored_non_step_callbacks[engine_idx] = 0
+        self._ignored_non_step_callbacks_by_reason[engine_idx] = Counter()
+        self._ignored_non_step_callbacks_with_frontend_token_activity[
+            engine_idx
+        ] = 0
+        self._ignored_non_step_callbacks_with_unverifiable_frontend_output[
+            engine_idx
+        ] = 0
+        self._dropped_records[engine_idx] = 0
+        self._previous_recorded_at_ns[engine_idx] = None
+        self._next_step_index[engine_idx] = 0
+
+    def record(
+        self,
+        scheduler_stats: Any,
+        iteration_stats: Any,
+        *,
+        engine_idx: int,
+    ) -> None:
+        """Record a model step without allowing instrumentation to kill vLLM."""
+        recorded_at_ns = self._monotonic_ns()
+        engine_idx = int(engine_idx)
+        with self._lock:
+            self._ensure_engine(engine_idx)
+            step_index = self._next_step_index[engine_idx]
+            try:
+                # vLLM emits stats-only control callbacks with no PerfStats.
+                # It also emits one finished-request cleanup callback after the
+                # final real step.  That cleanup gets a newly computed, zero-
+                # work MFU context but no GPU-runner CUDAGraphStat.  Classify it
+                # only from the exact scheduled-work context; positive work
+                # without CUDAGraphStats remains a contract error.
+                ignored_reason: str | None = None
+                if scheduler_stats is None:
+                    ignored_reason = "scheduler_stats_missing"
+                elif getattr(scheduler_stats, "perf_stats", None) is None:
+                    ignored_reason = "perf_stats_missing"
+                else:
+                    debug_stats, context = _required_mfu_context(
+                        scheduler_stats.perf_stats
+                    )
+                    scheduled_requests = (
+                        context["num_prefill_requests"]
+                        + context["num_decode_requests"]
+                    )
+                    scheduled_tokens = (
+                        context["prefill_num_tokens"]
+                        + context["decode_num_tokens"]
+                    )
+                    if (scheduled_requests == 0) != (scheduled_tokens == 0):
+                        raise VllmStepTraceContractError(
+                            "MFU context has inconsistent zero scheduled "
+                            f"work: requests={scheduled_requests}, "
+                            f"tokens={scheduled_tokens}"
+                        )
+                    if scheduled_requests == 0:
+                        if any(context.values()):
+                            raise VllmStepTraceContractError(
+                                "zero-work MFU cleanup context must have all "
+                                "context_breakdown fields equal to zero"
+                            )
+                        cudagraph_stats = _required_attr(
+                            scheduler_stats,
+                            "cudagraph_stats",
+                            "scheduler_stats",
+                        )
+                        if cudagraph_stats is not None:
+                            raise VllmStepTraceContractError(
+                                "zero-work MFU cleanup unexpectedly has "
+                                "cudagraph_stats"
+                            )
+                        running_requests = _nonnegative_int(
+                            _required_attr(
+                                scheduler_stats,
+                                "num_running_reqs",
+                                "scheduler_stats",
+                            ),
+                            "scheduler_stats.num_running_reqs",
+                        )
+                        waiting_requests = _nonnegative_int(
+                            _required_attr(
+                                scheduler_stats,
+                                "num_waiting_reqs",
+                                "scheduler_stats",
+                            ),
+                            "scheduler_stats.num_waiting_reqs",
+                        )
+                        if running_requests or waiting_requests:
+                            raise VllmStepTraceContractError(
+                                "zero-work MFU cleanup has nonempty scheduler "
+                                f"state: running={running_requests}, "
+                                f"waiting={waiting_requests}"
+                            )
+                        ignored_reason = _classify_zero_work_mfu_estimate(
+                            scheduler_stats.perf_stats,
+                            debug_stats,
+                        )
+
+                if ignored_reason is not None:
+                    self._ignored_non_step_callbacks[engine_idx] += 1
+                    self._ignored_non_step_callbacks_by_reason[engine_idx][
+                        ignored_reason
+                    ] += 1
+                    try:
+                        frontend_output = _optional_iteration_stats(
+                            iteration_stats
+                        )
+                    except Exception:
+                        self._ignored_non_step_callbacks_with_unverifiable_frontend_output[
+                            engine_idx
+                        ] += 1
+                    else:
+                        if frontend_output["present"] and any(
+                            int(frontend_output[field]) != 0
+                            for field in (
+                                "emitted_generation_tokens",
+                                "emitted_prompt_tokens",
+                                "computed_prompt_tokens",
+                                "preempted_requests",
+                            )
+                        ):
+                            self._ignored_non_step_callbacks_with_frontend_token_activity[
+                                engine_idx
+                            ] += 1
+                    return
+
+                record = build_vllm_step_trace_record(
+                    scheduler_stats,
+                    iteration_stats,
+                    engine_idx=engine_idx,
+                    step_index=step_index,
+                    recorded_at_monotonic_ns=recorded_at_ns,
+                    trace_window_started_monotonic_ns=self._window_started_at_ns,
+                    previous_recorded_at_monotonic_ns=(
+                        self._previous_recorded_at_ns[engine_idx]
+                    ),
+                )
+                if (
+                    int(self._aggregates[engine_idx]["model_step_count"])
+                    >= self._max_records_per_engine
+                ):
+                    self._dropped_records[engine_idx] += 1
+                else:
+                    _aggregate_record(
+                        self._aggregates[engine_idx],
+                        record,
+                        trace_window_started_monotonic_ns=(
+                            self._window_started_at_ns
+                        ),
+                    )
+            except Exception as error:
+                self._error_count += 1
+                if len(self._errors) < VLLM_STEP_TRACE_MAX_RETAINED_ERRORS:
+                    self._errors.append(
+                        {
+                            "engine_idx": engine_idx,
+                            "step_index": step_index,
+                            "frontend_recorded_at_monotonic_ns": recorded_at_ns,
+                            "error_type": type(error).__name__,
+                            "error": str(error),
+                        }
+                    )
+                else:
+                    self._dropped_error_count += 1
+                return
+
+            self._next_step_index[engine_idx] += 1
+            self._previous_recorded_at_ns[engine_idx] = recorded_at_ns
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "schema_version": VLLM_STEP_TRACE_SCHEMA_VERSION,
+                "capture_contract": {
+                    "source": (
+                        "SchedulerStats.perf_stats.debug_stats.context_breakdown"
+                    ),
+                    "model_step_discriminator": (
+                        VLLM_STEP_TRACE_MODEL_STEP_DISCRIMINATOR
+                    ),
+                    "model_step_discriminator_semantics": (
+                        "stats-only callbacks without PerfStats are control "
+                        "events; a PerfStats callback is ignored as finished-"
+                        "request cleanup only when every MFU context field is "
+                        "zero, scheduler running/waiting counts are zero, and "
+                        "CUDAGraphStat is absent. The terminal vLLM 0.17.1 "
+                        "read-only static-weight MFU estimate is accepted only "
+                        "when FLOPs/writes are zero and all totals equal their "
+                        "breakdowns; every positive scheduled-work callback "
+                        "requires CUDAGraphStat; ignored callbacks must report "
+                        "no new frontend token or preemption activity"
+                    ),
+                    "phase_classifier": VLLM_STEP_TRACE_PHASE_CLASSIFIER,
+                    "phase_classifier_rule": (
+                        "new requests are prefill; cached requests with "
+                        "num_scheduled_tokens > 1 are prefill; other cached "
+                        "requests are decode"
+                    ),
+                    "scheduler_state_semantics": "post_step_queue_state",
+                    "aggregation_version": (
+                        VLLM_STEP_TRACE_AGGREGATION_VERSION
+                    ),
+                    "aggregation_semantics": (
+                        "worker-side exact counters/distributions plus compact "
+                        "per-step timeline columns and bounded first/last "
+                        "record samples; full nested records are not retained"
+                    ),
+                    "timeline_column_encoding": (
+                        VLLM_STEP_TRACE_TIMELINE_COLUMN_ENCODING
+                    ),
+                    "retained_record_samples_per_edge": 3,
+                    "cadence_semantics": (
+                        "consecutive AsyncLLM frontend StatLogger.record "
+                        "callback interval; not model execution latency"
+                    ),
+                },
+                "capture_hostname": os.uname().nodename,
+                "trace_window_started_monotonic_ns": self._window_started_at_ns,
+                "max_records_per_engine": self._max_records_per_engine,
+                "aggregates_by_engine": {
+                    engine_idx: _snapshot_engine_aggregate(aggregate)
+                    for engine_idx, aggregate in self._aggregates.items()
+                },
+                "errors": copy.deepcopy(self._errors),
+                "error_count": self._error_count,
+                "dropped_error_count": self._dropped_error_count,
+                "ignored_non_step_callbacks_by_engine": copy.deepcopy(
+                    self._ignored_non_step_callbacks
+                ),
+                "ignored_non_step_callbacks_by_reason_by_engine": {
+                    engine_idx: dict(sorted(reason_counts.items()))
+                    for engine_idx, reason_counts in (
+                        self._ignored_non_step_callbacks_by_reason.items()
+                    )
+                },
+                "ignored_non_step_callbacks_with_frontend_token_activity_by_engine": (
+                    copy.deepcopy(
+                        self._ignored_non_step_callbacks_with_frontend_token_activity
+                    )
+                ),
+                "ignored_non_step_callbacks_with_unverifiable_frontend_output_by_engine": (
+                    copy.deepcopy(
+                        self._ignored_non_step_callbacks_with_unverifiable_frontend_output
+                    )
+                ),
+                "dropped_records_by_engine": copy.deepcopy(self._dropped_records),
+            }
+
+
+def summarize_exact_model_step_range(
+    raw_trace_by_dp: dict[int, dict[str, Any]],
+    *,
+    start_step_index: int,
+    stop_step_index: int,
+) -> dict[str, Any]:
+    """Select one exact, post-step-frontend-observed model-step range.
+
+    Step indexes are the zero-based, contiguous indexes assigned by
+    :class:`VllmStepTraceBuffer`.  The selected range is left-inclusive and
+    right-exclusive.  Exact elapsed time is measured from the callback after
+    ``start_step_index - 1`` through the callback after
+    ``stop_step_index - 1``; this is why a start index of zero is rejected.
+
+    The timestamps remain frontend observations and are not GPU timestamps.
+    The selector is nevertheless exact about which model-step records and
+    scheduler work enter the summary.
+    """
+    if (
+        isinstance(start_step_index, bool)
+        or not isinstance(start_step_index, int)
+        or isinstance(stop_step_index, bool)
+        or not isinstance(stop_step_index, int)
+        or start_step_index < 1
+        or stop_step_index <= start_step_index
+    ):
+        raise VllmStepTraceContractError(
+            "exact model-step range must be positive and nonempty: "
+            f"[{start_step_index!r}, {stop_step_index!r})"
+        )
+    if not isinstance(raw_trace_by_dp, dict) or not raw_trace_by_dp:
+        raise VllmStepTraceContractError(
+            "exact model-step selection requires at least one DP trace"
+        )
+
+    expected_columns = set(_TIMELINE_COLUMN_PATHS)
+    summed_columns = tuple(
+        name
+        for name in _TIMELINE_COLUMN_PATHS
+        if name != "recorded_at_monotonic_ns"
+    )
+    selected_step_count = stop_step_index - start_step_index
+    per_engine: list[dict[str, Any]] = []
+
+    for raw_dp_idx, snapshot in sorted(
+        raw_trace_by_dp.items(), key=lambda item: int(item[0])
+    ):
+        dp_idx = int(raw_dp_idx)
+        if not isinstance(snapshot, dict):
+            raise VllmStepTraceContractError(
+                f"DP {dp_idx} step trace is not a dictionary"
+            )
+        contract = snapshot.get("capture_contract")
+        if (
+            snapshot.get("schema_version") != VLLM_STEP_TRACE_SCHEMA_VERSION
+            or not isinstance(contract, dict)
+            or contract.get("aggregation_version")
+            != VLLM_STEP_TRACE_AGGREGATION_VERSION
+            or contract.get("timeline_column_encoding")
+            != VLLM_STEP_TRACE_TIMELINE_COLUMN_ENCODING
+        ):
+            raise VllmStepTraceContractError(
+                f"DP {dp_idx} step trace does not match the exact-range contract"
+            )
+        if (
+            int(snapshot.get("error_count", -1)) != 0
+            or int(snapshot.get("dropped_error_count", -1)) != 0
+            or snapshot.get("errors") != []
+        ):
+            raise VllmStepTraceContractError(
+                f"DP {dp_idx} step trace contains retained or dropped errors"
+            )
+        raw_drops = snapshot.get("dropped_records_by_engine")
+        if (
+            not isinstance(raw_drops, dict)
+            or not raw_drops
+            or any(int(value) != 0 for value in raw_drops.values())
+        ):
+            raise VllmStepTraceContractError(
+                f"DP {dp_idx} step trace contains dropped model steps"
+            )
+        aggregates = snapshot.get("aggregates_by_engine")
+        if not isinstance(aggregates, dict) or not aggregates:
+            raise VllmStepTraceContractError(
+                f"DP {dp_idx} step trace has no engine aggregates"
+            )
+
+        for raw_engine_idx, aggregate in sorted(
+            aggregates.items(), key=lambda item: int(item[0])
+        ):
+            engine_idx = int(raw_engine_idx)
+            if not isinstance(aggregate, dict):
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} aggregate is invalid"
+                )
+            model_step_count = int(aggregate.get("model_step_count", -1))
+            if (
+                model_step_count < stop_step_index
+                or aggregate.get("step_indexes_contiguous") is not True
+                or int(aggregate.get("first_step_index", -1)) != 0
+                or int(aggregate.get("last_step_index", -1))
+                != model_step_count - 1
+            ):
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} does not cover contiguous "
+                    f"steps [0, {stop_step_index})"
+                )
+            timeline = aggregate.get("timeline_columns")
+            if not isinstance(timeline, dict) or set(timeline) != expected_columns:
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} timeline columns differ"
+                )
+            columns = {
+                name: [int(value) for value in values]
+                for name, values in timeline.items()
+            }
+            if any(
+                len(values) != model_step_count for values in columns.values()
+            ):
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} timeline is truncated"
+                )
+            runtime_mode_timeline = aggregate.get(
+                "runtime_mode_timeline"
+            )
+            if (
+                not isinstance(runtime_mode_timeline, list)
+                or len(runtime_mode_timeline) != model_step_count
+                or any(
+                    not isinstance(mode, str) or not mode
+                    for mode in runtime_mode_timeline
+                )
+            ):
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} runtime-mode timeline "
+                    "is truncated or invalid"
+                )
+            timestamps = columns["recorded_at_monotonic_ns"]
+            if (
+                aggregate.get("timestamps_are_internally_consistent") is not True
+                or any(
+                    right <= left
+                    for left, right in zip(timestamps, timestamps[1:])
+                )
+            ):
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} timestamps are invalid"
+                )
+
+            boundary_before_start_ns = timestamps[start_step_index - 1]
+            boundary_after_stop_ns = timestamps[stop_step_index - 1]
+            elapsed_ns = boundary_after_stop_ns - boundary_before_start_ns
+            if elapsed_ns <= 0:
+                raise VllmStepTraceContractError(
+                    f"DP {dp_idx}/engine {engine_idx} selected duration is not "
+                    "positive"
+                )
+            selected_columns = {
+                name: values[start_step_index:stop_step_index]
+                for name, values in columns.items()
+                if name != "recorded_at_monotonic_ns"
+            }
+            selected_runtime_modes = runtime_mode_timeline[
+                start_step_index:stop_step_index
+            ]
+            runtime_mode_counts = dict(
+                sorted(Counter(selected_runtime_modes).items())
+            )
+            sums = {
+                name: sum(selected_columns[name]) for name in summed_columns
+            }
+            decode_requests = sums["decode_request_count"]
+            per_engine.append(
+                {
+                    "dp_idx": dp_idx,
+                    "engine_idx": engine_idx,
+                    "available_model_step_count": model_step_count,
+                    "selected_model_step_count": selected_step_count,
+                    "boundary_after_previous_step_monotonic_ns": (
+                        boundary_before_start_ns
+                    ),
+                    "boundary_after_final_selected_step_monotonic_ns": (
+                        boundary_after_stop_ns
+                    ),
+                    "frontend_observed_elapsed_ns": elapsed_ns,
+                    "frontend_observed_model_steps_per_s": (
+                        selected_step_count * 1_000_000_000 / elapsed_ns
+                    ),
+                    "minimum_scheduled_requests_per_step": min(
+                        selected_columns["scheduled_request_count"]
+                    ),
+                    "maximum_prefill_requests_per_step": max(
+                        selected_columns["prefill_request_count"]
+                    ),
+                    "mean_scheduled_requests_per_step": (
+                        sums["scheduled_request_count"] / selected_step_count
+                    ),
+                    "mean_scheduled_tokens_per_step": (
+                        sums["scheduled_token_count"] / selected_step_count
+                    ),
+                    "mean_decode_requests_per_step": (
+                        decode_requests / selected_step_count
+                    ),
+                    "request_weighted_mean_decode_context_len": (
+                        sums["decode_context_len_sum"] / decode_requests
+                        if decode_requests
+                        else None
+                    ),
+                    "prefill_requests_per_step": (
+                        sums["prefill_request_count"] / selected_step_count
+                    ),
+                    "padding_tokens_per_step": (
+                        sums["padding_token_count"] / selected_step_count
+                    ),
+                    "estimated_flops_per_gpu_per_step": (
+                        sums["estimated_flops_per_gpu"] / selected_step_count
+                    ),
+                    "estimated_read_bytes_per_gpu_per_step": (
+                        sums["estimated_read_bytes_per_gpu"]
+                        / selected_step_count
+                    ),
+                    "aggregate_sums": sums,
+                    "runtime_mode_model_step_counts": runtime_mode_counts,
+                    "selected_runtime_mode_sha256": _canonical_sha256(
+                        selected_runtime_modes
+                    ),
+                    "selected_work_columns_sha256": _canonical_sha256(
+                        {
+                            "start_step_index": start_step_index,
+                            "stop_step_index": stop_step_index,
+                            "columns": selected_columns,
+                        }
+                    ),
+                }
+            )
+
+    return {
+        "schema": "nrl-vllm-exact-model-step-range-v1",
+        "step_index_semantics": (
+            "zero-based contiguous worker-observed model-step index; "
+            "left-inclusive and right-exclusive"
+        ),
+        "timing_semantics": (
+            "elapsed frontend StatLogger callback time from immediately after "
+            "step start-1 through immediately after step stop-1; exact record "
+            "membership but not GPU execution latency"
+        ),
+        "start_step_index": start_step_index,
+        "stop_step_index": stop_step_index,
+        "selected_model_step_count_per_engine": selected_step_count,
+        "engine_count": len(per_engine),
+        "per_engine": per_engine,
+        "all_selected_work_columns_sha256": _canonical_sha256(
+            [
+                {
+                    "dp_idx": item["dp_idx"],
+                    "engine_idx": item["engine_idx"],
+                    "selected_work_columns_sha256": item[
+                        "selected_work_columns_sha256"
+                    ],
+                }
+                for item in per_engine
+            ]
+        ),
+    }
+
+
+@lru_cache(maxsize=1)
+def get_vllm_step_trace_logger_class() -> type[Any]:
+    """Create the custom logger only after the worker has imported vLLM."""
+    from vllm.v1.metrics.loggers import AggregateStatLoggerBase
+
+    class NrlVllmStepTraceStatLogger(AggregateStatLoggerBase):
+        _nrl_vllm_step_trace_logger = True
+
+        def __init__(self, vllm_config: Any, engine_indexes: list[int]) -> None:
+            self.vllm_config = vllm_config
+            raw_max_records = os.environ.get(
+                "NRL_VLLM_STEP_TRACE_MAX_RECORDS",
+                str(VLLM_STEP_TRACE_DEFAULT_MAX_RECORDS),
+            )
+            try:
+                max_records = int(raw_max_records)
+            except ValueError as error:
+                raise ValueError(
+                    "NRL_VLLM_STEP_TRACE_MAX_RECORDS must be an integer, "
+                    f"got {raw_max_records!r}"
+                ) from error
+            self._buffer = VllmStepTraceBuffer(
+                engine_indexes,
+                max_records_per_engine=max_records,
+            )
+
+        def record(
+            self,
+            scheduler_stats: Any,
+            iteration_stats: Any,
+            mm_cache_stats: Any = None,
+            engine_idx: int = 0,
+        ) -> None:
+            del mm_cache_stats
+            self._buffer.record(
+                scheduler_stats,
+                iteration_stats,
+                engine_idx=engine_idx,
+            )
+
+        def log_engine_initialized(self) -> None:
+            pass
+
+        def clear(self) -> None:
+            self._buffer.clear()
+
+        def snapshot(self) -> dict[str, Any]:
+            return self._buffer.snapshot()
+
+    NrlVllmStepTraceStatLogger.__name__ = "NrlVllmStepTraceStatLogger"
+    NrlVllmStepTraceStatLogger.__qualname__ = "NrlVllmStepTraceStatLogger"
+    return NrlVllmStepTraceStatLogger

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -31,10 +31,133 @@ from nemo_rl.models.generation.interfaces import (
     verify_right_padding,
 )
 from nemo_rl.models.generation.vllm.config import VllmConfig
+from nemo_rl.models.generation.vllm.inflight_profiler import (
+    InflightProfiler,
+    find_vllm_scheduler,
+    inflight_interval_s,
+    inflight_profiling_enabled,
+    read_scheduler_sample,
+)
 from nemo_rl.models.generation.vllm.utils import format_prompt_for_vllm_generation
 from nemo_rl.models.huggingface.common import ModelFlag
 from nemo_rl.models.policy.utils import is_vllm_v1_engine_enabled
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
+
+
+_VLLM_INNER_NSYS_MODE_ENV = "NRL_VLLM_INNER_NSYS_MODE"
+_VLLM_INNER_NSYS_MODES = frozenset(
+    {"cuda_graph", "cuda_hw", "cuda_node"}
+)
+_RAY_ENABLE_UV_RUN_RUNTIME_ENV = "RAY_ENABLE_UV_RUN_RUNTIME_ENV"
+_VLLM_NCCL_RUNTIME_ENV_VARS = (
+    "NCCL_CUMEM_ENABLE",
+    "NCCL_NVLS_ENABLE",
+)
+
+
+def _get_vllm_inner_nsys_mode() -> str | None:
+    """Return the validated inner vLLM Ray-worker Nsight mode."""
+
+    mode = os.environ.get(_VLLM_INNER_NSYS_MODE_ENV)
+    if mode is None or mode == "":
+        return None
+    if mode not in _VLLM_INNER_NSYS_MODES:
+        choices = ", ".join(sorted(_VLLM_INNER_NSYS_MODES))
+        raise ValueError(
+            f"{_VLLM_INNER_NSYS_MODE_ENV} must be one of {choices}; "
+            f"got {mode!r}"
+        )
+    return mode
+
+
+def _get_vllm_inner_nsys_config(mode: str) -> dict[str, str]:
+    """Build a bounded Nsight config for vLLM's inner Ray workers."""
+
+    if mode not in _VLLM_INNER_NSYS_MODES:
+        choices = ", ".join(sorted(_VLLM_INNER_NSYS_MODES))
+        raise ValueError(
+            f"inner vLLM Nsight mode must be one of {choices}; got {mode!r}"
+        )
+    config = {
+        "t": (
+            "cuda,nvtx"
+            if mode in {"cuda_graph", "cuda_node"}
+            else "cuda-hw,nvtx"
+        ),
+        "o": "'worker_process_%p'",
+        "stop-on-exit": "true",
+        "capture-range": "cudaProfilerApi",
+        "capture-range-end": "stop",
+    }
+    if mode in {"cuda_graph", "cuda_node"}:
+        config["cuda-graph-trace"] = (
+            "node" if mode == "cuda_node" else "graph"
+        )
+    return config
+
+
+def _build_vllm_nested_runtime_env(
+    python_executable: str,
+) -> dict[str, Any]:
+    """Build the runtime environment passed to vLLM's model workers."""
+
+    runtime_env: dict[str, Any] = {
+        "py_executable": python_executable,
+        "env_vars": {
+            _RAY_ENABLE_UV_RUN_RUNTIME_ENV: os.environ.get(
+                _RAY_ENABLE_UV_RUN_RUNTIME_ENV, "0"
+            )
+        },
+    }
+    for env_name in _VLLM_NCCL_RUNTIME_ENV_VARS:
+        if env_name in os.environ:
+            runtime_env["env_vars"][env_name] = os.environ[env_name]
+    if os.environ.get("NRL_VLLM_PROPAGATE_PYTHONPATH") == "1":
+        pythonpath = os.environ.get("PYTHONPATH")
+        if not pythonpath:
+            raise RuntimeError(
+                "NRL_VLLM_PROPAGATE_PYTHONPATH=1 requires PYTHONPATH"
+            )
+        runtime_env["env_vars"].update(
+            {
+                "PYTHONPATH": pythonpath,
+                "NRL_VLLM_PROPAGATE_PYTHONPATH": "1",
+            }
+        )
+        if os.environ.get("NRL_FORCED_SEQUENCE_AUDIT") == "1":
+            runtime_env["env_vars"]["NRL_FORCED_SEQUENCE_AUDIT"] = "1"
+
+    inner_nsys_mode = _get_vllm_inner_nsys_mode()
+    if inner_nsys_mode is not None:
+        runtime_env["nsight"] = _get_vllm_inner_nsys_config(
+            inner_nsys_mode
+        )
+        runtime_env.setdefault("env_vars", {})[
+            _VLLM_INNER_NSYS_MODE_ENV
+        ] = inner_nsys_mode
+    return runtime_env
+
+
+def _configure_vllm_ray_worker_nsight(
+    vllm_kwargs: dict[str, Any],
+    *,
+    profiling_requested: bool,
+) -> str | None:
+    """Select custom bounded or legacy vLLM-managed Ray-worker profiling."""
+
+    inner_nsys_mode = _get_vllm_inner_nsys_mode()
+    if vllm_kwargs.get("distributed_executor_backend") != "ray":
+        return inner_nsys_mode
+    if inner_nsys_mode is not None:
+        # The custom runtime_env.nsight entry is injected by
+        # NemoRayDistributedExecutor. Enabling vLLM's flag as well would
+        # overwrite it with vLLM's unbounded node-level CUDA Graph trace.
+        vllm_kwargs["ray_workers_use_nsight"] = False
+    elif profiling_requested:
+        # Preserve the existing vLLM-managed behavior when the opt-in mode is
+        # unset.
+        vllm_kwargs["ray_workers_use_nsight"] = True
+    return inner_nsys_mode
 
 
 # Use a base class to share some functions to avoid code duplication.
@@ -144,6 +267,10 @@ class BaseVllmGenerationWorker:
 
         # Store the Python executable being used by this worker
         self.py_executable = sys.executable
+        self._vllm_nested_runtime_env: dict[str, Any] | None = None
+        self._vllm_env_copy_layout: str | None = None
+        self._vllm_nested_runtime_env_patch_verified = False
+        self._vllm_nested_runtime_env_contract_sha256: str | None = None
 
         # Skip model loading if we're not the model owner
         if not self.is_model_owner:
@@ -193,44 +320,6 @@ class BaseVllmGenerationWorker:
                 )
 
             return file_path
-
-        def _patch_vllm_init_workers_ray():
-            """Patch the vLLM ray_distributed_executor.py file.
-
-            1. Pass custom runtime_env in _init_workers_ray call.
-                - This allows passing custom py_executable to worker initialization.
-            2. Add NCCL_CUMEM_ENABLE and NCCL_NVLS_ENABLE to vLLM ADDITIONAL_ENV_VARS.
-                - This is a workaround to fix async vllm in some scenarios.
-                - See https://github.com/NVIDIA-NeMo/RL/pull/898 for more details.
-            """
-            file_to_patch = _get_vllm_file("v1/executor/ray_executor.py")
-
-            with open(file_to_patch, "r") as f:
-                content = f.read()
-
-            old_lines = [
-                "self._init_workers_ray(placement_group)",
-                'ADDITIONAL_ENV_VARS = {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"}',
-            ]
-
-            new_lines = [
-                f'self._init_workers_ray(placement_group, runtime_env={{"py_executable": "{self.py_executable}"}})',
-                'ADDITIONAL_ENV_VARS = {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "NCCL_CUMEM_ENABLE", "NCCL_NVLS_ENABLE", "RAY_ENABLE_UV_RUN_RUNTIME_ENV"}',
-            ]
-
-            need_replace = False
-            for old_line, new_line in zip(old_lines, new_lines):
-                if new_line in content or old_line not in content:
-                    continue
-                content = content.replace(old_line, new_line)
-                need_replace = True
-
-            if not need_replace:
-                return
-
-            # Write back the patched content
-            with open(file_to_patch, "w") as f:
-                f.write(content)
 
         def _patch_vllm_llama_eagle3_own_lm_head():
             """Patch LlamaEagle3 to keep truncated draft lm_head ownership."""
@@ -406,9 +495,6 @@ class BaseVllmGenerationWorker:
 
             logger.info("Successfully patched hermes tool parser for thread-safety.")
 
-        _patch_vllm_init_workers_ray()
-        logger.info("Successfully patched vllm _init_workers_ray.")
-
         _patch_vllm_llama_eagle3_own_lm_head()
         _patch_vllm_hermes_tool_parser_thread_safety()
 
@@ -472,17 +558,46 @@ class BaseVllmGenerationWorker:
         if ModelFlag.VLLM_LOAD_FORMAT_AUTO.matches(self.model_name):
             load_format = "auto"
 
+        profiling_requested = (
+            len(
+                get_nsight_config_if_pattern_matches(
+                    "vllm_generation_worker"
+                )
+            )
+            > 0
+        )
+        inner_nsys_mode = _configure_vllm_ray_worker_nsight(
+            vllm_kwargs,
+            profiling_requested=profiling_requested,
+        )
         if (
-            len(get_nsight_config_if_pattern_matches("vllm_generation_worker")) > 0
+            profiling_requested
+            and vllm_kwargs["distributed_executor_backend"] == "ray"
+        ):
+            if inner_nsys_mode is not None:
+                logger.warning(
+                    "Bounded Nsight profiling is enabled for inner vLLM Ray "
+                    "workers with mode %s. Bypassing vLLM's hardcoded "
+                    "node-level Nsight configuration.",
+                    inner_nsys_mode,
+                )
+            else:
+                logger.warning(
+                    "Nsight profiling is enabled for vllm generation worker through the vllm ray distributed executor. "
+                    "The nsight command-line args and output file names are automatically picked by the ray distributed "
+                    "executor. Refer to https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/executor/ray_distributed_executor.py#L136 "
+                    "for more information."
+                )
+        elif (
+            inner_nsys_mode is not None
             and vllm_kwargs["distributed_executor_backend"] == "ray"
         ):
             logger.warning(
-                "Nsight profiling is enabled for vllm generation worker through the vllm ray distributed executor. "
-                "The nsight command-line args and output file names are automatically picked by the ray distributed "
-                "executor. Refer to https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/executor/ray_distributed_executor.py#L136 "
-                "for more information."
+                "Inner vLLM Ray-worker Nsight mode %s is configured without "
+                "an outer worker pattern; capture must be controlled by "
+                "explicit profiler RPCs.",
+                inner_nsys_mode,
             )
-            vllm_kwargs["ray_workers_use_nsight"] = True
 
         # Call init_fp8 when precision is fp8
         # (kv_cache_dtype can be fp8/fp8_e4m3 or auto, validated in init_fp8)
@@ -496,6 +611,38 @@ class BaseVllmGenerationWorker:
             vllm_kwargs.update(fp8_kwargs)
             # overriden by quant config, however vllm complains if this not passed
             self.precision = "bfloat16"
+
+        # Keep the exact string backend until all existing Ray-specific policy
+        # and profiling decisions above have run. A top-level class object is
+        # then serialized with EngineArgs into vLLM's spawned EngineCore, where
+        # it can inject the inner TP-worker runtime_env without mutating the
+        # installed vLLM package.
+        if vllm_kwargs["distributed_executor_backend"] == "ray":
+            from nemo_rl.models.generation.vllm.nested_runtime_env import (
+                export_nested_runtime_env_contract,
+            )
+            from nemo_rl.models.generation.vllm.ray_executor import (
+                NemoRayDistributedExecutor,
+            )
+
+            nested_runtime_env = _build_vllm_nested_runtime_env(
+                self.py_executable
+            )
+            (
+                nested_runtime_env,
+                contract_sha256,
+            ) = export_nested_runtime_env_contract(nested_runtime_env)
+            self._vllm_nested_runtime_env = copy.deepcopy(
+                nested_runtime_env
+            )
+            self._vllm_nested_runtime_env_contract_sha256 = (
+                contract_sha256
+            )
+            self._vllm_env_copy_layout = "custom_executor_class"
+            self._vllm_nested_runtime_env_patch_verified = True
+            vllm_kwargs["distributed_executor_backend"] = (
+                NemoRayDistributedExecutor
+            )
 
         if not isinstance(vllm_kwargs.get("hf_overrides"), dict):
             vllm_kwargs["hf_overrides"] = {}
@@ -594,6 +741,9 @@ class BaseVllmGenerationWorker:
         greedy: bool,
         stop_strings,
         max_new_tokens: Optional[int] = None,
+        force_generation_length: bool = False,
+        allowed_token_ids: Optional[list[int]] = None,
+        forced_generation_token_ids: Optional[list[int]] = None,
     ):
         top_k_cfg = self.cfg["top_k"]
         top_k_val = 1 if greedy else (top_k_cfg if top_k_cfg is not None else -1)
@@ -604,7 +754,7 @@ class BaseVllmGenerationWorker:
             max_new_tokens if max_new_tokens is not None else self.cfg["max_new_tokens"]
         )
 
-        return self.SamplingParams(
+        sampling_kwargs = dict(
             temperature=temperature,
             top_p=self.cfg["top_p"],
             top_k=top_k_val,
@@ -614,6 +764,30 @@ class BaseVllmGenerationWorker:
             stop=stop_strings,
             include_stop_str_in_output=True,
         )
+        if force_generation_length and forced_generation_token_ids is None:
+            # Used by deterministic trace replay.  Keeping this opt-in means
+            # normal rollout semantics (EOS and stop strings) are unchanged.
+            sampling_kwargs.update(min_tokens=max_tokens, ignore_eos=True)
+        elif force_generation_length:
+            # Exact-sequence replay must preserve a recorded EOS/EOT at the
+            # final position.  min_tokens=max_tokens would suppress that token
+            # when len(output_ids) == max_tokens - 1.  The per-position logits
+            # processor plus max_tokens already determines the replay length.
+            assert forced_generation_token_ids is not None
+        if allowed_token_ids is not None:
+            # Benchmark-only deterministic-content replay can constrain every
+            # generated position to the same explicit token.  The default
+            # remains unconstrained for normal rollout semantics.
+            sampling_kwargs["allowed_token_ids"] = allowed_token_ids
+        if forced_generation_token_ids is not None:
+            if allowed_token_ids is not None:
+                raise ValueError(
+                    "single-token and exact-sequence forcing are mutually exclusive"
+                )
+            sampling_kwargs["extra_args"] = {
+                "nrl_forced_token_ids": forced_generation_token_ids
+            }
+        return self.SamplingParams(**sampling_kwargs)
 
     def start_gpu_profiling(self) -> None:
         """Start GPU profiling."""
@@ -668,6 +842,30 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
 
     def post_init(self):
         self.vllm_device_ids = self.report_device_id()
+        self._maybe_start_inflight_profiler()
+
+    def _maybe_start_inflight_profiler(self) -> None:
+        """Start the in-flight batch profiler when NRL_PROFILE_INFLIGHT is set.
+
+        Only model-owner workers hold a live ``self.llm`` (and thus an in-process
+        scheduler), so the profiler is a no-op elsewhere.
+        """
+        self._inflight_profiler: Optional[InflightProfiler] = None
+        if not (self.is_model_owner and inflight_profiling_enabled()):
+            return
+        self._inflight_profiler = InflightProfiler(
+            sample_fn=lambda: read_scheduler_sample(find_vllm_scheduler(self.llm)),
+            dp_label=repr(self),
+            interval_s=inflight_interval_s(),
+        )
+        self._inflight_profiler.start()
+
+    def get_inflight_timeline(self) -> list[dict[str, Any]]:
+        """Return the in-flight samples captured during the last generate() call."""
+        profiler = getattr(self, "_inflight_profiler", None)
+        if profiler is None:
+            return []
+        return profiler.snapshot()
 
     def init_collective(
         self,
@@ -705,8 +903,15 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
                 - generation_lengths: Lengths of each response
                 - unpadded_sequence_lengths: Lengths of each input + generated sequence
         """
+        # Open the in-flight profiling window for this call (no-op when disabled).
+        inflight_profiler = getattr(self, "_inflight_profiler", None)
+        if inflight_profiler is not None:
+            inflight_profiler.mark_call_start()
+
         # Handle empty input case
         if len(data["input_ids"]) == 0:
+            if inflight_profiler is not None:
+                inflight_profiler.mark_call_end()
             # Return empty BatchedDataDict with all required fields
             return BatchedDataDict[GenerationOutputSpec](
                 {
@@ -716,6 +921,19 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
                     "unpadded_sequence_lengths": torch.zeros(0, dtype=torch.long),
                     "truncated": torch.zeros(0, dtype=torch.bool),
                 }
+            )
+
+        if "_nrl_forced_generation_token_id" in data:
+            raise RuntimeError(
+                "_nrl_forced_generation_token_id is supported only by the "
+                "async vLLM worker; refusing to claim a forced-content "
+                "contract on the synchronous path"
+            )
+        if "_nrl_forced_generation_token_ids" in data:
+            raise RuntimeError(
+                "_nrl_forced_generation_token_ids is supported only by the "
+                "async vLLM worker; refusing exact-sequence replay on the "
+                "synchronous path"
             )
 
         input_ids = data["input_ids"]
@@ -820,6 +1038,9 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
                 "truncated": torch.tensor(truncated_list, dtype=torch.bool),
             }
         )
+
+        if inflight_profiler is not None:
+            inflight_profiler.mark_call_end()
 
         return return_data
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -15,6 +15,7 @@
 import asyncio
 import copy
 import gc
+import os
 import threading
 import time
 import uuid
@@ -34,8 +35,75 @@ from nemo_rl.models.generation.interfaces import (
     GenerationOutputSpec,
     verify_right_padding,
 )
+from nemo_rl.models.generation.vllm.inflight_profiler import (
+    InflightProfiler,
+    inflight_interval_s,
+    inflight_profiling_enabled,
+)
+from nemo_rl.models.generation.vllm.vllm_metric_sampler import (
+    metric_capture_timing,
+    read_restricted_vllm_metrics,
+)
+from nemo_rl.models.generation.vllm.lfs.concurrency import (
+    get_engine_kv_cache_shape,
+)
 from nemo_rl.models.generation.vllm.utils import format_prompt_for_vllm_generation
-from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
+from nemo_rl.models.generation.vllm.vllm_worker import (
+    BaseVllmGenerationWorker,
+    _get_vllm_inner_nsys_mode,
+)
+
+
+async def _await_model_worker_collective_rpc(
+    llm: Any, method: str
+) -> None:
+    """Await an AsyncLLM collective RPC when its engine is initialized."""
+    if llm is not None:
+        await llm.collective_rpc(method, args=tuple())
+
+
+async def _submit_vllm_request(
+    llm: Any,
+    *,
+    prompt: Any,
+    sampling_params: Any,
+    request_id: str,
+    priority: int,
+) -> tuple[Any, float, float, str]:
+    """Submit to EngineCore and return the causal frontend boundary."""
+    request_output_collector = await llm.add_request(
+        request_id=request_id,
+        prompt=prompt,
+        params=sampling_params,
+        priority=priority,
+    )
+    submitted_at_unix_s = time.time()
+    submitted_at_monotonic_s = time.monotonic()
+    submitted_hostname = os.uname().nodename
+    return (
+        request_output_collector,
+        submitted_at_unix_s,
+        submitted_at_monotonic_s,
+        submitted_hostname,
+    )
+
+
+async def _iterate_request_output_collector(
+    request_output_collector: Any,
+    stream_finished: Any,
+) -> AsyncGenerator[Any, None]:
+    """Mirror AsyncLLM.generate's terminal-sentinel loop."""
+    finished = False
+    while not finished:
+        req_output = (
+            request_output_collector.get_nowait()
+            or await request_output_collector.get()
+        )
+        # STREAM_FINISHED is itself terminal. Read `finished` before deciding
+        # whether to yield it, exactly as AsyncLLM.generate does.
+        finished = bool(req_output.finished)
+        if req_output is not stream_finished:
+            yield req_output
 
 
 def _replace_prefix_tokens(
@@ -148,6 +216,136 @@ Template repr (detokenized): {repr(tokenizer.decode(template_token_ids))}"""
     runtime_env={**get_nsight_config_if_pattern_matches("vllm_async_generation_worker")}
 )  # pragma: no cover
 class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
+    async def start_gpu_profiling_async(self) -> None:
+        """Start profiling on every async-engine model worker."""
+        await _await_model_worker_collective_rpc(
+            self.llm, "start_gpu_profiling"
+        )
+
+    async def stop_gpu_profiling_async(self) -> None:
+        """Stop profiling on every async-engine model worker."""
+        await _await_model_worker_collective_rpc(
+            self.llm, "stop_gpu_profiling"
+        )
+
+    async def arm_model_step_gpu_profile_async(
+        self,
+        start_step: int,
+        stop_step: int,
+    ) -> list[dict[str, Any]]:
+        """Arm the same exact model-step range on every nested TP worker."""
+
+        if self.llm is None:
+            raise RuntimeError("async vLLM engine is not initialized")
+        result = await self.llm.collective_rpc(
+            "arm_model_step_gpu_profile",
+            args=(start_step, stop_step),
+        )
+        if not isinstance(result, list):
+            raise RuntimeError(
+                "vLLM collective arm RPC did not return one proof list"
+            )
+        return result
+
+    async def get_model_step_gpu_profile_async(
+        self,
+    ) -> list[dict[str, Any]]:
+        """Collect completed exact-range proofs from every nested TP worker."""
+
+        if self.llm is None:
+            raise RuntimeError("async vLLM engine is not initialized")
+        result = await self.llm.collective_rpc(
+            "get_model_step_gpu_profile",
+            args=tuple(),
+        )
+        if not isinstance(result, list):
+            raise RuntimeError(
+                "vLLM collective proof RPC did not return one proof list"
+            )
+        return result
+
+    def report_replay_runtime_provenance(self) -> dict[str, Any]:
+        """Report actual worker source, engine arguments, and processors."""
+        nested_runtime_env = getattr(
+            self, "_vllm_nested_runtime_env", None
+        )
+        inner_nsys_config = (
+            copy.deepcopy(nested_runtime_env.get("nsight"))
+            if isinstance(nested_runtime_env, dict)
+            and isinstance(nested_runtime_env.get("nsight"), dict)
+            else None
+        )
+        return {
+            "worker_module_file": __file__,
+            # Preserve the user-facing identifier before vLLM resolves a
+            # Hugging Face repository ID to its concrete cache snapshot.
+            "configured_model_name": self.model_name,
+            "pythonpath": os.environ.get("PYTHONPATH"),
+            "propagate_pythonpath": os.environ.get(
+                "NRL_VLLM_PROPAGATE_PYTHONPATH"
+            ),
+            "engine_logits_processors": list(
+                map(
+                    str,
+                    self.llm_async_engine_args.logits_processors or [],
+                )
+            ),
+            "inner_nsys_mode": _get_vllm_inner_nsys_mode(),
+            "inner_nsys_config": inner_nsys_config,
+            "vllm_nested_runtime_env": copy.deepcopy(
+                nested_runtime_env
+            ),
+            "vllm_nested_runtime_env_contract_sha256": getattr(
+                self,
+                "_vllm_nested_runtime_env_contract_sha256",
+                None,
+            ),
+            "vllm_nested_runtime_env_contract_exported": bool(
+                getattr(
+                    self,
+                    "_vllm_nested_runtime_env_patch_verified",
+                    False,
+                )
+            ),
+            # Backward-compatible observability alias used by the bounded
+            # inner-Nsight replay finalizer. The implementation is now the
+            # custom executor contract rather than an installed-source patch.
+            "inner_nsys_runtime_env_patch_verified": bool(
+                getattr(
+                    self,
+                    "_vllm_nested_runtime_env_patch_verified",
+                    False,
+                )
+            ),
+            "vllm_env_copy_layout": getattr(
+                self, "_vllm_env_copy_layout", None
+            ),
+            "model_worker_runtime_provenance": copy.deepcopy(
+                getattr(
+                    self,
+                    "vllm_model_worker_runtime_provenance",
+                    None,
+                )
+            ),
+            "ray_workers_use_nsight": bool(
+                self.llm_async_engine_args.ray_workers_use_nsight
+            ),
+            "async_engine_args": {
+                "enable_prefix_caching": (
+                    self.llm_async_engine_args.enable_prefix_caching
+                ),
+                "enforce_eager": getattr(
+                    self.llm_async_engine_args, "enforce_eager", None
+                ),
+                "max_num_seqs": self.llm_async_engine_args.max_num_seqs,
+                "max_num_batched_tokens": (
+                    self.llm_async_engine_args.max_num_batched_tokens
+                ),
+                "model": self.llm_async_engine_args.model,
+                "revision": self.llm_async_engine_args.revision,
+            },
+        }
+
     def _create_engine(self, llm_kwargs: dict[str, Any]) -> None:
         from vllm.config import CompilationConfig
         from vllm.engine.arg_utils import AsyncEngineArgs
@@ -175,15 +373,80 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 )
             llm_kwargs["compilation_config"] = CompilationConfig(**compilation_config)
 
-        self.llm_async_engine_args = AsyncEngineArgs(**llm_kwargs)
-        self.stat_loggers = (
-            [PrometheusStatLogger]
-            if self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False)
-            else []
+        # Experimental engine-level group-LFS waiting order (env-gated by
+        # NRL_VLLM_LFS_SCHED=1). This reorders whole requests only. The group
+        # id is carried in `priority`, so vLLM's own scheduling policy remains
+        # FCFS instead of using its priority heap.
+        if os.environ.get("NRL_VLLM_LFS_SCHED") == "1":
+            llm_kwargs["scheduler_cls"] = (
+                "nemo_rl.models.generation.vllm.lfs.engine_schedulers.ProbeLfsScheduler"
+            )
+        # Apply the same explicit per-engine concurrency cap to both A/B arms.
+        max_num_seqs = os.environ.get("NRL_VLLM_MAX_NUM_SEQS")
+        if max_num_seqs:
+            llm_kwargs["max_num_seqs"] = int(max_num_seqs)
+
+        # Falsification arm for the length-homogeneity effect measured on the
+        # TRTLLM-gen decode kernel. Setting attention_config.use_trtllm_attention
+        # to False makes can_use_trtllm_attention() return False, so decode falls
+        # back to FlashInfer's BatchDecodeWithPagedKVCacheWrapper, whose kernel
+        # time is driven by the batch's summed context rather than its longest
+        # member. Prefill selection is unchanged. Off by default.
+        if os.environ.get("NRL_VLLM_DISABLE_TRTLLM_ATTENTION") == "1":
+            from vllm.config import AttentionConfig
+
+            llm_kwargs["attention_config"] = AttentionConfig(
+                use_trtllm_attention=False
+            )
+
+        step_trace_enabled = bool(
+            self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False)
         )
+        step_trace_logger_class = None
+        if step_trace_enabled:
+            if os.environ.get("VLLM_DEBUG_MFU_METRICS") != "1":
+                raise RuntimeError(
+                    "enable_vllm_step_trace requires worker environment "
+                    "VLLM_DEBUG_MFU_METRICS=1"
+                )
+            # These are observability-only engine arguments. PerfStats supplies
+            # exact scheduled composition aggregates and CUDAGraphStat supplies
+            # the actual unpadded/padded token batch for the same step.
+            llm_kwargs["enable_mfu_metrics"] = True
+            llm_kwargs["cudagraph_metrics"] = True
+            from nemo_rl.models.generation.vllm.vllm_step_trace import (
+                get_vllm_step_trace_logger_class,
+            )
+
+            step_trace_logger_class = get_vllm_step_trace_logger_class()
+
+        self.llm_async_engine_args = AsyncEngineArgs(**llm_kwargs)
+        self.stat_loggers: list[Any] = []
+        if self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
+            self.stat_loggers.append(PrometheusStatLogger)
+        if step_trace_logger_class is not None:
+            self.stat_loggers.append(step_trace_logger_class)
         self.llm = AsyncLLM.from_engine_args(
             self.llm_async_engine_args, stat_loggers=self.stat_loggers
         )
+        self._vllm_step_trace_logger = None
+        if step_trace_enabled:
+            logger_manager = self.llm.logger_manager
+            if logger_manager is None:
+                raise RuntimeError(
+                    "vLLM did not create a StatLoggerManager for step tracing"
+                )
+            matching_loggers = [
+                logger
+                for logger in logger_manager.stat_loggers
+                if getattr(logger, "_nrl_vllm_step_trace_logger", False)
+            ]
+            if len(matching_loggers) != 1:
+                raise RuntimeError(
+                    "expected exactly one vLLM step trace logger, found "
+                    f"{len(matching_loggers)}"
+                )
+            self._vllm_step_trace_logger = matching_loggers[0]
 
         self.server_thread, self.base_url, self.http_server = None, None, None
         if self.cfg["vllm_cfg"].get("expose_http_server"):
@@ -197,13 +460,39 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         if self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
             self._start_vllm_metrics_logger()
 
+    def get_kv_cache_shape(self) -> dict[str, int]:
+        """Return the initialized per-engine KV cache capacity."""
+        kv_cache_tokens, block_size = get_engine_kv_cache_shape(self.llm)
+        return {
+            "kv_cache_tokens": kv_cache_tokens,
+            "block_size": block_size,
+        }
+
+    def get_vllm_step_trace(self) -> dict[str, Any]:
+        """Return a consistent copy of the current per-step trace window."""
+        if not self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False):
+            return {}
+        logger = getattr(self, "_vllm_step_trace_logger", None)
+        if logger is None:
+            raise RuntimeError("vLLM step tracing is enabled but logger is missing")
+        return logger.snapshot()
+
+    def clear_vllm_step_trace(self) -> None:
+        """Open a fresh per-step trace window."""
+        if not self.cfg["vllm_cfg"].get("enable_vllm_step_trace", False):
+            return
+        logger = getattr(self, "_vllm_step_trace_logger", None)
+        if logger is None:
+            raise RuntimeError("vLLM step tracing is enabled but logger is missing")
+        logger.clear()
+
     def _start_vllm_metrics_logger(self) -> None:
         """Start a background thread that periodically collects vLLM logger metrics.
 
         Controlled by vllm_metrics_logger_interval (default: 0.5) in vllm_cfg.
         Runs only on the model-owner actor.
         """
-        from vllm.v1.metrics.reader import Gauge, Counter, get_metrics_snapshot
+        from prometheus_client import REGISTRY
 
         assert self.cfg["vllm_cfg"].get("async_engine", False), (
             "vLLM metrics logger is only supported with async engine enabled"
@@ -228,34 +517,137 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         self.num_pending_samples: list[int] = []
         self.kv_cache_usage_perc: list[float] = []
         self.generation_tokens: list[int] = []
+        self.num_preemptions: list[int] = []
+        # Keep one structured record per collector pass.  The legacy metric
+        # lists above are retained for compatibility, but they cannot be
+        # aligned reliably by list index: collecting a snapshot takes
+        # non-zero time and individual metrics may occasionally be absent.
+        self.vllm_metric_samples: list[dict[str, Any]] = []
+        self.vllm_metric_source_series: dict[str, dict[str, Any]] | None = None
+        self.vllm_metric_sampler_errors: list[dict[str, Any]] = []
+        self.vllm_metric_sampler_interval_s = float(interval_s)
+        self.generation_tokens_baseline = 0
+        self.num_preemptions_baseline = 0
+
+        def _capture_sample(
+            anchor_kind: str = "periodic",
+            *,
+            scheduled_at_monotonic_s: float | None = None,
+            attempted_at_monotonic_s: float | None = None,
+        ) -> dict[str, Any]:
+            if attempted_at_monotonic_s is None:
+                attempted_at_monotonic_s = time.monotonic()
+            started_at_monotonic_s = time.monotonic()
+            values, source_series = read_restricted_vllm_metrics(REGISTRY)
+            finished_at_monotonic_s = time.monotonic()
+
+            if self.vllm_metric_source_series is None:
+                self.vllm_metric_source_series = copy.deepcopy(source_series)
+            elif source_series != self.vllm_metric_source_series:
+                raise RuntimeError(
+                    "vLLM Prometheus source series changed during sampling: "
+                    f"expected={self.vllm_metric_source_series!r}, "
+                    f"observed={source_series!r}"
+                )
+
+            # Record the observation time after reading the snapshot.
+            # Same-host benchmark processes align on monotonic time; Unix time
+            # is retained to diagnose clock adjustments and for display.
+            sample: dict[str, Any] = {
+                "anchor_kind": anchor_kind,
+                **values,
+                **metric_capture_timing(
+                    interval_s=interval_s,
+                    scheduled_at_monotonic_s=scheduled_at_monotonic_s,
+                    attempted_at_monotonic_s=attempted_at_monotonic_s,
+                    started_at_monotonic_s=started_at_monotonic_s,
+                    finished_at_monotonic_s=finished_at_monotonic_s,
+                ),
+            }
+            sample["sampled_at_unix_s"] = time.time()
+            sample["sampled_at_monotonic_s"] = finished_at_monotonic_s
+            sample["hostname"] = os.uname().nodename
+            return sample
+
+        def _append_sample(sample: dict[str, Any]) -> None:
+            self.vllm_metric_samples.append(sample)
+            if "inflight_batch_size" in sample:
+                self.inflight_batch_sizes.append(sample["inflight_batch_size"])
+            if "num_pending" in sample:
+                self.num_pending_samples.append(sample["num_pending"])
+            if "kv_cache_usage_perc" in sample:
+                self.kv_cache_usage_perc.append(sample["kv_cache_usage_perc"])
+            if "generation_tokens" in sample:
+                self.generation_tokens.append(sample["generation_tokens"])
+            if "num_preemptions" in sample:
+                self.num_preemptions.append(sample["num_preemptions"])
+
+        # clear() and get() use synchronous anchors from the same reader as the
+        # periodic sampler. All calls are serialized by _vllm_metrics_lock.
+        self._capture_vllm_metric_sample = _capture_sample
+        self._append_vllm_metric_sample = _append_sample
 
         def _logger_loop():
             # Delay a little to let engine settle
-            time.sleep(min(2.0, interval_s))
-            while True:
-                try:
-                    for m in get_metrics_snapshot():
-                        with self._vllm_metrics_lock:
-                            if isinstance(m, Gauge):
-                                # Log the vllm inflight batch sizes
-                                if m.name == "vllm:num_requests_running":
-                                    self.inflight_batch_sizes.append(int(m.value))
-                                # Log the vllm pending number of requests in the queue
-                                elif m.name == "vllm:num_requests_waiting":
-                                    self.num_pending_samples.append(int(m.value))
-                                # Log the vllm kv cache usage
-                                elif m.name == "vllm:kv_cache_usage_perc":
-                                    self.kv_cache_usage_perc.append(float(m.value))
-                            elif isinstance(m, Counter):
-                                if m.name == "vllm:generation_tokens":
-                                    self.generation_tokens.append(int(m.value))
-                except Exception:
+            if stop_event.wait(min(2.0, interval_s)):
+                return
+            next_sample_monotonic = time.monotonic()
+            while not stop_event.is_set():
+                scheduled_at_monotonic_s = next_sample_monotonic
+                attempted_at_monotonic_s = time.monotonic()
+                capture_error: Exception | None = None
+                # Snapshot, append, and error attribution share the same lock
+                # as clear(). If clear() ran between a failed warmup capture
+                # and recording that failure, the warmup error could otherwise
+                # be attributed to the measured rollout epoch.
+                with self._vllm_metrics_lock:
+                    try:
+                        _append_sample(
+                            _capture_sample(
+                                scheduled_at_monotonic_s=(
+                                    scheduled_at_monotonic_s
+                                ),
+                                attempted_at_monotonic_s=(
+                                    attempted_at_monotonic_s
+                                ),
+                            )
+                        )
+                    except Exception as error:
+                        capture_error = error
+                        self.vllm_metric_sampler_errors.append(
+                            {
+                                "error_type": type(error).__name__,
+                                "error": str(error),
+                                "scheduled_at_monotonic_s": (
+                                    scheduled_at_monotonic_s
+                                ),
+                                "attempted_at_monotonic_s": (
+                                    attempted_at_monotonic_s
+                                ),
+                                "failed_at_monotonic_s": time.monotonic(),
+                            }
+                        )
+                        if len(self.vllm_metric_sampler_errors) > 1000:
+                            del self.vllm_metric_sampler_errors[:100]
+                if capture_error is not None:
                     print(
-                        "⚠️[vLLM Metric Logger] Exception in vLLM metrics logger",
+                        "⚠️[vLLM Metric Logger] Exception in restricted "
+                        f"vLLM metrics sampler: {capture_error!r}",
                         flush=True,
                     )
-                    pass
-                time.sleep(interval_s)
+                # Use a deadline instead of sleep(interval) after collection;
+                # otherwise collector overhead accumulates into large timeline
+                # drift during long rollouts.
+                next_sample_monotonic += interval_s
+                now_monotonic = time.monotonic()
+                if next_sample_monotonic <= now_monotonic:
+                    # Do not burst through every missed deadline after a long
+                    # snapshot or lock pause. One fresh sample per interval is
+                    # sufficient and avoids perturbing the engine.
+                    next_sample_monotonic = now_monotonic + interval_s
+                stop_event.wait(
+                    max(0.0, next_sample_monotonic - time.monotonic())
+                )
 
         t = threading.Thread(
             target=_logger_loop, name="vllm-metrics-logger", daemon=True
@@ -271,27 +663,158 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         if not self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
             return {}
 
+        attempted_at_monotonic_s = time.monotonic()
         with self._vllm_metrics_lock:
+            # Capture an exact query-time terminal anchor instead of relying on
+            # the periodic thread to happen to sample after the final request.
+            self._append_vllm_metric_sample(
+                self._capture_vllm_metric_sample(
+                    "query_terminal",
+                    attempted_at_monotonic_s=attempted_at_monotonic_s,
+                )
+            )
             metric = {
                 "inflight_batch_sizes": copy.deepcopy(self.inflight_batch_sizes),
                 "num_pending_samples": copy.deepcopy(self.num_pending_samples),
                 "kv_cache_usage_perc": copy.deepcopy(self.kv_cache_usage_perc),
                 "generation_tokens": copy.deepcopy(self.generation_tokens),
+                "num_preemptions": copy.deepcopy(self.num_preemptions),
+                "metric_samples": copy.deepcopy(self.vllm_metric_samples),
+                "metric_source_series": copy.deepcopy(
+                    self.vllm_metric_source_series
+                ),
+                "metric_sampler_errors": copy.deepcopy(
+                    self.vllm_metric_sampler_errors
+                ),
+                "metric_sampler_interval_s": (
+                    self.vllm_metric_sampler_interval_s
+                ),
+                "generation_tokens_baseline": self.generation_tokens_baseline,
+                "num_preemptions_baseline": self.num_preemptions_baseline,
             }
         return metric
 
-    def clear_vllm_logger_metrics(self) -> None:
+    def clear_vllm_logger_metrics(self) -> dict[str, Any] | None:
         if not self.cfg["vllm_cfg"].get("enable_vllm_metrics_logger", False):
             return
 
+        attempted_at_monotonic_s = time.monotonic()
         with self._vllm_metrics_lock:
+            # Errors before this point belong to engine startup or warmup, not
+            # the measured rollout window.
+            self.vllm_metric_sampler_errors = []
+            # Synchronously sample while holding the same lock as the periodic
+            # thread. This is both the exact cumulative-counter baseline and a
+            # pre-measurement gauge anchor.
+            anchor = self._capture_vllm_metric_sample(
+                "measurement_start",
+                attempted_at_monotonic_s=attempted_at_monotonic_s,
+            )
+            self.num_preemptions_baseline = int(
+                anchor.get(
+                    "num_preemptions",
+                    max(
+                        self.num_preemptions,
+                        default=self.num_preemptions_baseline,
+                    ),
+                )
+            )
+            self.generation_tokens_baseline = int(
+                anchor.get(
+                    "generation_tokens",
+                    max(
+                        self.generation_tokens,
+                        default=self.generation_tokens_baseline,
+                    ),
+                )
+            )
             self.inflight_batch_sizes = []
             self.num_pending_samples = []
             self.kv_cache_usage_perc = []
             self.generation_tokens = []
+            self.num_preemptions = []
+            self.vllm_metric_samples = []
+            self._append_vllm_metric_sample(anchor)
+            return copy.deepcopy(anchor)
 
     async def post_init_async(self):
         self.vllm_device_ids = await self.report_device_id_async()
+        self.vllm_model_worker_runtime_provenance = (
+            await self.report_model_worker_runtime_environment_async()
+        )
+        self._maybe_start_inflight_profiler()
+
+    def _maybe_start_inflight_profiler(self) -> None:
+        """Start the in-flight batch profiler for the async engine.
+
+        The async engine runs its scheduler out-of-process, so (unlike the sync
+        worker) we cannot read ``scheduler.running`` directly. Instead we maintain
+        a live map of in-flight requests from the streamed RequestOutputs in this
+        front-end process (see generate_async) and sample that. Always created
+        (live map + lock) so the streaming hooks are safe; the sampler only runs
+        when NRL_PROFILE_INFLIGHT is set on a model-owner actor.
+        """
+        # request_id -> (input_len, generated_len_so_far); maintained by the
+        # _inflight_* hooks in generate_async, sampled by the profiler thread.
+        self._inflight_live: dict[str, tuple[int, int]] = {}
+        self._inflight_live_lock = threading.Lock()
+        self._inflight_profiler: Optional[InflightProfiler] = None
+        if not (
+            getattr(self, "is_model_owner", False) and inflight_profiling_enabled()
+        ):
+            return
+
+        def _live_sample() -> dict[str, Any]:
+            with self._inflight_live_lock:
+                items = list(self._inflight_live.values())
+            return {
+                "batch_size": len(items),
+                "waiting": -1,  # not visible from the front-end in async mode
+                "ctx_lens": [il + gl for il, gl in items],
+                "prompt_lens": [il for il, _ in items],
+                "gen_lens": [gl for _, gl in items],
+            }
+
+        self._inflight_profiler = InflightProfiler(
+            sample_fn=_live_sample,
+            dp_label=repr(self),
+            interval_s=inflight_interval_s(),
+        )
+        self._inflight_profiler.start()
+        self._inflight_profiler.mark_call_start()  # open the first window
+
+    def _inflight_register(self, request_id: str, input_len: int) -> None:
+        if getattr(self, "_inflight_profiler", None) is None:
+            return
+        with self._inflight_live_lock:
+            self._inflight_live[request_id] = (int(input_len), 0)
+
+    def _inflight_update(self, request_id: str, gen_len: int) -> None:
+        if getattr(self, "_inflight_profiler", None) is None:
+            return
+        with self._inflight_live_lock:
+            prev = self._inflight_live.get(request_id)
+            if prev is not None:
+                self._inflight_live[request_id] = (prev[0], int(gen_len))
+
+    def _inflight_unregister(self, request_id: str) -> None:
+        if getattr(self, "_inflight_profiler", None) is None:
+            return
+        with self._inflight_live_lock:
+            self._inflight_live.pop(request_id, None)
+
+    def get_inflight_timeline(self) -> list[dict[str, Any]]:
+        """Return the in-flight samples collected for the current window."""
+        profiler = getattr(self, "_inflight_profiler", None)
+        if profiler is None:
+            return []
+        return profiler.snapshot()
+
+    def clear_inflight_timeline(self) -> None:
+        """Open a fresh sampling window (called per training step before rollout)."""
+        profiler = getattr(self, "_inflight_profiler", None)
+        if profiler is not None:
+            profiler.mark_call_start()
 
     async def report_dp_openai_server_base_url(self) -> Optional[str]:
         return self.base_url
@@ -686,12 +1209,17 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         self,
         data: BatchedDataDict[GenerationDatumSpec],
         greedy: bool = False,
+        cross_dp_frontend_submission: dict[str, Any] | None = None,
     ) -> AsyncGenerator[tuple[int, BatchedDataDict[GenerationOutputSpec]], None]:
         """Generate a batch of data using vLLM's AsyncLLMEngine, yielding results as they are ready.
 
         Args:
             data: BatchedDataDict with input_ids and input_lengths
             greedy: Whether to use greedy decoding instead of sampling
+            cross_dp_frontend_submission: Dispatcher acknowledgement metadata.
+                When present, this worker holds the per-DP dispatcher gate until
+                vLLM's ``add_request`` has returned, which means EngineCore has
+                accepted this request.
 
         Yields:
             Tuple of (original_index, BatchedDataDict conforming to GenerationOutputSpec for the single sequence)
@@ -717,6 +1245,56 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             f"but received batch_size={batch_size}. Please handle batching outside this method."
         )
 
+        if cross_dp_frontend_submission is not None:
+            required_submission_keys = {
+                "dispatcher",
+                "session_id",
+                "request_id",
+                "assignment_sequence",
+                "dp_assignment_ordinal",
+                "session_dp_assignment_ordinal",
+            }
+            missing_submission_keys = required_submission_keys.difference(
+                cross_dp_frontend_submission
+            )
+            if missing_submission_keys:
+                raise ValueError(
+                    "Cross-DP frontend submission metadata is missing "
+                    f"{sorted(missing_submission_keys)}"
+                )
+
+            def first_cross_dp_data_value(key: str) -> str:
+                if key not in data or len(data[key]) != 1:
+                    raise ValueError(
+                        "Cross-DP frontend submission requires singleton "
+                        f"{key} request metadata"
+                    )
+                item = data[key][0]
+                if hasattr(item, "item"):
+                    item = item.item()
+                return str(item)
+
+            data_session_id = first_cross_dp_data_value(
+                "_cross_dp_session_id"
+            )
+            data_request_id = first_cross_dp_data_value(
+                "_cross_dp_request_id"
+            )
+            if data_session_id != str(
+                cross_dp_frontend_submission["session_id"]
+            ):
+                raise ValueError(
+                    "Cross-DP worker session metadata does not match its "
+                    "dispatcher lease"
+                )
+            if data_request_id != str(
+                cross_dp_frontend_submission["request_id"]
+            ):
+                raise ValueError(
+                    "Cross-DP worker request metadata does not match its "
+                    "dispatcher lease"
+                )
+
         batch_specific_stop_strings_list = data.get(
             "stop_strings", [[] for _ in range(batch_size)]
         )
@@ -740,7 +1318,74 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             remaining_ctx = (
                 self.cfg["vllm_cfg"]["max_model_len"] - current_input_actual_length
             )
-            allowed_new_tokens = max(0, min(self.cfg["max_new_tokens"], remaining_ctx))
+            request_max_new_tokens = self.cfg["max_new_tokens"]
+            if "_nrl_max_new_tokens" in data:
+                raw_request_max = data["_nrl_max_new_tokens"][sample_idx]
+                if hasattr(raw_request_max, "item"):
+                    raw_request_max = raw_request_max.item()
+                request_max_new_tokens = int(raw_request_max)
+                if request_max_new_tokens <= 0:
+                    raise ValueError(
+                        "_nrl_max_new_tokens must be positive, got "
+                        f"{request_max_new_tokens}"
+                    )
+                if request_max_new_tokens > self.cfg["max_new_tokens"]:
+                    raise ValueError(
+                        "_nrl_max_new_tokens cannot exceed the configured "
+                        f"max_new_tokens ({self.cfg['max_new_tokens']}), got "
+                        f"{request_max_new_tokens}"
+                    )
+
+            force_generation_length = False
+            if "_nrl_force_generation_length" in data:
+                raw_force_length = data["_nrl_force_generation_length"][sample_idx]
+                if hasattr(raw_force_length, "item"):
+                    raw_force_length = raw_force_length.item()
+                force_generation_length = bool(raw_force_length)
+                if force_generation_length and "_nrl_max_new_tokens" not in data:
+                    raise ValueError(
+                        "_nrl_force_generation_length requires "
+                        "_nrl_max_new_tokens"
+                    )
+
+            allowed_token_ids = None
+            forced_generation_token_ids = None
+            if "_nrl_forced_generation_token_id" in data:
+                raw_forced_token = data[
+                    "_nrl_forced_generation_token_id"
+                ][sample_idx]
+                if hasattr(raw_forced_token, "item"):
+                    raw_forced_token = raw_forced_token.item()
+                forced_token_id = int(raw_forced_token)
+                if forced_token_id < 0:
+                    raise ValueError(
+                        "_nrl_forced_generation_token_id must be "
+                        f"nonnegative, got {forced_token_id}"
+                    )
+                allowed_token_ids = [forced_token_id]
+            if "_nrl_forced_generation_token_ids" in data:
+                if allowed_token_ids is not None:
+                    raise ValueError(
+                        "single-token and exact-sequence forcing are mutually exclusive"
+                    )
+                raw_sequence = data["_nrl_forced_generation_token_ids"][sample_idx]
+                if hasattr(raw_sequence, "tolist"):
+                    raw_sequence = raw_sequence.tolist()
+                forced_generation_token_ids = [int(item) for item in raw_sequence]
+                if (
+                    not forced_generation_token_ids
+                    or any(item < 0 for item in forced_generation_token_ids)
+                    or len(forced_generation_token_ids)
+                    != request_max_new_tokens
+                ):
+                    raise ValueError(
+                        "_nrl_forced_generation_token_ids must contain exactly "
+                        "request_max_new_tokens non-negative token IDs"
+                    )
+
+            allowed_new_tokens = max(
+                0, min(request_max_new_tokens, remaining_ctx)
+            )
 
             # Handle case where no tokens can be generated due to length constraints
             if allowed_new_tokens == 0:
@@ -789,24 +1434,180 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 greedy=greedy,
                 stop_strings=final_stop_strings_for_sample,
                 max_new_tokens=allowed_new_tokens,
+                force_generation_length=force_generation_length,
+                allowed_token_ids=allowed_token_ids,
+                forced_generation_token_ids=forced_generation_token_ids,
             )
 
             request_id = str(uuid.uuid4())
 
-            # Generate using vLLM async engine
-            vllm_request_generator = self.llm.generate(
-                prompt=prompt,
-                sampling_params=sampling_params_for_request,
-                request_id=request_id,
+            # Carry the prompt-group id in vLLM's `priority` for the
+            # whole-request waiting order in lfs/engine_schedulers.py.
+            # This field defaults to zero when the rollout has no group id.
+            lfs_group = 0
+            if "lfs_group" in data:
+                group_value = data["lfs_group"][sample_idx]
+                lfs_group = (
+                    int(group_value.item())
+                    if hasattr(group_value, "item")
+                    else int(group_value)
+                )
+
+            # The causal benchmark opts into same-host monotonic timestamps
+            # that distinguish middleware admission from first engine progress.
+            record_engine_progress = (
+                os.environ.get("CROSS_DP_PERF_REQUEST_TIMELINE", "0") == "1"
+            )
+            engine_frontend_submit_at_monotonic_s = None
+            engine_frontend_submit_at_unix_s = None
+            engine_frontend_hostname = (
+                os.uname().nodename if record_engine_progress else None
             )
 
-            # Get the final result from the generator
+            async def record_frontend_submission(
+                submitted_at_unix_s: float,
+                submitted_at_monotonic_s: float,
+                submitted_hostname: str,
+            ) -> None:
+                nonlocal engine_frontend_submit_at_monotonic_s
+                nonlocal engine_frontend_submit_at_unix_s
+                nonlocal engine_frontend_hostname
+
+                if record_engine_progress:
+                    engine_frontend_submit_at_monotonic_s = (
+                        submitted_at_monotonic_s
+                    )
+                    engine_frontend_submit_at_unix_s = submitted_at_unix_s
+                    engine_frontend_hostname = submitted_hostname
+                if cross_dp_frontend_submission is None:
+                    return
+
+                dispatcher = cross_dp_frontend_submission["dispatcher"]
+                await dispatcher.confirm_engine_frontend_submitted.remote(
+                    str(cross_dp_frontend_submission["request_id"]),
+                    int(
+                        cross_dp_frontend_submission[
+                            "assignment_sequence"
+                        ]
+                    ),
+                    int(
+                        cross_dp_frontend_submission[
+                            "dp_assignment_ordinal"
+                        ]
+                    ),
+                    int(
+                        cross_dp_frontend_submission[
+                            "session_dp_assignment_ordinal"
+                        ]
+                    ),
+                    submitted_at_unix_s,
+                    submitted_at_monotonic_s,
+                    submitted_hostname,
+                )
+
+            # Use one explicit add_request/collector path for vanilla and
+            # cross-DP requests. Besides making timestamps comparable, this is
+            # required for a causal gate: constructing AsyncLLM.generate's
+            # async generator does not execute its add_request call.
+            async def generate_after_engine_submission():
+                from vllm.outputs import STREAM_FINISHED
+                from vllm.v1.engine.async_llm import InputStreamError
+                from vllm.v1.engine.exceptions import (
+                    EngineDeadError,
+                    EngineGenerateError,
+                )
+
+                request_output_collector = None
+
+                async def abort_registered_request() -> None:
+                    if request_output_collector is not None:
+                        await self.llm.abort(
+                            request_output_collector.request_id,
+                            internal=True,
+                        )
+
+                try:
+                    (
+                        request_output_collector,
+                        submitted_at_unix_s,
+                        submitted_at_monotonic_s,
+                        submitted_hostname,
+                    ) = await _submit_vllm_request(
+                        self.llm,
+                        prompt=prompt,
+                        sampling_params=sampling_params_for_request,
+                        request_id=request_id,
+                        priority=lfs_group,
+                    )
+                    await record_frontend_submission(
+                        submitted_at_unix_s,
+                        submitted_at_monotonic_s,
+                        submitted_hostname,
+                    )
+                    async for req_output in _iterate_request_output_collector(
+                        request_output_collector,
+                        STREAM_FINISHED,
+                    ):
+                        yield req_output
+                except (asyncio.CancelledError, GeneratorExit):
+                    await abort_registered_request()
+                    raise
+                except EngineDeadError:
+                    raise
+                except ValueError:
+                    await abort_registered_request()
+                    raise
+                except InputStreamError as error:
+                    await abort_registered_request()
+                    raise error.cause from error
+                except Exception as error:
+                    await abort_registered_request()
+                    raise EngineGenerateError() from error
+                finally:
+                    if request_output_collector is not None:
+                        request_output_collector.close()
+
+            vllm_request_generator = generate_after_engine_submission()
+
+            # Track this request's live context length for the in-flight profiler.
+            # The async scheduler is out-of-process, so we reconstruct the in-flight
+            # state from the streamed RequestOutputs here in the front-end.
+            self._inflight_register(request_id, current_input_actual_length)
+            # Get the final result from the generator while updating the profiler's
+            # front-end view of the request's generated length.
             final_request_output = None
-            async for req_output in vllm_request_generator:
-                final_request_output = req_output
+            engine_first_token_at_monotonic_s = None
+            engine_first_token_at_unix_s = None
+            engine_first_observed_generated_tokens = None
+            try:
+                async for req_output in vllm_request_generator:
+                    final_request_output = req_output
+                    if req_output.outputs:
+                        if (
+                            record_engine_progress
+                            and engine_first_token_at_monotonic_s is None
+                            and req_output.outputs[0].token_ids
+                        ):
+                            engine_first_token_at_monotonic_s = time.monotonic()
+                            engine_first_token_at_unix_s = time.time()
+                            engine_first_observed_generated_tokens = len(
+                                req_output.outputs[0].token_ids
+                            )
+                        self._inflight_update(
+                            request_id, len(req_output.outputs[0].token_ids)
+                        )
+            finally:
+                self._inflight_unregister(request_id)
 
             if final_request_output is None:
                 raise RuntimeError(f"No output received for request {request_id}")
+            if (
+                record_engine_progress
+                and engine_first_token_at_monotonic_s is None
+            ):
+                raise RuntimeError(
+                    f"Request {request_id} completed without an observed token"
+                )
 
             # Process the output
             generation_details = final_request_output.outputs[0]
@@ -887,15 +1688,37 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 device=original_input_ids_single_row.device,
             )
 
-            result_batch = BatchedDataDict[GenerationOutputSpec](
-                {
-                    "output_ids": output_ids_single_item_batched,
-                    "logprobs": logprobs_single_item,
-                    "generation_lengths": generation_lengths_tensor,
-                    "unpadded_sequence_lengths": unpadded_sequence_lengths_tensor,
-                    "truncated": truncated_tensor,
-                }
-            )
+            result_data: dict[str, Any] = {
+                "output_ids": output_ids_single_item_batched,
+                "logprobs": logprobs_single_item,
+                "generation_lengths": generation_lengths_tensor,
+                "unpadded_sequence_lengths": unpadded_sequence_lengths_tensor,
+                "truncated": truncated_tensor,
+            }
+            if record_engine_progress:
+                result_data.update(
+                    {
+                        "gen_engine_frontend_submit_at_monotonic_s": [
+                            engine_frontend_submit_at_monotonic_s
+                        ],
+                        "gen_engine_frontend_submit_at_unix_s": [
+                            engine_frontend_submit_at_unix_s
+                        ],
+                        "gen_engine_first_token_at_monotonic_s": [
+                            engine_first_token_at_monotonic_s
+                        ],
+                        "gen_engine_first_token_at_unix_s": [
+                            engine_first_token_at_unix_s
+                        ],
+                        "gen_engine_first_observed_generated_tokens": [
+                            engine_first_observed_generated_tokens
+                        ],
+                        "gen_engine_frontend_hostname": [
+                            engine_frontend_hostname
+                        ],
+                    }
+                )
+            result_batch = BatchedDataDict[GenerationOutputSpec](result_data)
 
             return (sample_idx, result_batch)
 
@@ -1038,6 +1861,24 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
 
         return cast(list[str], list_of_worker_results)
 
+    async def report_model_worker_runtime_environment_async(
+        self,
+    ) -> list[dict[str, Any]]:
+        """Collect non-secret environment proof from every TP worker."""
+
+        assert self.llm is not None, (
+            "Attempting to inspect an uninitialized vLLM"
+        )
+        result_or_coro = await self.llm.collective_rpc(
+            "report_runtime_environment",
+            args=tuple(),
+        )
+        if asyncio.iscoroutine(result_or_coro):
+            worker_results = await result_or_coro
+        else:
+            worker_results = result_or_coro
+        return cast(list[dict[str, Any]], worker_results)
+
     async def prepare_refit_info_async(self, state_dict_info: dict[str, Any]) -> None:
         """Async version of prepare_refit_info."""
         await self.llm.collective_rpc("prepare_refit_info", args=(state_dict_info,))
@@ -1178,6 +2019,20 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
     async def shutdown(self) -> bool:
         """Clean up vLLM resources."""
         try:
+            metrics_stop_event = getattr(
+                self, "_vllm_metrics_logger_stop_event", None
+            )
+            if metrics_stop_event is not None:
+                metrics_stop_event.set()
+            metrics_thread = getattr(self, "_vllm_metrics_logger_thread", None)
+            if metrics_thread is not None and metrics_thread.is_alive():
+                metrics_thread.join(timeout=2.0)
+                if metrics_thread.is_alive():
+                    print(
+                        "Warning: vLLM metrics logger did not stop within 2s",
+                        flush=True,
+                    )
+
             if self.llm is not None:
                 # Clean up extension resources (e.g., ZMQ sockets)
                 await self.llm.collective_rpc("cleanup", args=tuple())
@@ -1196,7 +2051,9 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             gc.collect()
             torch.cuda.empty_cache()
 
-            if self.server_thread is not None:
+            # getattr: non-model-owner workers never run _create_engine, which
+            # is where server_thread is initialized.
+            if getattr(self, "server_thread", None) is not None:
                 from threading import Thread
 
                 from uvicorn import Server

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -142,29 +142,6 @@ def destroy_parallel_state():
     except ImportError:
         pass
 
-    # Reset the third global async_calls instance in base strategy module
-    try:
-        import megatron.core.dist_checkpointing.strategies.base as base_strategy
-        from megatron.core.dist_checkpointing.strategies.async_utils import (
-            AsyncCallsQueue,
-        )
-
-        # Clean up and reset the global async_calls in base strategy
-        old_call_idx = getattr(base_strategy.async_calls, "call_idx", None)
-        num_unfinalized = base_strategy.async_calls.get_num_unfinalized_calls()
-        if num_unfinalized > 0:
-            print(
-                f"[WARNING] Resetting base strategy async_calls with {num_unfinalized} unfinalized calls"
-            )
-        try:
-            base_strategy.async_calls.close()
-        except:
-            pass
-        base_strategy.async_calls = AsyncCallsQueue()
-        print(f"[DEBUG] Reset base strategy async_calls (old call_idx: {old_call_idx})")
-    except ImportError:
-        pass
-
 
 def setup_distributed() -> None:
     """Handle NCCL settings, dtype mapping, and basic config setup."""

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -14,7 +14,7 @@
 
 
 MAJOR = 0
-MINOR = 5
+MINOR = 6
 PATCH = 0
 PRE_RELEASE = "rc0"
 

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -16,13 +16,31 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)
 
 __shortversion__ = ".".join(map(str, VERSION[:3]))
 __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
+
+import os as _os  # noqa: I001
+import subprocess as _subprocess
+
+
+if not int(_os.getenv("NO_VCS_VERSION", "0")):
+    try:
+        _git = _subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            cwd=_os.path.dirname(_os.path.abspath(__file__)),
+            check=True,
+            universal_newlines=True,
+        )
+    except (_subprocess.CalledProcessError, OSError):
+        pass
+    else:
+        __version__ += f"+{_git.stdout.strip()}"
 
 __package_name__ = "nemo_rl"
 __contact_names__ = "NVIDIA"

--- a/nemo_rl/utils/checkpoint.py
+++ b/nemo_rl/utils/checkpoint.py
@@ -225,7 +225,7 @@ class CheckpointManager:
         self.remove_old_checkpoints()
 
     def remove_old_checkpoints(self, exclude_latest: bool = True) -> None:
-        """Remove checkpoints that are not in the top-k or latest based on the (optional) metric.
+        """Remove checkpoints that are not in the top-k or latest.
 
         If keep_top_k is set, this method removes all checkpoints except the top-k
         best ones. The "best" checkpoints are determined by:
@@ -233,6 +233,10 @@ class CheckpointManager:
           When multiple checkpoints have the same metric value, more recent checkpoints
           (higher step numbers) are preferred.
         - If no metric is provided: the step number. The most recent k checkpoints are kept.
+        Checkpoints whose training metadata contains
+        ``"preserve_checkpoint": true`` are never removed and do not consume a
+        top-k slot. Algorithms use this for semantic boundaries such as the end
+        of an epoch while retaining only one rolling recovery checkpoint.
 
         Args:
             exclude_latest (bool): Whether to exclude the latest checkpoint from deletion. (may result in K+1 checkpoints)
@@ -246,24 +250,30 @@ class CheckpointManager:
             else None
         )
 
+        removable_history = [
+            checkpoint
+            for checkpoint in checkpoint_history
+            if not checkpoint[2].get("preserve_checkpoint", False)
+        ]
+
         if self.metric_name is None:
-            checkpoint_history.sort(key=lambda x: x[0], reverse=True)
+            removable_history.sort(key=lambda x: x[0], reverse=True)
         else:
             # sort by metric value first, then by step number (for equal metrics, prefer more recent)
             if self.higher_is_better:
                 # For higher_is_better=True: higher metric values first, then higher step numbers
-                checkpoint_history.sort(
+                removable_history.sort(
                     key=lambda x: (x[2].get(self.metric_name, -float("inf")), x[0]),
                     reverse=True,
                 )
             else:
                 # For higher_is_better=False: lower metric values first, then higher step numbers for equal values
-                checkpoint_history.sort(
+                removable_history.sort(
                     key=lambda x: (x[2].get(self.metric_name, float("inf")), -x[0])
                 )
 
         # remove checkpoints that are not in the top-k
-        for checkpoint in checkpoint_history[self.keep_top_k :]:
+        for checkpoint in removable_history[self.keep_top_k :]:
             if exclude_latest and checkpoint[0] == latest_step:
                 continue
             print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
   "cuda-bindings",                                                                                                    # for non-colocated refit
   "pybase64",                                                                                                         # for sglang refit
   "nvidia-cudnn-cu12==9.19.0.56",                                                                                     # for transformer-engine no build isolation
-  # nvidia-resiliency-ext removed: no Python 3.13 wheels available (v0.5.0 only has cp310-cp312)
 ]
 
 [project.optional-dependencies]
@@ -109,6 +108,9 @@ mcore = [
   "emerging-optimizers==0.2.0",
   "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480",
 ]
+nvrx = [
+  "nvidia-resiliency-ext",
+] # for ft_launcher (fault-tolerant training launcher)
 nemo_gym = ["nemo_gym"]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -504,11 +504,30 @@ requires-dist = [
   "torch>=2.6.0",
 ]
 
-# remove numpy upper-bound to resolve conflict of nvidia-resiliency-ext==0.6.0 and onnx>=1.21.0rc4
+# Override logsage metadata to remove numpy<=2.0.2 and pandas<=2.3.3 upper bounds
+# (numpy cap conflicts with onnx>=1.21.0rc4 CVE fix via nvidia-resiliency-ext)
+# Tracking: https://github.com/NVIDIA/nvidia-resiliency-ext/issues/301
 [[tool.uv.dependency-metadata]]
 name = "logsage"
 version = "0.1.5"
-requires-dist = []
+requires-dist = [
+  "drain3>=0.9.11,<0.10.0",
+  "langchain>=0.3.27,<0.4.0",
+  "langchain-core>=0.3.0,<1.0.0",
+  "langchain-nvidia-ai-endpoints>=0.3.18,<0.4.0",
+  "nh3>=0.3.1,<0.4.0",
+  "numpy",
+  "pandas",
+  "pydantic-settings>=2.11.0,<3.0.0",
+  "requests>=2.32.5,<3.0.0",
+]
+
+# Override drain3 to relax cachetools==4.2.1 pin (conflicts with mlflow's cachetools>=5.0.0)
+# Tracking: https://github.com/logpai/Drain3/issues/119
+[[tool.uv.dependency-metadata]]
+name = "drain3"
+version = "0.9.11"
+requires-dist = ["jsonpickle", "cachetools>=4.2.1"]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -497,7 +497,7 @@ requires-dist = [
   "flash-linear-attention",
   "timm",
   "open-clip-torch>=3.2.0",
-  "mlflow>=3.5.0",
+  "mlflow>=3.9.0",
   "comet-ml>=3.50.0",
   "torch>=2.6.0",
 ]

--- a/scripts/perf_qwen3-235b_128g_gb200_onpolicy.sh
+++ b/scripts/perf_qwen3-235b_128g_gb200_onpolicy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Perf tracker: Qwen series / on-policy / GB200 -- Qwen3-235B-A22B, 128 GPU
+#   (row 51). Same parallelism as the 64-GPU config (gen TP8/DP8,
+#   train TP2/CP2/EP16/PP4) scaled to 32 nodes. Recipe grpo-qwen3-235b-32n4g.
+# NOTE: Qwen3-235B-A22B is NOT cached locally (~470GB) and this needs 32 nodes.
+#   Pre-stage the model and ensure the allocation before running.
+# JSONL -> dp_inflight_profiles/qwen3-235b_128g-gb200_onpolicy/inflight_timeline.jsonl
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RECIPE=grpo-qwen3-235b-32n4g \
+NUM_ACTOR_NODES=32 GPUS_PER_NODE=4 \
+MODEL=${MODEL:-} \
+RUN_TAG=qwen3-235b_128g-gb200_onpolicy \
+PROFILE_INFLIGHT=1 \
+WALLTIME=${WALLTIME:-00:50:00} \
+bash ./scripts/run_qwen_perf.sh

--- a/scripts/perf_qwen3-235b_64g_gb200_onpolicy.sh
+++ b/scripts/perf_qwen3-235b_64g_gb200_onpolicy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Perf tracker: Qwen series / on-policy / GB200 -- Qwen3-235B-A22B, 64 GPU
+#   (rows 45,50). GRPO, OpenMathInstruct-2, seqlen 8192, BF16, colocated,
+#   rollout GBS 512, train GBS 512. gen TP8/DP8, train TP2/CP2/EP16/PP4.
+#   Recipe grpo-qwen3-235b-16n4g (16 nodes x 4 GPU).
+# NOTE: Qwen3-235B-A22B is NOT cached locally (~470GB) and this needs 16 nodes.
+#   Pre-stage the model and ensure the allocation before running.
+# JSONL -> dp_inflight_profiles/qwen3-235b_64g-gb200_onpolicy/inflight_timeline.jsonl
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RECIPE=grpo-qwen3-235b-16n4g \
+NUM_ACTOR_NODES=16 GPUS_PER_NODE=4 \
+MODEL=${MODEL:-} \
+RUN_TAG=qwen3-235b_64g-gb200_onpolicy \
+PROFILE_INFLIGHT=1 \
+WALLTIME=${WALLTIME:-00:50:00} \
+bash ./scripts/run_qwen_perf.sh

--- a/scripts/perf_qwen3-30ba3b_16g_gb200_onpolicy.sh
+++ b/scripts/perf_qwen3-30ba3b_16g_gb200_onpolicy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Perf tracker: Qwen series / on-policy / GB200 -- Qwen3-30B-A3B (MoE), 16 GPU
+#   (rows 25,30,35). GRPO, OpenMathInstruct-2, seqlen 4096, BF16, colocated,
+#   rollout GBS 2048, train GBS 512. gen TP1/DP16, train EP16/TP1 (MoE expert
+#   parallel). Recipe grpo-qwen3-30ba3b-4n4g.
+# NOTE: Qwen3-30B-A3B is NOT cached locally (~60GB) -- first run downloads it to
+#   HF_HOME. Pre-stage it or expect added startup time.
+# JSONL -> dp_inflight_profiles/qwen3-30ba3b_16g-gb200_onpolicy/inflight_timeline.jsonl
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RECIPE=grpo-qwen3-30ba3b-4n4g \
+NUM_ACTOR_NODES=4 GPUS_PER_NODE=4 \
+MODEL=${MODEL:-} \
+RUN_TAG=qwen3-30ba3b_16g-gb200_onpolicy \
+PROFILE_INFLIGHT=1 \
+WALLTIME=${WALLTIME:-00:40:00} \
+bash ./scripts/run_qwen_perf.sh

--- a/scripts/perf_qwen3-32b_16g_gb200_onpolicy.sh
+++ b/scripts/perf_qwen3-32b_16g_gb200_onpolicy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Perf tracker: Qwen series / on-policy / GB200 -- Qwen3-32B, 16 GPU (rows 11,15).
+#   GRPO, OpenMathInstruct-2, seqlen 4096, BF16, colocated, rollout GBS 2048,
+#   train GBS 512. gen TP2, train TP2/PP4 (recipe grpo-qwen3-32b-4n4g, v0.7 row).
+# JSONL -> dp_inflight_profiles/qwen3-32b_16g-gb200_onpolicy/inflight_timeline.jsonl
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RECIPE=grpo-qwen3-32b-4n4g \
+NUM_ACTOR_NODES=4 GPUS_PER_NODE=4 \
+MODEL=${MODEL:-${WORK_DIR:?set MODEL, or WORK_DIR to a shared path holding the HF cache}/hf_home/hub/models--Qwen--Qwen3-32B/snapshots/9216db5781bf21249d130ec9da846c4624c16137} \
+RUN_TAG=qwen3-32b_16g-gb200_onpolicy \
+PROFILE_INFLIGHT=1 \
+WALLTIME=${WALLTIME:-00:30:00} \
+bash ./scripts/run_qwen_perf.sh

--- a/scripts/run_deepseek.sh
+++ b/scripts/run_deepseek.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Run from the root of the NeMo RL repo.
+#
+# DeepSeek-V3 perf A/B:
+#   ENABLE_MTP=0 bash ./run-ds.sh   # baseline
+#   ENABLE_MTP=1 bash ./run-ds.sh   # vLLM-side MTP speculative decoding
+
+set -euo pipefail
+
+# Site-specific root: one path, visible on every node, holding the container
+# image, the HF cache and the mcore checkpoint cache. No default on purpose --
+# a wrong shared path is a multi-node failure that only shows up at init.
+WORK_DIR=${WORK_DIR:?set WORK_DIR to a shared path visible on every node}
+
+SLURM_ACCOUNT=${SLURM_ACCOUNT:?set SLURM_ACCOUNT to your Slurm account}
+NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-32}
+GPUS_PER_NODE=${GPUS_PER_NODE:-4}
+test_case=${test_case:-grpo-deepseek-v3-32n4g}
+
+ENABLE_MTP=${ENABLE_MTP:-0}
+MAX_STEPS=${MAX_STEPS:-8}
+ENABLE_WANDB=${ENABLE_WANDB:-0}
+WANDB_PROJECT=${WANDB_PROJECT:-async-grpo-perfscript-test}
+
+DS_BF16=${DS_BF16:-${WORK_DIR}/hf_home/Deepseek-V3-BF16}
+DS_BF16_MTP=${DS_BF16_MTP:-${WORK_DIR}/.cache/huggingface/nemo_rl/Deepseek-V3-BF16-mtp}
+
+CONTAINER=${CONTAINER:-${WORK_DIR}/sqsh/nemo_rl.v0.6.0.sqsh}
+HF_HOME=${HF_HOME:-${WORK_DIR}/hf_home}
+HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${WORK_DIR}/hf_home/cache}
+
+if [ ${NUM_ACTOR_NODES} -le 16 ]; then
+    SEGMENT=${SEGMENT:-${NUM_ACTOR_NODES}}
+else
+    SEGMENT=${SEGMENT:-16}
+fi
+
+if [ ! -f "${DS_BF16}/config.json" ] || [ ! -f "${DS_BF16}/model.safetensors.index.json" ]; then
+    echo "DeepSeek BF16 checkpoint is missing required files: ${DS_BF16}" >&2
+    exit 1
+fi
+
+if ! grep -q "model.layers.61.eh_proj.weight" "${DS_BF16}/model.safetensors.index.json"; then
+    echo "DeepSeek BF16 checkpoint does not appear to include the layer-61 MTP weights: ${DS_BF16}" >&2
+    exit 1
+fi
+
+MTP_OVERRIDES=""
+MTP_TAG="nomtp"
+POLICY_MODEL="${DS_BF16}"
+
+if [ "${ENABLE_MTP}" = "1" ]; then
+    mkdir -p "${DS_BF16_MTP}"
+    for f in "${DS_BF16}"/*; do
+        ln -sfn "$f" "${DS_BF16_MTP}/$(basename "$f")"
+    done
+    rm -f "${DS_BF16_MTP}/config.json"
+    jq '.num_nextn_predict_layers = 1' "${DS_BF16}/config.json" > "${DS_BF16_MTP}/config.json"
+
+    POLICY_MODEL="${DS_BF16_MTP}"
+    MTP_TAG="mtp"
+    MTP_OVERRIDES="++policy.generation.vllm_kwargs.speculative_config.method=mtp \
+++policy.generation.vllm_kwargs.speculative_config.num_speculative_tokens=1"
+elif [ "${ENABLE_MTP}" != "0" ]; then
+    echo "ENABLE_MTP must be 0 or 1, got: ${ENABLE_MTP}" >&2
+    exit 1
+fi
+
+wandb_log_name=${WANDB_NAME:-OCI-${test_case}-${MTP_TAG}-steps${MAX_STEPS}}
+
+if [ "${ENABLE_WANDB}" = "1" ]; then
+    if [ -z "${WANDB_API_KEY:-}" ]; then
+        echo "ENABLE_WANDB=1 requires WANDB_API_KEY to be set." >&2
+        exit 1
+    fi
+    WANDB_OVERRIDES="logger.wandb_enabled=true \
+logger.wandb.name=${wandb_log_name} \
+logger.wandb.project=${WANDB_PROJECT}"
+elif [ "${ENABLE_WANDB}" = "0" ]; then
+    WANDB_OVERRIDES="logger.wandb_enabled=false"
+else
+    echo "ENABLE_WANDB must be 0 or 1, got: ${ENABLE_WANDB}" >&2
+    exit 1
+fi
+
+COMMAND="HF_HOME=${HF_HOME} HF_DATASETS_CACHE=${HF_DATASETS_CACHE} uv run ./examples/run_grpo.py \
+--config examples/configs/recipes/llm/performance/${test_case}.yaml \
+cluster.num_nodes=${NUM_ACTOR_NODES} \
+${WANDB_OVERRIDES} \
+policy.model_name=${POLICY_MODEL} \
+grpo.max_num_steps=${MAX_STEPS} \
+${MTP_OVERRIDES}"
+
+echo "Submitting ${test_case}"
+echo "  ENABLE_MTP=${ENABLE_MTP}"
+echo "  policy.model_name=${POLICY_MODEL}"
+echo "  max steps=${MAX_STEPS}"
+echo "  wandb enabled=${ENABLE_WANDB}"
+if [ "${ENABLE_WANDB}" = "1" ]; then
+    echo "  wandb=${WANDB_PROJECT}/${wandb_log_name}"
+fi
+
+COMMAND="${COMMAND}" \
+CONTAINER="${CONTAINER}" \
+HF_HOME="${HF_HOME}" \
+HF_DATASETS_CACHE="${HF_DATASETS_CACHE}" \
+GPUS_PER_NODE="${GPUS_PER_NODE}" \
+WANDB_API_KEY="${WANDB_API_KEY:-}" \
+HF_TOKEN="${HF_TOKEN:-}" \
+MOUNTS="${MOUNTS:-${WORK_DIR}:${WORK_DIR}}" \
+sbatch \
+    --nodes=${NUM_ACTOR_NODES} \
+    --account=${SLURM_ACCOUNT} \
+    --job-name=${SLURM_ACCOUNT}-ds-${MTP_TAG} \
+    --partition=${SLURM_PARTITION:-batch} \
+    --time=${WALLTIME:-01:00:00} \
+    --segment=${SEGMENT} \
+    --gres=gpu:${GPUS_PER_NODE} \
+    ray.sub

--- a/scripts/run_qwen3.sh
+++ b/scripts/run_qwen3.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Run from the root of the NeMo RL repo.
+#
+# Qwen3-32B debug / A/B perf script (4-node 4-GPU-per-node).
+# Derived from scripts/run_deepseek.sh for quick iteration.
+#
+# Usage:
+#   bash ./scripts/run_qwen3.sh                  # default: 4n4g, 3 steps, no wandb
+#   MAX_STEPS=8 ENABLE_WANDB=1 bash ./scripts/run_qwen3.sh
+
+set -euo pipefail
+
+# Site-specific root: one path, visible on every node, holding the container
+# image, the HF cache and the mcore checkpoint cache. No default on purpose --
+# a wrong shared path is a multi-node failure that only shows up at init.
+WORK_DIR=${WORK_DIR:?set WORK_DIR to a shared path visible on every node}
+
+SLURM_ACCOUNT=${SLURM_ACCOUNT:?set SLURM_ACCOUNT to your Slurm account}
+NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-4}
+GPUS_PER_NODE=${GPUS_PER_NODE:-4}
+test_case=${test_case:-grpo-qwen3-32b-4n4g}
+
+# ray.sub pins `#SBATCH --dependency=singleton`, so jobs sharing a name run one
+# at a time. Override JOB_NAME to run submissions in parallel, e.g.
+#   JOB_NAME=qwen3-nsys NSYS=1 bash ./scripts/run_qwen3.sh
+JOB_NAME=${JOB_NAME:-${SLURM_ACCOUNT}-qwen3}
+
+MAX_STEPS=${MAX_STEPS:-3}
+ENABLE_WANDB=${ENABLE_WANDB:-0}
+WANDB_PROJECT=${WANDB_PROJECT:-async-grpo-perfscript-test}
+
+# Per-DP rollout batch/load stats for perf analysis (see VllmGeneration._log_dp_batch_stats).
+# Set LOG_DP_BATCH_STATS=1 to emit "[DP-BATCH-STATS]" lines per generate() call.
+LOG_DP_BATCH_STATS=${LOG_DP_BATCH_STATS:-0}
+
+# Live per-DP in-flight batch timeline (batch size + per-seq context length over
+# time), written to JSONL for offline plotting. See vllm/inflight_profiler.py.
+# PROFILE_INFLIGHT=1 to enable; INTERVAL is the sampling cadence in seconds.
+PROFILE_INFLIGHT=${PROFILE_INFLIGHT:-0}
+PROFILE_INFLIGHT_INTERVAL=${PROFILE_INFLIGHT_INTERVAL:-0.5}
+PROFILE_INFLIGHT_DIR=${PROFILE_INFLIGHT_DIR:-dp_inflight_profiles}
+
+# Use vLLM async engine (AsyncLLM + per-sample streaming rollouts). The
+# in-flight profiler also works under async (front-end streaming source).
+# ASYNC=1 only flips the engine; set async GRPO separately if desired.
+ASYNC=${ASYNC:-0}
+if [ "${ASYNC}" = "1" ]; then
+    ASYNC_OVERRIDES="policy.generation.vllm_cfg.async_engine=true"
+else
+    ASYNC_OVERRIDES=""
+fi
+
+# Nsight Systems (nsys) GPU profiling (see docs/nsys-profiling.md).
+# NSYS=1 enables it. NSYS_PATTERNS are fnmatch globs over worker names
+# (vllm_generation_worker / megatron_policy_worker); NSYS_STEP_RANGE is
+# start:stop (1-indexed, stop exclusive). To also profile the Megatron policy,
+# set NSYS_PATTERNS='*policy*,*vllm*' (the Megatron worker additionally needs
+# LD_LIBRARY_PATH per the docs). .nsys-rep files land under $JOB-logs/ray/...
+# and require RAY_LOG_SYNC_FREQUENCY to be synced off the container tmpfs.
+NSYS=${NSYS:-0}
+NSYS_PATTERNS=${NSYS_PATTERNS:-'*vllm*'}
+NSYS_STEP_RANGE=${NSYS_STEP_RANGE:-2:3}
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-30}
+
+if [ "${NSYS}" = "1" ]; then
+    NSYS_ENV="NRL_NSYS_WORKER_PATTERNS='${NSYS_PATTERNS}' NRL_NSYS_PROFILE_STEP_RANGE='${NSYS_STEP_RANGE}' "
+    _ray_log_sync="${RAY_LOG_SYNC_FREQUENCY}"
+else
+    NSYS_ENV=""
+    # Empty disables the ray.sub log-sync sidecar (its default-off behavior).
+    _ray_log_sync=""
+fi
+
+QWEN3_32B=${QWEN3_32B:-${WORK_DIR}/hf_home/hub/models--Qwen--Qwen3-32B/snapshots/9216db5781bf21249d130ec9da846c4624c16137}
+
+CONTAINER=${CONTAINER:-${WORK_DIR}/sqsh/nemo_rl.v0.6.0.sqsh}
+HF_HOME=${HF_HOME:-${WORK_DIR}/hf_home}
+HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${WORK_DIR}/hf_home/cache}
+
+# Pin the one-time HF->mcore conversion cache to a path mounted on
+# all nodes. get_megatron_checkpoint_dir() otherwise falls back to $HF_HOME/nemo_rl,
+# and a leaked HF_HOME pointing at a node-local path can resolve
+# to a directory not mounted on every node, which fails multi-node mcore init.
+NRL_MEGATRON_CHECKPOINT_DIR=${NRL_MEGATRON_CHECKPOINT_DIR:-${WORK_DIR}/hf_home/nemo_rl}
+
+if [ ${NUM_ACTOR_NODES} -le 16 ]; then
+    SEGMENT=${SEGMENT:-${NUM_ACTOR_NODES}}
+else
+    SEGMENT=${SEGMENT:-16}
+fi
+
+if [ ! -f "${QWEN3_32B}/config.json" ]; then
+    echo "Qwen3-32B checkpoint is missing config.json: ${QWEN3_32B}" >&2
+    exit 1
+fi
+
+wandb_log_name=${WANDB_NAME:-OCI-${test_case}-steps${MAX_STEPS}}
+
+if [ "${ENABLE_WANDB}" = "1" ]; then
+    _wandb_key="${WANDB_API_KEY:-}"
+    if [ -z "${_wandb_key}" ]; then
+        echo "ENABLE_WANDB=1 requires WANDB_API_KEY to be set." >&2
+        exit 1
+    fi
+    WANDB_OVERRIDES="logger.wandb_enabled=true \
+logger.wandb.name=${wandb_log_name} \
+logger.wandb.project=${WANDB_PROJECT}"
+elif [ "${ENABLE_WANDB}" = "0" ]; then
+    WANDB_OVERRIDES="logger.wandb_enabled=false"
+else
+    echo "ENABLE_WANDB must be 0 or 1, got: ${ENABLE_WANDB}" >&2
+    exit 1
+fi
+
+COMMAND="${NSYS_ENV}HF_HOME=${HF_HOME} HF_DATASETS_CACHE=${HF_DATASETS_CACHE} NRL_MEGATRON_CHECKPOINT_DIR=${NRL_MEGATRON_CHECKPOINT_DIR} NRL_LOG_DP_BATCH_STATS=${LOG_DP_BATCH_STATS} NRL_PROFILE_INFLIGHT=${PROFILE_INFLIGHT} NRL_PROFILE_INFLIGHT_INTERVAL=${PROFILE_INFLIGHT_INTERVAL} NRL_PROFILE_INFLIGHT_DIR=${PROFILE_INFLIGHT_DIR} uv run ./examples/run_grpo.py \
+--config examples/configs/recipes/llm/performance/${test_case}.yaml \
+cluster.num_nodes=${NUM_ACTOR_NODES} \
+logger.wandb_enabled=false \
+${WANDB_OVERRIDES} \
+policy.model_name=${QWEN3_32B} \
+${ASYNC_OVERRIDES} \
+grpo.max_num_steps=${MAX_STEPS}"
+
+echo "Submitting ${test_case}"
+echo "  policy.model_name=${QWEN3_32B}"
+echo "  max steps=${MAX_STEPS}"
+echo "  dp batch stats=${LOG_DP_BATCH_STATS}"
+echo "  async engine=${ASYNC}"
+echo "  inflight profile=${PROFILE_INFLIGHT} (interval=${PROFILE_INFLIGHT_INTERVAL}s, dir=${PROFILE_INFLIGHT_DIR})"
+if [ "${NSYS}" = "1" ]; then
+    echo "  nsys=ON patterns='${NSYS_PATTERNS}' steps=${NSYS_STEP_RANGE} (ray_log_sync=${_ray_log_sync}s)"
+else
+    echo "  nsys=OFF"
+fi
+echo "  wandb enabled=${ENABLE_WANDB}"
+if [ "${ENABLE_WANDB}" = "1" ]; then
+    echo "  wandb=${WANDB_PROJECT}/${wandb_log_name}"
+fi
+
+COMMAND="${COMMAND}" \
+CONTAINER="${CONTAINER}" \
+HF_HOME="${HF_HOME}" \
+HF_DATASETS_CACHE="${HF_DATASETS_CACHE}" \
+GPUS_PER_NODE="${GPUS_PER_NODE}" \
+WANDB_API_KEY="${WANDB_API_KEY:-}" \
+HF_TOKEN="${HF_TOKEN:-}" \
+RAY_LOG_SYNC_FREQUENCY="${_ray_log_sync}" \
+MOUNTS="${MOUNTS:-${WORK_DIR}:${WORK_DIR}}" \
+sbatch \
+    --nodes=${NUM_ACTOR_NODES} \
+    --account=${SLURM_ACCOUNT} \
+    --job-name=${JOB_NAME} \
+    --partition=${SLURM_PARTITION:-batch} \
+    --time=${WALLTIME:-00:30:00} \
+    --segment=${SEGMENT} \
+    --gres=gpu:${GPUS_PER_NODE} \
+    ray.sub

--- a/scripts/run_qwen_perf.sh
+++ b/scripts/run_qwen_perf.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Run from the root of the NeMo RL repo.
+#
+# Generic GRPO perf-profiling launcher for the "Qwen series / on-policy / GB200"
+# rows of the perf tracker. Parameterized over recipe + node layout + model so a
+# thin per-config wrapper (see scripts/perf_qwen*.sh) just sets a few vars.
+# The in-flight rollout profiler is ON by default and writes a meaningfully-named
+# JSONL under dp_inflight_profiles/${RUN_TAG}/.
+#
+# Required (usually set by the wrapper):
+#   RECIPE   recipe yaml stem under examples/configs/recipes/llm/performance/
+#   RUN_TAG  short slug used for JSONL dir, job name, wandb name
+# Optional:
+#   MODEL              local snapshot path OR HF repo id; empty => use recipe default
+#   NUM_ACTOR_NODES, GPUS_PER_NODE, MAX_STEPS, WALLTIME
+#   PROFILE_INFLIGHT (default 1), PROFILE_INFLIGHT_INTERVAL, ASYNC, NSYS, ENABLE_WANDB
+
+set -euo pipefail
+
+# Site-specific root: one path, visible on every node, holding the container
+# image, the HF cache and the mcore checkpoint cache. No default on purpose --
+# a wrong shared path is a multi-node failure that only shows up at init.
+WORK_DIR=${WORK_DIR:?set WORK_DIR to a shared path visible on every node}
+
+RECIPE=${RECIPE:?set RECIPE to a recipe yaml stem (e.g. grpo-qwen3-32b-4n4g)}
+RUN_TAG=${RUN_TAG:?set RUN_TAG to a short slug for naming outputs}
+
+SLURM_ACCOUNT=${SLURM_ACCOUNT:?set SLURM_ACCOUNT to your Slurm account}
+NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-4}
+GPUS_PER_NODE=${GPUS_PER_NODE:-4}
+MAX_STEPS=${MAX_STEPS:-3}
+
+# ray.sub pins `#SBATCH --dependency=singleton`, so distinct names run in parallel.
+JOB_NAME=${JOB_NAME:-${SLURM_ACCOUNT}-${RUN_TAG}}
+
+ENABLE_WANDB=${ENABLE_WANDB:-0}
+WANDB_PROJECT=${WANDB_PROJECT:-qwen-gb200-perf}
+
+# In-flight rollout profiler (per-DP batch size + per-seq context length over
+# time). ON by default for these perf scripts. JSONL is named by RUN_TAG.
+PROFILE_INFLIGHT=${PROFILE_INFLIGHT:-1}
+PROFILE_INFLIGHT_INTERVAL=${PROFILE_INFLIGHT_INTERVAL:-0.5}
+PROFILE_INFLIGHT_DIR=${PROFILE_INFLIGHT_DIR:-dp_inflight_profiles/${RUN_TAG}}
+# Resolve to an absolute path so it is unambiguous inside the container (the
+# driver's cwd is the repo root, but pin it explicitly).
+case "${PROFILE_INFLIGHT_DIR}" in
+    /*) ;;
+    *) PROFILE_INFLIGHT_DIR="$(pwd)/${PROFILE_INFLIGHT_DIR}" ;;
+esac
+mkdir -p "${PROFILE_INFLIGHT_DIR}"
+
+LOG_DP_BATCH_STATS=${LOG_DP_BATCH_STATS:-1}
+
+# vLLM async engine (AsyncLLM + per-sample streaming rollouts).
+ASYNC=${ASYNC:-0}
+if [ "${ASYNC}" = "1" ]; then
+    ASYNC_OVERRIDES="policy.generation.vllm_cfg.async_engine=true"
+else
+    ASYNC_OVERRIDES=""
+fi
+
+# Nsight Systems profiling (see docs/nsys-profiling.md).
+NSYS=${NSYS:-0}
+NSYS_PATTERNS=${NSYS_PATTERNS:-'*vllm*'}
+NSYS_STEP_RANGE=${NSYS_STEP_RANGE:-2:3}
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-30}
+if [ "${NSYS}" = "1" ]; then
+    NSYS_ENV="NRL_NSYS_WORKER_PATTERNS='${NSYS_PATTERNS}' NRL_NSYS_PROFILE_STEP_RANGE='${NSYS_STEP_RANGE}' "
+    _ray_log_sync="${RAY_LOG_SYNC_FREQUENCY}"
+else
+    NSYS_ENV=""
+    _ray_log_sync=""
+fi
+
+CONTAINER=${CONTAINER:-${WORK_DIR}/sqsh/nemo_rl.v0.6.0.sqsh}
+HF_HOME=${HF_HOME:-${WORK_DIR}/hf_home}
+HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${WORK_DIR}/hf_home/cache}
+# Pin the HF->mcore conversion cache under WORK_DIR (visible on every node);
+# avoids a leaked HF_HOME on a node-local path breaking multi-node mcore init.
+NRL_MEGATRON_CHECKPOINT_DIR=${NRL_MEGATRON_CHECKPOINT_DIR:-${WORK_DIR}/hf_home/nemo_rl}
+
+if [ ${NUM_ACTOR_NODES} -le 16 ]; then
+    SEGMENT=${SEGMENT:-${NUM_ACTOR_NODES}}
+else
+    SEGMENT=${SEGMENT:-16}
+fi
+
+# Only override policy.model_name if MODEL is given; empty => recipe default.
+# A local path (starts with /) must exist; a HF repo id is resolved/downloaded.
+MODEL=${MODEL:-}
+MODEL_OVERRIDE=""
+if [ -n "${MODEL}" ]; then
+    case "${MODEL}" in
+        /*)
+            if [ ! -f "${MODEL}/config.json" ]; then
+                echo "MODEL local path missing config.json: ${MODEL}" >&2
+                exit 1
+            fi
+            ;;
+    esac
+    MODEL_OVERRIDE="policy.model_name=${MODEL}"
+fi
+
+wandb_log_name=${WANDB_NAME:-${RUN_TAG}-steps${MAX_STEPS}}
+if [ "${ENABLE_WANDB}" = "1" ]; then
+    if [ -z "${WANDB_API_KEY:-}" ]; then
+        echo "ENABLE_WANDB=1 requires WANDB_API_KEY to be set." >&2
+        exit 1
+    fi
+    WANDB_OVERRIDES="logger.wandb_enabled=true logger.wandb.name=${wandb_log_name} logger.wandb.project=${WANDB_PROJECT}"
+else
+    WANDB_OVERRIDES="logger.wandb_enabled=false"
+fi
+
+COMMAND="${NSYS_ENV}HF_HOME=${HF_HOME} HF_DATASETS_CACHE=${HF_DATASETS_CACHE} NRL_MEGATRON_CHECKPOINT_DIR=${NRL_MEGATRON_CHECKPOINT_DIR} NRL_LOG_DP_BATCH_STATS=${LOG_DP_BATCH_STATS} NRL_PROFILE_INFLIGHT=${PROFILE_INFLIGHT} NRL_PROFILE_INFLIGHT_INTERVAL=${PROFILE_INFLIGHT_INTERVAL} NRL_PROFILE_INFLIGHT_DIR=${PROFILE_INFLIGHT_DIR} uv run ./examples/run_grpo.py \
+--config examples/configs/recipes/llm/performance/${RECIPE}.yaml \
+cluster.num_nodes=${NUM_ACTOR_NODES} \
+${WANDB_OVERRIDES} \
+${MODEL_OVERRIDE} \
+${ASYNC_OVERRIDES} \
+grpo.max_num_steps=${MAX_STEPS}"
+
+echo "Submitting ${RUN_TAG}"
+echo "  recipe=${RECIPE}  nodes=${NUM_ACTOR_NODES}x${GPUS_PER_NODE}gpu"
+echo "  model=${MODEL:-<recipe default>}"
+echo "  max steps=${MAX_STEPS}  walltime=${WALLTIME:-00:30:00}"
+echo "  async engine=${ASYNC}  nsys=${NSYS}  dp batch stats=${LOG_DP_BATCH_STATS}"
+echo "  inflight profile=${PROFILE_INFLIGHT} -> ${PROFILE_INFLIGHT_DIR}/inflight_timeline.jsonl"
+
+COMMAND="${COMMAND}" \
+CONTAINER="${CONTAINER}" \
+HF_HOME="${HF_HOME}" \
+HF_DATASETS_CACHE="${HF_DATASETS_CACHE}" \
+GPUS_PER_NODE="${GPUS_PER_NODE}" \
+WANDB_API_KEY="${WANDB_API_KEY:-}" \
+HF_TOKEN="${HF_TOKEN:-}" \
+RAY_LOG_SYNC_FREQUENCY="${_ray_log_sync}" \
+MOUNTS="${MOUNTS:-${WORK_DIR}:${WORK_DIR}}" \
+sbatch \
+    --nodes=${NUM_ACTOR_NODES} \
+    --account=${SLURM_ACCOUNT} \
+    --job-name=${JOB_NAME} \
+    --partition=${SLURM_PARTITION:-batch} \
+    --time=${WALLTIME:-00:30:00} \
+    --segment=${SEGMENT} \
+    --gres=gpu:${GPUS_PER_NODE} \
+    ray.sub

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-seqpack.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-seqpack.v1.sh
@@ -36,7 +36,7 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     uv run tests/check_metrics.py $JSON_METRICS \
         'data["train/loss"]["1"] < 1.5' \
         'data["train/loss"]["20"] < 0.3' \
-        'data["validation/accuracy"]["20"] > 0.1' \
+        'data["validation/accuracy"]["20"] > 0.075' \
         'mean(data["timing/train/total_step_time"], -6, -1) < 1000'
 
     # Clean up checkpoint directory after successful run to save space.

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# Use the DeepSeek-V3 checkpoint converted to BF16.
+if [[ -z "$NRL_DEEPSEEK_V3_BF16_CKPT" ]]; then
+    echo "Need to set NRL_DEEPSEEK_V3_BF16_CKPT to the path of DeepSeek-V3 checkpoint converted to BF16. See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/deepseek.md for more details."
+    exit 1
+fi
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=64
+GPUS_PER_NODE=4
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    policy.model_name=$NRL_DEEPSEEK_V3_BF16_CKPT \
+    policy.tokenizer.name=$NRL_DEEPSEEK_V3_BF16_CKPT \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# Use the DeepSeek-V3 checkpoint converted to BF16.
+if [[ -z "$NRL_DEEPSEEK_V3_BF16_CKPT" ]]; then
+    echo "Need to set NRL_DEEPSEEK_V3_BF16_CKPT to the path of DeepSeek-V3 checkpoint converted to BF16. See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/deepseek.md for more details."
+    exit 1
+fi
 
 # ===== BEGIN CONFIG =====
-NUM_NODES=8
-GPUS_PER_NODE=4
+NUM_NODES=64
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=100
+NUM_MINUTES=240
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached
@@ -18,6 +25,8 @@ cd $PROJECT_ROOT
 uv run examples/run_grpo.py \
     --config $CONFIG_PATH \
     grpo.max_num_steps=$MAX_STEPS \
+    policy.model_name=$NRL_DEEPSEEK_V3_BF16_CKPT \
+    policy.tokenizer.name=$NRL_DEEPSEEK_V3_BF16_CKPT \
     logger.log_dir=$LOG_DIR \
     logger.wandb_enabled=True \
     logger.wandb.project=nemo-rl \
@@ -41,4 +50,3 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     # Clean up checkpoint directory after successful run to save space.
     rm -rf "$CKPT_DIR"
 fi
-

--- a/tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+GPUS_PER_NODE=4
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=100
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["10"] < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-qwen3-235b-32n8g.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-235b-32n8g.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=115
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["10"] < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=4
+GPUS_PER_NODE=4
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=100
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["10"] < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi
+

--- a/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
+++ b/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
@@ -38,7 +38,7 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     uv run tests/check_metrics.py $JSON_METRICS \
         'data["train/loss"]["1"] < 0.55' \
         'data["train/loss"]["300"] < 0.285' \
-        'max(data["ray/node.0.gpu.0.mem_gb"]) < 140' \
+        'max(data["ray/node.0.gpu.0.mem_gb"]) < 160' \
         'mean(data["timing/train/total_step_time"], 2) < 20'
 
     # Clean up checkpoint directory after successful run to save space.

--- a/tests/test_suites/performance_gb200.txt
+++ b/tests/test_suites/performance_gb200.txt
@@ -9,11 +9,13 @@ tests/test_suites/llm/performance/grpo-llama3.1-8b-instruct-2n4g.sh
 tests/test_suites/llm/performance/grpo-qwen3-32b-4n4g.sh
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g.sh
 tests/test_suites/llm/performance/grpo-deepseek-v3-32n4g.sh
+tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-16n4g.sh
+tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g.sh
 
 ## ASYNC 1-off
 tests/test_suites/llm/performance/grpo-llama3.1-8b-instruct-2n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-32b-8n4g-async-1off.sh
-tests/test_suites/llm/performance/grpo-qwen3-30ba3b-8n4g-async-1off.sh
+tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g-async-1off.sh

--- a/tests/test_suites/performance_h100.txt
+++ b/tests/test_suites/performance_h100.txt
@@ -9,8 +9,10 @@ tests/test_suites/llm/performance/grpo-llama3.1-8b-instruct-2n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.sh
 tests/test_suites/llm/performance/grpo-deepseek-v3-32n8g.sh
+tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-32b-4n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-16n8g.sh
+tests/test_suites/llm/performance/grpo-qwen3-235b-32n8g.sh
 tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.sh
 
 ## ASYNC 1-off

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -103,6 +103,24 @@ class TestReplayBuffer:
 
         ray.kill(buffer)
 
+    def test_replay_buffer_fatal_error_reaches_trainer_polls(self):
+        """A background generation failure must not look like an empty buffer."""
+        buffer = ReplayBuffer.remote(max_size=10)
+        ray.get(buffer.set_fatal_error.remote("dispatcher lost remote state"))
+
+        with pytest.raises(RuntimeError, match="dispatcher lost remote state"):
+            ray.get(buffer.size.remote())
+        with pytest.raises(RuntimeError, match="dispatcher lost remote state"):
+            ray.get(
+                buffer.sample.remote(
+                    num_prompt_groups=1,
+                    current_weight_version=0,
+                    max_age_steps=1,
+                )
+            )
+
+        ray.kill(buffer)
+
     def test_replay_buffer_push_and_size(self):
         """Test pushing trajectories to buffer."""
         buffer = ReplayBuffer.remote(max_size=3)

--- a/tests/unit/data/test_dapo_math.py
+++ b/tests/unit/data/test_dapo_math.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datasets import Dataset
+
+from nemo_rl.data.datasets.response_datasets.dapo_math import (
+    _select_unique_dapo_prompts,
+)
+
+
+def _row(prompt: str, answer: str) -> dict:
+    return {
+        "prompt": [{"role": "user", "content": prompt}],
+        "reward_model": {"ground_truth": answer, "style": "rule"},
+    }
+
+
+def test_select_unique_dapo_prompts_drops_reward_conflicts() -> None:
+    dataset = Dataset.from_list(
+        [
+            _row("a", "1"),
+            _row("a", "1"),
+            _row("b", "2"),
+            _row("c", "3"),
+            _row("c", "different"),
+        ]
+    )
+
+    cleaned = _select_unique_dapo_prompts(
+        dataset, drop_conflicting_rewards=True
+    )
+
+    assert len(cleaned) == 2
+    assert [row[0]["content"] for row in cleaned["prompt"]] == ["a", "b"]
+
+
+def test_select_unique_dapo_prompts_can_keep_first_conflicting_row() -> None:
+    dataset = Dataset.from_list([_row("a", "1"), _row("a", "different")])
+
+    cleaned = _select_unique_dapo_prompts(
+        dataset, drop_conflicting_rewards=False
+    )
+
+    assert len(cleaned) == 1
+    assert cleaned[0]["reward_model"]["ground_truth"] == "1"

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -448,6 +448,9 @@ def test_run_multi_step_calculator_vllm_async(multi_step_setup_vllm_async):
     )
     max_rollout_turns = initial_batch["extra_env_info"][0]["max_steps"] + 1
     max_seq_len = 1024
+    # Use non-positional IDs so the test detects accidental replacement with
+    # the per-batch sample index inside the async rollout implementation.
+    initial_batch["idx"] = [101, 202]
 
     print("\nRunning async rollout with async generation engine (VLLM)...")
     vllm_generation.prepare_for_generation()
@@ -469,6 +472,7 @@ def test_run_multi_step_calculator_vllm_async(multi_step_setup_vllm_async):
     assert "message_log" in final_batch
     assert "total_reward" in final_batch
     assert len(final_batch["message_log"]) == len(initial_batch["message_log"])
+    assert final_batch["idx"] == initial_batch["idx"]
 
     for i in range(len(final_batch["message_log"])):
         sample_log = final_batch["message_log"][i]

--- a/tests/unit/models/generation/vllm/test_concurrency.py
+++ b/tests/unit/models/generation/vllm/test_concurrency.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_rl.models.generation.vllm.lfs.concurrency import (
+    get_engine_kv_cache_shape,
+    max_concurrency_without_preemption,
+)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        SimpleNamespace(
+            vllm_config=SimpleNamespace(
+                cache_config=SimpleNamespace(num_gpu_blocks=100, block_size=16)
+            )
+        ),
+        SimpleNamespace(
+            llm_engine=SimpleNamespace(
+                vllm_config=SimpleNamespace(
+                    cache_config=SimpleNamespace(
+                        num_gpu_blocks=100, block_size=16
+                    )
+                )
+            )
+        ),
+    ],
+)
+def test_get_engine_kv_cache_shape_supports_vllm_frontends(engine) -> None:
+    assert get_engine_kv_cache_shape(engine) == (1_600, 16)
+
+
+def test_get_engine_kv_cache_shape_requires_initialized_blocks() -> None:
+    engine = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            cache_config=SimpleNamespace(num_gpu_blocks=0, block_size=16)
+        )
+    )
+    with pytest.raises(RuntimeError, match="initialized vLLM KV cache"):
+        get_engine_kv_cache_shape(engine)
+
+
+def test_max_concurrency_uses_block_aligned_max_sequence_length() -> None:
+    concurrency = max_concurrency_without_preemption(
+        kv_cache_tokens=1_069_984,
+        max_sequence_length=16_532,
+        block_size=16,
+    )
+
+    assert concurrency == 64
+
+
+def test_max_concurrency_can_reserve_lookahead_blocks() -> None:
+    concurrency = max_concurrency_without_preemption(
+        kv_cache_tokens=1_069_984,
+        max_sequence_length=16_532,
+        block_size=16,
+        reserve_blocks_per_sequence=8,
+    )
+
+    assert concurrency == 64
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"kv_cache_tokens": 0}, "kv_cache_tokens"),
+        ({"max_sequence_length": 0}, "max_sequence_length"),
+        ({"block_size": 0}, "block_size"),
+        ({"reserve_blocks_per_sequence": -1}, "reserve_blocks_per_sequence"),
+    ],
+)
+def test_max_concurrency_rejects_invalid_inputs(
+    kwargs: dict[str, int], match: str
+) -> None:
+    valid = {
+        "kv_cache_tokens": 1_069_984,
+        "max_sequence_length": 16_532,
+        "block_size": 16,
+        "reserve_blocks_per_sequence": 0,
+    }
+    valid.update(kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        max_concurrency_without_preemption(**valid)
+
+
+def test_max_concurrency_rejects_cache_smaller_than_one_sequence() -> None:
+    with pytest.raises(ValueError, match="cannot fit one"):
+        max_concurrency_without_preemption(
+            kv_cache_tokens=1_024,
+            max_sequence_length=2_048,
+            block_size=16,
+        )

--- a/tests/unit/models/generation/vllm/test_cross_dp_dispatcher.py
+++ b/tests/unit/models/generation/vllm/test_cross_dp_dispatcher.py
@@ -1,0 +1,590 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import threading
+import time
+
+import pytest
+import ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+from nemo_rl.models.generation.vllm.lfs.dispatcher import (
+    CrossDpDispatcherActor,
+)
+
+
+async def await_ref(ref):
+    return await ref
+
+
+async def acquire(actor, request_id: str, group_id: str):
+    return await actor.acquire.remote("s", "p", request_id, group_id, 128)
+
+
+def confirm_frontend(actor, lease: dict) -> None:
+    ray.get(
+        actor.confirm_engine_frontend_submitted.remote(
+            lease["request_id"],
+            lease["assignment_sequence"],
+            lease["dp_assignment_ordinal"],
+            lease["session_dp_assignment_ordinal"],
+        )
+    )
+
+
+@pytest.fixture
+def local_ray():
+    owned = not ray.is_initialized()
+    if owned:
+        ray.init(num_cpus=1, include_dashboard=False)
+    yield
+    if owned:
+        ray.shutdown()
+
+
+def test_dispatcher_handle_works_across_repeated_asyncio_run(local_ray) -> None:
+    # This test compares dispatcher and client CLOCK_MONOTONIC timestamps.
+    # Keep the actor in the same clock domain even when pytest is attached to
+    # a multi-node Ray cluster, matching VllmGeneration's production setup.
+    actor = CrossDpDispatcherActor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(
+            node_id=ray.get_runtime_context().get_node_id(),
+            soft=False,
+        )
+    ).remote(1, 1, "lfs", False)
+    catalog = [
+        {"request_id": "r0", "group_id": "a", "fallback_cost": 128},
+        {"request_id": "r1", "group_id": "b", "fallback_cost": 128},
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = asyncio.run(acquire(actor, "r0", "a"))
+    assert first["dp_idx"] == 0
+    snapshot = ray.get(actor.snapshot.remote())
+    assert snapshot["assignment_history"][0]["assigned_at_monotonic_s"] > 0
+    assert snapshot["assignment_history"][0]["assigned_at_unix_s"] > 0
+    assert snapshot["assignment_history"][0]["dispatcher_hostname"]
+    reported_at_unix = time.time()
+    reported_at_monotonic = time.monotonic()
+    asyncio.run(
+        await_ref(
+            actor.complete.remote(
+                "r0",
+                10,
+                reported_at_unix,
+                reported_at_monotonic,
+                os.uname().nodename,
+            )
+        )
+    )
+    snapshot = ray.get(actor.snapshot.remote())
+    refill = snapshot["assignment_history"][1]
+    assert refill["trigger_completion_request_id"] == "r0"
+    assert refill["client_completion_to_refill_assignment_s"] >= 0
+    completion = snapshot["completion_history"][0]
+    assert completion["request_id"] == "r0"
+    assert completion["refill_assignment_sequences"] == [refill["sequence"]]
+    assert completion["client_to_dispatcher_rpc_s"] >= 0
+    second = asyncio.run(acquire(actor, "r1", "b"))
+    assert second["dp_idx"] == 0
+    asyncio.run(await_ref(actor.complete.remote("r1", 20)))
+    asyncio.run(await_ref(actor.close_participant.remote("s", "p")))
+
+
+def test_dispatcher_propagates_inflight_count_dp_selection_mode(
+    local_ray,
+) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        2,
+        2,
+        "fcfs",
+        False,
+        None,
+        0,
+        3,
+        "inflight_count",
+    )
+    catalog = [
+        {"request_id": "long", "group_id": "a", "fallback_cost": 1000},
+        {"request_id": "short-0", "group_id": "b", "fallback_cost": 1},
+        {"request_id": "short-1", "group_id": "c", "fallback_cost": 1},
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    snapshot = ray.get(actor.snapshot.remote())
+    assert snapshot["dp_selection_mode"] == "inflight_count"
+    assert [
+        event["dp_idx"] for event in snapshot["assignment_history"]
+    ] == [0, 1, 0]
+
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+def test_dispatcher_propagates_lfs_admission_fairness_interval(
+    local_ray,
+) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        2,
+        "lfs",
+        False,
+        None,
+        0,
+        2,
+        "inflight_count",
+        1,
+    )
+    catalog = [
+        {"request_id": "r0", "group_id": "a", "fallback_cost": 128},
+        {"request_id": "r1", "group_id": "a", "fallback_cost": 128},
+        {"request_id": "r2", "group_id": "a", "fallback_cost": 128},
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "a", 128))
+    confirm_frontend(actor, first)
+    second = ray.get(actor.acquire.remote("s", "p", "r1", "a", 128))
+    confirm_frontend(actor, second)
+    ray.get(actor.complete.remote(first["request_id"], 10))
+    third = ray.get(actor.acquire.remote("s", "p", "r2", "a", 128))
+    confirm_frontend(actor, third)
+    snapshot = ray.get(actor.snapshot.remote())
+
+    assert snapshot["lfs_admission_fairness"]["interval"] == 1
+    assert snapshot["assignment_history"][2]["admission_fairness_due"]
+    assert snapshot["assignment_history"][2][
+        "admission_fairness_due_but_no_candidate"
+    ]
+
+    ray.get(actor.complete.remote(second["request_id"], 20))
+    ray.get(actor.complete.remote(third["request_id"], 30))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+@pytest.mark.timeout(30)
+def test_pending_acquire_can_span_another_thread_and_event_loop(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(1, 1, "lfs", False)
+    catalog = [
+        {"request_id": "r0", "group_id": "a", "fallback_cost": 128},
+        {"request_id": "r1", "group_id": "b", "fallback_cost": 128},
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+    asyncio.run(acquire(actor, "r0", "a"))
+
+    result: dict = {}
+
+    def wait_for_second_lease() -> None:
+        result.update(asyncio.run(acquire(actor, "r1", "b")))
+
+    thread = threading.Thread(target=wait_for_second_lease)
+    thread.start()
+    asyncio.run(await_ref(actor.complete.remote("r0", 10)))
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert result["dp_idx"] == 0
+    asyncio.run(await_ref(actor.complete.remote("r1", 20)))
+    asyncio.run(await_ref(actor.close_participant.remote("s", "p")))
+
+
+@pytest.mark.timeout(30)
+def test_per_dp_launch_gate_ignores_client_acquire_arrival_order(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        2,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(3)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    third_ref = actor.acquire.remote("s", "p", "r2", "g", 128)
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+    first_ref = actor.acquire.remote("s", "p", "r0", "g", 128)
+
+    first = ray.get(first_ref)
+    assert first["request_id"] == "r0"
+    ready, _ = ray.wait([second_ref, third_ref], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    confirm_frontend(actor, first)
+    second = ray.get(second_ref)
+    assert second["request_id"] == "r1"
+    ready, _ = ray.wait([third_ref], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    confirm_frontend(actor, second)
+    third = ray.get(third_ref)
+    assert third["request_id"] == "r2"
+    confirm_frontend(actor, third)
+
+    for request_id in ("r0", "r1", "r2"):
+        ray.get(actor.complete.remote(request_id, 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+    snapshot = ray.get(actor.snapshot.remote())
+    assert [
+        event["request_id"] for event in snapshot["engine_frontend_ack_history"]
+    ] == ["r0", "r1", "r2"]
+    assert all(
+        event["source"] == "engine_frontend_submitted"
+        for event in snapshot["engine_frontend_ack_history"]
+    )
+    assert snapshot["launch_queues_by_dp"] == [[]]
+    assert snapshot["launch_outstanding_by_dp"] == [None]
+
+
+@pytest.mark.timeout(30)
+def test_invalid_or_duplicate_frontend_ack_does_not_release_gate(
+    local_ray,
+) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(2)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "g", 128))
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+
+    with pytest.raises(RuntimeError, match="assignment sequence mismatch"):
+        ray.get(
+            actor.confirm_engine_frontend_submitted.remote(
+                first["request_id"],
+                first["assignment_sequence"] + 1,
+                first["dp_assignment_ordinal"],
+                first["session_dp_assignment_ordinal"],
+            )
+        )
+    snapshot = ray.get(actor.snapshot.remote())
+    assert snapshot["engine_frontend_ack_history"] == []
+    assert snapshot["launch_outstanding_by_dp"] == ["r0"]
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.05)
+    assert ready == []
+
+    confirm_frontend(actor, first)
+    second = ray.get(second_ref)
+    with pytest.raises(RuntimeError, match="not the outstanding launch"):
+        confirm_frontend(actor, first)
+    snapshot = ray.get(actor.snapshot.remote())
+    assert [
+        event["request_id"]
+        for event in snapshot["engine_frontend_ack_history"]
+    ] == ["r0"]
+    assert snapshot["launch_outstanding_by_dp"] == ["r1"]
+
+    confirm_frontend(actor, second)
+    ray.get(actor.complete.remote("r0", 1))
+    ray.get(actor.complete.remote("r1", 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+@pytest.mark.timeout(30)
+def test_explicit_unknown_failure_retains_capacity_and_rejects_waiters(
+    local_ray,
+) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(2)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "g", 128))
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+    ray.get(
+        actor.fail_unknown.remote(
+            first["request_id"],
+            "Ray transport failed with remote engine state unknown",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="remote state became unknown"):
+        ray.get(second_ref)
+    snapshot = ray.get(actor.snapshot.remote())
+    assert snapshot["fatal_error"] is not None
+    assert snapshot["dp_inflight"] == [["r0"]]
+    assert snapshot["launch_outstanding_by_dp"] == [None]
+    assert snapshot["engine_frontend_ack_history"] == []
+
+
+@pytest.mark.timeout(30)
+def test_worker_proxy_creation_cannot_release_next_frontend_call(
+    local_ray,
+) -> None:
+    """Model the measured proxy/worker race at the real engine boundary."""
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        2,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(2)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "g", 128))
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+
+    # A driver-side worker proxy for r0 now exists, but its remote method is
+    # deliberately delayed. Under the old acknowledgement boundary this would
+    # release r1, whose remote call could reach the worker first.
+    proxy_created = threading.Event()
+    allow_frontend_submission = threading.Event()
+    frontend_invocations: list[str] = []
+
+    def delayed_first_worker_frontend() -> None:
+        proxy_created.set()
+        assert allow_frontend_submission.wait(timeout=5)
+        frontend_invocations.append(first["request_id"])
+        confirm_frontend(actor, first)
+
+    first_worker = threading.Thread(target=delayed_first_worker_frontend)
+    first_worker.start()
+    assert proxy_created.wait(timeout=5)
+
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.05)
+    assert ready == []
+
+    allow_frontend_submission.set()
+    second = ray.get(second_ref)
+    frontend_invocations.append(second["request_id"])
+    confirm_frontend(actor, second)
+    first_worker.join(timeout=5)
+
+    assert not first_worker.is_alive()
+    assert frontend_invocations == ["r0", "r1"]
+    ray.get(actor.complete.remote("r0", 1))
+    ray.get(actor.complete.remote("r1", 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+@pytest.mark.timeout(30)
+def test_launch_gates_are_independent_across_dp_ranks(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        2,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(4)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    refs = {
+        request_id: actor.acquire.remote(
+            "s", "p", request_id, "g", 128
+        )
+        for request_id in ("r3", "r2", "r1", "r0")
+    }
+    first_dp0, first_dp1 = ray.get([refs["r0"], refs["r1"]])
+    assert (first_dp0["dp_idx"], first_dp1["dp_idx"]) == (0, 1)
+    ready, _ = ray.wait(
+        [refs["r2"], refs["r3"]], num_returns=1, timeout=0.2
+    )
+    assert ready == []
+
+    confirm_frontend(actor, first_dp0)
+    second_dp0 = ray.get(refs["r2"])
+    assert second_dp0["dp_idx"] == 0
+    ready, _ = ray.wait([refs["r3"]], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    confirm_frontend(actor, first_dp1)
+    second_dp1 = ray.get(refs["r3"])
+    assert second_dp1["dp_idx"] == 1
+    confirm_frontend(actor, second_dp0)
+    confirm_frontend(actor, second_dp1)
+
+    for request_id in ("r0", "r1", "r2", "r3"):
+        ray.get(actor.complete.remote(request_id, 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+@pytest.mark.timeout(30)
+def test_cancelling_unsubmitted_launch_releases_next_gate_entry(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(2)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "g", 128))
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    ray.get(actor.cancel_unsubmitted.remote("r0"))
+    second = ray.get(second_ref)
+    assert second["request_id"] == "r1"
+    confirm_frontend(actor, second)
+    ray.get(actor.complete.remote("r1", 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+
+@pytest.mark.timeout(30)
+def test_frontend_failure_before_ack_releases_gate_without_deadlock(
+    local_ray,
+) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {"request_id": f"r{index}", "group_id": "g", "fallback_cost": 128}
+        for index in range(2)
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p"]))
+
+    first = ray.get(actor.acquire.remote("s", "p", "r0", "g", 128))
+    second_ref = actor.acquire.remote("s", "p", "r1", "g", 128)
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.05)
+    assert ready == []
+
+    ray.get(
+        actor.fail_terminated.remote(
+            first["request_id"],
+            "vLLM add_request failed before frontend acknowledgement",
+        )
+    )
+    second = ray.get(second_ref)
+    assert second["request_id"] == "r1"
+    confirm_frontend(actor, second)
+    ray.get(actor.complete.remote("r1", 1))
+    ray.get(actor.close_participant.remote("s", "p"))
+
+    snapshot = ray.get(actor.snapshot.remote())
+    assert [
+        (event["request_id"], event["source"])
+        for event in snapshot["engine_frontend_ack_history"]
+    ] == [
+        ("r0", "terminated_failure"),
+        ("r1", "engine_frontend_submitted"),
+    ]
+    assert snapshot["launch_outstanding_by_dp"] == [None]
+
+
+@pytest.mark.timeout(30)
+def test_participant_close_skips_unclaimed_launch_queue_head(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {
+            "request_id": "p0-r0",
+            "group_id": "a",
+            "participant_id": "p0",
+            "fallback_cost": 128,
+        },
+        {
+            "request_id": "p1-r0",
+            "group_id": "b",
+            "participant_id": "p1",
+            "fallback_cost": 128,
+        },
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p0", "p1"]))
+    second_ref = actor.acquire.remote("s", "p1", "p1-r0", "b", 128)
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    ray.get(actor.close_participant.remote("s", "p0"))
+    second = ray.get(second_ref)
+    assert second["request_id"] == "p1-r0"
+    confirm_frontend(actor, second)
+    ray.get(actor.complete.remote("p1-r0", 1))
+    ray.get(actor.close_participant.remote("s", "p1"))
+
+
+@pytest.mark.timeout(30)
+def test_participant_close_fail_fasts_unknown_frontend_state(local_ray) -> None:
+    actor = CrossDpDispatcherActor.remote(
+        1,
+        1,
+        "fcfs",
+        False,
+        lookahead_per_dp=1,
+    )
+    catalog = [
+        {
+            "request_id": "p0-r0",
+            "group_id": "a",
+            "participant_id": "p0",
+            "fallback_cost": 128,
+        },
+        {
+            "request_id": "p1-r0",
+            "group_id": "b",
+            "participant_id": "p1",
+            "fallback_cost": 128,
+        },
+    ]
+    ray.get(actor.open_session.remote("s", catalog, ["p0", "p1"]))
+    first = ray.get(
+        actor.acquire.remote("s", "p0", "p0-r0", "a", 128)
+    )
+    assert first["request_id"] == "p0-r0"
+    second_ref = actor.acquire.remote("s", "p1", "p1-r0", "b", 128)
+    ready, _ = ray.wait([second_ref], num_returns=1, timeout=0.2)
+    assert ready == []
+
+    # No engine-frontend ACK was observed for p0-r0, but add_request() may have
+    # already returned while that ACK RPC is in flight. The slot must not be
+    # released or reused.
+    ray.get(actor.close_participant.remote("s", "p0"))
+    with pytest.raises(RuntimeError, match="remote state became unknown"):
+        ray.get(second_ref)
+    snapshot = ray.get(actor.snapshot.remote())
+    assert snapshot["fatal_error"] is not None
+    assert snapshot["launch_outstanding_by_dp"] == [None]
+    assert snapshot["dp_inflight"] == [["p0-r0"]]
+    assert snapshot["engine_frontend_ack_history"] == []

--- a/tests/unit/models/generation/vllm/test_cross_dp_scheduler.py
+++ b/tests/unit/models/generation/vllm/test_cross_dp_scheduler.py
@@ -1,0 +1,1667 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_rl.models.generation.vllm.lfs import (
+    LFS_ADMISSION_FAIRNESS_SEMANTICS,
+    CrossDpSchedulerState,
+    build_async_cross_dp_group_ids,
+)
+
+
+class _Batch(dict):
+    def __init__(self, *, size: int | None = None, **values) -> None:
+        super().__init__(values)
+        self._size = size
+
+    @property
+    def size(self) -> int:
+        if self._size is not None:
+            return self._size
+        return len(next(iter(self.values())))
+
+
+def test_async_cross_dp_group_ids_use_stable_dataset_idx() -> None:
+    first_batch = _Batch(idx=[91, 17])
+    second_batch = _Batch(idx=[17, 91])
+
+    assert build_async_cross_dp_group_ids(
+        first_batch, num_generations=3
+    ) == ["91", "91", "91", "17", "17", "17"]
+    assert build_async_cross_dp_group_ids(
+        second_batch, num_generations=3
+    ) == ["17", "17", "17", "91", "91", "91"]
+
+
+def test_async_cross_dp_group_ids_fallback_and_validation() -> None:
+    assert build_async_cross_dp_group_ids(
+        _Batch(size=2), num_generations=2
+    ) == ["0", "0", "1", "1"]
+    with pytest.raises(ValueError, match="positive"):
+        build_async_cross_dp_group_ids(_Batch(idx=[1]), num_generations=0)
+    with pytest.raises(ValueError, match="idx count"):
+        build_async_cross_dp_group_ids(
+            _Batch(size=1, idx=[1, 2]), num_generations=1
+        )
+
+
+def catalog(groups: list[str], fallback_cost: int = 128) -> list[dict]:
+    return [
+        {
+            "request_id": f"r{index}",
+            "group_id": group,
+            "fallback_cost": fallback_cost,
+        }
+        for index, group in enumerate(groups)
+    ]
+
+
+def designated_catalog(
+    groups: list[str],
+    designated_indices: set[int],
+    fallback_cost: int = 128,
+) -> list[dict]:
+    return [
+        {
+            "request_id": f"r{index}",
+            "group_id": group,
+            "fallback_cost": fallback_cost,
+            "is_designated_probe": index in designated_indices,
+            "oracle_cost": (index + 1) * 10,
+        }
+        for index, group in enumerate(groups)
+    ]
+
+
+def acquire_assigned(state: CrossDpSchedulerState, request_id: str, group: str):
+    lease = state.acquire("s", "s:participant:0", request_id, group, 128)
+    assert lease is not None
+    return lease
+
+
+def test_predicted_lfs_orders_long_groups_from_session_open() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="predicted_lfs",
+    )
+    predicted_catalog = catalog(["short", "short", "long", "long"])
+    for item in predicted_catalog:
+        item["predicted_cost"] = (
+            100 if item["group_id"] == "long" else 10
+        )
+    state.open_session("s", predicted_catalog)
+
+    assert [
+        (event["group_id"], event["tier"], event["estimate"])
+        for event in state.assignment_history
+    ] == [
+        ("long", "predicted_lfs", 100),
+        ("long", "predicted_lfs", 100),
+    ]
+
+
+def test_predicted_lfs_rejects_inconsistent_group_predictions() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode="predicted_lfs",
+    )
+    predicted_catalog = catalog(["same", "same"])
+    predicted_catalog[0]["predicted_cost"] = 10
+    predicted_catalog[1]["predicted_cost"] = 11
+    with pytest.raises(ValueError, match="identical within a prompt group"):
+        state.open_session("s", predicted_catalog)
+
+
+def test_prepare_acquire_preserves_assignment_until_ordered_claim() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="fcfs",
+    )
+    state.open_session("s", catalog(["a", "b"]))
+
+    state.prepare_acquire(
+        "s",
+        "s:participant:0",
+        "r1",
+        "b",
+        128,
+    )
+    assert state.requests["r1"].status == "assigned"
+    assert not state.requests["r1"].lease_started
+
+    lease = state.claim_if_assigned("r1")
+    assert lease is not None
+    event = state.assignment_history[1]
+    assert lease["assignment_sequence"] == event["sequence"] == 1
+    assert lease["dp_assignment_ordinal"] == event["dp_assignment_ordinal"] == 1
+    assert (
+        lease["session_dp_assignment_ordinal"]
+        == event["session_dp_assignment_ordinal"]
+        == 1
+    )
+
+
+def test_session_dp_assignment_ordinal_resets_but_global_ordinal_does_not() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode="fcfs",
+    )
+    state.open_session("s", catalog(["a"]))
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 1)
+    state.close_participant("s", "s:participant:0")
+
+    state.open_session(
+        "next",
+        [{"request_id": "next-r0", "group_id": "a", "fallback_cost": 128}],
+    )
+    event = state.assignment_history[-1]
+    assert event["dp_assignment_ordinal"] == 1
+    assert event["session_dp_assignment_ordinal"] == 0
+
+
+def test_first_wave_probes_groups_then_round_robins_spare_capacity() -> None:
+    state = CrossDpSchedulerState(dp_size=2, max_num_seqs_per_dp=4, mode="lfs")
+    # Catalog arrival is deliberately group-contiguous, as repeat_interleave(G)
+    # presents it in GRPO.
+    groups = ["a"] * 3 + ["b"] * 3 + ["c"] * 3
+    state.open_session("s", catalog(groups))
+
+    first_wave = state.assignment_history[:8]
+    assert [event["group_id"] for event in first_wave] == [
+        "a",
+        "b",
+        "c",
+        "a",
+        "b",
+        "c",
+        "a",
+        "b",
+    ]
+    assert [event["tier"] for event in first_wave[:3]] == [
+        "probe",
+        "probe",
+        "probe",
+    ]
+    assert max(event["dp_inflight"][0] for event in first_wave) <= 4
+    assert max(event["dp_inflight"][1] for event in first_wave) <= 4
+
+
+def test_unresolved_upper_bound_ties_finite_estimate_numerically() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=2, mode="lfs")
+    state.open_session("s", catalog(["a", "a", "b", "b"], fallback_cost=128))
+
+    # Both groups receive their probe before any ordinary request.
+    assert [
+        (event["request_id"], event["tier"])
+        for event in state.assignment_history
+    ] == [("r0", "probe"), ("r2", "probe")]
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r2", "b")
+
+    # Group a's finite estimate equals b's unresolved max_tokens upper bound.
+    # They therefore tie in approximate-LFS and stable arrival order selects a;
+    # unresolved b must not win merely because it used to occupy a lower tier.
+    state.complete("r0", 128)
+
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r1"
+    assert event["group_id"] == "a"
+    assert event["tier"] == "lfs"
+    assert event["estimate"] == 128
+    assert event["pending_unknown_group_count_before_assignment"] == 1
+    assert event["pending_finite_group_count_before_assignment"] == 1
+    assert event["policy_active_priority_tier"] == 2
+    assert {
+        item["group_id"]
+        for item in event["policy_eligible_pending_groups"]
+    } == {"a", "b"}
+    assert event["policy_priority_class_count_before_assignment"] == 1
+    assert event["policy_expected_request_id"] == "r1"
+    assert event["policy_expected_group_id"] == "a"
+    assert event["policy_expected_priority_key"] == [
+        0,
+        2,
+        -128.0,
+        1,
+        1,
+    ]
+    assert {
+        item["group_id"]: item["policy_priority_key"]
+        for item in event["policy_eligible_pending_groups"]
+    } == {
+        "a": [0, 2, -128.0, 1, 1],
+        "b": [0, 2, -128.0, 1, 3],
+    }
+
+
+@pytest.mark.parametrize("mode", ["lfs", "oracle_probe_lfs"])
+def test_explicit_designated_probes_only_reorder_lfs_group_queues(
+    mode: str,
+) -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=4,
+        mode=mode,
+    )
+    state.open_session(
+        "s",
+        designated_catalog(
+            ["a", "a", "a", "b", "b", "b"],
+            designated_indices={2, 5},
+        ),
+    )
+
+    events = state.assignment_history
+    assert [event["request_id"] for event in events] == [
+        "r2",
+        "r5",
+        "r0",
+        "r3",
+    ]
+    assert [event["tier"] for event in events] == [
+        "probe",
+        "probe",
+        "unknown_rr",
+        "unknown_rr",
+    ]
+    assert [event["is_designated_probe"] for event in events] == [
+        True,
+        True,
+        False,
+        False,
+    ]
+    assert all(not event["probe_replacement"] for event in events)
+    assert {
+        event["probe_selection_semantics"] for event in events
+    } == {"explicit_catalog_flag-v1"}
+
+    # Explicit selection changes only the LFS group deque. Catalog arrival
+    # order and the independent FCFS diagnostic remain untouched.
+    assert [state.requests[f"r{index}"].arrival_seq for index in range(6)] == list(
+        range(6)
+    )
+    assert events[0]["fcfs_front_request_id"] == "r0"
+    assert events[0]["policy_expected_request_id"] == "r2"
+    assert events[1]["policy_expected_request_id"] == "r5"
+    assert events[0]["selected_differs_from_fcfs_front"]
+
+
+def test_disabled_lfs_admission_fairness_has_no_candidates_or_actions() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="lfs",
+        lfs_admission_fairness_interval=0,
+    )
+    state.open_session("s", catalog(["a", "a", "b", "b"]))
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r2", "b")
+    state.complete("r0", 10)
+    state.complete("r2", 100)
+
+    assert all(
+        event["admission_fairness_eligible_pending_groups"] == []
+        and event["admission_fairness_candidate_count"] == 0
+        and not event["admission_fairness_due"]
+        and not event["admission_fairness_selected"]
+        for event in state.assignment_history
+    )
+    assert state.snapshot()["lfs_admission_fairness"] == {
+        "policy": "prose-inspired-idle-group-admission-age-v1",
+        "semantics": LFS_ADMISSION_FAIRNESS_SEMANTICS,
+        "interval": 0,
+        "ordinary_admission_opportunity_count": 2,
+        "due_count": 0,
+        "selected_count": 0,
+        "override_count": 0,
+        "noop_count": 0,
+        "no_candidate_count": 0,
+    }
+
+
+def test_lfs_admission_fairness_rescues_underestimated_idle_group() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="lfs",
+        lfs_admission_fairness_interval=1,
+    )
+    state.open_session("s", catalog(["a", "a", "a", "b", "b"]))
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r3", "b")
+
+    # Base LFS prefers unresolved group b at the numerical upper bound.
+    # The due safeguard instead gives idle, underestimated group a another
+    # sample without changing capacity or DP placement.
+    state.complete("r0", 10)
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r1"
+    assert event["base_policy_expected_request_id"] == "r4"
+    assert event["admission_fairness_expected_request_id"] == "r1"
+    assert event["admission_fairness_selected"]
+    assert event["admission_fairness_changed_base_choice"]
+    assert event["admission_selection_reason"] == "fairness_override"
+    assert event["ordinary_admission_ordinal"] == 1
+    assert event["admission_fairness_candidate_count"] == 1
+
+    acquire_assigned(state, "r1", "a")
+    state.complete("r1", 200)
+    assert state.sessions["s"].estimates["a"] == 200
+    rebase = state.estimate_rebase_history[-1]
+    assert rebase["previous_estimate"] == 10
+    assert rebase["estimate"] == 200
+    assert rebase["completed_request_was_admission_fairness_selected"]
+    assert rebase["completed_request_ordinary_admission_ordinal"] == 1
+
+
+def test_lfs_admission_fairness_rotates_only_across_idle_groups() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=3,
+        mode="lfs",
+        lfs_admission_fairness_interval=1,
+    )
+    state.open_session(
+        "s",
+        catalog(["a", "a", "b", "b", "c", "c"]),
+    )
+    for request_id, group in (("r0", "a"), ("r2", "b"), ("r4", "c")):
+        acquire_assigned(state, request_id, group)
+
+    state.complete("r0", 10)
+    state.complete("r2", 20)
+    state.complete("r4", 30)
+    ordinary = [
+        event
+        for event in state.assignment_history
+        if event["ordinary_admission_opportunity"]
+    ]
+    assert [event["group_id"] for event in ordinary] == ["a", "b", "c"]
+    assert [
+        event["ordinary_admission_ordinal"] for event in ordinary
+    ] == [1, 2, 3]
+    assert all(event["admission_fairness_selected"] for event in ordinary)
+
+
+def test_lfs_admission_fairness_due_without_idle_group_falls_back() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="lfs",
+        lfs_admission_fairness_interval=1,
+    )
+    state.open_session("s", catalog(["a", "a", "a"]))
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r1", "a")
+    state.complete("r0", 10)
+
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r2"
+    assert event["admission_fairness_due"]
+    assert not event["admission_fairness_selected"]
+    assert event["admission_fairness_due_but_no_candidate"]
+    assert event["admission_selection_reason"] == (
+        "fairness_no_candidate_fallback"
+    )
+    assert event["admission_fairness_candidate_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("mode", "interval"),
+    [
+        ("fcfs", 1),
+        ("history_lfs", 1),
+        ("exact_length_lpt", 1),
+        ("lfs", -1),
+        ("lfs", True),
+    ],
+)
+def test_lfs_admission_fairness_rejects_invalid_configuration(
+    mode: str,
+    interval: int,
+) -> None:
+    with pytest.raises(ValueError, match="lfs_admission_fairness_interval"):
+        CrossDpSchedulerState(
+            dp_size=1,
+            max_num_seqs_per_dp=1,
+            mode=mode,  # type: ignore[arg-type]
+            lfs_admission_fairness_interval=interval,
+        )
+
+
+def test_explicit_designated_probes_do_not_reorder_fcfs() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=6,
+        mode="fcfs",
+    )
+    state.open_session(
+        "s",
+        designated_catalog(
+            ["a", "a", "a", "b", "b", "b"],
+            designated_indices={2, 5},
+        ),
+    )
+
+    events = state.assignment_history
+    assert [event["request_id"] for event in events] == [
+        f"r{index}" for index in range(6)
+    ]
+    assert [event["is_designated_probe"] for event in events] == [
+        False,
+        False,
+        True,
+        False,
+        False,
+        True,
+    ]
+    assert all(not event["probe_replacement"] for event in events)
+    assert {
+        event["probe_selection_semantics"] for event in events
+    } == {"explicit_catalog_flag-v1"}
+
+
+def test_legacy_catalog_keeps_implicit_probe_selection_semantics() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode="lfs",
+    )
+    state.open_session("s", catalog(["a", "a"]))
+
+    event = state.assignment_history[0]
+    assert event["request_id"] == "r0"
+    assert not event["is_designated_probe"]
+    assert not event["probe_replacement"]
+    assert (
+        event["probe_selection_semantics"]
+        == "implicit_first_pending-v1"
+    )
+
+
+@pytest.mark.parametrize(
+    ("request_catalog", "message"),
+    [
+        (
+            [
+                {
+                    "request_id": "r0",
+                    "group_id": "a",
+                    "fallback_cost": 128,
+                    "is_designated_probe": True,
+                },
+                {
+                    "request_id": "r1",
+                    "group_id": "a",
+                    "fallback_cost": 128,
+                },
+            ],
+            "must be present on every catalog request",
+        ),
+        (
+            [
+                {
+                    "request_id": "r0",
+                    "group_id": "a",
+                    "fallback_cost": 128,
+                    "is_designated_probe": 1,
+                },
+                {
+                    "request_id": "r1",
+                    "group_id": "a",
+                    "fallback_cost": 128,
+                    "is_designated_probe": False,
+                },
+            ],
+            "must be a bool",
+        ),
+        (
+            designated_catalog(["a", "a"], designated_indices=set()),
+            "exactly one",
+        ),
+        (
+            designated_catalog(["a", "a"], designated_indices={0, 1}),
+            "exactly one",
+        ),
+    ],
+)
+def test_explicit_designated_probe_catalog_validation(
+    request_catalog: list[dict],
+    message: str,
+) -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode="lfs",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        state.open_session("s", request_catalog)
+
+
+def test_probe_catalog_spans_multiple_waves_when_capacity_is_small() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=2, mode="lfs")
+    groups = ["a"] * 2 + ["b"] * 2 + ["c"] * 2 + ["d"] * 2
+    state.open_session("s", catalog(groups))
+
+    assert [event["group_id"] for event in state.assignment_history] == ["a", "b"]
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r2", "b")
+    state.complete("r0", 100)
+    state.complete("r2", 10)
+
+    # Newly learned estimates must not bypass groups that have not yet been
+    # probed, even when the probe catalog spans more than one capacity wave.
+    assert [event["group_id"] for event in state.assignment_history[:4]] == [
+        "a",
+        "b",
+        "c",
+        "d",
+    ]
+    assert [event["tier"] for event in state.assignment_history[:4]] == [
+        "probe",
+        "probe",
+        "probe",
+        "probe",
+    ]
+
+
+def test_explicit_empty_participant_list_is_rejected() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    with pytest.raises(ValueError, match="participant_ids must be non-empty"):
+        state.open_session("s", catalog(["a"]), [])
+
+
+def test_probe_results_drive_global_lfs_across_dp_ranks() -> None:
+    state = CrossDpSchedulerState(dp_size=3, max_num_seqs_per_dp=1, mode="lfs")
+    groups = ["a"] * 3 + ["b"] * 3 + ["c"] * 3
+    state.open_session("s", catalog(groups))
+
+    # One probe from each group is assigned across all three DP ranks.
+    assert [event["group_id"] for event in state.assignment_history[:3]] == [
+        "a",
+        "b",
+        "c",
+    ]
+    assert [event["dp_idx"] for event in state.assignment_history[:3]] == [0, 1, 2]
+
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r3", "b")
+    acquire_assigned(state, "r6", "c")
+    state.complete("r0", 10)
+    state.complete("r3", 100)
+    state.complete("r6", 50)
+
+    # While probes are unresolved, spare slots remain in the unknown RR tier.
+    # Once all estimates exist, the newly freed slot goes to longest group b.
+    assert state.assignment_history[5]["group_id"] == "b"
+    assert state.assignment_history[5]["tier"] == "lfs"
+    assert state.assignment_history[5]["estimate"] == 100
+    assert state.assignment_history[5][
+        "pending_finite_group_count_before_assignment"
+    ] == 3
+    assert state.assignment_history[5]["pending_finite_estimate_min"] == 10
+    assert state.assignment_history[5]["pending_finite_estimate_max"] == 100
+    assert state.assignment_history[5]["policy_eligible_session_ids"] == [
+        "s"
+    ]
+    assert state.assignment_history[5]["policy_active_priority_tier"] == 2
+    assert state.assignment_history[5][
+        "policy_eligible_pending_finite_group_count"
+    ] == 3
+    assert state.assignment_history[5][
+        "policy_eligible_pending_finite_estimate_min"
+    ] == 10
+    assert state.assignment_history[5][
+        "policy_eligible_pending_finite_estimate_max"
+    ] == 100
+    assert state.assignment_history[5][
+        "policy_priority_class_count_before_assignment"
+    ] == 3
+    assert state.assignment_history[5]["fcfs_front_request_id"] == "r1"
+    assert state.assignment_history[5]["selected_differs_from_fcfs_front"]
+    assert state.estimate_rebase_history[0]["pending_request_ids"] == [
+        "r1",
+        "r2",
+    ]
+
+
+def test_completed_probe_rebases_stale_inflight_group_upper_bounds() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2,
+        max_num_seqs_per_dp=2,
+        mode="lfs",
+    )
+    state.open_session("s", catalog(["a", "a", "b", "b"]))
+    acquire_assigned(state, "r0", "a")
+
+    assert state.requests["r1"].predicted_length == 128
+    r1_dp = state.requests["r1"].dp_idx
+    assert r1_dp is not None
+    assert state.dp_inflight[r1_dp]["r1"] == 128
+
+    state.complete("r0", 10)
+
+    assert state.requests["r1"].predicted_length == 10
+    assert state.dp_inflight[r1_dp]["r1"] == 10
+    rebase = state.estimate_rebase_history[-1]
+    assert rebase["group_id"] == "a"
+    assert rebase["estimate"] == 10
+    assert rebase["first_finite_estimate"]
+    assert rebase["previous_estimate"] is None
+    assert rebase["completed_request_id"] == "r0"
+    assert rebase["pending_request_ids"] == []
+    assert rebase["inflight_request_ids"] == ["r1"]
+    assert rebase["touched_request_count"] == 1
+    assert rebase["changed_request_count"] == 1
+    assert rebase["no_op_request_count"] == 0
+    assert rebase["changed_requests"] == [{
+        "request_id": "r1",
+        "dp_idx": r1_dp,
+        "status_at_rebase": "assigned",
+        "old_static_admission_cost": 128,
+        "new_static_admission_cost": 10,
+        "cost_changed": True,
+    }]
+
+
+@pytest.mark.parametrize("mode", ["lfs", "oracle_probe_lfs"])
+def test_unknown_rr_completion_cannot_reveal_before_designated_probe(
+    mode: str,
+) -> None:
+    request_catalog = [
+        {
+            "request_id": "ordinary",
+            "group_id": "a",
+            "fallback_cost": 128,
+            "is_designated_probe": False,
+            **({"oracle_cost": 10} if mode == "oracle_probe_lfs" else {}),
+        },
+        {
+            "request_id": "probe",
+            "group_id": "a",
+            "fallback_cost": 128,
+            "is_designated_probe": True,
+            **({"oracle_cost": 100} if mode == "oracle_probe_lfs" else {}),
+        },
+        {
+            "request_id": "other-probe",
+            "group_id": "b",
+            "fallback_cost": 128,
+            "is_designated_probe": True,
+            **({"oracle_cost": 50} if mode == "oracle_probe_lfs" else {}),
+        },
+    ]
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=3,
+        mode=mode,
+    )
+    state.open_session("s", request_catalog)
+
+    assert [event["request_id"] for event in state.assignment_history] == [
+        "probe",
+        "other-probe",
+        "ordinary",
+    ]
+    assert state.requests["probe"].probe_admission is True
+    assert state.requests["ordinary"].probe_admission is False
+    acquire_assigned(state, "probe", "a")
+    acquire_assigned(state, "other-probe", "b")
+    acquire_assigned(state, "ordinary", "a")
+
+    state.complete("ordinary", 10)
+    assert "a" not in state.sessions["s"].estimates
+    assert not any(
+        item["completed_request_id"] == "ordinary"
+        for item in state.estimate_rebase_history
+    )
+
+    state.complete("probe", 20)
+    expected = 100 if mode == "oracle_probe_lfs" else 20
+    assert state.sessions["s"].estimates["a"] == expected
+    assert state.estimate_rebase_history[-1]["completed_request_id"] == "probe"
+    assert state.estimate_rebase_history[-1]["first_finite_estimate"]
+    assert state.estimate_rebase_history[-1][
+        "completed_request_is_designated_probe"
+    ]
+    assert state.estimate_rebase_history[-1][
+        "completed_request_is_probe_admission"
+    ]
+    assert (
+        state.estimate_rebase_history[-1]["designated_probe_request_id"]
+        == "probe"
+    )
+
+
+def test_rebase_distinguishes_unchanged_cost_refresh_from_change() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=3,
+        mode="lfs",
+    )
+    state.open_session("s", catalog(["a", "a", "a"]))
+    for request_id in ("r0", "r1", "r2"):
+        acquire_assigned(state, request_id, "a")
+
+    state.complete("r0", 10)
+    state.complete("r1", 5)
+
+    rebase = state.estimate_rebase_history[-1]
+    assert rebase["estimate_transition"] == "unchanged"
+    assert rebase["touched_request_count"] == 1
+    assert rebase["changed_request_count"] == 0
+    assert rebase["no_op_request_count"] == 1
+    assert not rebase["touched_requests"][0]["cost_changed"]
+
+
+def test_completion_refills_only_the_freed_dp_without_migration() -> None:
+    state = CrossDpSchedulerState(dp_size=2, max_num_seqs_per_dp=1, mode="fcfs")
+    state.open_session("s", catalog(["a", "b", "c"]))
+    first = acquire_assigned(state, "r0", "a")
+    second = acquire_assigned(state, "r1", "b")
+    assert (first["dp_idx"], second["dp_idx"]) == (0, 1)
+
+    state.complete("r0", 20)
+    third = acquire_assigned(state, "r2", "c")
+    assert third["dp_idx"] == 0
+    assert state.requests["r1"].dp_idx == 1
+    refill = state.assignment_history[-1]
+    assert refill["candidate_dp_count"] == 1
+    assert refill["candidate_dp_indices"] == [0]
+    assert refill["dp_static_admission_cost_before_assignment"] == [
+        0,
+        128,
+    ]
+    assert refill["candidate_dp_count"] == 1
+    assert not refill["static_admission_cost_affected_dp_selection"]
+
+
+def test_dispatcher_lookahead_prequeues_engine_waiting_requests() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode="fcfs",
+        lookahead_per_dp=1,
+    )
+    state.open_session("s", catalog(["a", "b", "c", "d"]))
+
+    assert [event["request_id"] for event in state.assignment_history] == [
+        "r0",
+        "r1",
+        "r2",
+    ]
+    snapshot = state.snapshot()
+    assert snapshot["max_num_seqs_per_dp"] == 2
+    assert snapshot["lookahead_per_dp"] == 1
+    assert snapshot["admission_limit_per_dp"] == 3
+    assert snapshot["max_total_inflight_observed"] == 3
+    assert snapshot["max_inflight_observed_by_dp"] == [3]
+    assert snapshot["pending"] == 1
+    assert snapshot["pending_counter_matches_request_states"]
+    assert snapshot["inflight_group_index_matches_dp_inflight"]
+
+
+def test_global_window_preserves_cross_dp_choice_below_per_dp_caps() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2,
+        max_num_seqs_per_dp=2,
+        mode="fcfs",
+        global_admission_limit=3,
+        dp_selection_mode="static_cost",
+    )
+    request_catalog = [
+        {"request_id": "r0", "group_id": "a", "fallback_cost": 100},
+        {"request_id": "r1", "group_id": "b", "fallback_cost": 1},
+        {"request_id": "r2", "group_id": "c", "fallback_cost": 1},
+        {"request_id": "r3", "group_id": "d", "fallback_cost": 1},
+    ]
+    state.open_session("s", request_catalog)
+
+    assert [event["dp_idx"] for event in state.assignment_history] == [0, 1, 1]
+    snapshot = state.snapshot()
+    assert snapshot["global_admission_limit"] == 3
+    assert snapshot["max_total_inflight_observed"] == 3
+    assert snapshot["max_inflight_observed_by_dp"] == [1, 2]
+    assert snapshot["pending"] == 1
+
+    assert state.claim_if_assigned("r1") is not None
+    state.complete("r1", 1)
+
+    refill = state.assignment_history[-1]
+    assert refill["request_id"] == "r3"
+    assert refill["candidate_dp_indices"] == [0, 1]
+    assert refill["dp_static_admission_cost_before_assignment"] == [100, 1]
+    assert refill["dp_inflight_count_before_assignment"] == [1, 1]
+    assert refill["dp_selected_without_static_admission_cost"] == 0
+    assert refill["dp_idx"] == 1
+    assert refill["static_admission_cost_affected_dp_selection"]
+    assert sum(refill["dp_inflight"]) == 3
+
+
+def test_default_dp_selection_mode_is_length_independent() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2,
+        max_num_seqs_per_dp=2,
+        mode="fcfs",
+        global_admission_limit=3,
+    )
+    state.open_session(
+        "s",
+        [
+            {"request_id": "long", "group_id": "a", "fallback_cost": 100},
+            {"request_id": "short-0", "group_id": "b", "fallback_cost": 1},
+            {"request_id": "short-1", "group_id": "c", "fallback_cost": 1},
+        ],
+    )
+
+    assert state.snapshot()["dp_selection_mode"] == "inflight_count"
+    assert [event["dp_idx"] for event in state.assignment_history] == [0, 1, 0]
+    assert all(
+        event["dp_idx"] == event["dp_selected_by_inflight_count"]
+        for event in state.assignment_history
+    )
+    assert state.assignment_history[-1][
+        "static_admission_cost_affected_dp_selection"
+    ]
+
+
+def test_inflight_count_dp_selection_is_independent_of_length_costs() -> None:
+    def placements(costs: list[int]) -> tuple[list[int], bool]:
+        state = CrossDpSchedulerState(
+            dp_size=2,
+            max_num_seqs_per_dp=2,
+            mode="fcfs",
+            global_admission_limit=3,
+            dp_selection_mode="inflight_count",
+        )
+        state.open_session(
+            "s",
+            [
+                {
+                    "request_id": f"r{index}",
+                    "group_id": str(index),
+                    "fallback_cost": cost,
+                }
+                for index, cost in enumerate(costs)
+            ],
+        )
+        assert state.snapshot()["dp_selection_mode"] == "inflight_count"
+        assert all(
+            event["dp_selection_mode"] == "inflight_count"
+            and event["dp_selection_matches_declared_mode"]
+            and event["dp_idx"]
+            == event["dp_selected_by_inflight_count"]
+            and event["dp_selected_without_static_admission_cost"]
+            == event["dp_selected_by_inflight_count"]
+            for event in state.assignment_history
+        )
+        final_event = state.assignment_history[-1]
+        return (
+            [event["dp_idx"] for event in state.assignment_history],
+            bool(
+                final_event[
+                    "static_admission_cost_affected_dp_selection"
+                ]
+            ),
+        )
+
+    first_placements, first_counterfactual_differs = placements(
+        [1000, 1, 999]
+    )
+    second_placements, second_counterfactual_differs = placements(
+        [1, 1000, 2]
+    )
+    assert first_placements == second_placements == [0, 1, 0]
+    assert first_counterfactual_differs
+    assert not second_counterfactual_differs
+
+
+def test_empty_pumps_do_not_advance_dp_tiebreak_across_sessions() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=3,
+        max_num_seqs_per_dp=1,
+        mode="fcfs",
+        global_admission_limit=1,
+    )
+    state.open_session(
+        "warmup",
+        [
+            {
+                "request_id": "warmup-r0",
+                "group_id": "warmup-group",
+                "fallback_cost": 128,
+            }
+        ],
+    )
+    warmup_lease = state.claim_if_assigned("warmup-r0")
+    assert warmup_lease is not None
+    assert warmup_lease["dp_idx"] == 0
+
+    # Both calls pump with no pending request. Neither is an assignment and
+    # therefore neither may consume the next cyclic DP tie-break.
+    state.complete("warmup-r0", 1)
+    state.close_participant("warmup", "warmup:participant:0")
+
+    state.open_session(
+        "measured",
+        [
+            {
+                "request_id": "measured-r0",
+                "group_id": "measured-group",
+                "fallback_cost": 128,
+            }
+        ],
+    )
+    measured_event = state.assignment_history[-1]
+    assert measured_event["dp_tiebreak_before_assignment"] == 1
+    assert measured_event["dp_idx"] == 1
+
+
+def test_invalid_dp_selection_mode_is_rejected() -> None:
+    with pytest.raises(ValueError, match="dp_selection_mode"):
+        CrossDpSchedulerState(
+            dp_size=2,
+            max_num_seqs_per_dp=2,
+            mode="fcfs",
+            dp_selection_mode="length_magic",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("completed_request_id", ["r0", "r1"])
+def test_half_aggregate_window_keeps_both_dp_ranks_eligible_after_completion(
+    completed_request_id: str,
+) -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2,
+        max_num_seqs_per_dp=2,
+        mode="fcfs",
+        global_admission_limit=2,
+    )
+    state.open_session("s", catalog(["a", "b", "c"]))
+
+    assert [event["dp_idx"] for event in state.assignment_history] == [0, 1]
+    assert state.claim_if_assigned(completed_request_id) is not None
+    state.complete(completed_request_id, 1)
+
+    assert state.assignment_history[-1]["candidate_dp_indices"] == [0, 1]
+
+
+@pytest.mark.parametrize("global_limit", [0, 5])
+def test_global_window_rejects_invalid_capacity(global_limit: int) -> None:
+    with pytest.raises(ValueError, match="global_admission_limit"):
+        CrossDpSchedulerState(
+            dp_size=2,
+            max_num_seqs_per_dp=2,
+            mode="fcfs",
+            global_admission_limit=global_limit,
+        )
+
+
+def test_unsubmitted_cancellation_releases_capacity() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a", "b"]))
+    first = acquire_assigned(state, "r0", "a")
+    assert first["dp_idx"] == 0
+
+    state.cancel_unsubmitted("r0")
+    second = acquire_assigned(state, "r1", "b")
+    assert second["dp_idx"] == 0
+
+
+def test_cancelled_probe_is_retried_as_a_probe() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a", "a", "b"]))
+    acquire_assigned(state, "r0", "a")
+
+    state.cancel_unsubmitted("r0")
+
+    assert state.assignment_history[-1]["request_id"] == "r1"
+    assert state.assignment_history[-1]["group_id"] == "a"
+    assert state.assignment_history[-1]["tier"] == "probe"
+
+
+def test_cancelled_designated_probe_records_replacement_probe() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode="lfs",
+    )
+    state.open_session(
+        "s",
+        designated_catalog(["a", "a", "a"], designated_indices={1}),
+    )
+    acquire_assigned(state, "r1", "a")
+
+    state.cancel_unsubmitted("r1")
+
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r0"
+    assert event["tier"] == "probe"
+    assert not event["is_designated_probe"]
+    assert event["probe_replacement"]
+    assert event["probe_selection_semantics"] == "explicit_catalog_flag-v1"
+
+
+@pytest.mark.parametrize("mode", ["lfs", "oracle_probe_lfs"])
+def test_terminally_failed_designated_probe_replacement_can_reveal(
+    mode: str,
+) -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=1,
+        mode=mode,
+    )
+    state.open_session(
+        "s",
+        designated_catalog(["a", "a", "a"], designated_indices={1}),
+    )
+    acquire_assigned(state, "r1", "a")
+
+    state.fail_terminated("r1", "worker raised")
+
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r0"
+    assert event["tier"] == "probe"
+    assert not event["is_designated_probe"]
+    assert event["probe_replacement"]
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 7)
+
+    expected = 30 if mode == "oracle_probe_lfs" else 7
+    assert state.sessions["s"].estimates["a"] == expected
+    reveal = state.estimate_rebase_history[-1]
+    assert reveal["completed_request_id"] == "r0"
+    assert reveal["first_finite_estimate"]
+    assert not reveal["completed_request_is_designated_probe"]
+    assert reveal["completed_request_is_probe_admission"]
+    assert reveal["designated_probe_request_id"] == "r1"
+    assert reveal["designated_probe_request_status"] == "failed_terminal"
+
+
+@pytest.mark.parametrize("mode", ["lfs", "oracle_probe_lfs"])
+def test_inflight_unknown_replaces_terminally_failed_designated_probe(
+    mode: str,
+) -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1,
+        max_num_seqs_per_dp=2,
+        mode=mode,
+    )
+    state.open_session(
+        "s",
+        designated_catalog(["a", "a", "a", "a"], designated_indices={1}),
+    )
+    assert [event["request_id"] for event in state.assignment_history] == [
+        "r1",
+        "r0",
+    ]
+    acquire_assigned(state, "r1", "a")
+    acquire_assigned(state, "r0", "a")
+
+    # An ordinary member that finishes before the designated probe fails may
+    # not reveal an estimate. Its free slot admits another unknown member.
+    state.complete("r0", 3)
+    assert "a" not in state.sessions["s"].estimates
+    assert state.assignment_history[-1]["request_id"] == "r2"
+    assert state.assignment_history[-1]["tier"] == "unknown_rr"
+    acquire_assigned(state, "r2", "a")
+
+    # Once the designated probe is definitively gone, that already-in-flight
+    # unknown is the next causal observation available as a replacement.
+    state.fail_terminated("r1", "worker raised")
+    state.complete("r2", 7)
+
+    expected = 40 if mode == "oracle_probe_lfs" else 7
+    assert state.sessions["s"].estimates["a"] == expected
+    reveal = state.estimate_rebase_history[-1]
+    assert reveal["completed_request_id"] == "r2"
+    assert reveal["first_finite_estimate"]
+    assert not reveal["completed_request_is_designated_probe"]
+    assert not reveal["completed_request_is_probe_admission"]
+    assert reveal["completed_request_is_unknown_admission"]
+    assert reveal["designated_probe_request_id"] == "r1"
+    assert reveal["designated_probe_request_status"] == "failed_terminal"
+
+
+def test_cancelled_probe_uses_another_inflight_unknown_as_probe() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=2, mode="lfs")
+    state.open_session("s", catalog(["a", "a", "a"]))
+    acquire_assigned(state, "r0", "a")
+
+    state.cancel_unsubmitted("r0")
+
+    assert state.assignment_history[-1]["request_id"] == "r2"
+    assert state.assignment_history[-1]["tier"] == "unknown_rr"
+
+
+def test_last_cancelled_unknown_reopens_probe_tier() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=2, mode="lfs")
+    state.open_session("s", catalog(["a", "a", "a"]))
+    acquire_assigned(state, "r0", "a")
+    acquire_assigned(state, "r1", "a")
+
+    # The request originally labelled as the probe can leave before another
+    # unknown admission. If every unresolved admission then leaves, the next
+    # request must become the replacement probe.
+    state.cancel_unsubmitted("r0")
+    state.cancel_unsubmitted("r1")
+    state.cancel_unsubmitted("r2")
+    lease = state.acquire("s", "s:participant:0", "dynamic", "a", 128)
+
+    assert lease is not None
+    assert state.assignment_history[-1]["request_id"] == "dynamic"
+    assert state.assignment_history[-1]["tier"] == "probe"
+
+
+def test_definitively_terminated_rpc_releases_capacity() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a", "b"]))
+    acquire_assigned(state, "r0", "a")
+
+    state.fail_terminated("r0", "worker raised")
+
+    assert state.snapshot()["fatal_error"] is None
+    assert acquire_assigned(state, "r1", "b")["dp_idx"] == 0
+
+
+def test_submitted_failure_does_not_guess_that_remote_capacity_is_free() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a", "b"]))
+    acquire_assigned(state, "r0", "a")
+
+    state.fail_unknown("r0", "timeout")
+
+    assert state.snapshot()["dp_inflight"] == [["r0"]]
+    with pytest.raises(RuntimeError, match="timeout"):
+        state.acquire("s", "s:participant:0", "r1", "b", 128)
+
+
+def test_older_session_is_not_starved_by_new_session_probes() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a", "a"]))
+    state.open_session(
+        "new",
+        [{"request_id": "new-r0", "group_id": "new", "fallback_cost": 128}],
+    )
+    acquire_assigned(state, "r0", "a")
+
+    state.complete("r0", 10)
+
+    assert state.assignment_history[-1]["request_id"] == "r1"
+    assert state.assignment_history[-1]["session_id"] == "s"
+
+
+def test_closing_one_participant_releases_only_its_reservations() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session(
+        "s",
+        [
+            {
+                "request_id": "p0-r0",
+                "group_id": "a",
+                "participant_id": "p0",
+                "fallback_cost": 128,
+            },
+            {
+                "request_id": "p1-r0",
+                "group_id": "b",
+                "participant_id": "p1",
+                "fallback_cost": 128,
+            },
+        ],
+        ["p0", "p1"],
+    )
+
+    state.close_participant("s", "p0")
+    state.close_participant("s", "p0")  # idempotent per participant
+
+    lease = state.acquire("s", "p1", "p1-r0", "b", 128)
+    assert lease is not None and lease["dp_idx"] == 0
+    assert state.sessions["s"].open_participants == {"p1"}
+
+
+def test_closing_unknown_participant_is_rejected() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a"]))
+
+    with pytest.raises(KeyError, match="unknown participant"):
+        state.close_participant("s", "typo")
+
+
+def test_session_estimates_do_not_leak_into_the_next_rollout() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a"]))
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 100)
+    state.close_participant("s", "s:participant:0")
+    assert "s" not in state.sessions
+
+    state.open_session(
+        "next",
+        [{"request_id": "next-r0", "group_id": "a", "fallback_cost": 128}],
+    )
+    assert state.assignment_history[-1]["tier"] == "probe"
+    assert state.assignment_history[-1]["estimate"] is None
+
+
+def test_history_lfs_uses_only_completed_previous_session_means() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="history_lfs"
+    )
+    state.open_session("s", catalog(["a", "a", "b", "b"]))
+
+    # Cold-start requests are FCFS and are never labelled/admitted as probes.
+    for request_id, group, length in [
+        ("r0", "a", 100),
+        ("r1", "a", 60),
+        ("r2", "b", 20),
+        ("r3", "b", 40),
+    ]:
+        acquire_assigned(state, request_id, group)
+        state.complete(request_id, length)
+    assert {event["tier"] for event in state.assignment_history} == {
+        "cold_start_fcfs"
+    }
+    assert state.group_history == {}
+
+    state.close_participant("s", "s:participant:0")
+    assert state.snapshot()["group_history"]["a"]["mean"] == 80
+    assert state.snapshot()["group_history"]["b"]["mean"] == 30
+
+    state.open_session(
+        "next",
+        [
+            {"request_id": "next-b", "group_id": "b", "fallback_cost": 128},
+            {"request_id": "next-a", "group_id": "a", "fallback_cost": 128},
+        ],
+    )
+    # Catalog order is b,a, but historical longest-first schedules a first.
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "next-a"
+    assert event["tier"] == "history_lfs"
+    assert event["estimate"] == 80
+
+
+def test_history_lfs_does_not_use_partial_current_session_results() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="history_lfs"
+    )
+    state.group_history["a"] = (100, 2)
+    state.open_session("s", catalog(["a", "a"]))
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 200)
+
+    # The second request still uses the pre-session mean 50, not 200 or 100.
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "r1"
+    assert event["estimate"] == 50
+    assert state.group_history["a"] == (100, 2)
+
+
+def test_history_lfs_restores_previous_process_history() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="history_lfs"
+    )
+    state.restore_group_history(
+        {
+            "a": {"sum": 240, "count": 2, "mean": 120},
+            "b": {"sum": 40, "count": 2, "mean": 20},
+        }
+    )
+    state.open_session(
+        "resumed",
+        [
+            {"request_id": "resumed-b", "group_id": "b", "fallback_cost": 128},
+            {"request_id": "resumed-a", "group_id": "a", "fallback_cost": 128},
+        ],
+    )
+
+    event = state.assignment_history[-1]
+    assert event["request_id"] == "resumed-a"
+    assert event["tier"] == "history_lfs"
+    assert event["estimate"] == 120
+
+
+def test_history_restore_rejects_invalid_state() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="history_lfs"
+    )
+    with pytest.raises(ValueError, match="count=0"):
+        state.restore_group_history({"a": {"sum": 1, "count": 0}})
+
+
+def test_exact_length_lpt_uses_per_request_output_lengths() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="exact_length_lpt"
+    )
+    state.open_session(
+        "s",
+        [
+            {"request_id": "short", "group_id": "a", "fallback_cost": 10},
+            {"request_id": "long", "group_id": "a", "fallback_cost": 100},
+            {"request_id": "medium", "group_id": "b", "fallback_cost": 50},
+        ],
+    )
+
+    for request_id, group, expected_cost in [
+        ("long", "a", 100),
+        ("medium", "b", 50),
+        ("short", "a", 10),
+    ]:
+        lease = state.acquire(
+            "s", "s:participant:0", request_id, group, expected_cost
+        )
+        assert lease is not None
+        assert lease["predicted_length"] == expected_cost
+        event = state.assignment_history[-1]
+        assert event["tier"] == "exact_length_lpt"
+        assert event["preferred_dp_idx"] is None
+        assert event["dp_placement_mode"] == "scheduler_selected"
+        assert event["dp_selector_applied"]
+        assert event["preferred_dp_pin_honored"] is None
+        assert event["dp_selection_matches_declared_mode"]
+        state.complete(request_id, expected_cost)
+
+
+def test_exact_length_pinning_skips_full_dp_without_head_of_line_blocking() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2, max_num_seqs_per_dp=1, mode="exact_length_lpt"
+    )
+    state.open_session(
+        "s",
+        [
+            {
+                "request_id": "dp0-longest",
+                "group_id": "a",
+                "fallback_cost": 100,
+                "preferred_dp_idx": 0,
+            },
+            {
+                "request_id": "dp0-blocked",
+                "group_id": "b",
+                "fallback_cost": 90,
+                "preferred_dp_idx": 0,
+            },
+            {
+                "request_id": "dp1-runnable",
+                "group_id": "c",
+                "fallback_cost": 80,
+                "preferred_dp_idx": 1,
+            },
+            {
+                "request_id": "dp1-refill",
+                "group_id": "d",
+                "fallback_cost": 10,
+                "preferred_dp_idx": 1,
+            },
+        ],
+    )
+
+    assert [
+        (event["request_id"], event["dp_idx"])
+        for event in state.assignment_history
+    ] == [("dp0-longest", 0), ("dp1-runnable", 1)]
+    assert state.requests["dp0-blocked"].status == "pending"
+    assert all(
+        event["preferred_dp_idx"] == event["dp_idx"]
+        and event["dp_placement_mode"] == "preferred_dp_pinned"
+        and not event["dp_selector_applied"]
+        and event["preferred_dp_pin_honored"]
+        and not event["dp_selection_matches_declared_mode"]
+        for event in state.assignment_history
+    )
+
+    dp1_lease = state.acquire(
+        "s", "s:participant:0", "dp1-runnable", "c", 80
+    )
+    assert dp1_lease is not None
+    state.complete("dp1-runnable", 80)
+    assert state.assignment_history[-1]["request_id"] == "dp1-refill"
+    assert state.assignment_history[-1]["dp_idx"] == 1
+    assert state.requests["dp0-blocked"].status == "pending"
+
+    dp0_lease = state.acquire(
+        "s", "s:participant:0", "dp0-longest", "a", 100
+    )
+    assert dp0_lease is not None
+    state.complete("dp0-longest", 100)
+    assert state.assignment_history[-1]["request_id"] == "dp0-blocked"
+    assert state.assignment_history[-1]["dp_idx"] == 0
+
+    snapshot = state.snapshot()
+    assert snapshot["sessions"]["s"]["dp_placement_mode"] == (
+        "preferred_dp_pinned"
+    )
+    assert snapshot["pending_preferred_dp"] == 0
+    assert snapshot["pending_preferred_dp_counter_matches_request_states"]
+
+
+def test_exact_length_pinned_session_rejects_later_unrouted_request() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2, max_num_seqs_per_dp=1, mode="exact_length_lpt"
+    )
+    state.open_session(
+        "s",
+        [
+            {
+                "request_id": "catalog-request",
+                "group_id": "a",
+                "fallback_cost": 100,
+                "preferred_dp_idx": 0,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="bounded first-turn request catalog"):
+        state.prepare_acquire(
+            "s",
+            "s:participant:0",
+            "later-request",
+            "a",
+            100,
+        )
+
+    snapshot = state.snapshot()
+    assert "later-request" not in state.requests
+    assert snapshot["pending"] == 0
+    assert snapshot["pending_preferred_dp"] == 0
+    assert snapshot["pending_counter_matches_request_states"]
+    assert snapshot["pending_preferred_dp_counter_matches_request_states"]
+
+
+def test_exact_length_pinning_cancellation_preserves_pending_counter() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2,
+        max_num_seqs_per_dp=1,
+        global_admission_limit=1,
+        mode="exact_length_lpt",
+    )
+    state.open_session(
+        "s",
+        [
+            {
+                "request_id": "assigned",
+                "group_id": "a",
+                "fallback_cost": 100,
+                "preferred_dp_idx": 0,
+            },
+            {
+                "request_id": "cancelled",
+                "group_id": "b",
+                "fallback_cost": 90,
+                "preferred_dp_idx": 1,
+            },
+        ],
+    )
+
+    assert state.snapshot()["pending_preferred_dp"] == 1
+    state.cancel_unsubmitted("cancelled")
+    snapshot = state.snapshot()
+    assert snapshot["pending"] == 0
+    assert snapshot["pending_preferred_dp"] == 0
+    assert snapshot["pending_counter_matches_request_states"]
+    assert snapshot["pending_preferred_dp_counter_matches_request_states"]
+
+
+def test_exact_length_pinning_catalog_validation_is_fail_closed() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=2, max_num_seqs_per_dp=1, mode="exact_length_lpt"
+    )
+    with pytest.raises(ValueError, match="present on every catalog request"):
+        state.open_session(
+            "partial",
+            [
+                {
+                    "request_id": "a",
+                    "group_id": "a",
+                    "fallback_cost": 10,
+                    "preferred_dp_idx": 0,
+                },
+                {
+                    "request_id": "b",
+                    "group_id": "b",
+                    "fallback_cost": 10,
+                },
+            ],
+        )
+
+    for session_id, invalid_value in (
+        ("bool", True),
+        ("float", 1.0),
+        ("negative", -1),
+        ("too-large", 2),
+    ):
+        with pytest.raises(ValueError, match=r"int \(not bool\) in \[0, 2\)"):
+            state.open_session(
+                session_id,
+                [
+                    {
+                        "request_id": f"{session_id}-request",
+                        "group_id": "a",
+                        "fallback_cost": 10,
+                        "preferred_dp_idx": invalid_value,
+                    }
+                ],
+            )
+
+    fcfs_state = CrossDpSchedulerState(
+        dp_size=2, max_num_seqs_per_dp=1, mode="fcfs"
+    )
+    with pytest.raises(ValueError, match="only supported for exact_length_lpt"):
+        fcfs_state.open_session(
+            "wrong-mode",
+            [
+                {
+                    "request_id": "request",
+                    "group_id": "a",
+                    "fallback_cost": 10,
+                    "preferred_dp_idx": 0,
+                }
+            ],
+        )
+
+
+def test_oracle_probe_lfs_reveals_true_group_max_after_probe() -> None:
+    state = CrossDpSchedulerState(
+        dp_size=1, max_num_seqs_per_dp=1, mode="oracle_probe_lfs"
+    )
+    state.open_session(
+        "s",
+        [
+            {
+                "request_id": "a-short",
+                "group_id": "a",
+                "fallback_cost": 200,
+                "oracle_cost": 10,
+            },
+            {
+                "request_id": "b",
+                "group_id": "b",
+                "fallback_cost": 200,
+                "oracle_cost": 50,
+            },
+            {
+                "request_id": "a-long",
+                "group_id": "a",
+                "fallback_cost": 200,
+                "oracle_cost": 100,
+            },
+        ],
+    )
+
+    assert state.snapshot()["sessions"]["s"]["estimates"] == {}
+    assert state.sessions["s"].oracle_estimates == {"a": 100, "b": 50}
+    expected = [
+        ("a-short", "a", "probe", 200, 100),
+        ("b", "b", "probe", 200, 50),
+        ("a-long", "a", "oracle_probe_lfs", 200, 100),
+    ]
+    for request_id, group, tier, fallback, group_max in expected:
+        lease = state.acquire(
+            "s", "s:participant:0", request_id, group, group_max
+        )
+        assert lease is not None
+        event = state.assignment_history[-1]
+        assert event["tier"] == tier
+        if tier == "probe":
+            assert event["estimate"] is None
+            assert lease["predicted_length"] == fallback
+        else:
+            assert event["estimate"] == group_max
+            assert lease["predicted_length"] == group_max
+        state.complete(request_id, 1)
+
+    assert state.sessions["s"].probed_groups == {"a", "b"}
+    assert state.snapshot()["sessions"]["s"]["estimates"] == {
+        "a": 100,
+        "b": 50,
+    }
+
+
+def test_close_is_idempotent_after_the_session_is_dropped() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="lfs")
+    state.open_session("s", catalog(["a"]))
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 10)
+    state.close_participant("s", "s:participant:0")
+
+    assert "s" not in state.sessions
+    state.close_participant("s", "s:participant:0")
+    with pytest.raises(KeyError, match="unknown cross-DP session"):
+        state.close_participant("typo", "s:participant:0")
+
+
+def test_assignment_history_is_bounded() -> None:
+    state = CrossDpSchedulerState(dp_size=1, max_num_seqs_per_dp=1, mode="fcfs")
+    state.open_session("s", catalog(["a"]))
+    acquire_assigned(state, "r0", "a")
+    state.complete("r0", 1)
+
+    for index in range(1, 12501):
+        request_id = f"dynamic-{index}"
+        lease = state.acquire(
+            "s", "s:participant:0", request_id, "a", 128
+        )
+        assert lease is not None
+        state.complete(request_id, 1)
+
+    assert len(state.assignment_history) <= 12000
+    assert state.assignment_history[0]["sequence"] > 0

--- a/tests/unit/models/generation/vllm/test_engine_schedulers.py
+++ b/tests/unit/models/generation/vllm/test_engine_schedulers.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler  # noqa: E402
+
+from nemo_rl.models.generation.vllm.lfs.engine_schedulers import (  # noqa: E402
+    OracleLengthRequestQueue,
+    OracleLengthScheduler,
+    ProbeLfsRequestQueue,
+    ProbeLfsScheduler,
+)
+
+
+def request(group_id: int, request_id: str, arrival_time: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        priority=group_id,
+        request_id=request_id,
+        arrival_time=arrival_time,
+    )
+
+
+def test_scheduler_preserves_vllm_async_scheduling() -> None:
+    assert issubclass(ProbeLfsScheduler, AsyncScheduler)
+    assert issubclass(OracleLengthScheduler, AsyncScheduler)
+
+
+def test_oracle_queue_uses_exact_length_priority() -> None:
+    queue = OracleLengthRequestQueue()
+    queue.add_request(request(10, "short", 0.0))
+    queue.add_request(request(100, "long-first", 1.0))
+    queue.add_request(request(100, "long-second", 2.0))
+    queue.add_request(request(50, "medium", 3.0))
+
+    assert [queue.pop_request().request_id for _ in range(4)] == [
+        "long-first",
+        "long-second",
+        "medium",
+        "short",
+    ]
+
+
+def test_queue_launches_one_probe_from_every_group_first() -> None:
+    queue = ProbeLfsRequestQueue({})
+    for group_id in range(3):
+        queue.add_request(request(group_id, f"{group_id}-0", group_id * 2.0))
+        queue.add_request(request(group_id, f"{group_id}-1", group_id * 2.0 + 1.0))
+
+    probes = [queue.pop_request() for _ in range(3)]
+
+    assert [probe.priority for probe in probes] == [0, 1, 2]
+    assert [probe.request_id for probe in probes] == ["0-0", "1-0", "2-0"]
+
+
+def test_queue_round_robins_when_probes_do_not_fill_first_batch() -> None:
+    queue = ProbeLfsRequestQueue({})
+    for group_id in range(3):
+        for sample_id in range(3):
+            queue.add_request(
+                request(
+                    group_id,
+                    f"{group_id}-{sample_id}",
+                    group_id * 3.0 + sample_id,
+                )
+            )
+
+    first_batch = [queue.pop_request() for _ in range(8)]
+
+    assert [item.priority for item in first_batch] == [0, 1, 2, 0, 1, 2, 0, 1]
+    assert [item.request_id for item in first_batch] == [
+        "0-0",
+        "1-0",
+        "2-0",
+        "0-1",
+        "1-1",
+        "2-1",
+        "0-2",
+        "1-2",
+    ]
+
+
+def test_queue_uses_longest_group_first_after_probe_results() -> None:
+    estimates: dict[int, int] = {}
+    queue = ProbeLfsRequestQueue(estimates)
+    for group_id in range(3):
+        queue.add_request(request(group_id, f"{group_id}-0", group_id * 2.0))
+        queue.add_request(request(group_id, f"{group_id}-1", group_id * 2.0 + 1.0))
+
+    for _ in range(3):
+        queue.pop_request()
+    estimates.update({0: 10, 1: 100, 2: 50})
+
+    assert [queue.pop_request().priority for _ in range(3)] == [1, 2, 0]
+
+
+def test_prepend_restores_an_unscheduled_probe() -> None:
+    queue = ProbeLfsRequestQueue({})
+    first_probe = request(0, "0-0", 0.0)
+    queue.add_request(first_probe)
+    queue.add_request(request(0, "0-1", 1.0))
+    queue.add_request(request(1, "1-0", 2.0))
+
+    assert queue.pop_request() is first_probe
+    queue.prepend_request(first_probe)
+
+    assert queue.pop_request() is first_probe
+
+
+def test_prepend_restores_round_robin_position() -> None:
+    queue = ProbeLfsRequestQueue({})
+    for group_id in range(2):
+        queue.add_request(request(group_id, f"{group_id}-0", group_id * 2.0))
+        queue.add_request(request(group_id, f"{group_id}-1", group_id * 2.0 + 1.0))
+
+    queue.pop_request()
+    queue.pop_request()
+    extra_request = queue.pop_request()
+    queue.prepend_request(extra_request)
+
+    assert queue.pop_request() is extra_request

--- a/tests/unit/models/generation/vllm/test_lfs_admission_golden.py
+++ b/tests/unit/models/generation/vllm/test_lfs_admission_golden.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden test for cross-DP admission ordering.
+
+The scheduler is a pure state machine, so a fixed workload must always produce
+the same assignment trace, the same ~75-field assignment records, and the same
+snapshot.  The digests below were captured from the pre-refactor implementation
+and are what "functional parity" means here: change them only when a scheduling
+decision is *meant* to change, and say so in the commit message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import random
+
+import pytest
+
+from nemo_rl.models.generation.vllm.lfs.scheduler import CrossDpSchedulerState
+
+def make_workload(*, groups, per_group, seed, explicit_probe=True):
+    rng = random.Random(seed)
+    catalog, true_len = [], {}
+    for g in range(groups):
+        base = rng.choice([300, 900, 2500, 6000, 12000, 16000])
+        for k in range(per_group):
+            rid = f"r{g}_{k}"
+            L = max(64, int(base * rng.uniform(0.55, 1.45)))
+            true_len[rid] = L
+            item = {
+                "request_id": rid,
+                "group_id": f"g{g}",
+                "fallback_cost": 1024,
+                "oracle_cost": L,
+                "predicted_cost": max(1, base),
+            }
+            if explicit_probe:
+                item["is_designated_probe"] = (k == 0)
+            catalog.append(item)
+    rng.shuffle(catalog)
+    return catalog, true_len
+
+
+def _simulate(scheduler_cls, *, mode, dp_size, cap, catalog, true_len, **kw):
+    S = scheduler_cls(dp_size, cap, mode, **kw)
+    S.open_session("s0", catalog, ["p0"])
+    trace, events, running, now = [], [], [], 0.0
+    ids = [item["request_id"] for item in catalog]
+
+    def claim_ready():
+        # the full ~50-field assignment record is the real downstream contract
+        events.extend(S.drain_new_assignment_events())
+        for rid in ids:
+            a = S.claim_if_assigned(rid)
+            if a is None:
+                continue
+            trace.append((a["assignment_sequence"], rid, a["dp_idx"],
+                          a["predicted_length"], a["dp_assignment_ordinal"],
+                          a["session_dp_assignment_ordinal"]))
+            heapq.heappush(
+                running, (now + true_len[rid], a["assignment_sequence"], rid)
+            )
+
+    claim_ready()
+    while running:
+        finish, _, rid = heapq.heappop(running)
+        now = finish
+        S.complete(rid, true_len[rid])
+        claim_ready()
+    events.extend(S.drain_new_assignment_events())
+    return trace, events, S.snapshot()
+
+
+MODES = ["fcfs", "lfs", "oracle_probe_lfs", "predicted_lfs", "exact_length_lpt"]
+CASES = {
+    1: dict(groups=4, per_group=8, dp_size=1, cap=32),
+    2: dict(groups=8, per_group=8, dp_size=2, cap=16),
+    3: dict(groups=12, per_group=4, dp_size=2, cap=8),
+    4: dict(groups=6, per_group=16, dp_size=4, cap=8),
+    5: dict(groups=16, per_group=2, dp_size=1, cap=4),
+}
+GOLDEN = {
+    "1:exact_length_lpt": "f66d1ee0fce4a1ec0335384be0c075f147507a41ac9fc62cc5e230b724d6f4d7",
+    "1:fcfs": "c0c285b5f213a7c39dd89546fc6423bbdc117589f8ceb62a74ef0b59ae84bc9c",
+    "1:lfs": "8a4b3178e41f418d34fc936bad62ee3b79e61711324704bfc3ef62413387b0bb",
+    "1:oracle_probe_lfs": "ba9e1438b609bb435c32ea89636cd7260324404a6ce1fddffc0755830fad5be8",
+    "1:predicted_lfs": "87b4193778b45e8c462367df3baaf1a03c60c07044b5b70f48bf958d3baa910e",
+    "2:exact_length_lpt": "a96649839ec305509ee5a661e8335b0ee0ed41e6561fff4ec7a2d5796cf07a2a",
+    "2:fcfs": "cdb91466f881b72af460bbbb43cf49777903a8ba5f5fb84a8b5fad9d87891fac",
+    "2:lfs": "b6babda7432169efe3f5a29338d1f4c6ba39a7c2f5eea0186e975ad413e6414b",
+    "2:oracle_probe_lfs": "62fd25e88f2aa84e40e2eb5ec9e3fae97a2d589ca3453567a367708fddd7c3bf",
+    "2:predicted_lfs": "67736105214e5b98b103c80b2c7089cbb8d01fd904fae22a8a747a29a7252b36",
+    "3:exact_length_lpt": "f30e278dd633e96dae412fd35367c65fec52984a6920889614b358e6341b2193",
+    "3:fcfs": "83cffb57a58f06ca065dde6ebb7456cd1de2875e0b27b06295a2864ee5a75dab",
+    "3:lfs": "fb95a0d98b7c5acdadc91c6ad343feb1733a3710ea891bff6637c80694b3d3f8",
+    "3:oracle_probe_lfs": "814f90b500ba46f197794efc2b42de9c2576e07f6af41849f6b7d3420f3f5e4d",
+    "3:predicted_lfs": "0f4c894e1b63dbae25f0a843760a1400dc03bbe9cb3429c7c57b509de213f654",
+    "4:exact_length_lpt": "fd82a4be041b6646f418ad18408a1d65c71ca19804b3517e38af287867566789",
+    "4:fcfs": "7d21bbc401c0f4c472ed424c9cc101392c7b4aaca27138ea23a0c92f10263e7a",
+    "4:lfs": "1ecb9835ea1131febe4dfc3bb3c5df9170f863df01a94f53b525c4699d45a4ca",
+    "4:oracle_probe_lfs": "537e4081efd2e96e0658c0b3d18181fdc04cac9702c1b4ef34002e967d371c8c",
+    "4:predicted_lfs": "cf95b835ef6bfaa8a91f2e9d2f263534d04fa318cc17d494b0011af37a7b26d3",
+    "5:exact_length_lpt": "028ce613bfc9b5951981d844912f1c701ebef413aec70002b419d856bc43b01d",
+    "5:fcfs": "e7545981e06d5408ae9d248940c4a0c316a4c7632d0b52c095420c203b35b1bf",
+    "5:lfs": "aa84170e7c5dbfb8022e6260df224ce8cc58738a6237af288db7a92ace47f1d0",
+    "5:oracle_probe_lfs": "225f2ce6e711e169d8f8efe9d367e855c7a9a509fb3efd4d233f784d2ab8caf0",
+    "5:predicted_lfs": "2394691f0f1739ddf4a240228d2a10c2339c4cf4d4480abec295537954a7b347"
+}
+
+
+@pytest.mark.parametrize("seed", sorted(CASES))
+@pytest.mark.parametrize("mode", MODES)
+def test_admission_matches_golden(seed: int, mode: str) -> None:
+    case = CASES[seed]
+    catalog, true_len = make_workload(
+        groups=case["groups"], per_group=case["per_group"], seed=seed
+    )
+    if mode == "exact_length_lpt":
+        catalog = [
+            dict(item, fallback_cost=true_len[item["request_id"]])
+            for item in catalog
+        ]
+    trace, events, snapshot = _simulate(
+        CrossDpSchedulerState,
+        mode=mode,
+        dp_size=case["dp_size"],
+        cap=case["cap"],
+        catalog=catalog,
+        true_len=true_len,
+    )
+    payload = {
+        "assignments": len(trace),
+        "events": events,
+        "snapshot": snapshot,
+        "trace": trace,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode()
+    ).hexdigest()
+    assert digest == GOLDEN[f"{seed}:{mode}"], (
+        f"admission behaviour changed for seed={seed} mode={mode}"
+    )

--- a/tests/unit/models/generation/vllm/test_model_step_gpu_profiler.py
+++ b/tests/unit/models/generation/vllm/test_model_step_gpu_profiler.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nemo_rl.models.generation.vllm.model_step_gpu_profiler import (
+    MODEL_STEP_GPU_PROFILER_PROOF_SCHEMA_VERSION,
+    DeterministicModelStepGpuProfiler,
+    ModelStepGpuProfilerContractError,
+)
+
+
+class FakeCuda:
+    def __init__(
+        self,
+        events: list[Any],
+        *,
+        fail_operation: str | None = None,
+    ) -> None:
+        self._events = events
+        self._fail_operation = fail_operation
+        self.profiler = SimpleNamespace(
+            start=lambda: self._call("profiler_start"),
+            stop=lambda: self._call("profiler_stop"),
+        )
+        self.nvtx = SimpleNamespace(
+            range_push=lambda name: self._call("nvtx_push", name),
+            range_pop=lambda: self._call("nvtx_pop"),
+        )
+
+    def current_device(self) -> int:
+        return 3
+
+    def synchronize(self) -> None:
+        self._call("synchronize")
+
+    def _call(self, operation: str, *args: Any) -> None:
+        self._events.append((operation, *args))
+        if operation == self._fail_operation:
+            raise RuntimeError(f"{operation} failed")
+
+
+class FakeTorch:
+    def __init__(
+        self,
+        events: list[Any],
+        *,
+        fail_operation: str | None = None,
+    ) -> None:
+        self.cuda = FakeCuda(events, fail_operation=fail_operation)
+
+
+class FakeModelRunner:
+    device = "cuda:3"
+
+    def __init__(
+        self,
+        events: list[Any],
+        *,
+        fail_on_value: int | None = None,
+    ) -> None:
+        self._events = events
+        self._fail_on_value = fail_on_value
+
+    def execute_model(self, value: int) -> str:
+        self._events.append(("execute_model", value))
+        if value == self._fail_on_value:
+            raise RuntimeError(f"execute_model failed for {value}")
+        return f"result-{value}"
+
+
+def make_controller(
+    *,
+    fail_operation: str | None = None,
+    fail_on_value: int | None = None,
+) -> tuple[
+    list[Any],
+    FakeModelRunner,
+    DeterministicModelStepGpuProfiler,
+]:
+    events: list[Any] = []
+    runner = FakeModelRunner(events, fail_on_value=fail_on_value)
+    controller = DeterministicModelStepGpuProfiler(
+        runner,
+        torch_module=FakeTorch(events, fail_operation=fail_operation),
+        hostname_fn=lambda: "worker-host",
+        pid_fn=lambda: 1234,
+    )
+    return events, runner, controller
+
+
+def test_exact_half_open_capture_and_callable_restoration() -> None:
+    events, runner, controller = make_controller()
+    original_function = runner.execute_model.__func__
+    controller.arm(1, 3)
+
+    assert runner.execute_model(10) == "result-10"
+    assert runner.execute_model(11) == "result-11"
+    assert runner.execute_model(12) == "result-12"
+    assert runner.execute_model.__func__ is original_function
+    assert runner.execute_model(13) == "result-13"
+
+    assert events == [
+        ("execute_model", 10),
+        ("synchronize",),
+        ("profiler_start",),
+        ("nvtx_push", "NRL_MODEL_STEP:1"),
+        ("execute_model", 11),
+        ("nvtx_pop",),
+        ("nvtx_push", "NRL_MODEL_STEP:2"),
+        ("execute_model", 12),
+        ("nvtx_pop",),
+        ("synchronize",),
+        ("profiler_stop",),
+        ("execute_model", 13),
+    ]
+
+    proof = controller.require_complete()
+    assert proof["schema_version"] == (
+        MODEL_STEP_GPU_PROFILER_PROOF_SCHEMA_VERSION
+    )
+    assert proof["hostname"] == "worker-host"
+    assert proof["pid"] == 1234
+    assert proof["device"] == {
+        "cuda_current_device": 3,
+        "model_runner_device": "cuda:3",
+    }
+    assert proof["range"] == {
+        "semantics": "[start_inclusive, stop_exclusive)",
+        "ordinal_origin": (
+            "first model_runner.execute_model call after arm returns"
+        ),
+        "start_step": 1,
+        "stop_step": 3,
+        "expected_captured_model_step_count": 2,
+        "nvtx_range_name_format": "NRL_MODEL_STEP:<zero_based_ordinal>",
+    }
+    assert proof["observed_model_step_count"] == 3
+    assert proof["completed_execute_model_count"] == 3
+    assert proof["completed_captured_model_step_count"] == 2
+    assert proof["last_observed_model_step_ordinal"] == 2
+    assert proof["capture_boundaries"] == {
+        "profiler_started_before_model_step_ordinal": 1,
+        "profiler_stopped_after_model_step_ordinal": 2,
+    }
+    assert proof["completion"] == {
+        "complete": True,
+        "state": "completed",
+        "profiler_may_be_active": False,
+        "nvtx_range_open": False,
+    }
+    assert proof["callable_identity"]["installed_exactly_once"] is True
+    assert proof["callable_identity"]["wrapper_currently_installed"] is False
+    assert proof["callable_identity"]["original_callable_restored"] is True
+    assert proof["errors"] == []
+
+
+def test_zero_start_profiles_first_call_and_stops_before_return() -> None:
+    events, runner, controller = make_controller()
+    controller.arm(0, 1)
+
+    assert runner.execute_model(7) == "result-7"
+    assert events == [
+        ("synchronize",),
+        ("profiler_start",),
+        ("nvtx_push", "NRL_MODEL_STEP:0"),
+        ("execute_model", 7),
+        ("nvtx_pop",),
+        ("synchronize",),
+        ("profiler_stop",),
+    ]
+    assert controller.snapshot()["completion"]["complete"] is True
+
+
+@pytest.mark.parametrize(
+    ("start_step", "stop_step"),
+    [
+        (-1, 1),
+        (0, 0),
+        (2, 1),
+        (False, 1),
+        (0, True),
+        (0.0, 1),
+        (0, 1.0),
+    ],
+)
+def test_invalid_bounds_fail_before_install(
+    start_step: Any,
+    stop_step: Any,
+) -> None:
+    events, runner, controller = make_controller()
+    original_function = runner.execute_model.__func__
+
+    with pytest.raises(ModelStepGpuProfilerContractError):
+        controller.arm(start_step, stop_step)
+
+    proof = controller.snapshot()
+    assert runner.execute_model.__func__ is original_function
+    assert proof["completion"]["state"] == "failed"
+    assert proof["calls"]["wrapper_install"]["attempted"] == 0
+    assert proof["callable_identity"]["wrapper_currently_installed"] is False
+    assert proof["errors"][0]["operation"] == "arm"
+    assert events == []
+
+
+def test_double_arm_poison_wrapper_fails_closed() -> None:
+    events, runner, controller = make_controller()
+    controller.arm(0, 2)
+
+    with pytest.raises(
+        ModelStepGpuProfilerContractError,
+        match="one-shot",
+    ):
+        controller.arm(0, 2)
+    with pytest.raises(
+        ModelStepGpuProfilerContractError,
+        match="failed state",
+    ):
+        runner.execute_model(1)
+
+    proof = controller.snapshot()
+    assert proof["completion"]["state"] == "failed"
+    assert proof["callable_identity"]["wrapper_currently_installed"] is True
+    assert proof["errors"][0]["phase"] == "double_arm"
+    assert events == []
+
+
+def test_execute_error_closes_open_range_and_profiler_then_poison_wrapper() -> None:
+    events, runner, controller = make_controller(fail_on_value=9)
+    controller.arm(0, 2)
+
+    with pytest.raises(RuntimeError, match="execute_model failed for 9"):
+        runner.execute_model(9)
+    with pytest.raises(ModelStepGpuProfilerContractError, match="failed state"):
+        runner.execute_model(10)
+
+    assert events == [
+        ("synchronize",),
+        ("profiler_start",),
+        ("nvtx_push", "NRL_MODEL_STEP:0"),
+        ("execute_model", 9),
+        ("nvtx_pop",),
+        ("synchronize",),
+        ("profiler_stop",),
+    ]
+    proof = controller.snapshot()
+    assert proof["completion"] == {
+        "complete": False,
+        "state": "failed",
+        "profiler_may_be_active": False,
+        "nvtx_range_open": False,
+    }
+    assert proof["calls"]["execute_model"] == {
+        "attempted": 1,
+        "succeeded": 0,
+    }
+    assert proof["errors"][0] == {
+        "operation": "execute_model",
+        "phase": "model_step",
+        "model_step_ordinal": 0,
+        "error_type": "RuntimeError",
+        "error": "execute_model failed for 9",
+    }
+
+
+@pytest.mark.parametrize("fail_operation", ["synchronize", "profiler_start"])
+def test_start_boundary_failure_does_not_execute_included_step(
+    fail_operation: str,
+) -> None:
+    events, runner, controller = make_controller(
+        fail_operation=fail_operation
+    )
+    controller.arm(0, 1)
+
+    with pytest.raises(RuntimeError, match=f"{fail_operation} failed"):
+        runner.execute_model(4)
+
+    proof = controller.snapshot()
+    assert ("execute_model", 4) not in events
+    assert proof["completion"]["state"] == "failed"
+    assert proof["completion"]["complete"] is False
+    assert proof["errors"][0]["operation"] == (
+        "cuda_synchronize"
+        if fail_operation == "synchronize"
+        else "profiler_start"
+    )
+
+
+def test_stop_failure_rejects_completed_model_result_and_invalidates_proof() -> None:
+    events, runner, controller = make_controller(
+        fail_operation="profiler_stop"
+    )
+    controller.arm(0, 1)
+
+    with pytest.raises(RuntimeError, match="profiler_stop failed"):
+        runner.execute_model(5)
+
+    proof = controller.snapshot()
+    assert ("execute_model", 5) in events
+    assert proof["completed_execute_model_count"] == 1
+    assert proof["completed_captured_model_step_count"] == 1
+    assert proof["completion"]["complete"] is False
+    assert proof["completion"]["state"] == "failed"
+    assert proof["errors"][0]["operation"] == "profiler_stop"
+    assert proof["callable_identity"]["wrapper_currently_installed"] is True
+
+
+def test_require_complete_stops_partial_capture_and_raises() -> None:
+    events, runner, controller = make_controller()
+    controller.arm(0, 2)
+    assert runner.execute_model(1) == "result-1"
+
+    with pytest.raises(
+        ModelStepGpuProfilerContractError,
+        match="did not complete",
+    ):
+        controller.require_complete()
+
+    assert events[-2:] == [("synchronize",), ("profiler_stop",)]
+    proof = controller.snapshot()
+    assert proof["completion"]["complete"] is False
+    assert proof["completion"]["state"] == "failed"
+    assert proof["errors"][0]["operation"] == "require_complete"
+
+
+def test_non_callable_execute_model_is_rejected() -> None:
+    events: list[Any] = []
+    runner = SimpleNamespace(device="cuda:3", execute_model=None)
+    controller = DeterministicModelStepGpuProfiler(
+        runner,
+        torch_module=FakeTorch(events),
+    )
+
+    with pytest.raises(
+        ModelStepGpuProfilerContractError,
+        match="must be callable",
+    ):
+        controller.arm(0, 1)
+
+    assert controller.snapshot()["completion"]["state"] == "failed"
+
+
+def test_runner_without_real_instance_dict_is_rejected() -> None:
+    class SlotsRunner:
+        __slots__ = ("device",)
+
+        def __init__(self) -> None:
+            self.device = "cuda:0"
+
+        def execute_model(self, value: int) -> int:
+            return value
+
+    events: list[Any] = []
+    controller = DeterministicModelStepGpuProfiler(
+        SlotsRunner(),
+        torch_module=FakeTorch(events),
+    )
+
+    with pytest.raises(
+        ModelStepGpuProfilerContractError,
+        match="__dict__",
+    ):
+        controller.arm(0, 1)
+
+    proof = controller.snapshot()
+    assert proof["completion"]["state"] == "failed"
+    assert proof["calls"]["wrapper_install"]["attempted"] == 0

--- a/tests/unit/models/generation/vllm/test_prompt_groups.py
+++ b/tests/unit/models/generation/vllm/test_prompt_groups.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_rl.models.generation.vllm.lfs.prompt_groups import make_request_unique_prompts
+
+
+def test_make_request_unique_prompts_diverges_at_first_token() -> None:
+    prompts = make_request_unique_prompts([3, 2, 4])
+    token_ids = [prompt["prompt_token_ids"] for prompt in prompts]
+
+    assert token_ids == [
+        [1000, 1000, 1000],
+        [1001, 1000],
+        [1002, 1000, 1000, 1000],
+    ]
+    assert len({tokens[0] for tokens in token_ids}) == len(token_ids)
+
+
+def test_make_request_unique_prompts_rejects_empty_prompt() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        make_request_unique_prompts([1, 0])

--- a/tests/unit/models/generation/vllm/test_vllm_frontend_submission.py
+++ b/tests/unit/models/generation/vllm/test_vllm_frontend_submission.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+import nemo_rl.models.generation.vllm.vllm_generation as generation_module
+from nemo_rl.models.generation.vllm.vllm_generation import VllmGeneration
+from nemo_rl.models.generation.vllm.vllm_worker_async import (
+    VllmAsyncGenerationWorker,
+    _await_model_worker_collective_rpc,
+    _iterate_request_output_collector,
+    _submit_vllm_request,
+)
+
+
+def test_submit_timestamp_is_after_add_request_returns() -> None:
+    events: list[str] = []
+    add_returned_at: list[float] = []
+    collector = object()
+
+    class FakeLlm:
+        async def add_request(self, **kwargs):
+            events.append("add_request")
+            await asyncio.sleep(0)
+            add_returned_at.append(time.monotonic())
+            assert kwargs == {
+                "request_id": "request-0",
+                "prompt": "prompt",
+                "params": "sampling-params",
+                "priority": 7,
+            }
+            return collector
+
+    async def run():
+        return await _submit_vllm_request(
+            FakeLlm(),
+            prompt="prompt",
+            sampling_params="sampling-params",
+            request_id="request-0",
+            priority=7,
+        )
+
+    (
+        actual_collector,
+        submitted_at_unix_s,
+        submitted_at_monotonic_s,
+        submitted_hostname,
+    ) = asyncio.run(run())
+
+    assert events == ["add_request"]
+    assert actual_collector is collector
+    assert submitted_at_unix_s > 0
+    assert submitted_at_monotonic_s >= add_returned_at[0]
+    assert submitted_hostname
+
+
+def test_terminal_stream_sentinel_stops_without_being_yielded() -> None:
+    class Output:
+        def __init__(self, *, finished: bool) -> None:
+            self.finished = finished
+
+    first = Output(finished=False)
+    stream_finished = Output(finished=True)
+
+    class FakeCollector:
+        def __init__(self) -> None:
+            self.items = deque([first, stream_finished])
+            self.get_nowait_calls = 0
+
+        def get_nowait(self):
+            self.get_nowait_calls += 1
+            return self.items.popleft()
+
+        async def get(self):
+            raise AssertionError("all fake outputs should be immediately ready")
+
+    collector = FakeCollector()
+
+    async def collect():
+        return [
+            item
+            async for item in _iterate_request_output_collector(
+                collector,
+                stream_finished,
+            )
+        ]
+
+    outputs = asyncio.run(asyncio.wait_for(collect(), timeout=1))
+    assert outputs == [first]
+    assert collector.get_nowait_calls == 2
+
+
+def test_terminal_request_output_is_yielded_once() -> None:
+    class Output:
+        finished = True
+
+    final_output = Output()
+
+    class FakeCollector:
+        def get_nowait(self):
+            return final_output
+
+        async def get(self):
+            raise AssertionError("the final output should be immediately ready")
+
+    async def collect():
+        return [
+            item
+            async for item in _iterate_request_output_collector(
+                FakeCollector(),
+                object(),
+            )
+        ]
+
+    assert asyncio.run(collect()) == [final_output]
+
+
+def test_async_gpu_profiler_collective_rpc_is_awaited() -> None:
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    class FakeLlm:
+        async def collective_rpc(self, method: str, *, args: tuple[object, ...]):
+            await asyncio.sleep(0)
+            calls.append((method, args))
+
+    asyncio.run(
+        _await_model_worker_collective_rpc(
+            FakeLlm(), "start_gpu_profiling"
+        )
+    )
+    asyncio.run(
+        _await_model_worker_collective_rpc(
+            FakeLlm(), "stop_gpu_profiling"
+        )
+    )
+
+    assert calls == [
+        ("start_gpu_profiling", ()),
+        ("stop_gpu_profiling", ()),
+    ]
+
+
+def test_gpu_profiler_selects_async_worker_entrypoints() -> None:
+    class FakeWorkerGroup:
+        def __init__(self) -> None:
+            self.methods: list[str] = []
+
+        def run_all_workers_single_data(self, method: str):
+            self.methods.append(method)
+            return []
+
+    for async_engine, expected in (
+        (False, ["start_gpu_profiling", "stop_gpu_profiling"]),
+        (
+            True,
+            [
+                "start_gpu_profiling_async",
+                "stop_gpu_profiling_async",
+            ],
+        ),
+    ):
+        generation = object.__new__(VllmGeneration)
+        generation.cfg = {"vllm_cfg": {"async_engine": async_engine}}
+        generation.worker_group = FakeWorkerGroup()
+
+        generation.start_gpu_profiling()
+        generation.stop_gpu_profiling()
+
+        assert generation.worker_group.methods == expected
+
+
+def test_async_exact_model_step_rpc_returns_every_tp_proof() -> None:
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    class FakeLlm:
+        async def collective_rpc(self, method: str, *, args: tuple[object, ...]):
+            calls.append((method, args))
+            return [{"rank": 0}, {"rank": 1}]
+
+    worker = SimpleNamespace(llm=FakeLlm())
+    worker_class = VllmAsyncGenerationWorker.__ray_metadata__.modified_class
+    armed = asyncio.run(
+        worker_class.arm_model_step_gpu_profile_async(
+            worker,
+            512,
+            1024,
+        )
+    )
+    completed = asyncio.run(
+        worker_class.get_model_step_gpu_profile_async(worker)
+    )
+
+    assert armed == [{"rank": 0}, {"rank": 1}]
+    assert completed == armed
+    assert calls == [
+        ("arm_model_step_gpu_profile", (512, 1024)),
+        ("get_model_step_gpu_profile", ()),
+    ]
+
+
+def test_generation_exact_model_step_rpc_covers_every_dp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int, dict[str, int]]] = []
+
+    class FakeWorkerGroup:
+        dp_size = 2
+
+        @staticmethod
+        def get_dp_leader_worker_idx(dp_idx: int) -> int:
+            return 10 + dp_idx
+
+        def run_single_worker_single_data(
+            self,
+            method: str,
+            *,
+            worker_idx: int,
+            **kwargs: int,
+        ):
+            calls.append((method, worker_idx, kwargs))
+            return [{"worker_idx": worker_idx, "method": method}]
+
+    monkeypatch.setattr(generation_module.ray, "get", lambda values: values)
+    generation = object.__new__(VllmGeneration)
+    generation.cfg = {"vllm_cfg": {"async_engine": True}}
+    generation.worker_group = FakeWorkerGroup()
+
+    armed = generation.arm_model_step_gpu_profile(2, 6)
+    completed = generation.get_model_step_gpu_profile()
+
+    assert set(armed) == {0, 1}
+    assert set(completed) == {0, 1}
+    assert calls == [
+        (
+            "arm_model_step_gpu_profile_async",
+            10,
+            {"start_step": 2, "stop_step": 6},
+        ),
+        (
+            "arm_model_step_gpu_profile_async",
+            11,
+            {"start_step": 2, "stop_step": 6},
+        ),
+        ("get_model_step_gpu_profile_async", 10, {}),
+        ("get_model_step_gpu_profile_async", 11, {}),
+    ]

--- a/tests/unit/models/generation/vllm/test_vllm_inner_nsys.py
+++ b/tests/unit/models/generation/vllm/test_vllm_inner_nsys.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_rl.models.generation.vllm.vllm_worker import (
+    _build_vllm_nested_runtime_env,
+    _configure_vllm_ray_worker_nsight,
+    _get_vllm_inner_nsys_config,
+    _get_vllm_inner_nsys_mode,
+)
+
+
+ENV = "NRL_VLLM_INNER_NSYS_MODE"
+RAY_UV_ENV = "RAY_ENABLE_UV_RUN_RUNTIME_ENV"
+
+
+def clear_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        ENV,
+        RAY_UV_ENV,
+        "NCCL_CUMEM_ENABLE",
+        "NCCL_NVLS_ENABLE",
+        "VLLM_ENABLE_V1_MULTIPROCESSING",
+        "NRL_VLLM_PROPAGATE_PYTHONPATH",
+        "NRL_FORCED_SEQUENCE_AUDIT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_default_keeps_existing_vllm_managed_nsight_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    assert _get_vllm_inner_nsys_mode() is None
+    assert _build_vllm_nested_runtime_env("/venv/python") == {
+        "py_executable": "/venv/python",
+        "env_vars": {RAY_UV_ENV: "0"},
+    }
+
+    kwargs = {"distributed_executor_backend": "ray"}
+    mode = _configure_vllm_ray_worker_nsight(
+        kwargs, profiling_requested=True
+    )
+    assert mode is None
+    assert kwargs["ray_workers_use_nsight"] is True
+
+    no_profile_kwargs = {"distributed_executor_backend": "ray"}
+    _configure_vllm_ray_worker_nsight(
+        no_profile_kwargs, profiling_requested=False
+    )
+    assert "ray_workers_use_nsight" not in no_profile_kwargs
+
+
+def test_nested_runtime_env_propagates_present_nccl_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "0")
+
+    runtime_env = _build_vllm_nested_runtime_env("/venv/python")
+
+    assert runtime_env["env_vars"] == {
+        RAY_UV_ENV: "0",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_NVLS_ENABLE": "0",
+    }
+
+
+def test_cuda_graph_injects_bounded_graph_level_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "cuda_graph")
+    expected = {
+        "t": "cuda,nvtx",
+        "o": "'worker_process_%p'",
+        "stop-on-exit": "true",
+        "capture-range": "cudaProfilerApi",
+        "capture-range-end": "stop",
+        "cuda-graph-trace": "graph",
+    }
+    assert _get_vllm_inner_nsys_config("cuda_graph") == expected
+    assert _build_vllm_nested_runtime_env("/venv/python") == {
+        "py_executable": "/venv/python",
+        "nsight": expected,
+        "env_vars": {
+            RAY_UV_ENV: "0",
+            ENV: "cuda_graph",
+        },
+    }
+
+    kwargs = {
+        "distributed_executor_backend": "ray",
+        "ray_workers_use_nsight": True,
+    }
+    assert (
+        _configure_vllm_ray_worker_nsight(
+            kwargs, profiling_requested=True
+        )
+        == "cuda_graph"
+    )
+    assert kwargs["ray_workers_use_nsight"] is False
+
+
+def test_cuda_hw_injects_bounded_hardware_trace_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "cuda_hw")
+    config = _get_vllm_inner_nsys_config("cuda_hw")
+    assert config == {
+        "t": "cuda-hw,nvtx",
+        "o": "'worker_process_%p'",
+        "stop-on-exit": "true",
+        "capture-range": "cudaProfilerApi",
+        "capture-range-end": "stop",
+    }
+    assert "cuda-graph-trace" not in config
+
+    runtime_env = _build_vllm_nested_runtime_env("/venv/python")
+    assert runtime_env["nsight"] == config
+    assert runtime_env["env_vars"][ENV] == "cuda_hw"
+
+
+def test_cuda_node_injects_bounded_graph_node_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "cuda_node")
+    expected = {
+        "t": "cuda,nvtx",
+        "o": "'worker_process_%p'",
+        "stop-on-exit": "true",
+        "capture-range": "cudaProfilerApi",
+        "capture-range-end": "stop",
+        "cuda-graph-trace": "node",
+    }
+    assert _get_vllm_inner_nsys_config("cuda_node") == expected
+    runtime_env = _build_vllm_nested_runtime_env("/venv/python")
+    assert runtime_env == {
+        "py_executable": "/venv/python",
+        "nsight": expected,
+        "env_vars": {
+            RAY_UV_ENV: "0",
+            ENV: "cuda_node",
+        },
+    }
+
+
+def test_async_worker_runtime_provenance_reports_exact_applied_nsight_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "cuda_node")
+    expected = _get_vllm_inner_nsys_config("cuda_node")
+
+    from nemo_rl.models.generation.vllm import vllm_worker_async
+
+    worker_class = (
+        vllm_worker_async.VllmAsyncGenerationWorker.__ray_metadata__
+        .modified_class
+    )
+    worker = SimpleNamespace(
+        model_name="Qwen/Qwen3-30B-A3B",
+        llm_async_engine_args=SimpleNamespace(
+            logits_processors=[],
+            ray_workers_use_nsight=False,
+            enable_prefix_caching=False,
+            enforce_eager=True,
+            max_num_seqs=128,
+            max_num_batched_tokens=8192,
+            model="Qwen/Qwen3-30B-A3B",
+            revision=None,
+        ),
+        _vllm_nested_runtime_env={
+            "py_executable": "/venv/python",
+            "nsight": dict(expected),
+            "env_vars": {ENV: "cuda_node"},
+        },
+        _vllm_nested_runtime_env_patch_verified=True,
+        _vllm_nested_runtime_env_contract_sha256="a" * 64,
+        _vllm_env_copy_layout="custom_executor_class",
+        vllm_model_worker_runtime_provenance=[
+            {"python_executable": "/venv/python"}
+        ],
+    )
+
+    provenance = worker_class.report_replay_runtime_provenance(worker)
+
+    assert provenance["inner_nsys_mode"] == "cuda_node"
+    assert provenance["inner_nsys_config"] == expected
+    assert provenance["vllm_nested_runtime_env_contract_exported"] is True
+    assert provenance["inner_nsys_runtime_env_patch_verified"] is True
+    assert (
+        provenance["vllm_nested_runtime_env_contract_sha256"] == "a" * 64
+    )
+    assert provenance["vllm_env_copy_layout"] == "custom_executor_class"
+    assert provenance["model_worker_runtime_provenance"] == [
+        {"python_executable": "/venv/python"}
+    ]
+    assert provenance["ray_workers_use_nsight"] is False
+    assert provenance["async_engine_args"]["enforce_eager"] is True
+    provenance["inner_nsys_config"]["cuda-graph-trace"] = "graph"
+    assert (
+        worker._vllm_nested_runtime_env["nsight"]["cuda-graph-trace"]
+        == "node"
+    )
+
+
+def test_invalid_inner_nsys_mode_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "node")
+    with pytest.raises(ValueError, match="cuda_graph, cuda_hw, cuda_node"):
+        _get_vllm_inner_nsys_mode()
+    with pytest.raises(ValueError, match="cuda_graph, cuda_hw, cuda_node"):
+        _build_vllm_nested_runtime_env("/venv/python")
+
+    kwargs = {"distributed_executor_backend": "ray"}
+    with pytest.raises(ValueError, match="cuda_graph, cuda_hw, cuda_node"):
+        _configure_vllm_ray_worker_nsight(
+            kwargs, profiling_requested=True
+        )
+    assert "ray_workers_use_nsight" not in kwargs
+
+
+def test_inner_nsys_mode_preserves_pythonpath_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_runtime_env(monkeypatch)
+    monkeypatch.setenv(ENV, "cuda_hw")
+    monkeypatch.setenv("NRL_VLLM_PROPAGATE_PYTHONPATH", "1")
+    monkeypatch.setenv("PYTHONPATH", "/repo")
+    monkeypatch.setenv("NRL_FORCED_SEQUENCE_AUDIT", "1")
+    runtime_env = _build_vllm_nested_runtime_env("/venv/python")
+    assert runtime_env["env_vars"] == {
+        RAY_UV_ENV: "0",
+        "PYTHONPATH": "/repo",
+        "NRL_VLLM_PROPAGATE_PYTHONPATH": "1",
+        "NRL_FORCED_SEQUENCE_AUDIT": "1",
+        ENV: "cuda_hw",
+    }

--- a/tests/unit/models/generation/vllm/test_vllm_metric_sampler.py
+++ b/tests/unit/models/generation/vllm/test_vllm_metric_sampler.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+from prometheus_client import CollectorRegistry, Counter, Gauge
+from prometheus_client.core import GaugeMetricFamily
+
+from nemo_rl.models.generation.vllm.vllm_metric_sampler import (
+    VLLM_METRIC_FIELDS,
+    metric_capture_timing,
+    read_restricted_vllm_metrics,
+)
+
+
+def populated_registry() -> CollectorRegistry:
+    registry = CollectorRegistry()
+    labels = ["model_name", "engine"]
+    label_values = {"model_name": "Qwen3-30B-A3B", "engine": "0"}
+    Gauge(
+        "vllm:num_requests_running",
+        "running",
+        labels,
+        registry=registry,
+    ).labels(**label_values).set(128)
+    Gauge(
+        "vllm:num_requests_waiting",
+        "waiting",
+        labels,
+        registry=registry,
+    ).labels(**label_values).set(7)
+    Gauge(
+        "vllm:kv_cache_usage_perc",
+        "kv",
+        labels,
+        registry=registry,
+    ).labels(**label_values).set(0.42)
+    Counter(
+        "vllm:generation_tokens",
+        "tokens",
+        labels,
+        registry=registry,
+    ).labels(**label_values).inc(1234)
+    Counter(
+        "vllm:num_preemptions",
+        "preemptions",
+        labels,
+        registry=registry,
+    ).labels(**label_values).inc(2)
+    return registry
+
+
+class UnrelatedExplodingCollector:
+    """A full-registry scan would collect this unrelated expensive metric."""
+
+    def describe(self):
+        yield GaugeMetricFamily("unrelated_expensive_metric", "unrelated")
+
+    def collect(self):
+        raise AssertionError("unrelated collector must not be collected")
+
+
+def test_restricted_reader_reads_only_required_series_with_source_labels() -> None:
+    registry = populated_registry()
+    registry.register(UnrelatedExplodingCollector())
+
+    values, sources = read_restricted_vllm_metrics(registry)
+
+    assert values == {
+        "inflight_batch_size": 128,
+        "num_pending": 7,
+        "kv_cache_usage_perc": pytest.approx(0.42),
+        "generation_tokens": 1234,
+        "num_preemptions": 2,
+    }
+    assert set(sources) == VLLM_METRIC_FIELDS
+    for source in sources.values():
+        assert source["labels"] == {
+            "model_name": "Qwen3-30B-A3B",
+            "engine": "0",
+        }
+    assert sources["generation_tokens"]["sample_name"] == (
+        "vllm:generation_tokens_total"
+    )
+    assert sources["num_preemptions"]["sample_name"] == (
+        "vllm:num_preemptions_total"
+    )
+
+
+def test_restricted_reader_rejects_missing_required_series() -> None:
+    registry = populated_registry()
+    collector = registry._names_to_collectors["vllm:num_preemptions_total"]
+    registry.unregister(collector)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"fields=\['num_preemptions'\].*"
+        r"vllm:num_preemptions_total",
+    ):
+        read_restricted_vllm_metrics(registry)
+
+
+def test_restricted_reader_rejects_multiple_label_series() -> None:
+    registry = populated_registry()
+    running = registry._names_to_collectors["vllm:num_requests_running"]
+    running.labels(model_name="Qwen3-30B-A3B", engine="1").set(64)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Multiple Prometheus series matched.*inflight_batch_size",
+    ):
+        read_restricted_vllm_metrics(registry)
+
+
+def test_restricted_reader_has_no_full_registry_fallback() -> None:
+    class RegistryWithoutRestrictedCollection:
+        def collect(self):
+            raise AssertionError("full registry must not be collected")
+
+    with pytest.raises(RuntimeError, match="refusing to fall back"):
+        read_restricted_vllm_metrics(RegistryWithoutRestrictedCollection())
+
+
+def test_capture_timing_separates_wake_lock_and_snapshot_delay() -> None:
+    timing = metric_capture_timing(
+        interval_s=0.25,
+        scheduled_at_monotonic_s=10.0,
+        attempted_at_monotonic_s=10.5,
+        started_at_monotonic_s=10.6,
+        finished_at_monotonic_s=10.8,
+    )
+
+    assert timing["capture_duration_s"] == pytest.approx(0.2)
+    assert timing["capture_lock_wait_s"] == pytest.approx(0.1)
+    assert timing["capture_wake_lateness_s"] == pytest.approx(0.5)
+    assert timing["capture_deadline_lateness_s"] == pytest.approx(0.6)
+    assert timing["capture_finish_lateness_s"] == pytest.approx(0.8)
+    assert timing["capture_missed_periods"] == 3
+
+
+def test_synchronous_capture_has_no_deadline_or_missed_periods() -> None:
+    timing = metric_capture_timing(
+        interval_s=0.25,
+        scheduled_at_monotonic_s=None,
+        attempted_at_monotonic_s=20.0,
+        started_at_monotonic_s=20.0,
+        finished_at_monotonic_s=20.01,
+    )
+
+    assert timing["capture_scheduled_at_monotonic_s"] is None
+    assert timing["capture_wake_lateness_s"] is None
+    assert timing["capture_deadline_lateness_s"] is None
+    assert timing["capture_finish_lateness_s"] is None
+    assert timing["capture_missed_periods"] == 0

--- a/tests/unit/models/generation/vllm/test_vllm_nested_runtime_env.py
+++ b/tests/unit/models/generation/vllm/test_vllm_nested_runtime_env.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+import pytest
+
+from nemo_rl.models.generation.vllm.nested_runtime_env import (
+    NESTED_RUNTIME_ENV_JSON_ENV,
+    NESTED_RUNTIME_ENV_SCHEMA,
+    NESTED_RUNTIME_ENV_SHA256_ENV,
+    RUNTIME_ENV_CONTRACT_SHA256_ENV,
+    NestedRuntimeEnvContractError,
+    export_nested_runtime_env_contract,
+    load_nested_runtime_env_contract,
+    merge_nested_runtime_env,
+)
+
+
+def _clear_contract_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(NESTED_RUNTIME_ENV_JSON_ENV, raising=False)
+    monkeypatch.delenv(NESTED_RUNTIME_ENV_SHA256_ENV, raising=False)
+
+
+def test_export_and_load_round_trip_is_canonical_and_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    source = {
+        "nsight": {"t": "cuda,nvtx", "o": "worker_%p"},
+        "env_vars": {
+            "RAY_ENABLE_UV_RUN_RUNTIME_ENV": "0",
+            "NCCL_CUMEM_ENABLE": "1",
+        },
+        "py_executable": "/opt/nemo/bin/python",
+    }
+
+    exported, digest = export_nested_runtime_env_contract(source)
+
+    expected_serialized = json.dumps(
+        {
+            "runtime_env": source,
+            "schema": NESTED_RUNTIME_ENV_SCHEMA,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    assert os.environ[NESTED_RUNTIME_ENV_JSON_ENV] == expected_serialized
+    assert digest == hashlib.sha256(
+        expected_serialized.encode("utf-8")
+    ).hexdigest()
+    assert (
+        os.environ[NESTED_RUNTIME_ENV_SHA256_ENV]
+        == digest
+    )
+    assert exported["env_vars"][RUNTIME_ENV_CONTRACT_SHA256_ENV] == digest
+    assert RUNTIME_ENV_CONTRACT_SHA256_ENV not in source["env_vars"]
+    assert load_nested_runtime_env_contract() == (exported, digest)
+
+
+@pytest.mark.parametrize(
+    "runtime_env,match",
+    [
+        (
+            {"py_executable": "/python", "env_vars": {}, "pip": []},
+            "unsupported keys",
+        ),
+        ({"py_executable": "/python"}, "missing required keys"),
+        (
+            {"py_executable": "", "env_vars": {}},
+            "non-empty string",
+        ),
+        (
+            {"py_executable": "/python", "env_vars": {"A": 1}},
+            "must be a string",
+        ),
+        (
+            {"py_executable": "/python", "env_vars": {}, "nsight": []},
+            "nsight must be a mapping",
+        ),
+        (
+            {
+                "py_executable": "/python",
+                "env_vars": {
+                    RUNTIME_ENV_CONTRACT_SHA256_ENV: "0" * 64
+                },
+            },
+            "reserved",
+        ),
+    ],
+)
+def test_export_rejects_invalid_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_env: dict[str, object],
+    match: str,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    with pytest.raises(NestedRuntimeEnvContractError, match=match):
+        export_nested_runtime_env_contract(runtime_env)
+
+
+def test_load_rejects_missing_contract_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    with pytest.raises(NestedRuntimeEnvContractError, match="missing"):
+        load_nested_runtime_env_contract()
+
+
+def test_load_rejects_modified_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    export_nested_runtime_env_contract(
+        {"py_executable": "/python", "env_vars": {"A": "1"}}
+    )
+    serialized = os.environ[NESTED_RUNTIME_ENV_JSON_ENV]
+    monkeypatch.setenv(
+        NESTED_RUNTIME_ENV_JSON_ENV,
+        serialized.replace('"A":"1"', '"A":"2"'),
+    )
+
+    with pytest.raises(NestedRuntimeEnvContractError, match="SHA-256"):
+        load_nested_runtime_env_contract()
+
+
+def test_load_rejects_modified_or_noncanonical_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    export_nested_runtime_env_contract(
+        {"py_executable": "/python", "env_vars": {}}
+    )
+    monkeypatch.setenv(NESTED_RUNTIME_ENV_SHA256_ENV, "A" * 64)
+
+    with pytest.raises(
+        NestedRuntimeEnvContractError,
+        match="lowercase SHA-256",
+    ):
+        load_nested_runtime_env_contract()
+
+
+def test_load_rejects_noncanonical_json_even_with_matching_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    export_nested_runtime_env_contract(
+        {"py_executable": "/python", "env_vars": {}}
+    )
+    envelope = json.loads(os.environ[NESTED_RUNTIME_ENV_JSON_ENV])
+    noncanonical = json.dumps(envelope, indent=2)
+    monkeypatch.setenv(NESTED_RUNTIME_ENV_JSON_ENV, noncanonical)
+    monkeypatch.setenv(
+        NESTED_RUNTIME_ENV_SHA256_ENV,
+        hashlib.sha256(noncanonical.encode("utf-8")).hexdigest(),
+    )
+
+    with pytest.raises(NestedRuntimeEnvContractError, match="canonical"):
+        load_nested_runtime_env_contract()
+
+
+def test_load_rejects_duplicate_json_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_contract_env(monkeypatch)
+    serialized = (
+        '{"runtime_env":{"env_vars":{},"py_executable":"/python"},'
+        f'"schema":"{NESTED_RUNTIME_ENV_SCHEMA}",'
+        f'"schema":"{NESTED_RUNTIME_ENV_SCHEMA}"}}'
+    )
+    monkeypatch.setenv(NESTED_RUNTIME_ENV_JSON_ENV, serialized)
+    monkeypatch.setenv(
+        NESTED_RUNTIME_ENV_SHA256_ENV,
+        hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
+    )
+
+    with pytest.raises(NestedRuntimeEnvContractError, match="duplicate"):
+        load_nested_runtime_env_contract()
+
+
+def test_merge_preserves_unrelated_settings_and_adds_contract_values() -> None:
+    desired = {
+        "py_executable": "/python",
+        "env_vars": {
+            "A": "1",
+            RUNTIME_ENV_CONTRACT_SHA256_ENV: "a" * 64,
+        },
+        "nsight": {"t": "cuda,nvtx"},
+    }
+    existing = {
+        "working_dir": "/workspace",
+        "env_vars": {"A": "1", "OTHER": "kept"},
+        "nsight": {"t": "cuda,nvtx", "o": "kept"},
+    }
+
+    merged = merge_nested_runtime_env(existing, desired)
+
+    assert merged == {
+        "working_dir": "/workspace",
+        "py_executable": "/python",
+        "env_vars": {
+            "A": "1",
+            "OTHER": "kept",
+            RUNTIME_ENV_CONTRACT_SHA256_ENV: "a" * 64,
+        },
+        "nsight": {"t": "cuda,nvtx", "o": "kept"},
+    }
+    assert existing["env_vars"] == {"A": "1", "OTHER": "kept"}
+
+
+def test_merge_accepts_none_and_returns_an_independent_copy() -> None:
+    desired = {
+        "py_executable": "/python",
+        "env_vars": {
+            RUNTIME_ENV_CONTRACT_SHA256_ENV: "b" * 64,
+        },
+    }
+
+    merged = merge_nested_runtime_env(None, desired)
+    merged["env_vars"]["NEW"] = "value"
+
+    assert "NEW" not in desired["env_vars"]
+
+
+@pytest.mark.parametrize(
+    "existing,match",
+    [
+        (
+            {
+                "py_executable": "/other",
+                "env_vars": {},
+            },
+            "py_executable",
+        ),
+        (
+            {
+                "env_vars": {"A": "different"},
+            },
+            r"env_vars\['A'\]",
+        ),
+        (
+            {
+                "env_vars": {},
+                "nsight": {"t": "cuda-hw"},
+            },
+            r"nsight\['t'\]",
+        ),
+    ],
+)
+def test_merge_rejects_conflicts(
+    existing: dict[str, object],
+    match: str,
+) -> None:
+    desired = {
+        "py_executable": "/python",
+        "env_vars": {
+            "A": "1",
+            RUNTIME_ENV_CONTRACT_SHA256_ENV: "c" * 64,
+        },
+        "nsight": {"t": "cuda,nvtx"},
+    }
+
+    with pytest.raises(NestedRuntimeEnvContractError, match=match):
+        merge_nested_runtime_env(existing, desired)

--- a/tests/unit/models/generation/vllm/test_vllm_ray_executor.py
+++ b/tests/unit/models/generation/vllm/test_vllm_ray_executor.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def ray_executor_module() -> Iterator[ModuleType]:
+    """Import the NeMo executor without requiring vLLM in the test venv."""
+
+    module_name = "nemo_rl.models.generation.vllm.ray_executor"
+    previous_module = sys.modules.pop(module_name, None)
+
+    vllm = ModuleType("vllm")
+    vllm.__path__ = []  # type: ignore[attr-defined]
+    vllm_v1 = ModuleType("vllm.v1")
+    vllm_v1.__path__ = []  # type: ignore[attr-defined]
+    vllm_executor = ModuleType("vllm.v1.executor")
+    vllm_executor.__path__ = []  # type: ignore[attr-defined]
+    vllm_ray_executor = ModuleType(
+        "vllm.v1.executor.ray_executor"
+    )
+
+    class FakeRayDistributedExecutor:
+        def _init_workers_ray(self, placement_group, **kwargs):
+            raise NotImplementedError
+
+    vllm_ray_executor.RayDistributedExecutor = (
+        FakeRayDistributedExecutor
+    )
+    fake_vllm_modules = {
+        "vllm": vllm,
+        "vllm.v1": vllm_v1,
+        "vllm.v1.executor": vllm_executor,
+        "vllm.v1.executor.ray_executor": vllm_ray_executor,
+    }
+    try:
+        with patch.dict(sys.modules, fake_vllm_modules):
+            module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_module is not None:
+            sys.modules[module_name] = previous_module
+
+
+def test_custom_executor_injects_authenticated_nested_runtime_env(
+    ray_executor_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desired = {
+        "py_executable": "/venv/bin/python",
+        "env_vars": {"RAY_ENABLE_UV_RUN_RUNTIME_ENV": "0"},
+    }
+    merged = {
+        **desired,
+        "nsight": {"cuda-graph-trace": "node"},
+    }
+    observed: dict[str, object] = {}
+
+    monkeypatch.setenv("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+    monkeypatch.setattr(
+        ray_executor_module.ray_constants,
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+        False,
+    )
+    monkeypatch.setattr(
+        ray_executor_module,
+        "load_nested_runtime_env_contract",
+        lambda: (desired, "a" * 64),
+    )
+
+    def merge_runtime_env(existing, requested):
+        observed["existing"] = existing
+        observed["requested"] = requested
+        return merged
+
+    monkeypatch.setattr(
+        ray_executor_module,
+        "merge_nested_runtime_env",
+        merge_runtime_env,
+    )
+
+    def parent_init(self, placement_group, **kwargs):
+        observed["placement_group"] = placement_group
+        observed["kwargs"] = kwargs
+        return "initialized"
+
+    monkeypatch.setattr(
+        ray_executor_module.RayDistributedExecutor,
+        "_init_workers_ray",
+        parent_init,
+    )
+    executor = object.__new__(
+        ray_executor_module.NemoRayDistributedExecutor
+    )
+
+    assert (
+        executor._init_workers_ray(
+            "placement-group",
+            runtime_env={"env_vars": {"EXISTING": "1"}},
+            num_cpus=1,
+        )
+        == "initialized"
+    )
+    assert observed["existing"] == {
+        "env_vars": {"EXISTING": "1"}
+    }
+    assert observed["requested"] == desired
+    assert observed["placement_group"] == "placement-group"
+    assert observed["kwargs"] == {
+        "runtime_env": merged,
+        "num_cpus": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("environment_value", "import_constant"),
+    (("1", False), ("0", True)),
+)
+def test_custom_executor_rejects_uncontrolled_ray_uv_environment(
+    ray_executor_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    environment_value: str,
+    import_constant: bool,
+) -> None:
+    monkeypatch.setenv(
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+        environment_value,
+    )
+    monkeypatch.setattr(
+        ray_executor_module.ray_constants,
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+        import_constant,
+    )
+    executor = object.__new__(
+        ray_executor_module.NemoRayDistributedExecutor
+    )
+
+    with pytest.raises(
+        ray_executor_module.NestedRuntimeEnvContractError,
+        match="RAY_ENABLE_UV_RUN_RUNTIME_ENV|Ray imported",
+    ):
+        executor._init_workers_ray("placement-group")

--- a/tests/unit/models/generation/vllm/test_vllm_sampling_params.py
+++ b/tests/unit/models/generation/vllm/test_vllm_sampling_params.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_rl.models.generation.vllm.vllm_generation import VllmGeneration
+from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
+
+
+def make_worker() -> BaseVllmGenerationWorker:
+    worker = object.__new__(BaseVllmGenerationWorker)
+    worker.cfg = {
+        "top_k": None,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "max_new_tokens": 128,
+        "stop_token_ids": [2],
+    }
+    worker.SamplingParams = lambda **kwargs: kwargs
+    return worker
+
+
+def test_sampling_params_keep_normal_rollout_stop_semantics() -> None:
+    params = make_worker()._build_sampling_params(
+        greedy=False,
+        stop_strings=["stop"],
+        max_new_tokens=64,
+    )
+
+    assert params["max_tokens"] == 64
+    assert "min_tokens" not in params
+    assert "ignore_eos" not in params
+
+
+def test_sampling_params_can_force_exact_trace_length() -> None:
+    params = make_worker()._build_sampling_params(
+        greedy=True,
+        stop_strings=None,
+        max_new_tokens=37,
+        force_generation_length=True,
+    )
+
+    assert params["temperature"] == 0.0
+    assert params["max_tokens"] == 37
+    assert params["min_tokens"] == 37
+    assert params["ignore_eos"] is True
+
+
+def test_sampling_params_can_force_exact_trace_content() -> None:
+    params = make_worker()._build_sampling_params(
+        greedy=True,
+        stop_strings=None,
+        max_new_tokens=37,
+        force_generation_length=True,
+        allowed_token_ids=[1000],
+    )
+
+    assert params["temperature"] == 0.0
+    assert params["allowed_token_ids"] == [1000]
+
+
+def test_sampling_params_can_force_a_recorded_sequence() -> None:
+    params = make_worker()._build_sampling_params(
+        greedy=True,
+        stop_strings=None,
+        max_new_tokens=3,
+        force_generation_length=True,
+        forced_generation_token_ids=[7, 8, 9],
+    )
+
+    assert params["extra_args"] == {
+        "nrl_forced_token_ids": [7, 8, 9]
+    }
+    assert "min_tokens" not in params
+    assert "ignore_eos" not in params
+
+
+def test_forced_sequence_processor_selects_each_recorded_position() -> None:
+    from types import SimpleNamespace
+
+    pytest.importorskip(
+        "vllm",
+        reason=(
+            "the custom processor is loaded in the isolated vLLM worker "
+            "environment and is validated there by "
+            "validate_forced_sequence_processor.py"
+        ),
+    )
+    from nemo_rl.models.generation.vllm.forced_sequence_logits_processor import (
+        ForcedSequenceLogitsProcessor,
+    )
+
+    params = SimpleNamespace(
+        max_tokens=3,
+        extra_args={"nrl_forced_token_ids": [7, 8, 9]},
+    )
+    ForcedSequenceLogitsProcessor.validate_params(params)
+    adapter = object.__new__(ForcedSequenceLogitsProcessor)
+    processor = adapter.new_req_logits_processor(params)
+    assert processor is not None
+    for output_ids, target in (([], 7), ([7], 8), ([7, 8], 9)):
+        logits = torch.arange(16, dtype=torch.float32)
+        transformed = processor(output_ids, logits)
+        assert int(transformed.argmax().item()) == target
+        assert torch.isneginf(transformed).sum().item() == 15
+
+
+def test_oracle_probe_metadata_does_not_replace_unknown_fallback() -> None:
+    class NoopWorkerGroup:
+        def shutdown(self, **_kwargs) -> bool:
+            return True
+
+    generation = object.__new__(VllmGeneration)
+    generation._cross_dp_dispatcher = object()
+    generation.worker_group = NoopWorkerGroup()
+    generation._cross_dp_scheduler_mode = "oracle_probe_lfs"
+    generation.cfg = {"max_new_tokens": 16384}
+
+    _, catalog = generation._build_cross_dp_session(
+        ["a", "a"],
+        participant_count=1,
+        participant_indices=None,
+        request_costs=[10, 100],
+    )
+
+    assert [item["fallback_cost"] for item in catalog] == [16384, 16384]
+    assert [item["oracle_cost"] for item in catalog] == [10, 100]
+    generation._cross_dp_dispatcher = None
+
+
+def test_predicted_lfs_metadata_is_group_aligned() -> None:
+    generation = make_cross_dp_generation("predicted_lfs")
+
+    _, catalog = generation._build_cross_dp_session(
+        ["a", "a", "b"],
+        participant_count=1,
+        participant_indices=None,
+        request_costs=None,
+        predicted_group_costs=[100, 100, 20],
+    )
+
+    assert [item["predicted_cost"] for item in catalog] == [100, 100, 20]
+    assert [item["fallback_cost"] for item in catalog] == [16384] * 3
+    generation._cross_dp_dispatcher = None
+
+
+def make_cross_dp_generation(mode: str = "lfs") -> VllmGeneration:
+    class NoopWorkerGroup:
+        def shutdown(self, **_kwargs) -> bool:
+            return True
+
+    generation = object.__new__(VllmGeneration)
+    generation._cross_dp_dispatcher = object()
+    generation.worker_group = NoopWorkerGroup()
+    generation._cross_dp_scheduler_mode = mode
+    generation.dp_size = 2
+    generation.cfg = {"max_new_tokens": 16384}
+    return generation
+
+
+def test_cross_dp_session_builder_transmits_designated_probe_flags() -> None:
+    generation = make_cross_dp_generation()
+
+    _, catalog = generation._build_cross_dp_session(
+        ["a", "a", "b"],
+        participant_count=1,
+        participant_indices=None,
+        request_costs=None,
+        designated_probe_flags=[False, True, True],
+    )
+
+    assert [item["group_id"] for item in catalog] == ["a", "a", "b"]
+    assert [item["is_designated_probe"] for item in catalog] == [
+        False,
+        True,
+        True,
+    ]
+    assert [item["fallback_cost"] for item in catalog] == [16384] * 3
+    assert all("oracle_cost" not in item for item in catalog)
+    generation._cross_dp_dispatcher = None
+
+
+@pytest.mark.parametrize(
+    ("flags", "message"),
+    [
+        ([True], "must align with group_ids"),
+        ([False, 1, True], "only bool values"),
+        ([False, False, True], "exactly one request per group"),
+        ([True, True, True], "exactly one request per group"),
+    ],
+)
+def test_cross_dp_session_builder_validates_designated_probe_flags(
+    flags: list[bool],
+    message: str,
+) -> None:
+    generation = make_cross_dp_generation()
+
+    with pytest.raises(ValueError, match=message):
+        generation._build_cross_dp_session(
+            ["a", "a", "b"],
+            participant_count=1,
+            participant_indices=None,
+            request_costs=None,
+            designated_probe_flags=flags,
+        )
+
+    generation._cross_dp_dispatcher = None
+
+
+def test_cross_dp_session_builder_transmits_exact_length_dp_pinning() -> None:
+    generation = make_cross_dp_generation("exact_length_lpt")
+
+    _, catalog = generation._build_cross_dp_session(
+        ["a", "b", "c"],
+        participant_count=1,
+        participant_indices=None,
+        request_costs=[100, 20, 10],
+        preferred_dp_indices=[0, 1, 1],
+    )
+
+    assert [item["fallback_cost"] for item in catalog] == [100, 20, 10]
+    assert [item["preferred_dp_idx"] for item in catalog] == [0, 1, 1]
+    generation._cross_dp_dispatcher = None
+
+
+@pytest.mark.parametrize(
+    ("mode", "request_costs", "preferred_dp_indices", "message"),
+    [
+        ("lfs", [10, 20], [0, 1], "require.*exact_length_lpt"),
+        (
+            "exact_length_lpt",
+            None,
+            [0, 1],
+            "require explicit exact-length request_costs",
+        ),
+        (
+            "exact_length_lpt",
+            [10, 20],
+            [0],
+            "must align with group_ids",
+        ),
+        (
+            "exact_length_lpt",
+            [10, 20],
+            [True, 1],
+            "ints \\(not bool\\)",
+        ),
+        (
+            "exact_length_lpt",
+            [10, 20],
+            [0, 2],
+            r"in \[0, 2\)",
+        ),
+    ],
+)
+def test_cross_dp_session_builder_validates_exact_length_dp_pinning(
+    mode: str,
+    request_costs: list[int] | None,
+    preferred_dp_indices: list[int],
+    message: str,
+) -> None:
+    generation = make_cross_dp_generation(mode)
+
+    with pytest.raises(ValueError, match=message):
+        generation._build_cross_dp_session(
+            ["a", "b"],
+            participant_count=1,
+            participant_indices=None,
+            request_costs=request_costs,
+            preferred_dp_indices=preferred_dp_indices,
+        )
+
+    generation._cross_dp_dispatcher = None

--- a/tests/unit/models/generation/vllm/test_vllm_step_trace.py
+++ b/tests/unit/models/generation/vllm/test_vllm_step_trace.py
@@ -1,0 +1,585 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_rl.models.generation.vllm.vllm_step_trace import (
+    VLLM_STEP_TRACE_AGGREGATION_VERSION,
+    VLLM_STEP_TRACE_MODEL_STEP_DISCRIMINATOR,
+    VLLM_STEP_TRACE_PHASE_CLASSIFIER,
+    VLLM_STEP_TRACE_SCHEMA_VERSION,
+    VLLM_STEP_TRACE_TIMELINE_COLUMN_ENCODING,
+    VllmStepTraceBuffer,
+    VllmStepTraceContractError,
+    build_vllm_step_trace_record,
+    summarize_exact_model_step_range,
+)
+
+
+def make_scheduler_stats(*, unpadded_tokens: int = 6) -> SimpleNamespace:
+    debug_stats = SimpleNamespace(
+        calc_duration=0.001,
+        num_prefill_requests=1,
+        num_decode_requests=2,
+        context_breakdown={
+            "num_prefill_requests": 1,
+            "prefill_num_tokens": 4,
+            "prefill_context_len": 8,
+            "prefill_token_context_product": 32,
+            "num_decode_requests": 2,
+            "decode_num_tokens": 2,
+            "decode_context_len": 21,
+            "decode_token_context_product": 21,
+        },
+        num_flops_per_gpu_breakdown={"attention": 7, "mlp": 5},
+        num_read_bytes_per_gpu_breakdown={"weights": 10, "kv": 3},
+        num_write_bytes_per_gpu_breakdown={"kv": 4},
+    )
+    perf_stats = SimpleNamespace(
+        num_flops_per_gpu=12,
+        num_read_bytes_per_gpu=13,
+        num_write_bytes_per_gpu=4,
+        debug_stats=debug_stats,
+    )
+    return SimpleNamespace(
+        num_running_reqs=3,
+        num_waiting_reqs=5,
+        kv_cache_usage=0.25,
+        perf_stats=perf_stats,
+        cudagraph_stats=SimpleNamespace(
+            num_unpadded_tokens=unpadded_tokens,
+            num_padded_tokens=8,
+            num_paddings=2,
+            runtime_mode="FULL",
+        ),
+    )
+
+
+def make_iteration_stats() -> SimpleNamespace:
+    return SimpleNamespace(
+        num_generation_tokens=2,
+        prompt_token_stats=SimpleNamespace(total=4, computed=4),
+        num_preempted_reqs=0,
+        finished_requests=[object()],
+    )
+
+
+def make_zero_work_cleanup_stats() -> SimpleNamespace:
+    stats = make_scheduler_stats(unpadded_tokens=0)
+    debug_stats = stats.perf_stats.debug_stats
+    debug_stats.num_prefill_requests = 0
+    debug_stats.num_decode_requests = 0
+    debug_stats.context_breakdown = {
+        field: 0 for field in debug_stats.context_breakdown
+    }
+    debug_stats.num_flops_per_gpu_breakdown = {}
+    debug_stats.num_read_bytes_per_gpu_breakdown = {}
+    debug_stats.num_write_bytes_per_gpu_breakdown = {}
+    stats.perf_stats.num_flops_per_gpu = 0
+    stats.perf_stats.num_read_bytes_per_gpu = 0
+    stats.perf_stats.num_write_bytes_per_gpu = 0
+    stats.cudagraph_stats = None
+    stats.num_running_reqs = 0
+    stats.num_waiting_reqs = 0
+    stats.kv_cache_usage = 0.0
+    return stats
+
+
+def make_zero_context_stats(*, keep_cudagraph: bool) -> SimpleNamespace:
+    stats = make_zero_work_cleanup_stats()
+    if keep_cudagraph:
+        stats.cudagraph_stats = SimpleNamespace(
+            num_unpadded_tokens=0,
+            num_padded_tokens=0,
+            num_paddings=0,
+            runtime_mode="FULL",
+        )
+    return stats
+
+
+def test_adapter_records_actual_scheduled_composition_and_cadence() -> None:
+    record = build_vllm_step_trace_record(
+        make_scheduler_stats(),
+        make_iteration_stats(),
+        engine_idx=2,
+        step_index=7,
+        recorded_at_monotonic_ns=1_250,
+        trace_window_started_monotonic_ns=1_000,
+        previous_recorded_at_monotonic_ns=1_200,
+    )
+
+    assert record["phase_classifier"] == VLLM_STEP_TRACE_PHASE_CLASSIFIER
+    assert record["schema_version"] == VLLM_STEP_TRACE_SCHEMA_VERSION == 4
+    assert record["engine_idx"] == 2
+    assert record["step_index"] == 7
+    assert record["since_trace_window_start_ns"] == 250
+    assert record["frontend_observed_cadence_ns"] == 50
+    assert record["post_step_scheduler_state"] == {
+        "running_requests": 3,
+        "waiting_requests": 5,
+        "kv_cache_usage": 0.25,
+    }
+    assert record["scheduled"]["request_count"] == 3
+    assert record["scheduled"]["token_count"] == 6
+    assert record["scheduled"]["token_context_product"] == 53
+    assert record["scheduled"]["prefill"] == {
+        "request_count": 1,
+        "token_count": 4,
+        "context_len_sum": 8,
+        "mean_context_len": 8.0,
+        "token_context_product": 32,
+    }
+    assert record["scheduled"]["decode"] == {
+        "request_count": 2,
+        "token_count": 2,
+        "context_len_sum": 21,
+        "mean_context_len": 10.5,
+        "token_context_product": 21,
+    }
+    assert record["cudagraph"] == {
+        "unpadded_tokens": 6,
+        "padded_tokens": 8,
+        "padding_tokens": 2,
+        "runtime_mode": "FULL",
+        "unpadded_matches_mfu_scheduled_tokens": True,
+        "padded_equals_unpadded_plus_padding": True,
+    }
+    assert record["frontend_output"] == {
+        "present": True,
+        "emitted_generation_tokens": 2,
+        "emitted_prompt_tokens": 4,
+        "computed_prompt_tokens": 4,
+        "preempted_requests": 0,
+        "finished_requests": 1,
+    }
+
+
+def test_adapter_rejects_missing_mfu_debug_stats() -> None:
+    stats = make_scheduler_stats()
+    stats.perf_stats.debug_stats = None
+
+    with pytest.raises(VllmStepTraceContractError, match="debug_stats is None"):
+        build_vllm_step_trace_record(
+            stats,
+            None,
+            engine_idx=0,
+            step_index=0,
+            recorded_at_monotonic_ns=10,
+            trace_window_started_monotonic_ns=0,
+            previous_recorded_at_monotonic_ns=None,
+        )
+
+
+def test_adapter_reports_cudagraph_and_mfu_token_disagreement() -> None:
+    record = build_vllm_step_trace_record(
+        make_scheduler_stats(unpadded_tokens=7),
+        None,
+        engine_idx=0,
+        step_index=0,
+        recorded_at_monotonic_ns=10,
+        trace_window_started_monotonic_ns=0,
+        previous_recorded_at_monotonic_ns=None,
+    )
+
+    assert not record["cudagraph"]["unpadded_matches_mfu_scheduled_tokens"]
+
+
+def test_buffer_is_bounded_and_reports_errors_without_raising() -> None:
+    timestamps = iter([100, 120, 160, 200])
+    buffer = VllmStepTraceBuffer(
+        [0],
+        max_records_per_engine=1,
+        monotonic_ns=lambda: next(timestamps),
+    )
+
+    buffer.record(make_scheduler_stats(), make_iteration_stats(), engine_idx=0)
+    buffer.record(make_scheduler_stats(), None, engine_idx=0)
+    invalid_stats = make_scheduler_stats()
+    invalid_stats.perf_stats.debug_stats = None
+    buffer.record(invalid_stats, None, engine_idx=0)
+    snapshot = buffer.snapshot()
+
+    assert "records_by_engine" not in snapshot
+    aggregate = snapshot["aggregates_by_engine"][0]
+    assert aggregate["model_step_count"] == 1
+    assert aggregate["first_records"][0][
+        "frontend_observed_cadence_ns"
+    ] is None
+    assert snapshot["dropped_records_by_engine"] == {0: 1}
+    assert snapshot["error_count"] == 1
+    assert snapshot["dropped_error_count"] == 0
+    assert snapshot["errors"][0]["error_type"] == "VllmStepTraceContractError"
+    assert snapshot["errors"][0]["step_index"] == 2
+
+
+def test_buffer_ignores_non_model_control_callbacks_and_clear_resets_window() -> None:
+    timestamps = iter([100, 120, 140, 200])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+
+    buffer.record(SimpleNamespace(perf_stats=None), None, engine_idx=0)
+    buffer.record(make_zero_work_cleanup_stats(), None, engine_idx=0)
+    before_clear = buffer.snapshot()
+    assert before_clear["ignored_non_step_callbacks_by_engine"] == {0: 2}
+    assert before_clear[
+        "ignored_non_step_callbacks_by_reason_by_engine"
+    ] == {
+        0: {
+            "finished_request_cleanup_zero_scheduled_work": 1,
+            "perf_stats_missing": 1,
+        }
+    }
+    assert before_clear[
+        "ignored_non_step_callbacks_with_frontend_token_activity_by_engine"
+    ] == {0: 0}
+    assert before_clear[
+        "ignored_non_step_callbacks_with_unverifiable_frontend_output_by_engine"
+    ] == {0: 0}
+
+    buffer.clear()
+    snapshot = buffer.snapshot()
+    assert snapshot["trace_window_started_monotonic_ns"] == 200
+    assert snapshot["ignored_non_step_callbacks_by_engine"] == {0: 0}
+    assert snapshot[
+        "ignored_non_step_callbacks_by_reason_by_engine"
+    ] == {0: {}}
+    assert "records_by_engine" not in snapshot
+    assert snapshot["aggregates_by_engine"][0]["model_step_count"] == 0
+    assert isinstance(snapshot["capture_hostname"], str)
+    assert snapshot["capture_hostname"]
+
+
+def test_buffer_flags_ignored_callback_with_frontend_token_activity() -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+
+    buffer.record(
+        make_zero_work_cleanup_stats(),
+        make_iteration_stats(),
+        engine_idx=0,
+    )
+    snapshot = buffer.snapshot()
+
+    assert snapshot["error_count"] == 0
+    assert snapshot["aggregates_by_engine"][0]["model_step_count"] == 0
+    assert snapshot[
+        "ignored_non_step_callbacks_with_frontend_token_activity_by_engine"
+    ] == {0: 1}
+
+
+def test_buffer_flags_ignored_callback_with_prompt_only_activity() -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+    iteration_stats = make_iteration_stats()
+    iteration_stats.num_generation_tokens = 0
+    iteration_stats.prompt_token_stats = SimpleNamespace(total=1, computed=0)
+    iteration_stats.finished_requests = []
+
+    buffer.record(
+        make_zero_work_cleanup_stats(),
+        iteration_stats,
+        engine_idx=0,
+    )
+
+    assert buffer.snapshot()[
+        "ignored_non_step_callbacks_with_frontend_token_activity_by_engine"
+    ] == {0: 1}
+
+
+def test_buffer_accepts_terminal_static_read_estimate_as_control_callback() -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+    stats = make_zero_work_cleanup_stats()
+    stats.perf_stats.num_read_bytes_per_gpu = 13
+    stats.perf_stats.debug_stats.num_read_bytes_per_gpu_breakdown = {
+        "weights": 10,
+        "unembed": 3,
+    }
+
+    buffer.record(stats, None, engine_idx=0)
+    snapshot = buffer.snapshot()
+
+    assert snapshot["error_count"] == 0
+    assert snapshot["aggregates_by_engine"][0]["model_step_count"] == 0
+    assert snapshot[
+        "ignored_non_step_callbacks_by_reason_by_engine"
+    ] == {
+        0: {
+            (
+                "finished_request_cleanup_zero_scheduled_work_"
+                "with_static_read_estimate"
+            ): 1
+        }
+    }
+
+
+def test_buffer_rejects_zero_work_callback_with_nonempty_scheduler() -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+    stats = make_zero_work_cleanup_stats()
+    stats.num_running_reqs = 1
+
+    buffer.record(stats, None, engine_idx=0)
+
+    snapshot = buffer.snapshot()
+    assert snapshot["ignored_non_step_callbacks_by_engine"] == {0: 0}
+    assert snapshot["error_count"] == 1
+    assert "nonempty scheduler state" in snapshot["errors"][0]["error"]
+
+
+def test_buffer_rejects_unbalanced_terminal_static_read_estimate() -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+    stats = make_zero_work_cleanup_stats()
+    stats.perf_stats.num_read_bytes_per_gpu = 13
+    stats.perf_stats.debug_stats.num_read_bytes_per_gpu_breakdown = {
+        "weights": 12
+    }
+
+    buffer.record(stats, None, engine_idx=0)
+
+    snapshot = buffer.snapshot()
+    assert snapshot["ignored_non_step_callbacks_by_engine"] == {0: 0}
+    assert snapshot["error_count"] == 1
+    assert "totals disagree with breakdowns" in snapshot["errors"][0]["error"]
+
+
+def zero_work_with_cudagraph(stats: SimpleNamespace) -> None:
+    zero = make_zero_context_stats(keep_cudagraph=True)
+    stats.perf_stats = zero.perf_stats
+    stats.cudagraph_stats = zero.cudagraph_stats
+
+
+def zero_totals_with_nonzero_breakdown(stats: SimpleNamespace) -> None:
+    debug_stats = stats.perf_stats.debug_stats
+    debug_stats.num_prefill_requests = 0
+    debug_stats.num_decode_requests = 0
+    debug_stats.context_breakdown = {
+        field: 0 for field in debug_stats.context_breakdown
+    }
+    stats.perf_stats.num_flops_per_gpu = 0
+    stats.perf_stats.num_read_bytes_per_gpu = 0
+    stats.perf_stats.num_write_bytes_per_gpu = 0
+    stats.cudagraph_stats = None
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda stats: setattr(stats, "cudagraph_stats", None),
+        lambda stats: (
+            setattr(stats.perf_stats.debug_stats, "num_prefill_requests", 0),
+            setattr(stats.perf_stats.debug_stats, "num_decode_requests", 0),
+            stats.perf_stats.debug_stats.context_breakdown.update(
+                {
+                    "num_prefill_requests": 0,
+                    "num_decode_requests": 0,
+                }
+            ),
+            setattr(stats, "cudagraph_stats", None),
+        ),
+        zero_work_with_cudagraph,
+        lambda stats: (
+            setattr(stats.perf_stats.debug_stats, "num_prefill_requests", 0),
+            setattr(stats.perf_stats.debug_stats, "num_decode_requests", 0),
+            stats.perf_stats.debug_stats.context_breakdown.update(
+                {
+                    field: 0
+                    for field in stats.perf_stats.debug_stats.context_breakdown
+                }
+            ),
+            setattr(stats, "cudagraph_stats", None),
+        ),
+        zero_totals_with_nonzero_breakdown,
+    ],
+    ids=[
+        "positive-work-without-cudagraph",
+        "tokens-without-requests",
+        "zero-work-with-cudagraph",
+        "zero-context-with-nonzero-estimated-work",
+        "zero-totals-with-nonzero-breakdown",
+    ],
+)
+def test_buffer_rejects_ambiguous_or_inconsistent_work_callbacks(
+    mutate,
+) -> None:
+    timestamps = iter([100, 120])
+    buffer = VllmStepTraceBuffer([0], monotonic_ns=lambda: next(timestamps))
+    stats = make_scheduler_stats()
+    mutate(stats)
+
+    buffer.record(stats, None, engine_idx=0)
+    snapshot = buffer.snapshot()
+
+    assert snapshot["ignored_non_step_callbacks_by_engine"] == {0: 0}
+    assert snapshot["aggregates_by_engine"][0]["model_step_count"] == 0
+    assert snapshot["error_count"] == 1
+    assert snapshot["errors"][0]["error_type"] == "VllmStepTraceContractError"
+
+
+def test_buffer_online_aggregate_is_exact_and_retains_only_samples() -> None:
+    timestamps = iter(range(100, 108))
+    buffer = VllmStepTraceBuffer(
+        [0],
+        max_records_per_engine=20,
+        monotonic_ns=lambda: next(timestamps),
+    )
+
+    for _ in range(7):
+        buffer.record(
+            make_scheduler_stats(),
+            make_iteration_stats(),
+            engine_idx=0,
+        )
+    snapshot = buffer.snapshot()
+    aggregate = snapshot["aggregates_by_engine"][0]
+
+    assert snapshot["schema_version"] == VLLM_STEP_TRACE_SCHEMA_VERSION == 4
+    assert (
+        snapshot["capture_contract"]["aggregation_version"]
+        == VLLM_STEP_TRACE_AGGREGATION_VERSION
+        == 1
+    )
+    assert (
+        snapshot["capture_contract"]["timeline_column_encoding"]
+        == VLLM_STEP_TRACE_TIMELINE_COLUMN_ENCODING
+        == "python-array-q-v1"
+    )
+    assert (
+        snapshot["capture_contract"]["model_step_discriminator"]
+        == VLLM_STEP_TRACE_MODEL_STEP_DISCRIMINATOR
+        == "mfu_scheduled_work_then_cudagraph_required-v2"
+    )
+    assert snapshot["capture_contract"]["retained_record_samples_per_edge"] == 3
+    assert "records_by_engine" not in snapshot
+    assert aggregate["model_step_count"] == 7
+    assert len(aggregate["first_records"]) == 3
+    assert len(aggregate["last_records"]) == 3
+    assert aggregate["first_records"][0]["step_index"] == 0
+    assert aggregate["last_records"][-1]["step_index"] == 6
+    assert all(
+        len(column) == 7
+        for column in aggregate["timeline_columns"].values()
+    )
+    assert aggregate["runtime_mode_timeline"] == ["FULL"] * 7
+    assert aggregate["distributions"]["scheduled_request_count"] == {3: 7}
+    assert aggregate["distributions"]["scheduled_token_count"] == {6: 7}
+    assert aggregate["scheduled"]["decode"] == {
+        "request_count_sum": 14,
+        "token_count_sum": 14,
+        "context_len_sum": 147,
+        "token_context_product_sum": 147,
+    }
+    estimated = aggregate["estimated_work_per_gpu"]
+    assert estimated["flops_sum"] == 84
+    assert estimated["flops_breakdown_component_sums"] == {
+        "attention": 49,
+        "mlp": 35,
+    }
+    assert estimated["read_bytes_breakdown_component_sums"] == {
+        "weights": 70,
+        "kv": 21,
+    }
+    assert aggregate["cudagraph"]["runtime_mode_model_step_counts"] == {
+        "FULL": 7
+    }
+    assert aggregate["frontend_output"]["emitted_generation_tokens"] == 14
+
+
+def test_exact_model_step_range_selects_contiguous_work_and_timing() -> None:
+    timestamps = iter(range(100, 108))
+    buffer = VllmStepTraceBuffer(
+        [0],
+        max_records_per_engine=20,
+        monotonic_ns=lambda: next(timestamps),
+    )
+    for _ in range(7):
+        buffer.record(
+            make_scheduler_stats(),
+            make_iteration_stats(),
+            engine_idx=0,
+        )
+
+    selected = summarize_exact_model_step_range(
+        {0: buffer.snapshot()},
+        start_step_index=2,
+        stop_step_index=6,
+    )
+
+    assert selected["schema"] == "nrl-vllm-exact-model-step-range-v1"
+    assert selected["selected_model_step_count_per_engine"] == 4
+    assert selected["engine_count"] == 1
+    engine = selected["per_engine"][0]
+    assert engine["available_model_step_count"] == 7
+    assert engine["selected_model_step_count"] == 4
+    assert engine["boundary_after_previous_step_monotonic_ns"] == 102
+    assert engine["boundary_after_final_selected_step_monotonic_ns"] == 106
+    assert engine["frontend_observed_elapsed_ns"] == 4
+    assert engine["frontend_observed_model_steps_per_s"] == 1_000_000_000
+    assert engine["minimum_scheduled_requests_per_step"] == 3
+    assert engine["maximum_prefill_requests_per_step"] == 1
+    assert engine["mean_decode_requests_per_step"] == 2
+    assert engine["request_weighted_mean_decode_context_len"] == 10.5
+    assert engine["aggregate_sums"]["estimated_flops_per_gpu"] == 48
+    assert engine["runtime_mode_model_step_counts"] == {"FULL": 4}
+    assert len(engine["selected_runtime_mode_sha256"]) == 64
+    assert len(engine["selected_work_columns_sha256"]) == 64
+    assert len(selected["all_selected_work_columns_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("start_step_index", "stop_step_index"),
+    ((0, 2), (3, 3), (4, 3)),
+)
+def test_exact_model_step_range_rejects_invalid_boundaries(
+    start_step_index: int,
+    stop_step_index: int,
+) -> None:
+    with pytest.raises(
+        VllmStepTraceContractError,
+        match="positive and nonempty",
+    ):
+        summarize_exact_model_step_range(
+            {0: {}},
+            start_step_index=start_step_index,
+            stop_step_index=stop_step_index,
+        )
+
+
+def test_exact_model_step_range_fails_closed_on_dropped_records() -> None:
+    timestamps = iter(range(100, 105))
+    buffer = VllmStepTraceBuffer(
+        [0],
+        max_records_per_engine=20,
+        monotonic_ns=lambda: next(timestamps),
+    )
+    for _ in range(4):
+        buffer.record(
+            make_scheduler_stats(),
+            make_iteration_stats(),
+            engine_idx=0,
+        )
+    snapshot = buffer.snapshot()
+    snapshot["dropped_records_by_engine"][0] = 1
+
+    with pytest.raises(
+        VllmStepTraceContractError,
+        match="dropped model steps",
+    ):
+        summarize_exact_model_step_range(
+            {0: snapshot},
+            start_step_index=1,
+            stop_step_index=4,
+        )

--- a/tests/unit/models/generation/vllm/test_vllm_worker_runtime_proof.py
+++ b/tests/unit/models/generation/vllm/test_vllm_worker_runtime_proof.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def backend_module() -> Iterator[ModuleType]:
+    """Import the worker extension without requiring vLLM in the test venv."""
+
+    module_name = "nemo_rl.models.generation.vllm.vllm_backend"
+    previous_module = sys.modules.pop(module_name, None)
+    try:
+        with patch.dict(sys.modules, {"vllm": ModuleType("vllm")}):
+            module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_module is not None:
+            sys.modules[module_name] = previous_module
+
+
+def test_runtime_proof_normalizes_nsight_and_exposes_only_whitelist(
+    backend_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ray
+    from ray._private import ray_constants
+
+    proof_env = {
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV": "0",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_NVLS_ENABLE": "0",
+        "NRL_VLLM_RUNTIME_ENV_CONTRACT_SHA256": "a" * 64,
+        "PYTHONPATH": "/immutable/replay",
+        "NRL_VLLM_PROPAGATE_PYTHONPATH": "1",
+        "NRL_FORCED_SEQUENCE_AUDIT": "1",
+        "NRL_VLLM_INNER_NSYS_MODE": "cuda_hw",
+    }
+    for name in backend_module._RUNTIME_ENV_PROOF_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    for name, value in proof_env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("SHOULD_NOT_APPEAR_IN_RUNTIME_PROOF", "secret")
+
+    nsight = {
+        "t": "cuda-hw,nvtx",
+        "capture-range": "cudaProfilerApi",
+    }
+    runtime_context = SimpleNamespace(
+        runtime_env={
+            "py_executable": "/venv/bin/python",
+            "_nsight": nsight,
+            "env_vars": {
+                **proof_env,
+                "SHOULD_NOT_APPEAR_IN_RUNTIME_PROOF": "secret",
+            },
+            "working_dir": "gcs://not-part-of-the-proof",
+        },
+        get_actor_id=lambda: "actor-id",
+        get_node_id=lambda: "node-id",
+    )
+    monkeypatch.setattr(ray, "get_runtime_context", lambda: runtime_context)
+    monkeypatch.setattr(
+        ray_constants,
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV",
+        False,
+    )
+
+    proof = (
+        backend_module.VllmInternalWorkerExtension()
+        .report_runtime_environment()
+    )
+
+    assert proof["worker_module_file"] == backend_module.__file__
+    assert proof["selected_env"] == proof_env
+    assert proof["ray_runtime_env"] == {
+        "py_executable": "/venv/bin/python",
+        "nsight": nsight,
+        "env_vars": proof_env,
+    }
+    assert proof["actor_id"] == "actor-id"
+    assert proof["node_id"] == "node-id"
+    assert "SHOULD_NOT_APPEAR_IN_RUNTIME_PROOF" not in str(proof)
+    assert "_nsight" not in proof["ray_runtime_env"]
+
+
+def test_runtime_proof_rejects_conflicting_nsight_spellings(
+    backend_module: ModuleType,
+) -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="conflicting 'nsight' and '_nsight'",
+    ):
+        backend_module._sanitize_ray_runtime_env(
+            {
+                "nsight": {"t": "cuda,nvtx"},
+                "_nsight": {"t": "cuda-hw,nvtx"},
+            }
+        )
+
+
+def test_runtime_proof_accepts_matching_nsight_spellings(
+    backend_module: ModuleType,
+) -> None:
+    nsight = {"t": "cuda,nvtx"}
+    assert backend_module._sanitize_ray_runtime_env(
+        {
+            "nsight": dict(nsight),
+            "_nsight": dict(nsight),
+        }
+    ) == {"nsight": nsight}

--- a/tests/unit/utils/test_checkpoint.py
+++ b/tests/unit/utils/test_checkpoint.py
@@ -312,6 +312,33 @@ def test_checkpoint_without_keep_top_k(tmp_path):
     assert len(remaining_dirs) == len(steps)
 
 
+def test_preserved_checkpoints_survive_rolling_cleanup(tmp_path):
+    checkpoint_dir = tmp_path.resolve() / "checkpoints"
+    manager = CheckpointManager(
+        {
+            "enabled": True,
+            "checkpoint_dir": checkpoint_dir,
+            "metric_name": None,
+            "higher_is_better": True,
+            # Keep no ordinary historical checkpoints. The latest remains a
+            # rolling recovery point via exclude_latest=True.
+            "keep_top_k": 0,
+            "save_optimizer": True,
+        }
+    )
+
+    for step, preserve in [(10, True), (12, False), (20, True)]:
+        tmp_dir = manager.init_tmp_checkpoint(
+            step, {"preserve_checkpoint": preserve}
+        )
+        manager.finalize_checkpoint(tmp_dir)
+
+    remaining_steps = {
+        int(path.name.split("_")[1]) for path in checkpoint_dir.glob("step_*")
+    }
+    assert remaining_steps == {10, 20}
+
+
 def test_load_checkpoint_empty_dir(checkpoint_manager, checkpoint_dir):
     """Test that loading from an empty checkpoint directory returns None."""
     # Get latest checkpoint path from empty directory

--- a/uv.lock
+++ b/uv.lock
@@ -4205,6 +4205,9 @@ mcore = [
 nemo-gym = [
     { name = "nemo-gym" },
 ]
+nvrx = [
+    { name = "nvidia-resiliency-ext" },
+]
 sglang = [
     { name = "sglang" },
     { name = "sglang-kernel" },
@@ -4302,6 +4305,7 @@ requires-dist = [
     { name = "nvidia-cutlass-dsl", marker = "extra == 'vllm'", specifier = ">=4.4.0.dev1" },
     { name = "nvidia-ml-py" },
     { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-resiliency-ext", marker = "extra == 'nvrx'" },
     { name = "nvtx" },
     { name = "omegaconf" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -4331,7 +4335,7 @@ requires-dist = [
     { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.17.1" },
     { name = "wandb", specifier = ">=0.25.1" },
 ]
-provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nemo-gym"]
+provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nvrx", "nemo-gym"]
 
 [package.metadata.requires-dev]
 build = [

--- a/uv.lock
+++ b/uv.lock
@@ -131,12 +131,18 @@ version = "2.0.0+7b6b556"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
+name = "drain3"
+version = "0.9.11"
+requires-dist = ["jsonpickle", "cachetools>=4.2.1"]
+
+[[manifest.dependency-metadata]]
 name = "flash-attn"
 requires-dist = ["torch", "einops", "setuptools", "psutil", "ninja"]
 
 [[manifest.dependency-metadata]]
 name = "logsage"
 version = "0.1.5"
+requires-dist = ["drain3>=0.9.11,<0.10.0", "langchain>=0.3.27,<0.4.0", "langchain-core>=0.3.0,<1.0.0", "langchain-nvidia-ai-endpoints>=0.3.18,<0.4.0", "nh3>=0.3.1,<0.4.0", "numpy", "pandas", "pydantic-settings>=2.11.0,<3.0.0", "requests>=2.32.5,<3.0.0"]
 
 [[manifest.dependency-metadata]]
 name = "mamba-ssm"
@@ -1568,6 +1574,16 @@ wheels = [
 ]
 
 [[package]]
+name = "drain3"
+version = "0.9.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "jsonpickle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/83/4da2d3a11b5e0edf1a4f4c0c2dd42126d2eb1f31c733967edd3dfac1af94/drain3-0.9.11.tar.gz", hash = "sha256:9ab4b1407fad74f56554ae371ef019c3c7985861631f4bab46a0e92585125f75", size = 27960, upload-time = "2022-07-17T06:40:11.433Z" }
+
+[[package]]
 name = "dulwich"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2750,6 +2766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpickle"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a6/d07afcfdef402900229bcca795f80506b207af13a838d4d99ad45abf530c/jsonpickle-4.1.1.tar.gz", hash = "sha256:f86e18f13e2b96c1c1eede0b7b90095bbb61d99fedc14813c44dc2f361dbbae1", size = 316885, upload-time = "2025-06-02T20:36:11.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/73/04df8a6fa66d43a9fd45c30f283cc4afff17da671886e451d52af60bdc7e/jsonpickle-4.1.1-py3-none-any.whl", hash = "sha256:bb141da6057898aa2438ff268362b126826c812a1721e31cf08a6e142910dc91", size = 47125, upload-time = "2025-06-02T20:36:08.647Z" },
+]
+
+[[package]]
 name = "jsonpointer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2864,8 +2889,26 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "0.3.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/bb/a65e29c8e4aaf0348c2617962e427c8e760d82a67adbd197019e49c7769d/langchain-0.3.28.tar.gz", hash = "sha256:30a32f44cc6690bcc6a6fb7c14d61a15406d5eda1a0e7eab60b3660944888741", size = 10242473, upload-time = "2026-03-06T22:45:17.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/f5/ecd71e5b78e67944b2600a155ef63000bc00148e6794e8e7809b2453887a/langchain-0.3.28-py3-none-any.whl", hash = "sha256:1ba1244477b67b812b775f346209fa596e78bf055a34e45ce22acb7a45842a32", size = 1024717, upload-time = "2026-03-06T22:45:15.545Z" },
+]
+
+[[package]]
 name = "langchain-core"
-version = "1.2.26"
+version = "0.3.84"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2877,24 +2920,35 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/b0/30ed29e5820580bc13d70b1f8a212b4fe0609a9737164ed1a90167941ca2/langchain_core-1.2.26.tar.gz", hash = "sha256:ba025ec70e19b56467f46b9109de19d30d169d328a174986b353cb23fd0ff0fe", size = 844795, upload-time = "2026-04-03T23:30:32.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/3e/1e70598fac522eaeeeb22f03107da06495160533b25ba4388be9cef01d55/langchain_core-0.3.84.tar.gz", hash = "sha256:814b75bfe67a8460a53f5839bae9505bbfffc7af6f1aa0a5155715563f5cc490", size = 599092, upload-time = "2026-04-08T19:14:00.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/8b/c184205a52b37a4a3166b3567323495701929b1dbfd528e5ba1df62bd404/langchain_core-1.2.26-py3-none-any.whl", hash = "sha256:3d0a3913dff77a930b017a05afe979e4959d27bec0c77ee51f9a100754510509", size = 508298, upload-time = "2026-04-03T23:30:30.253Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/ba75d5b80bd1f60ae799c8cbda5477eb7489fb21d40c967ec509bbd51933/langchain_core-0.3.84-py3-none-any.whl", hash = "sha256:d0b3a7b6473e30a2b3d4588ee09dc6471b8d38c46cd48f3e7c3d1ab6547f63cb", size = 459123, upload-time = "2026-04-08T19:13:57.818Z" },
 ]
 
 [[package]]
 name = "langchain-nvidia-ai-endpoints"
-version = "1.2.1"
+version = "0.3.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "filetype" },
     { name = "langchain-core" },
-    { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/d5/5d70c7b7a66dfabc4c355e408a066e8bef7d2715f3b7854ce44704886119/langchain_nvidia_ai_endpoints-1.2.1.tar.gz", hash = "sha256:055d2511fa7374da65e5d3dd1705fb09125620a124c6247212d661286f64fa8d", size = 57520, upload-time = "2026-03-16T16:42:34.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6f/0fcad6732f124c0d96fd7e8487a0b51db9f167964cfe041e4669a2148dbe/langchain_nvidia_ai_endpoints-0.3.19.tar.gz", hash = "sha256:1c420c88f7c78b2b2c2fdcef8e46104c2dd19c81e036bdd03a4838a6340950fe", size = 42884, upload-time = "2025-10-31T00:17:19.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b7/99f72331842b0f62da891411c5590ff7fab70a1a753a9a1be9348921995e/langchain_nvidia_ai_endpoints-1.2.1-py3-none-any.whl", hash = "sha256:eafb2186dea25d163089552c062274664540f2cbe251861c515700645fbf256d", size = 61820, upload-time = "2026-03-16T16:42:33.657Z" },
+    { url = "https://files.pythonhosted.org/packages/de/46/d7529004de384b2abc9e5b76cf4a84a23f3028ec6381bd5f7c00ac39bfab/langchain_nvidia_ai_endpoints-0.3.19-py3-none-any.whl", hash = "sha256:40161a71646fcbe457ac5f2222c5eadcbe31a7d79d618f5a0857c37fffa3a6d5", size = 46229, upload-time = "2025-10-31T00:17:18.306Z" },
+]
+
+[[package]]
+name = "langchain-text-splitters"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
 ]
 
 [[package]]
@@ -3027,6 +3081,18 @@ wheels = [
 name = "logsage"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "drain3" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langchain-nvidia-ai-endpoints" },
+    { name = "nh3" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm') or (extra != 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang') or (extra != 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-7-nemo-rl-automodel' or extra == 'extra-7-nemo-rl-mcore' or extra == 'extra-7-nemo-rl-sglang'" },
+    { name = "pandas" },
+    { name = "pydantic-settings" },
+    { name = "requests" },
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/eb/d44608c5fc69ac216a41cd164453df5784114d07f28ece6c6ab8a351f636/logsage-0.1.5-py3-none-any.whl", hash = "sha256:4c144ea2b339f370e943929dc2d1f755b04351a75a2d8fd4201bd6d90045ed7a", size = 65098, upload-time = "2026-01-25T10:12:30.042Z" },
 ]
@@ -4383,6 +4449,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/86/f8d3a7c9bd1bbaa181f6312c757e0b74d25f71ecf84ea3c0dc5e0f01840d/nh3-0.3.4.tar.gz", hash = "sha256:96709a379997c1b28c8974146ca660b0dcd3794f4f6d50c1ea549bab39ac6ade", size = 19520, upload-time = "2026-03-25T10:57:30.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/5e/c400663d14be2216bc084ed2befc871b7b12563f85d40904f2a4bf0dd2b7/nh3-0.3.4-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8b61058f34c2105d44d2a4d4241bacf603a1ef5c143b08766bbd0cf23830118f", size = 1417991, upload-time = "2026-03-25T10:56:59.13Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f5/109526f5002ec41322ac8cafd50f0f154bae0c26b9607c0fcb708bdca8ec/nh3-0.3.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:554cc2bab281758e94d770c3fb0bf2d8be5fb403ef6b2e8841dd7c1615df7a0f", size = 790566, upload-time = "2026-03-25T10:57:00.445Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/66/38950f2b4b316ffd82ee51ed8f9143d1f56fdd620312cacc91613b77b3e7/nh3-0.3.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dbe76feaa44e2ef9436f345016012a591550e77818876a8de5c8bc2a248e08df", size = 837538, upload-time = "2026-03-25T10:57:01.848Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9f/9d6da970e9524fe360ea02a2082856390c2c8ba540409d1be6e5851887b3/nh3-0.3.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:87dac8d611b4a478400e0821a13b35770e88c266582f065e7249d6a37b0f86e8", size = 1012154, upload-time = "2026-03-25T10:57:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/54/92/7c85c33c241e9dd51dda115bd3f765e940446588cdaaca62ef8edffe675f/nh3-0.3.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8d697e19f2995b337f648204848ac3a528eaafffc39e7ce4ac6b7a2fbe6c84af", size = 1092516, upload-time = "2026-03-25T10:57:04.726Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/597842bdb2890999a3faa2f3fcb02db8aa6ad09320d3d843ff6d0a1f737b/nh3-0.3.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:7cae217f031809321db962cd7e092bda8d4e95a87f78c0226628fa6c2ea8ebc5", size = 1053793, upload-time = "2026-03-25T10:57:06.171Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/32/669da65147bc10746d2e1d7a8a3dbfbffe0315f419e74b559e2ee3471a01/nh3-0.3.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:07999b998bf89692738f15c0eac76a416382932f855709e0b7488b595c30ec89", size = 1035975, upload-time = "2026-03-25T10:57:07.292Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7e/9e97a8b3c5161c79b4bf21cc54e9334860a52cc54ede15bf2239ef494b73/nh3-0.3.4-cp314-cp314t-win32.whl", hash = "sha256:ca90397c8d36c1535bf1988b2bed006597337843a164c7ec269dc8813f37536b", size = 600419, upload-time = "2026-03-25T10:57:08.342Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c7/6849d8d4295d3997d148eacb2d4b1c9faada4895ee3c1b1e12e72f4611e2/nh3-0.3.4-cp314-cp314t-win_amd64.whl", hash = "sha256:41e46b3499918ab6128b6421677b316e79869d0c140da24069d220a94f4e72d1", size = 613342, upload-time = "2026-03-25T10:57:09.593Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0e/14a3f510f36c20b922c123a2730f071f938d006fb513aacfd46d6cbc03a7/nh3-0.3.4-cp314-cp314t-win_arm64.whl", hash = "sha256:80b955d802bf365bd42e09f6c3d64567dce777d20e97968d94b3e9d9e99b265e", size = 607025, upload-time = "2026-03-25T10:57:10.959Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/57/a97955bc95960cfb1f0517043d60a121f4ba93fde252d4d9ffd3c2a9eead/nh3-0.3.4-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d8bebcb20ab4b91858385cd98fe58046ec4a624275b45ef9b976475604f45b49", size = 1439519, upload-time = "2026-03-25T10:57:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/c9a33361da8cde7c7760f091cd10467bc470634e4eea31c8bb70935b00a4/nh3-0.3.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d825722a1e8cbc87d7ca1e47ffb1d2a6cf343ad4c1b8465becf7cadcabcdfd0", size = 833798, upload-time = "2026-03-25T10:57:13.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/19/9487790780b8c94eacca37866c1270b747a4af8e244d43b3b550fddbbf62/nh3-0.3.4-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aa8b43e68c26b68069a3b6cef09de166d1d7fa140cf8d77e409a46cbf742e44", size = 820414, upload-time = "2026-03-25T10:57:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b4/c6a340dd321d20b1e4a663307032741da045685c87403926c43656f6f5ec/nh3-0.3.4-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f5f214618ad5eff4f2a6b13a8d4da4d9e7f37c569d90a13fb9f0caaf7d04fe21", size = 1061531, upload-time = "2026-03-25T10:57:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/49/f6b4b474e0032e4bcbb7174b44e4cf6915670e09c62421deb06ccfcb88b8/nh3-0.3.4-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3390e4333883673a684ce16c1716b481e91782d6f56dec5c85fed9feedb23382", size = 1021889, upload-time = "2026-03-25T10:57:16.454Z" },
+    { url = "https://files.pythonhosted.org/packages/43/da/e52a6941746d1f974752af3fc8591f1dbcdcf7fd8c726c7d99f444ba820e/nh3-0.3.4-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18a2e44ccb29cbb45071b8f3f2dab9ebfb41a6516f328f91f1f1fd18196239a4", size = 912965, upload-time = "2026-03-25T10:57:17.624Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b7/ec1cbc6b297a808c513f59f501656389623fc09ad6a58c640851289c7854/nh3-0.3.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0961a27dc2057c38d0364cb05880e1997ae1c80220cbc847db63213720b8f304", size = 804975, upload-time = "2026-03-25T10:57:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/56/b1275aa2c6510191eed76178da4626b0900402439cb9f27d6b9bf7c6d5e9/nh3-0.3.4-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:9337517edb7c10228252cce2898e20fb3d77e32ffaccbb3c66897927d74215a0", size = 833400, upload-time = "2026-03-25T10:57:20.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a5/5d574ffa3c6e49a5364d1b25ebad165501c055340056671493beb467a15e/nh3-0.3.4-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d866701affe67a5171b916b5c076e767a74c6a9efb7fb2006eb8d3c5f9a293d5", size = 854277, upload-time = "2026-03-25T10:57:21.433Z" },
+    { url = "https://files.pythonhosted.org/packages/79/36/8aeb2ab21517cefa212db109e41024e02650716cb42bf293d0a88437a92d/nh3-0.3.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:47d749d99ae005ab19517224140b280dd56e77b33afb82f9b600e106d0458003", size = 1022021, upload-time = "2026-03-25T10:57:22.433Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/95/9fd860997685e64abe2d5a995ca2eb5004c0fb6d6585429612a7871548b9/nh3-0.3.4-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f987cb56458323405e8e5ea827e1befcf141ffa0c0ac797d6d02e6b646056d9a", size = 1103526, upload-time = "2026-03-25T10:57:23.487Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0d/df545070614c1007f0109bb004230226c9000e7857c9785583ec25cda9d7/nh3-0.3.4-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:883d5a6d6ee8078c4afc8e96e022fe579c4c265775ff6ee21e39b8c542cabab3", size = 1068050, upload-time = "2026-03-25T10:57:24.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d5/17b016df52df052f714c53be71df26a1943551d9931e9383b92c998b88f8/nh3-0.3.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:75643c22f5092d8e209f766ee8108c400bc1e44760fc94d2d638eb138d18f853", size = 1046037, upload-time = "2026-03-25T10:57:25.799Z" },
+    { url = "https://files.pythonhosted.org/packages/51/39/49f737907e6ab2b4ca71855d3bd63dd7958862e9c8b94fb4e5b18ccf6988/nh3-0.3.4-cp38-abi3-win32.whl", hash = "sha256:72e4e9ca1c4bd41b4a28b0190edc2e21e3f71496acd36a0162858e1a28db3d7e", size = 609542, upload-time = "2026-03-25T10:57:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4f/af8e9071d7464575a7316831938237ffc9d92d27f163dbdd964b1309cd9b/nh3-0.3.4-cp38-abi3-win_amd64.whl", hash = "sha256:c10b1f0c741e257a5cb2978d6bac86e7c784ab20572724b20c6402c2e24bce75", size = 624244, upload-time = "2026-03-25T10:57:28.302Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/37695d6b0168f6714b5c492331636a9e6123d6ec22d25876c68d06eab1b8/nh3-0.3.4-cp38-abi3-win_arm64.whl", hash = "sha256:43ad4eedee7e049b9069bc015b7b095d320ed6d167ecec111f877de1540656e9", size = 616649, upload-time = "2026-03-25T10:57:29.623Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = ["torch", "packaging", "ninja", "causal-conv1d"]
 [[manifest.dependency-metadata]]
 name = "megatron-bridge"
 version = "0.0.0"
-requires-dist = ["transformers>=5.0.0,<=5.3.0", "peft>=0.18.1", "datasets>=2.20.0", "accelerate", "diffusers>=0.36.0", "peft>=0.18.0", "einops", "imageio", "imageio-ffmpeg", "omegaconf>=2.3.0", "tensorboard>=2.19.0", "typing-extensions", "rich", "wandb>=0.25.0", "six>=1.17.0", "regex>=2024.11.6", "pyyaml>=6.0.2", "tqdm>=4.67.1", "hydra-core>1.3,<=1.3.2", "qwen-vl-utils", "transformer-engine[pytorch,core-cu12]", "mamba-ssm", "nvidia-resiliency-ext", "causal-conv1d", "flash-linear-attention", "timm", "open-clip-torch>=3.2.0", "mlflow>=3.5.0", "comet-ml>=3.50.0", "torch>=2.6.0"]
+requires-dist = ["transformers>=5.0.0,<=5.3.0", "peft>=0.18.1", "datasets>=2.20.0", "accelerate", "diffusers>=0.36.0", "peft>=0.18.0", "einops", "imageio", "imageio-ffmpeg", "omegaconf>=2.3.0", "tensorboard>=2.19.0", "typing-extensions", "rich", "wandb>=0.25.0", "six>=1.17.0", "regex>=2024.11.6", "pyyaml>=6.0.2", "tqdm>=4.67.1", "hydra-core>1.3,<=1.3.2", "qwen-vl-utils", "transformer-engine[pytorch,core-cu12]", "mamba-ssm", "nvidia-resiliency-ext", "causal-conv1d", "flash-linear-attention", "timm", "open-clip-torch>=3.2.0", "mlflow>=3.9.0", "comet-ml>=3.50.0", "torch>=2.6.0"]
 
 [[manifest.dependency-metadata]]
 name = "nv-grouped-gemm"
@@ -3309,7 +3309,7 @@ requires-dist = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "mamba-ssm" },
-    { name = "mlflow", specifier = ">=3.5.0" },
+    { name = "mlflow", specifier = ">=3.9.0" },
     { name = "nvidia-resiliency-ext" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "open-clip-torch", specifier = ">=3.2.0" },
@@ -3381,7 +3381,7 @@ requires-dist = [
     { name = "multi-storage-client", specifier = "~=0.27" },
     { name = "numpy" },
     { name = "nvidia-modelopt", extras = ["torch"], marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-resiliency-ext", git = "https://github.com/NVIDIA/nvidia-resiliency-ext.git?rev=63154570cea17f8805a7fd15cc3b8cc2919ba575" },
+    { name = "nvidia-resiliency-ext", git = "https://github.com/NVIDIA/nvidia-resiliency-ext.git?rev=15a851565a4ce846c04431ecb0cf09903ab4837e" },
     { name = "nvtx", specifier = "~=0.2" },
     { name = "onnxscript" },
     { name = "openai", extras = ["aiohttp"] },
@@ -4807,8 +4807,8 @@ wheels = [
 
 [[package]]
 name = "nvidia-resiliency-ext"
-version = "0.6.0"
-source = { git = "https://github.com/NVIDIA/nvidia-resiliency-ext.git?rev=63154570cea17f8805a7fd15cc3b8cc2919ba575#63154570cea17f8805a7fd15cc3b8cc2919ba575" }
+version = "0.6.0.dev33+15a8515"
+source = { git = "https://github.com/NVIDIA/nvidia-resiliency-ext.git?rev=15a851565a4ce846c04431ecb0cf09903ab4837e#15a851565a4ce846c04431ecb0cf09903ab4837e" }
 dependencies = [
     { name = "defusedxml" },
     { name = "grpcio" },
@@ -4818,8 +4818,10 @@ dependencies = [
     { name = "mcp" },
     { name = "nvidia-ml-py" },
     { name = "packaging" },
+    { name = "protobuf" },
     { name = "psutil" },
     { name = "pyyaml" },
+    { name = "setproctitle" },
     { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
     { name = "torch", version = "2.10.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
 ]


### PR DESCRIPTION
# What does this PR do ?

**Schedules rollout requests by predicted output length instead of FCFS, so a cross-DP generation wave is not held open by one long straggler.**

Within a wave, requests are admitted and placed across DP replicas by a length
estimate rather than arrival order. The PR also carries the tracing and
profiling used to evaluate the idea.

- `nemo_rl/models/generation/vllm/lfs/` — the admission and cross-DP dispatch
  package: scheduler, dispatcher, per-engine schedulers, concurrency cap,
  group state, validation, diagnostics.
- `vllm_step_trace.py` — per-step engine trace.
- `model_step_gpu_profiler.py` — bounded Nsight capture around model steps.
- `nested_runtime_env.py` / `ray_executor.py` — propagate a runtime env into
  vLLM's Ray workers without mutating vLLM sources.
- `inflight_profiler.py`, `vllm_metric_sampler.py` — in-flight rollout and
  DP-batch statistics.
- `forced_sequence_logits_processor.py` — deterministic sequence replay, used
  to make scheduling experiments reproducible.

plus the corresponding changes in `vllm_generation`, `vllm_worker`,
`vllm_worker_async`, `vllm_backend`, `grpo`, `rollouts`, `async_utils` and
`dapo_math`, and 19 unit tests.

# Issues

None filed yet. Happy to open one to hold the design discussion if that is
preferred over discussing it here.

# Usage

LFS is off by default; generation behavior is unchanged unless it is enabled.
It is currently driven by environment variables rather than config keys:

```bash
# Cross-DP admission mode. Off unless set.
#   fcfs | lfs | predicted_lfs | history_lfs | oracle_probe_lfs | exact_length_lpt
NRL_VLLM_CROSS_DP_SCHED=lfs

# Single-engine length-grouped admission (independent of the cross-DP path)
NRL_VLLM_LFS_SCHED=1
NRL_VLLM_LFS_SCHED_G=16          # group size
```

The one config key added is for the tracing facility, not the scheduler:

```yaml
policy:
  generation:
    vllm_cfg:
      enable_vllm_step_trace: true   # read-only per-step batch composition
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — 19 unit tests under `tests/unit/models/generation/vllm/`
- [ ] Did you run the unit tests and functional tests locally? — **no.** Not run against this branch.
- [ ] Did you add or update any necessary documentation? — **no.** Not written yet, pending direction on whether this belongs in tree.