### PR TITLE
feat: shared-prefix GRPO training

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -302,6 +302,11 @@ policy:
     algorithm: "modified_first_fit_decreasing"
     sequence_length_round: 64
 
+  # Qwen3-only train-time shared-prefix optimization. Requires DTensor v2,
+  # sequence packing, and dtensor_cfg.automodel_kwargs.force_hf=true. Bin
+  # packing charges each prompt once per group/bin; logprob inference stays dense.
+  shared_prefix_training: False
+
   # makes the training sequence length divisible by the tensor parallel size
   # this is useful for sequence parallel training
   make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -302,7 +302,7 @@ policy:
     algorithm: "modified_first_fit_decreasing"
     sequence_length_round: 64
 
-  # Qwen3-only train-time shared-prefix optimization. Requires DTensor v2,
+  # Qwen3/Llama train-time shared-prefix optimization. Requires DTensor v2,
   # sequence packing, and dtensor_cfg.automodel_kwargs.force_hf=true. Bin
   # packing charges each prompt once per group/bin; logprob inference stays dense.
   shared_prefix_training: False

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -302,9 +302,10 @@ policy:
     algorithm: "modified_first_fit_decreasing"
     sequence_length_round: 64
 
-  # Qwen3/Llama train-time shared-prefix optimization. Requires DTensor v2,
-  # sequence packing, and dtensor_cfg.automodel_kwargs.force_hf=true. Bin
-  # packing charges each prompt once per group/bin; logprob inference stays dense.
+  # Qwen3/Llama/Qwen3-MoE train-time shared-prefix optimization. Requires
+  # DTensor v2 and sequence packing. Dense models use force_hf=true; native
+  # Qwen3-MoE EP uses force_hf=false. Bin packing charges each prompt once per
+  # group/bin; logprob inference stays dense.
   shared_prefix_training: False
 
   # makes the training sequence length divisible by the tensor parallel size

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -102,6 +102,11 @@ from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
 )
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+    infer_shared_prefix_response_bounds,
+)
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -344,6 +349,22 @@ def setup(
     cluster_config = master_config.cluster
     checkpointing_config = master_config.checkpointing
 
+    if policy_config.get("shared_prefix_training") and (
+        master_config.data_plane or {}
+    ).get("enabled", False):
+        raise NotImplementedError(
+            "shared-prefix training v1 requires data_plane.enabled=false"
+        )
+    if (
+        policy_config.get("shared_prefix_training")
+        and grpo_config["use_dynamic_sampling"]
+        and grpo_config["use_leave_one_out_baseline"]
+    ):
+        raise NotImplementedError(
+            "shared-prefix training v1 does not support dynamic sampling with "
+            "leave-one-out baselines because it can retain partial prompt groups"
+        )
+
     checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
     if checkpointing_pretrained is not None:
         policy_config["pretrained_checkpoint"] = checkpointing_pretrained
@@ -512,6 +533,13 @@ def setup(
     loss_fn = ClippedPGLossFn(
         loss_config, use_fused_linear_logprobs=use_fused_linear_logprobs
     )
+    if (
+        policy_config.get("shared_prefix_training")
+        and loss_config.positive_example_nll_weight != 0
+    ):
+        raise NotImplementedError(
+            "shared-prefix training v1 does not support positive_example_nll_weight"
+        )
 
     # Validate force_on_policy_ratio
     if loss_config.force_on_policy_ratio:
@@ -1791,6 +1819,42 @@ def _preserve_router_replay_routed_experts(
         target["routed_experts"] = flat_messages["routed_experts"]
 
 
+def _add_shared_prefix_training_metadata(
+    train_data: BatchedDataDict[ClippedPGLossDataDict],
+    policy_config: PolicyConfig,
+    num_generations_per_prompt: int,
+) -> None:
+    """Attach logical prompt groups without changing the dense GRPO batch."""
+    if not policy_config.get("shared_prefix_training"):
+        return
+    batch_size = train_data.size
+    if batch_size % num_generations_per_prompt != 0:
+        raise ValueError(
+            "shared-prefix GRPO expects complete prompt groups before policy.train"
+        )
+
+    prompt_lengths, effective_input_lengths = infer_shared_prefix_response_bounds(
+        train_data["token_mask"], train_data["input_lengths"]
+    )
+    train_data[SHARED_PREFIX_LENGTHS] = prompt_lengths.to(
+        device=train_data["input_lengths"].device,
+        dtype=train_data["input_lengths"].dtype,
+    )
+    # Native rollouts append a terminal environment observation after the
+    # generated assistant response. It has zero loss mask and no later trainable
+    # token depends on it, so compact training can safely drop that tail.
+    train_data["input_lengths"] = effective_input_lengths.to(
+        device=train_data["input_lengths"].device,
+        dtype=train_data["input_lengths"].dtype,
+    )
+    train_data[SHARED_PREFIX_GROUP_IDS] = (
+        torch.arange(
+            batch_size, device=train_data["input_ids"].device, dtype=torch.long
+        )
+        // num_generations_per_prompt
+    )
+
+
 def _build_async_grpo_train_data(
     flat_messages: BatchedDataDict,
     input_lengths: torch.Tensor,
@@ -2731,6 +2795,11 @@ def grpo_train(
                             "token_mask": flat_messages["token_loss_mask"],
                             "sample_mask": repeated_batch["loss_multiplier"],
                         }
+                    )
+                    _add_shared_prefix_training_metadata(
+                        train_data,
+                        master_config.policy,
+                        master_config.grpo["num_generations_per_prompt"],
                     )
                     # this will be mini-batched inside the policy, so maintain the packed multimodal structure
                     # This is also used to populate part of the downstream logprob calculation data
@@ -4248,6 +4317,13 @@ def async_grpo_train(
 
                 print("▶ Preparing for training...")
                 with timer.time("training_prep"):
+                    # Async logprob inference consumes train_data directly, so
+                    # attach train-only compaction metadata only after it ends.
+                    _add_shared_prefix_training_metadata(
+                        train_data,
+                        master_config.policy,
+                        master_config.grpo["num_generations_per_prompt"],
+                    )
                     policy.prepare_for_training()
                     POLICY_GENERATION_STALE = True
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1840,13 +1840,20 @@ def _add_shared_prefix_training_metadata(
         device=train_data["input_lengths"].device,
         dtype=train_data["input_lengths"].dtype,
     )
-    # Native rollouts append a terminal environment observation after the
-    # generated assistant response. It has zero loss mask and no later trainable
-    # token depends on it, so compact training can safely drop that tail.
-    train_data["input_lengths"] = effective_input_lengths.to(
-        device=train_data["input_lengths"].device,
-        dtype=train_data["input_lengths"].dtype,
-    )
+    # Temporarily disabled so the shared-prefix path consumes exactly the same
+    # input_lengths as the dense/packed baseline. Cropping the terminal
+    # environment observation is safe (it has zero loss mask and sits after every
+    # trainable token, so nothing depends on it) and it does shrink the compact
+    # microbatch, but it is an optimization orthogonal to prefix deduplication:
+    # pack_sequences keeps that tail on the dense path, so leaving it enabled
+    # gives shared-prefix a packing advantage that would be miscredited to
+    # deduplication in an A/B. Re-enable once the same crop is applied to both
+    # paths, or once it is measured separately.
+    # train_data["input_lengths"] = effective_input_lengths.to(
+    #     device=train_data["input_lengths"].device,
+    #     dtype=train_data["input_lengths"].dtype,
+    # )
+    del effective_input_lengths
     train_data[SHARED_PREFIX_GROUP_IDS] = (
         torch.arange(
             batch_size, device=train_data["input_ids"].device, dtype=torch.long

--- a/nemo_rl/data/packing/__init__.py
+++ b/nemo_rl/data/packing/__init__.py
@@ -20,6 +20,8 @@ from nemo_rl.data.packing.algorithms import (
     PackingAlgorithm,
     SequencePacker,
     get_packer,
+    pack_shared_prefix_sequences,
+    shared_prefix_bin_length,
 )
 from nemo_rl.data.packing.metrics import PackingMetrics
 
@@ -31,5 +33,7 @@ __all__ = [
     "FirstFitShufflePacker",
     "ModifiedFirstFitDecreasingPacker",
     "get_packer",
+    "pack_shared_prefix_sequences",
+    "shared_prefix_bin_length",
     "PackingMetrics",
 ]

--- a/nemo_rl/data/packing/algorithms.py
+++ b/nemo_rl/data/packing/algorithms.py
@@ -652,6 +652,180 @@ class ModifiedFirstFitDecreasingPacker(SequencePacker):
         return [[idx for idx, _ in b] for b in bins if b]
 
 
+def shared_prefix_bin_length(
+    bin_indices: List[int],
+    sequence_lengths: List[int],
+    prompt_lengths: List[int],
+    group_ids: List[int],
+) -> int:
+    """Return physical tokens after deduplicating each group's prompt in a bin."""
+    seen_groups = set()
+    total = 0
+    for index in bin_indices:
+        prompt_length = prompt_lengths[index]
+        total += sequence_lengths[index] - prompt_length
+        if group_ids[index] not in seen_groups:
+            total += prompt_length
+            seen_groups.add(group_ids[index])
+    return total
+
+
+def pack_shared_prefix_sequences(
+    sequence_lengths: List[int],
+    prompt_lengths: List[int],
+    group_ids: List[int],
+    bin_capacity: int,
+    min_bin_count: Optional[int] = None,
+    bin_count_multiple: Optional[int] = None,
+) -> List[List[int]]:
+    """First-fit pack rollouts, charging a prompt once per group and bin.
+
+    Each group is first split into the minimum first-fit response fragments, each
+    charged for one prompt. Those fragments are then packed without splitting,
+    so another group's tail space cannot cause an avoidable prompt recomputation.
+    """
+    if not (len(sequence_lengths) == len(prompt_lengths) == len(group_ids)):
+        raise ValueError(
+            "sequence_lengths, prompt_lengths, and group_ids must have equal size"
+        )
+    if not sequence_lengths:
+        return []
+
+    rows_by_group: Dict[int, List[int]] = {}
+    group_order = []
+    group_prompt_lengths: Dict[int, int] = {}
+    for index, (sequence_length, prompt_length, group_id) in enumerate(
+        zip(sequence_lengths, prompt_lengths, group_ids)
+    ):
+        if not 0 < prompt_length < sequence_length <= bin_capacity:
+            raise ValueError(
+                "shared-prefix packing requires 0 < prompt < sequence <= capacity"
+            )
+        if group_id not in rows_by_group:
+            rows_by_group[group_id] = []
+            group_order.append(group_id)
+            group_prompt_lengths[group_id] = prompt_length
+        elif group_prompt_lengths[group_id] != prompt_length:
+            raise ValueError("a shared-prefix group must have one prompt length")
+        rows_by_group[group_id].append(index)
+
+    fragments: List[List[int]] = []
+    fragment_lengths: List[int] = []
+    fragment_prompt_lengths: List[int] = []
+    for group_id in group_order:
+        prompt_length = group_prompt_lengths[group_id]
+        rows = sorted(
+            rows_by_group[group_id],
+            key=lambda index: sequence_lengths[index] - prompt_lengths[index],
+            reverse=True,
+        )
+        group_fragments: List[List[int]] = []
+        group_response_lengths: List[int] = []
+        for index in rows:
+            response_length = sequence_lengths[index] - prompt_lengths[index]
+            for fragment_index, current_response_length in enumerate(
+                group_response_lengths
+            ):
+                if (
+                    prompt_length + current_response_length + response_length
+                    <= bin_capacity
+                ):
+                    group_fragments[fragment_index].append(index)
+                    group_response_lengths[fragment_index] += response_length
+                    break
+            else:
+                group_fragments.append([index])
+                group_response_lengths.append(response_length)
+        for fragment, response_length in zip(group_fragments, group_response_lengths):
+            fragments.append(fragment)
+            fragment_lengths.append(prompt_length + response_length)
+            fragment_prompt_lengths.append(prompt_length)
+
+    # Treat each minimal within-group fragment as indivisible when combining
+    # different prompt groups. This avoids creating an extra prompt copy merely
+    # to fill another group's small tail gap.
+    fragment_bins: List[List[int]] = []
+    outer_bin_lengths: List[int] = []
+    for fragment_index in sorted(
+        range(len(fragments)),
+        key=lambda index: fragment_lengths[index],
+        reverse=True,
+    ):
+        for bin_index, current_length in enumerate(outer_bin_lengths):
+            if current_length + fragment_lengths[fragment_index] <= bin_capacity:
+                fragment_bins[bin_index].append(fragment_index)
+                outer_bin_lengths[bin_index] += fragment_lengths[fragment_index]
+                break
+        else:
+            fragment_bins.append([fragment_index])
+            outer_bin_lengths.append(fragment_lengths[fragment_index])
+
+    target_bin_count = len(fragment_bins)
+    if min_bin_count is not None:
+        target_bin_count = max(target_bin_count, min_bin_count)
+    if bin_count_multiple is not None:
+        remainder = target_bin_count % bin_count_multiple
+        if remainder:
+            target_bin_count += bin_count_multiple - remainder
+    if target_bin_count > len(sequence_lengths):
+        raise ValueError(
+            f"Cannot create {target_bin_count} nonempty bins from "
+            f"{len(sequence_lengths)} sequences"
+        )
+    while len(fragment_bins) < target_bin_count:
+        multi_fragment_sources = [
+            index for index, contents in enumerate(fragment_bins) if len(contents) > 1
+        ]
+        if multi_fragment_sources:
+            source = max(
+                multi_fragment_sources,
+                key=lambda index: outer_bin_lengths[index],
+            )
+            moved_fragment = max(
+                fragment_bins[source], key=lambda index: fragment_lengths[index]
+            )
+            fragment_bins[source].remove(moved_fragment)
+            outer_bin_lengths[source] -= fragment_lengths[moved_fragment]
+            fragment_bins.append([moved_fragment])
+            outer_bin_lengths.append(fragment_lengths[moved_fragment])
+            continue
+
+        source = max(
+            (
+                index
+                for index in range(len(fragment_bins))
+                if len(fragments[fragment_bins[index][0]]) > 1
+            ),
+            key=lambda index: fragment_lengths[fragment_bins[index][0]],
+        )
+        fragment_index = fragment_bins[source][0]
+        left_rows: List[int] = []
+        right_rows: List[int] = []
+        response_totals = [0, 0]
+        for row in sorted(
+            fragments[fragment_index],
+            key=lambda index: sequence_lengths[index] - prompt_lengths[index],
+            reverse=True,
+        ):
+            target = 0 if response_totals[0] <= response_totals[1] else 1
+            (left_rows if target == 0 else right_rows).append(row)
+            response_totals[target] += sequence_lengths[row] - prompt_lengths[row]
+        prompt_length = fragment_prompt_lengths[fragment_index]
+        fragments[fragment_index] = left_rows
+        fragment_lengths[fragment_index] = prompt_length + response_totals[0]
+        outer_bin_lengths[source] = fragment_lengths[fragment_index]
+        fragments.append(right_rows)
+        fragment_lengths.append(prompt_length + response_totals[1])
+        fragment_prompt_lengths.append(prompt_length)
+        fragment_bins.append([len(fragments) - 1])
+        outer_bin_lengths.append(fragment_lengths[-1])
+
+    return [
+        [row for fragment_index in fragment_bin for row in fragments[fragment_index]]
+        for fragment_bin in fragment_bins
+    ]
+
+
 def get_packer(
     algorithm: Union[PackingAlgorithm, str],
     bin_capacity: int,

--- a/nemo_rl/distributed/batched_data_dict.py
+++ b/nemo_rl/distributed/batched_data_dict.py
@@ -27,12 +27,16 @@ from typing import (
 )
 
 import torch
-from typing_extensions import Self
+from typing_extensions import NotRequired, Self
 
 from nemo_rl.data.multimodal_utils import (
     PackedTensor,
 )
-from nemo_rl.data.packing import get_packer
+from nemo_rl.data.packing import (
+    get_packer,
+    pack_shared_prefix_sequences,
+    shared_prefix_bin_length,
+)
 from nemo_rl.distributed.collectives import (
     gather_jagged_object_lists,
     rebalance_nd_tensor,
@@ -54,6 +58,8 @@ class SequencePackingArgs(TypedDict):
     sequence_length_pad_multiple: (
         int  # pad each sequence to a multiple of this value (for CP/TP alignment)
     )
+    shared_prefix_group_ids_key: NotRequired[str]
+    shared_prefix_lengths_key: NotRequired[str]
 
 
 class DynamicBatchingArgs(TypedDict):
@@ -447,12 +453,23 @@ class BatchedDataDict(UserDict, Generic[DictT]):
                 data[k] = sorted_v
 
         elif sequence_packing_args is not None:
-            bin_packer = get_packer(
-                algorithm=sequence_packing_args["algorithm"],
-                bin_capacity=sequence_packing_args["max_tokens_per_microbatch"],
-                collect_metrics=False,  # TODO(ahmadki): make configurable
-                min_bin_count=shards,
-                bin_count_multiple=shards,
+            shared_group_key = sequence_packing_args.get("shared_prefix_group_ids_key")
+            shared_prompt_key = sequence_packing_args.get("shared_prefix_lengths_key")
+            if (shared_group_key is None) != (shared_prompt_key is None):
+                raise ValueError(
+                    "shared-prefix sequence packing requires both metadata keys"
+                )
+            use_shared_prefix_cost = shared_group_key is not None
+            bin_packer = (
+                None
+                if use_shared_prefix_cost
+                else get_packer(
+                    algorithm=sequence_packing_args["algorithm"],
+                    bin_capacity=sequence_packing_args["max_tokens_per_microbatch"],
+                    collect_metrics=False,  # TODO(ahmadki): make configurable
+                    min_bin_count=shards,
+                    bin_count_multiple=shards,
+                )
             )
 
             input_lengths_key = sequence_packing_args["input_lengths_key"]
@@ -465,6 +482,28 @@ class BatchedDataDict(UserDict, Generic[DictT]):
             def _get_padded_seqlen(seqlen: int) -> int:
                 return (seqlen + pad_multiple - 1) // pad_multiple * pad_multiple
 
+            padded_input_lens = [
+                _get_padded_seqlen(int(sequence_length))
+                for sequence_length in input_lens.tolist()
+            ]
+            if use_shared_prefix_cost:
+                assert shared_group_key is not None and shared_prompt_key is not None
+                prompt_lens = [
+                    int(prompt_length)
+                    for prompt_length in self.data[shared_prompt_key].tolist()
+                ]
+                group_ids = [
+                    int(group_id) for group_id in self.data[shared_group_key].tolist()
+                ]
+                # Compact execution consumes the real input lengths and drops
+                # the ordinary TP-alignment tail. Charging rounded full lengths
+                # here would turn that tail into fake response tokens.
+                packing_input_lens = [
+                    int(sequence_length) for sequence_length in input_lens.tolist()
+                ]
+            else:
+                packing_input_lens = padded_input_lens
+
             # Store bin assignments for each chunk to reuse later
             all_chunk_bin_assignments = []
 
@@ -473,16 +512,23 @@ class BatchedDataDict(UserDict, Generic[DictT]):
                 chunk_start = chunk_idx * batch_size
                 chunk_end = (chunk_idx + 1) * batch_size
 
-                # Get sequence lengths for this chunk
-                chunk_seqlens = input_lens[chunk_start:chunk_end]
-                chunk_padded_seqlens_list = [
-                    _get_padded_seqlen(seq_len.item()) for seq_len in chunk_seqlens
-                ]
+                chunk_padded_seqlens_list = packing_input_lens[chunk_start:chunk_end]
 
                 # Pack sequences in this chunk into bins
-                chunk_bin_assignments = bin_packer.pack(
-                    sequence_lengths=chunk_padded_seqlens_list,
-                )
+                if use_shared_prefix_cost:
+                    chunk_bin_assignments = pack_shared_prefix_sequences(
+                        sequence_lengths=chunk_padded_seqlens_list,
+                        prompt_lengths=prompt_lens[chunk_start:chunk_end],
+                        group_ids=group_ids[chunk_start:chunk_end],
+                        bin_capacity=sequence_packing_args["max_tokens_per_microbatch"],
+                        min_bin_count=shards,
+                        bin_count_multiple=shards,
+                    )
+                else:
+                    assert bin_packer is not None
+                    chunk_bin_assignments = bin_packer.pack(
+                        sequence_lengths=chunk_padded_seqlens_list,
+                    )
                 all_chunk_bin_assignments.append(chunk_bin_assignments)
 
             # create shards with the packed bins
@@ -509,12 +555,17 @@ class BatchedDataDict(UserDict, Generic[DictT]):
                         self.select_indices(global_bin_indices)
                     )
                     global_indices_per_shard[shard_idx].extend(global_bin_indices)
-                    bin_seqlen = sum(
-                        [
-                            _get_padded_seqlen(input_lens[i].item())
-                            for i in global_bin_indices
-                        ]
-                    )
+                    if use_shared_prefix_cost:
+                        bin_seqlen = shared_prefix_bin_length(
+                            global_bin_indices,
+                            packing_input_lens,
+                            prompt_lens,
+                            group_ids,
+                        )
+                    else:
+                        bin_seqlen = sum(
+                            padded_input_lens[i] for i in global_bin_indices
+                        )
 
                     if chunk_sharded_micro_indices[shard_idx] == []:
                         chunk_sharded_micro_indices[shard_idx].append(

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -1555,6 +1555,88 @@ def get_logprobs_from_vocab_parallel_logits(
     )
 
 
+def get_aligned_target_logprobs_from_vocab_parallel_logits(
+    vocab_parallel_logits: DTensor,
+    target: torch.Tensor,
+    *,
+    chunk_size: Optional[int] = None,
+) -> torch.Tensor:
+    """Compute TP logprobs for targets already aligned with their predictors.
+
+    Unlike :func:`get_logprobs_from_vocab_parallel_logits`, this helper does
+    not shift targets or drop the final predictor. It is intended for layouts
+    such as shared-prefix training, where predictor positions are gathered into
+    a custom order before the vocabulary-parallel LM head.
+
+    Args:
+        vocab_parallel_logits: Vocabulary-sharded DTensor with global shape
+            ``[batch_size, num_predictors, vocab_size]``.
+        target: Global token IDs with shape ``[batch_size, num_predictors]``.
+        chunk_size: Optional predictor-dimension chunk size.
+
+    Returns:
+        Target log probabilities with shape ``[batch_size, num_predictors]``.
+
+    Raises:
+        ValueError: If the logits, targets, or TP vocabulary shard are invalid.
+    """
+    if vocab_parallel_logits.ndim != 3:
+        raise ValueError(
+            "aligned target logprobs require rank-3 vocabulary-parallel logits"
+        )
+    if target.shape != vocab_parallel_logits.shape[:-1]:
+        raise ValueError(
+            "aligned target IDs must match the logits batch and predictor dimensions"
+        )
+    if target.dtype != torch.long:
+        raise ValueError("aligned target IDs must use torch.long dtype")
+    if chunk_size is not None and chunk_size <= 0:
+        raise ValueError("aligned target logprob chunk_size must be positive")
+
+    device_mesh = vocab_parallel_logits.device_mesh
+    if device_mesh.mesh_dim_names is None or "tp" not in device_mesh.mesh_dim_names:
+        raise ValueError("vocabulary-parallel logits must use a named TP mesh")
+    tp_group = device_mesh.get_group("tp")
+    tp_rank = tp_group.rank()
+    tp_size = tp_group.size()
+    global_vocab_size = vocab_parallel_logits.shape[-1]
+    if global_vocab_size % tp_size != 0:
+        raise ValueError("global vocabulary size must be divisible by TP size")
+
+    local_logits = vocab_parallel_logits.to_local()
+    vocab_interval_per_rank = global_vocab_size // tp_size
+    if local_logits.shape != (*target.shape, vocab_interval_per_rank):
+        raise ValueError(
+            "vocabulary-parallel logits must be sharded only on the vocabulary dimension"
+        )
+    if target.device != local_logits.device:
+        raise ValueError(
+            "aligned target IDs and local logits must be on the same device"
+        )
+
+    vocab_start_index = vocab_interval_per_rank * tp_rank
+    vocab_end_index = vocab_interval_per_rank * (tp_rank + 1)
+    inference_only = not torch.is_grad_enabled()
+    if chunk_size is not None:
+        return ChunkedDistributedLogprob.apply(  # type: ignore
+            local_logits,
+            target,
+            vocab_start_index,
+            vocab_end_index,
+            chunk_size,
+            tp_group,
+            inference_only,
+        ).contiguous()
+    return DistributedLogprob.apply(  # type: ignore
+        local_logits,
+        target,
+        vocab_start_index,
+        vocab_end_index,
+        tp_group,
+        inference_only,
+    ).contiguous()
+
+
 def get_next_token_logprobs_from_logits(
     input_ids: torch.Tensor,
     next_token_logits: torch.Tensor,

--- a/nemo_rl/models/automodel/data.py
+++ b/nemo_rl/models/automodel/data.py
@@ -61,8 +61,8 @@ class ProcessedInputs:
     cp_buffers: list[torch.Tensor] = field(default_factory=list)
     seq_index: Optional[torch.Tensor] = None
 
-    # Present only for train-time Qwen3 shared-prefix execution. Keeping this
-    # optional preserves the normal inference, reward-model, and VLM paths.
+    # Present only for train-time Qwen3/Llama shared-prefix execution. Keeping
+    # this optional preserves the normal inference, reward-model, and VLM paths.
     shared_prefix_layout: Optional[SharedPrefixLayout] = None
 
     @property

--- a/nemo_rl/models/automodel/data.py
+++ b/nemo_rl/models/automodel/data.py
@@ -271,9 +271,9 @@ def process_microbatch(
             ],  # flash attention 2 expects flattened input
             padding_value=tokenizer.eos_token_id,
             return_attention_mask=False,
-            # The fixed-size tail is a TP workaround. Shared-prefix v1 requires
-            # TP=1, and its model-wide custom backend needs physical tokens to
-            # match the real-token cu_seqlens during dense logprob forwards.
+            # The fixed-size tail is a TP workaround for ordinary packed
+            # forwards. The shared-prefix backend instead requires physical
+            # tokens to match the real-token cu_seqlens.
             min_seq_len=(
                 0
                 if cfg.get("shared_prefix_training")

--- a/nemo_rl/models/automodel/data.py
+++ b/nemo_rl/models/automodel/data.py
@@ -27,6 +27,12 @@ from nemo_rl.models.huggingface.common import (
     get_flash_attention_kwargs,
     pack_sequences,
 )
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+    SharedPrefixLayout,
+    build_shared_prefix_layout,
+)
 
 
 @dataclass
@@ -54,6 +60,10 @@ class ProcessedInputs:
     # Context parallel support (cp_size > 1)
     cp_buffers: list[torch.Tensor] = field(default_factory=list)
     seq_index: Optional[torch.Tensor] = None
+
+    # Present only for train-time Qwen3 shared-prefix execution. Keeping this
+    # optional preserves the normal inference, reward-model, and VLM paths.
+    shared_prefix_layout: Optional[SharedPrefixLayout] = None
 
     @property
     def has_context_parallel(self) -> bool:
@@ -216,9 +226,43 @@ def process_microbatch(
     Returns:
         ProcessedInputs containing all tensors and metadata for forward pass
     """
+    has_shared_groups = SHARED_PREFIX_GROUP_IDS in mb
+    has_shared_lengths = SHARED_PREFIX_LENGTHS in mb
+    if has_shared_groups != has_shared_lengths:
+        raise ValueError("shared-prefix training requires both metadata tensors")
+    if has_shared_groups and not cfg.get("shared_prefix_training"):
+        raise ValueError(
+            "shared-prefix metadata is present, but shared_prefix_training is disabled"
+        )
+
     input_ids = mb.get("input_ids").cuda()
 
-    if enable_seq_packing:
+    if has_shared_groups:
+        if not enable_seq_packing:
+            raise ValueError(
+                "shared-prefix training currently requires sequence packing"
+            )
+        if cp_size != 1:
+            raise ValueError(
+                "shared-prefix training does not support context parallelism"
+            )
+        if len(mb.get_multimodal_dict(as_tensors=False)) > 0:
+            raise ValueError(
+                "shared-prefix training does not support multimodal inputs"
+            )
+        shared_prefix_layout = build_shared_prefix_layout(
+            input_ids=input_ids,
+            input_lengths=mb["input_lengths"],
+            prompt_lengths=mb[SHARED_PREFIX_LENGTHS],
+            group_ids=mb[SHARED_PREFIX_GROUP_IDS],
+        )
+        input_ids = shared_prefix_layout.compact_input_ids
+        position_ids = shared_prefix_layout.compact_position_ids
+        seq_len = input_ids.shape[1]
+        attention_mask = None
+        flash_attn_kwargs = {}
+    elif enable_seq_packing:
+        shared_prefix_layout = None
         input_ids, position_ids, _ = pack_sequences(
             input_ids=input_ids,
             input_lengths=mb["input_lengths"],
@@ -227,9 +271,14 @@ def process_microbatch(
             ],  # flash attention 2 expects flattened input
             padding_value=tokenizer.eos_token_id,
             return_attention_mask=False,
-            min_seq_len=cfg["sequence_packing"][
-                "train_mb_tokens"
-            ],  # TODO: this is a WAR for sequence packing, we should fix this. Without this, backward will fail when TP is enabled.
+            # The fixed-size tail is a TP workaround. Shared-prefix v1 requires
+            # TP=1, and its model-wide custom backend needs physical tokens to
+            # match the real-token cu_seqlens during dense logprob forwards.
+            min_seq_len=(
+                0
+                if cfg.get("shared_prefix_training")
+                else cfg["sequence_packing"]["train_mb_tokens"]
+            ),
         )
         seq_len = input_ids.shape[1]
         attention_mask = None
@@ -237,6 +286,7 @@ def process_microbatch(
             input_lengths=mb["input_lengths"],
         )
     else:
+        shared_prefix_layout = None
         batch_size, seq_len = input_ids.shape
 
         # DTensor requires the causal attention kernel to hit,
@@ -318,6 +368,7 @@ def process_microbatch(
         cp_buffers=cp_buffers,
         seq_index=seq_index,
         seq_len=seq_len,
+        shared_prefix_layout=shared_prefix_layout,
     )
 
 

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -413,14 +413,16 @@ def validate_and_prepare_config(
             raise ValueError(
                 "shared-prefix training currently supports text causal language models only"
             )
-        if model_config.model_type != "qwen3":
+        if model_config.model_type not in {"llama", "qwen3"}:
             raise ValueError(
-                f"shared-prefix training currently supports qwen3, got {model_config.model_type}"
+                "shared-prefix training currently supports Qwen3 and Llama, "
+                f"got {model_config.model_type}"
             )
         layer_types = getattr(model_config, "layer_types", ["full_attention"])
         if any(layer_type != "full_attention" for layer_type in layer_types):
             raise ValueError(
-                "shared-prefix training currently supports full-attention Qwen3 layers only"
+                "shared-prefix training currently supports full-attention "
+                "Qwen3 and Llama models only"
             )
         if getattr(model_config, "attention_dropout", 0.0) != 0.0:
             raise ValueError("shared-prefix training requires attention_dropout=0")

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -16,6 +16,8 @@
 
 import importlib
 import inspect
+import math
+import numbers
 import os
 from functools import partial
 from typing import Any, Optional, Union
@@ -56,6 +58,7 @@ from nemo_automodel.components.distributed.config import FSDP2Config
 from nemo_automodel.components.distributed.mesh_utils import create_device_mesh
 from nemo_automodel.components.distributed.tensor_utils import get_cpu_state_dict
 from nemo_automodel.components.moe.config import MoEParallelizerConfig
+from nemo_automodel.shared.utils import dtype_from_str
 from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 from transformers import (
     AutoConfig,
@@ -78,6 +81,13 @@ from nemo_rl.models.automodel.shared_prefix import (
     SHARED_PREFIX_ATTENTION,
     register_shared_prefix_attention,
 )
+from nemo_rl.models.automodel.shared_prefix_moe import (
+    enable_custom_qwen3_moe_shared_prefix,
+    enable_qwen3_moe_checkpoint_wrapper_compatibility,
+    enable_qwen3_moe_configured_dtype,
+    enable_qwen3_moe_ep_free_checkpoint_adapter,
+    enable_qwen3_moe_ep_router_gradients,
+)
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.models.policy.utils import configure_dynamo_cache, resolve_model_class
 
@@ -86,6 +96,21 @@ STRING_TO_DTYPE = {
     "bfloat16": torch.bfloat16,
     "float16": torch.float16,
 }
+
+
+def _prewarm_native_shared_prefix_moe_world(world_size: int) -> None:
+    """Initialize NCCL before AutoModel creates overlapping EP/FSDP groups.
+
+    With both EP and EP-shard dimensions, ranks can otherwise lazily initialize
+    overlapping communicators in different orders and block in the first expert
+    all-gather.  A default-process-group collective before device-mesh creation
+    establishes one common NCCL ordering without changing model state.
+    """
+    device = torch.device("cuda", torch.cuda.current_device())
+    token = torch.zeros(1, dtype=torch.int64, device=device)
+    gathered = torch.empty(world_size, dtype=torch.int64, device=device)
+    torch.distributed.all_gather_into_tensor(gathered, token)
+    torch.cuda.synchronize(device)
 
 
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
@@ -390,6 +415,7 @@ def validate_and_prepare_config(
     # Get parallelization sizes
     tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
     cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
+    ep_size = config["dtensor_cfg"].get("expert_parallel_size", 1)
     sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
 
     if enable_shared_prefix_training:
@@ -404,25 +430,205 @@ def validate_and_prepare_config(
             raise ValueError(
                 "shared-prefix training currently requires CP=1 and sequence_parallel=false"
             )
-        if automodel_kwargs is None or automodel_kwargs.get("force_hf") is not True:
-            raise ValueError(
-                "shared-prefix training requires "
-                "policy.dtensor_cfg.automodel_kwargs.force_hf=true"
-            )
         if is_vlm or is_reward_model:
             raise ValueError(
                 "shared-prefix training currently supports text causal language models only"
             )
-        if model_config.model_type not in {"llama", "qwen3"}:
+        if model_config.model_type not in {"llama", "qwen3", "qwen3_moe"}:
             raise ValueError(
-                "shared-prefix training currently supports Qwen3 and Llama, "
+                "shared-prefix training currently supports Qwen3, Qwen3-MoE, "
+                "and Llama, "
                 f"got {model_config.model_type}"
             )
         layer_types = getattr(model_config, "layer_types", ["full_attention"])
         if any(layer_type != "full_attention" for layer_type in layer_types):
             raise ValueError(
                 "shared-prefix training currently supports full-attention "
-                "Qwen3 and Llama models only"
+                "Qwen3, Qwen3-MoE, and Llama models only"
+            )
+        if getattr(model_config, "sliding_window", None) is not None:
+            raise ValueError(
+                "shared-prefix training currently supports full attention only"
+            )
+        if model_config.model_type == "qwen3_moe":
+            if isinstance(ep_size, bool) or not isinstance(ep_size, int) or ep_size < 1:
+                raise ValueError("expert_parallel_size must be a positive integer")
+            if cpu_offload:
+                raise ValueError(
+                    "shared-prefix native Qwen3-MoE currently requires "
+                    "policy.dtensor_cfg.cpu_offload=false"
+                )
+            force_hf = (
+                None if automodel_kwargs is None else automodel_kwargs.get("force_hf")
+            )
+            if force_hf is True:
+                raise ValueError(
+                    "shared-prefix Qwen3-MoE requires force_hf=false so native "
+                    "Gate adapters can preserve logical router auxiliary loss "
+                    "and load statistics"
+                )
+            if force_hf is False:
+                backend = automodel_kwargs.get("backend")
+                if not isinstance(backend, dict) or "_target_" not in backend:
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE requires an explicit "
+                        "automodel_kwargs.backend with _target_, dispatcher='torch', "
+                        "and experts='torch' or 'torch_mm'"
+                    )
+                if backend.get("dispatcher") != "torch":
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE currently requires "
+                        "automodel_kwargs.backend.dispatcher='torch'"
+                    )
+                if backend.get("enable_deepep"):
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE requires "
+                        "automodel_kwargs.backend.enable_deepep=false because "
+                        "the deprecated flag overrides dispatcher='torch'"
+                    )
+                if backend.get("experts") not in {"torch", "torch_mm"}:
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE currently requires "
+                        "automodel_kwargs.backend.experts='torch' or 'torch_mm'"
+                    )
+                fake_balanced_gate = backend.get("fake_balanced_gate")
+                if fake_balanced_gate is not None and not isinstance(
+                    fake_balanced_gate, bool
+                ):
+                    raise ValueError(
+                        "automodel_kwargs.backend.fake_balanced_gate must be boolean"
+                    )
+                if fake_balanced_gate:
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE requires "
+                        "automodel_kwargs.backend.fake_balanced_gate=false so "
+                        "logical router loss and load statistics use the learned Gate"
+                    )
+                if "enable_hf_state_dict_adapter" in backend:
+                    enable_hf_adapter = backend["enable_hf_state_dict_adapter"]
+                    if not isinstance(enable_hf_adapter, bool):
+                        raise ValueError(
+                            "automodel_kwargs.backend.enable_hf_state_dict_adapter "
+                            "must be boolean"
+                        )
+                    if not enable_hf_adapter:
+                        raise ValueError(
+                            "shared-prefix native Qwen3-MoE requires "
+                            "automodel_kwargs.backend.enable_hf_state_dict_adapter=true "
+                            "for rollout refit and checkpoint compatibility"
+                        )
+                if backend.get("te_fp8") is not None:
+                    raise ValueError(
+                        "shared-prefix native Qwen3-MoE currently requires "
+                        "automodel_kwargs.backend.te_fp8=null because the Policy "
+                        "train loop does not own a Transformer Engine FP8 autocast"
+                    )
+                gate_precision = backend.get("gate_precision")
+                if gate_precision is not None:
+                    try:
+                        resolved_gate_precision = dtype_from_str(gate_precision)
+                    except (AttributeError, KeyError, TypeError) as error:
+                        raise ValueError(
+                            "automodel_kwargs.backend.gate_precision must be a "
+                            "floating-point dtype"
+                        ) from error
+                    if resolved_gate_precision not in {
+                        torch.float16,
+                        torch.bfloat16,
+                        torch.float32,
+                        torch.float64,
+                    }:
+                        raise ValueError(
+                            "automodel_kwargs.backend.gate_precision must be a "
+                            "floating-point dtype"
+                        )
+            if force_hf is False and tp_size != 1:
+                raise ValueError(
+                    "shared-prefix native Qwen3-MoE currently requires TP=1"
+                )
+            if ep_size > 1 and force_hf is not False:
+                raise ValueError(
+                    "shared-prefix Qwen3-MoE EP requires "
+                    "policy.dtensor_cfg.automodel_kwargs.force_hf=false so "
+                    "AutoModel can shard its native grouped experts"
+                )
+            if ep_size == 1 and force_hf is not False:
+                raise ValueError(
+                    "shared-prefix Qwen3-MoE requires an explicit "
+                    "policy.dtensor_cfg.automodel_kwargs.force_hf=false for the "
+                    "native EP=1 semantic baseline"
+                )
+            if config["dtensor_cfg"].get("dp_replicate_size", 1) != 1:
+                raise ValueError(
+                    "shared-prefix native Qwen3-MoE currently requires "
+                    "dp_replicate_size=1"
+                )
+            num_experts = getattr(model_config, "num_experts", 0)
+            if ep_size > 1 and (num_experts <= 0 or num_experts % ep_size != 0):
+                raise ValueError(
+                    f"Qwen3-MoE num_experts ({num_experts}) must be divisible "
+                    f"by expert_parallel_size ({ep_size})"
+                )
+            if getattr(model_config, "output_router_logits", False):
+                raise ValueError(
+                    "shared-prefix Qwen3-MoE training requires "
+                    "output_router_logits=false; the native EP path injects its "
+                    "logical-token router auxiliary loss at each Gate"
+                )
+            raw_moe_overrides = (
+                None
+                if automodel_kwargs is None
+                else automodel_kwargs.get("moe_overrides")
+            )
+            if raw_moe_overrides is not None and not isinstance(
+                raw_moe_overrides, dict
+            ):
+                raise ValueError("Qwen3-MoE moe_overrides must be a mapping")
+            moe_overrides = raw_moe_overrides or {}
+            if "gate_bias_update_factor" in moe_overrides:
+                bias_update_factor = moe_overrides["gate_bias_update_factor"]
+                if (
+                    isinstance(bias_update_factor, bool)
+                    or not isinstance(bias_update_factor, numbers.Real)
+                    or not math.isfinite(float(bias_update_factor))
+                    or bias_update_factor != 0
+                ):
+                    raise ValueError(
+                        "dynamic routing bias is not supported for Qwen3-MoE "
+                        "because its rollout backends do not consume a "
+                        "correction-bias state; gate_bias_update_factor must be 0"
+                    )
+            supported_overrides = {
+                "aux_loss_coeff",
+                "gate_bias_update_factor",
+            }
+            unsupported_overrides = set(moe_overrides) - supported_overrides
+            if unsupported_overrides:
+                raise ValueError(
+                    "shared-prefix Qwen3-MoE only supports checkpoint-compatible "
+                    "moe_overrides "
+                    f"{sorted(supported_overrides)}, got "
+                    f"{sorted(unsupported_overrides)}"
+                )
+            aux_loss_coeff = (
+                moe_overrides["aux_loss_coeff"]
+                if "aux_loss_coeff" in moe_overrides
+                else getattr(model_config, "router_aux_loss_coef", 0.0)
+            )
+            if (
+                isinstance(aux_loss_coeff, bool)
+                or not isinstance(aux_loss_coeff, numbers.Real)
+                or not math.isfinite(float(aux_loss_coeff))
+                or aux_loss_coeff < 0
+            ):
+                raise ValueError(
+                    "Qwen3-MoE router aux_loss_coeff must be a finite "
+                    "non-negative real number"
+                )
+        elif automodel_kwargs is None or automodel_kwargs.get("force_hf") is not True:
+            raise ValueError(
+                "shared-prefix training requires "
+                "policy.dtensor_cfg.automodel_kwargs.force_hf=true"
             )
         if getattr(model_config, "attention_dropout", 0.0) != 0.0:
             raise ValueError("shared-prefix training requires attention_dropout=0")
@@ -519,6 +725,27 @@ def setup_distributed(
     dp_replicate_size = config["dtensor_cfg"].get("dp_replicate_size", 1)
     sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
 
+    use_native_shared_prefix_moe = (
+        config.get("shared_prefix_training")
+        and runtime_config.model_config.model_type == "qwen3_moe"
+        and config["dtensor_cfg"].get("automodel_kwargs", {}).get("force_hf") is False
+    )
+    # AutoModel's EP mesh must evenly partition ranks. Keep the diagnostic
+    # scoped to this new native ZoRRo path; preserve existing recipes' setup
+    # pre-validation unchanged.
+    if use_native_shared_prefix_moe and world_size % ep_size != 0:
+        raise ValueError(
+            f"world_size ({world_size}) must be divisible by "
+            f"expert_parallel_size ({ep_size})"
+        )
+    if use_native_shared_prefix_moe and world_size == 1:
+        raise ValueError(
+            "shared-prefix native Qwen3-MoE requires world_size > 1 so "
+            "AutoModel applies FSDP mixed precision before FA2"
+        )
+    if use_native_shared_prefix_moe and 1 < ep_size < world_size:
+        _prewarm_native_shared_prefix_moe_world(world_size)
+
     # HSDP requires the data-parallel axis to evenly contain the replicate dim.
     model_parallel_size = tp_size * cp_size * ep_size
     dp_size = world_size // model_parallel_size
@@ -550,6 +777,10 @@ def setup_distributed(
     # Create MoEParallelizerConfig from nested moe_parallelizer options
     moe_parallelizer_cfg = config["dtensor_cfg"].get("moe_parallelizer", {})
     moe_config = MoEParallelizerConfig(**moe_parallelizer_cfg)
+    if use_native_shared_prefix_moe:
+        # The native MoE parallelizer otherwise uses its own default BF16
+        # policy, which can diverge from the configured master-weight policy.
+        moe_config.mp_policy = fsdp2_config.mp_policy
 
     # Handle world_size=1 + cpu_offload
     if world_size == 1 and cpu_offload:
@@ -558,7 +789,7 @@ def setup_distributed(
             "If you need this feature, please file an issue on https://github.com/NVIDIA-NeMo/Automodel."
         )
 
-    # Create device meshes (dp_size is derived from world_size / (tp * cp * ep))
+    # AutoModel constructs the PP x DP x CP x TP mesh plus its EP view.
     device_mesh, moe_mesh = create_device_mesh(
         fsdp2_config,
         dp_replicate_size=dp_replicate_size,
@@ -568,7 +799,6 @@ def setup_distributed(
         ep_size=ep_size,
         world_size=world_size,
     )
-
     # Derive sizes from mesh
     resolved_dp_size = device_mesh["dp"].size()
     resolved_tp_size = device_mesh["tp"].size()
@@ -730,13 +960,16 @@ def setup_model_and_optimizer(
     print(f"[Rank {rank}] Initializing model via from_pretrained...")
 
     # Prepare automodel kwargs
-    automodel_kwargs = config["dtensor_cfg"].get("automodel_kwargs", {})
+    automodel_kwargs = dict(config["dtensor_cfg"].get("automodel_kwargs", {}) or {})
     if automodel_kwargs.get("backend", None) is not None:
         backend_class = _resolve_target(
             automodel_kwargs.get("backend", None)["_target_"]
         )
-        backend_kwargs = automodel_kwargs.get("backend")
-        backend_kwargs.pop("_target_")
+        backend_kwargs = {
+            key: value
+            for key, value in automodel_kwargs["backend"].items()
+            if key != "_target_"
+        }
         backend = backend_class(**backend_kwargs)
         automodel_kwargs["backend"] = backend
 
@@ -812,6 +1045,31 @@ def setup_model_and_optimizer(
     # checkpoint dtype, which would break optimizer master-weight precision (see helper).
     _disable_automodel_checkpoint_dtype_restore()
 
+    use_native_shared_prefix_moe = (
+        config.get("shared_prefix_training")
+        and model_config.model_type == "qwen3_moe"
+        and automodel_kwargs.get("force_hf") is False
+    )
+    if use_native_shared_prefix_moe:
+        # The pinned native implementation otherwise mixes bf16 helper defaults
+        # into NeMo-RL's fp32 master model before FSDP can shard it.
+        enable_qwen3_moe_configured_dtype()
+        if config["dtensor_cfg"]["activation_checkpointing"]:
+            # Default AutoModel activation checkpointing wraps individual MLPs;
+            # keep Qwen's dense/MoE dispatch wrapper-transparent.
+            enable_qwen3_moe_checkpoint_wrapper_compatibility()
+    if use_native_shared_prefix_moe and ep_size == 1:
+        # The pinned state-dict adapter assumes every expert DTensor owns an
+        # ``ep`` mesh. Under the EP=1 semantic baseline FSDP shards the grouped
+        # expert axis over ``dp`` instead, so install the narrow rank-local
+        # staged-copy backport before AutoModel creates or loads the model.
+        enable_qwen3_moe_ep_free_checkpoint_adapter()
+    if use_native_shared_prefix_moe and ep_size > 1:
+        # Backport NVIDIA-NeMo/Automodel#2995 before any EP forward can be
+        # compiled or activation-checkpointed. Without it, the model loss has
+        # no gradient path from remote experts to the learned Gate.
+        enable_qwen3_moe_ep_router_gradients()
+
     # Create model via from_pretrained - handles meta device init, parallelization,
     # LoRA, and base weight loading internally
     model = model_class.from_pretrained(
@@ -829,6 +1087,9 @@ def setup_model_and_optimizer(
         **from_pretrained_kwargs,
         **automodel_kwargs,
     )
+
+    if use_native_shared_prefix_moe:
+        enable_custom_qwen3_moe_shared_prefix(model)
 
     print(model)
 

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -98,21 +98,6 @@ STRING_TO_DTYPE = {
 }
 
 
-def _prewarm_native_shared_prefix_moe_world(world_size: int) -> None:
-    """Initialize NCCL before AutoModel creates overlapping EP/FSDP groups.
-
-    With both EP and EP-shard dimensions, ranks can otherwise lazily initialize
-    overlapping communicators in different orders and block in the first expert
-    all-gather.  A default-process-group collective before device-mesh creation
-    establishes one common NCCL ordering without changing model state.
-    """
-    device = torch.device("cuda", torch.cuda.current_device())
-    token = torch.zeros(1, dtype=torch.int64, device=device)
-    gathered = torch.empty(world_size, dtype=torch.int64, device=device)
-    torch.distributed.all_gather_into_tensor(gathered, token)
-    torch.cuda.synchronize(device)
-
-
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
     """Validate and maybe auto-set force_hf based on adapter compatibility.
 
@@ -709,27 +694,36 @@ def setup_distributed(
     Returns:
         DistributedContext containing device meshes and distributed configuration
     """
-    # Initialize process group
-    backend = "nccl" if not runtime_config.cpu_offload else "cuda:nccl,cpu:gloo"
-    torch.distributed.init_process_group(backend=backend)
-    world_size = torch.distributed.get_world_size()
-
-    # Extract configuration values
-    dtype = runtime_config.dtype
     cpu_offload = runtime_config.cpu_offload
-
-    # Extract parallelization config
-    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
-    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
     ep_size = config["dtensor_cfg"].get("expert_parallel_size", 1)
-    dp_replicate_size = config["dtensor_cfg"].get("dp_replicate_size", 1)
-    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
-
     use_native_shared_prefix_moe = (
         config.get("shared_prefix_training")
         and runtime_config.model_config.model_type == "qwen3_moe"
         and config["dtensor_cfg"].get("automodel_kwargs", {}).get("force_hf") is False
     )
+
+    # Binding WORLD to the actor's CUDA device eagerly establishes NCCL and lets
+    # DeviceMesh use coordinated communicator splits for its derived EP and
+    # EP-shard groups.  Keep this scoped to the native shared-prefix MoE path so
+    # existing distributed setups retain their current initialization behavior.
+    backend = "nccl" if not cpu_offload else "cuda:nccl,cpu:gloo"
+    if use_native_shared_prefix_moe and ep_size > 1 and not cpu_offload:
+        torch.distributed.init_process_group(
+            backend=backend,
+            device_id=torch.device("cuda", torch.cuda.current_device()),
+        )
+    else:
+        torch.distributed.init_process_group(backend=backend)
+    world_size = torch.distributed.get_world_size()
+
+    # Extract configuration values
+    dtype = runtime_config.dtype
+
+    # Extract parallelization config
+    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
+    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
+    dp_replicate_size = config["dtensor_cfg"].get("dp_replicate_size", 1)
+    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
     # AutoModel's EP mesh must evenly partition ranks. Keep the diagnostic
     # scoped to this new native ZoRRo path; preserve existing recipes' setup
     # pre-validation unchanged.
@@ -743,9 +737,6 @@ def setup_distributed(
             "shared-prefix native Qwen3-MoE requires world_size > 1 so "
             "AutoModel applies FSDP mixed precision before FA2"
         )
-    if use_native_shared_prefix_moe and 1 < ep_size < world_size:
-        _prewarm_native_shared_prefix_moe_world(world_size)
-
     # HSDP requires the data-parallel axis to evenly contain the replicate dim.
     model_parallel_size = tp_size * cp_size * ep_size
     dp_size = world_size // model_parallel_size

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -400,9 +400,9 @@ def validate_and_prepare_config(
             raise ValueError("shared-prefix training requires sequence packing")
         if config["dynamic_batching"]["enabled"]:
             raise ValueError("shared-prefix training does not support dynamic batching")
-        if tp_size != 1 or cp_size != 1 or sequence_parallel_enabled:
+        if cp_size != 1 or sequence_parallel_enabled:
             raise ValueError(
-                "shared-prefix training currently requires TP=1, CP=1, and sequence_parallel=false"
+                "shared-prefix training currently requires CP=1 and sequence_parallel=false"
             )
         if automodel_kwargs is None or automodel_kwargs.get("force_hf") is not True:
             raise ValueError(

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -576,12 +576,17 @@ def validate_and_prepare_config(
                     isinstance(bias_update_factor, bool)
                     or not isinstance(bias_update_factor, numbers.Real)
                     or not math.isfinite(float(bias_update_factor))
-                    or bias_update_factor != 0
+                    or bias_update_factor < 0
                 ):
                     raise ValueError(
-                        "dynamic routing bias is not supported for Qwen3-MoE "
-                        "because its rollout backends do not consume a "
-                        "correction-bias state; gate_bias_update_factor must be 0"
+                        "Qwen3-MoE gate_bias_update_factor must be a finite "
+                        "non-negative real number"
+                    )
+                generation_backend = (config.get("generation") or {}).get("backend")
+                if bias_update_factor > 0 and generation_backend not in {None, "vllm"}:
+                    raise ValueError(
+                        "Qwen3-MoE dynamic routing bias currently supports "
+                        "generation.backend='vllm' only"
                     )
             supported_overrides = {
                 "aux_loss_coeff",
@@ -1061,6 +1066,20 @@ def setup_model_and_optimizer(
         # no gradient path from remote experts to the learned Gate.
         enable_qwen3_moe_ep_router_gradients()
 
+    model_automodel_kwargs = automodel_kwargs
+    routing_bias_factor = 0.0
+    if use_native_shared_prefix_moe:
+        moe_overrides = automodel_kwargs.get("moe_overrides") or {}
+        routing_bias_factor = float(moe_overrides.get("gate_bias_update_factor", 0.0))
+        if routing_bias_factor > 0:
+            # Add the correction-bias buffer only after the base checkpoint is
+            # loaded. The pinned AutoModel DCP adapter cannot plan an EP load
+            # for a newly configured buffer that is absent from the HF source.
+            construction_overrides = dict(moe_overrides)
+            construction_overrides["gate_bias_update_factor"] = 0.0
+            model_automodel_kwargs = dict(automodel_kwargs)
+            model_automodel_kwargs["moe_overrides"] = construction_overrides
+
     # Create model via from_pretrained - handles meta device init, parallelization,
     # LoRA, and base weight loading internally
     model = model_class.from_pretrained(
@@ -1076,11 +1095,11 @@ def setup_model_and_optimizer(
         trust_remote_code=True,
         sdpa_method=sdpa_method,
         **from_pretrained_kwargs,
-        **automodel_kwargs,
+        **model_automodel_kwargs,
     )
 
     if use_native_shared_prefix_moe:
-        enable_custom_qwen3_moe_shared_prefix(model)
+        enable_custom_qwen3_moe_shared_prefix(model, routing_bias_factor)
 
     print(model)
 

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -64,12 +64,19 @@ from transformers import (
     PreTrainedTokenizerBase,
 )
 
-from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
+from nemo_rl.algorithms.logits_sampling_utils import (
+    TrainingSamplingParams,
+    need_top_k_or_top_p_filtering,
+)
 from nemo_rl.data.chat_templates import COMMON_CHAT_TEMPLATES
 from nemo_rl.models.automodel.config import (
     DistributedContext,
     ModelAndOptimizerState,
     RuntimeConfig,
+)
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_ATTENTION,
+    register_shared_prefix_attention,
 )
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.models.policy.utils import configure_dynamo_cache, resolve_model_class
@@ -293,6 +300,7 @@ def validate_and_prepare_config(
     offload_optimizer_for_logprob = config.get("offload_optimizer_for_logprob", False)
     max_grad_norm = config["max_grad_norm"]
     enable_seq_packing = config["sequence_packing"]["enabled"]
+    enable_shared_prefix_training = bool(config.get("shared_prefix_training"))
     model_name = config["model_name"]
 
     # Validate sequence packing
@@ -318,18 +326,22 @@ def validate_and_prepare_config(
     # so we need to set it to None if sequence packing is disabled
     # See https://github.com/NVIDIA-NeMo/Automodel/blob/7e748be260651349307862426c0c168cebdeeec3/nemo_automodel/components/_transformers/auto_model.py#L180
     cp_size_cfg = config["dtensor_cfg"]["context_parallel_size"]
-    attn_impl = (
-        "flash_attention_2"
-        if (enable_seq_packing and cp_size_cfg == 1)
-        else ("sdpa" if cp_size_cfg > 1 else None)
-    )
+    if enable_shared_prefix_training:
+        register_shared_prefix_attention()
+        attn_impl = SHARED_PREFIX_ATTENTION
+    else:
+        attn_impl = (
+            "flash_attention_2"
+            if (enable_seq_packing and cp_size_cfg == 1)
+            else ("sdpa" if cp_size_cfg > 1 else None)
+        )
 
     # Load model config
     model_config = AutoConfig.from_pretrained(
         model_name,
         torch_dtype=torch.float32,  # Always load in float32 for master weights
         trust_remote_code=True,
-        attn_implementation="flash_attention_2" if enable_seq_packing else None,
+        attn_implementation=attn_impl,
         **hf_config_overrides,
     )
 
@@ -379,6 +391,47 @@ def validate_and_prepare_config(
     tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
     cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
     sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
+
+    if enable_shared_prefix_training:
+        automodel_kwargs = config["dtensor_cfg"].get("automodel_kwargs")
+        if not config["dtensor_cfg"].get("_v2"):
+            raise ValueError("shared-prefix training requires DTensor v2")
+        if not enable_seq_packing:
+            raise ValueError("shared-prefix training requires sequence packing")
+        if config["dynamic_batching"]["enabled"]:
+            raise ValueError("shared-prefix training does not support dynamic batching")
+        if tp_size != 1 or cp_size != 1 or sequence_parallel_enabled:
+            raise ValueError(
+                "shared-prefix training currently requires TP=1, CP=1, and sequence_parallel=false"
+            )
+        if automodel_kwargs is None or automodel_kwargs.get("force_hf") is not True:
+            raise ValueError(
+                "shared-prefix training requires "
+                "policy.dtensor_cfg.automodel_kwargs.force_hf=true"
+            )
+        if is_vlm or is_reward_model:
+            raise ValueError(
+                "shared-prefix training currently supports text causal language models only"
+            )
+        if model_config.model_type != "qwen3":
+            raise ValueError(
+                f"shared-prefix training currently supports qwen3, got {model_config.model_type}"
+            )
+        layer_types = getattr(model_config, "layer_types", ["full_attention"])
+        if any(layer_type != "full_attention" for layer_type in layer_types):
+            raise ValueError(
+                "shared-prefix training currently supports full-attention Qwen3 layers only"
+            )
+        if getattr(model_config, "attention_dropout", 0.0) != 0.0:
+            raise ValueError("shared-prefix training requires attention_dropout=0")
+        if dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "shared-prefix FA2 training requires float16 or bfloat16 precision"
+            )
+        if need_top_k_or_top_p_filtering(sampling_params):
+            raise ValueError(
+                "shared-prefix training does not yet support train-time top-k/top-p filtering"
+            )
 
     # Validate parallelization configuration
     if cp_size > 1 and enable_seq_packing:
@@ -696,9 +749,14 @@ def setup_model_and_optimizer(
         # other backend would silently run cross-document attention. Packing with
         # cp_size > 1 is already rejected above (see the cp_size/enable_seq_packing
         # check), so enable_seq_packing here implies cp_size == 1 -> flash_attention_2.
-        if runtime_config.enable_seq_packing and requested != "flash_attention_2":
+        expected_attention = (
+            SHARED_PREFIX_ATTENTION
+            if config.get("shared_prefix_training")
+            else "flash_attention_2"
+        )
+        if runtime_config.enable_seq_packing and requested != expected_attention:
             raise ValueError(
-                "sequence_packing requires attn_implementation='flash_attention_2', "
+                f"sequence_packing requires attn_implementation={expected_attention!r}, "
                 f"but the recipe set automodel_kwargs.attn_implementation={requested!r}."
             )
         attn_impl = requested

--- a/nemo_rl/models/automodel/shared_prefix.py
+++ b/nemo_rl/models/automodel/shared_prefix.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Train-time shared-prefix execution for Hugging Face Qwen3.
+"""Train-time shared-prefix execution for Hugging Face Qwen3 and Llama.
 
 The logical GRPO microbatch remains a normal ``[batch, sequence]`` tensor.  This
 module builds a physical ``[1, compact_tokens]`` representation containing one
-copy of each prompt followed by all responses that share it.  Qwen3 norm, MLP,
-and projections run directly on that compact representation.  The registered
-attention backend preserves the logical causal semantics with two varlen FA2
-calls: prompt self-attention and response-to-(prompt + own response) attention.
+copy of each prompt followed by all responses that share it.  Decoder norms,
+MLPs, and projections run directly on that compact representation.  The
+registered attention backend preserves the logical causal semantics with two
+varlen FA2 calls: prompt self-attention and response-to-(prompt + own response)
+attention.
 """
 
 from dataclasses import dataclass
@@ -310,7 +311,7 @@ def _flash_attention_functions():
         from flash_attn import flash_attn_func, flash_attn_varlen_func
     except ImportError as error:  # pragma: no cover - exercised in the GPU environment
         raise ImportError(
-            "shared-prefix Qwen3 training requires flash-attn with FA2 varlen support"
+            "shared-prefix training requires flash-attn with FA2 varlen support"
         ) from error
     return flash_attn_func, flash_attn_varlen_func
 
@@ -407,10 +408,10 @@ def shared_prefix_flash_attention_forward(
     shared_prefix_layout: SharedPrefixLayout | None = None,
     **kwargs: Any,
 ) -> tuple[torch.Tensor, None]:
-    """Transformers ``AttentionInterface`` implementation for Qwen3 + FA2."""
+    """Transformers ``AttentionInterface`` for Qwen3/Llama with FA2."""
     if query.dtype == torch.float32:
-        # Match Transformers' native FA2 wrapper. Qwen3's fp32 norm weights can
-        # promote Q/K even while the surrounding forward is autocast to BF16.
+        # Match Transformers' native FA2 wrapper. Some training setups retain
+        # fp32 norm weights, which can promote Q/K despite BF16 autocast.
         from transformers.integrations.flash_attention import get_target_dtype
 
         target_dtype = get_target_dtype(query, module)
@@ -424,7 +425,7 @@ def shared_prefix_flash_attention_forward(
 
     if shared_prefix_layout is None:
         if sliding_window is not None:
-            raise ValueError("the Qwen3 shared-prefix backend requires full attention")
+            raise ValueError("the shared-prefix backend requires full attention")
         output = _standard_flash_attention(
             query,
             key,
@@ -443,9 +444,7 @@ def shared_prefix_flash_attention_forward(
     if attention_mask is not None:
         raise ValueError("shared-prefix attention expects attention_mask=None")
     if sliding_window is not None:
-        raise ValueError(
-            "shared-prefix attention does not support sliding-window Qwen3"
-        )
+        raise ValueError("shared-prefix attention does not support sliding windows")
     if dropout != 0.0:
         raise ValueError("shared-prefix attention requires attention_dropout=0")
     if query.shape[0] != 1:
@@ -497,7 +496,7 @@ def shared_prefix_flash_attention_forward(
 
 
 def register_shared_prefix_attention() -> None:
-    """Register the Qwen3 backend before config/model construction."""
+    """Register the Qwen3/Llama backend before config/model construction."""
     from transformers import AttentionInterface
     from transformers.masking_utils import (
         AttentionMaskInterface,
@@ -581,10 +580,10 @@ def response_logprobs_from_logits(
     layout: SharedPrefixLayout,
     chunk_size: int | None = None,
 ) -> torch.Tensor:
-    """Select response-target logprobs from predictor-only Qwen3 logits."""
+    """Select response-target logprobs from predictor-only model logits."""
     if logits.ndim != 3 or logits.shape[0] != 1:
         raise ValueError(
-            "shared-prefix Qwen3 logits must have shape [1, response_tokens, vocab]"
+            "shared-prefix logits must have shape [1, response_tokens, vocab]"
         )
     if logits.shape[1] != layout.response_tokens:
         raise ValueError(

--- a/nemo_rl/models/automodel/shared_prefix.py
+++ b/nemo_rl/models/automodel/shared_prefix.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Train-time shared-prefix execution for Hugging Face Qwen3 and Llama.
+"""Train-time shared-prefix execution for Qwen3, Qwen3-MoE, and Llama.
 
 The logical GRPO microbatch remains a normal ``[batch, sequence]`` tensor.  This
 module builds a physical ``[1, compact_tokens]`` representation containing one
@@ -21,13 +21,18 @@ MLPs, and projections run directly on that compact representation.  The
 registered attention backend preserves the logical causal semantics with two
 varlen FA2 calls: prompt self-attention and response-to-(prompt + own response)
 attention.
+
+For dropless token-local MoE computation, autograd sums the downstream gradients
+from every response at the shared prompt node. Router auxiliary losses and load
+statistics are different: they operate on logical token counts. The layout
+therefore also records a token multiplicity vector. ``shared_prefix_moe`` uses
+that vector for router statistics without duplicating physical expert dispatch.
 """
 
 from dataclasses import dataclass
 from typing import Any
 
 import torch
-
 
 # Deliberately contains no ``flash`` substring. Transformers treats any backend
 # name containing it as a built-in/hub FlashAttention request before dispatch.
@@ -42,6 +47,7 @@ class SharedPrefixLayout:
 
     compact_input_ids: torch.Tensor
     compact_position_ids: torch.Tensor
+    logical_token_weights: torch.Tensor
 
     prompt_token_indices: torch.Tensor
     response_token_indices: torch.Tensor
@@ -179,6 +185,7 @@ def build_shared_prefix_layout(
 
     compact_ids_parts: list[torch.Tensor] = []
     compact_positions_parts: list[torch.Tensor] = []
+    logical_weight_parts: list[torch.Tensor] = []
     prompt_indices_parts: list[torch.Tensor] = []
     response_indices_parts: list[torch.Tensor] = []
     response_kv_indices_parts: list[torch.Tensor] = []
@@ -211,6 +218,14 @@ def build_shared_prefix_layout(
 
         compact_ids_parts.append(prompt)
         compact_positions_parts.append(torch.arange(prompt_length, device=device))
+        logical_weight_parts.append(
+            torch.full(
+                (prompt_length,),
+                len(rows),
+                device=device,
+                dtype=torch.long,
+            )
+        )
         prompt_indices_parts.append(prompt_indices)
         prompt_cu.append(prompt_cu[-1] + prompt_length)
         max_prompt_length = max(max_prompt_length, prompt_length)
@@ -243,6 +258,9 @@ def build_shared_prefix_layout(
             compact_ids_parts.append(response)
             compact_positions_parts.append(
                 torch.arange(prompt_length, total_length, device=device)
+            )
+            logical_weight_parts.append(
+                torch.ones(response_length, device=device, dtype=torch.long)
             )
             response_indices_parts.append(response_indices)
             response_kv_indices_parts.append(
@@ -287,6 +305,7 @@ def build_shared_prefix_layout(
     return SharedPrefixLayout(
         compact_input_ids=torch.cat(compact_ids_parts).unsqueeze(0),
         compact_position_ids=torch.cat(compact_positions_parts).unsqueeze(0),
+        logical_token_weights=torch.cat(logical_weight_parts),
         prompt_token_indices=_cat(prompt_indices_parts),
         response_token_indices=_cat(response_indices_parts),
         response_kv_indices=_cat(response_kv_indices_parts),
@@ -408,7 +427,7 @@ def shared_prefix_flash_attention_forward(
     shared_prefix_layout: SharedPrefixLayout | None = None,
     **kwargs: Any,
 ) -> tuple[torch.Tensor, None]:
-    """Transformers ``AttentionInterface`` for Qwen3/Llama with FA2."""
+    """Transformers ``AttentionInterface`` for Qwen3/Qwen3-MoE/Llama with FA2."""
     if query.dtype == torch.float32:
         # Match Transformers' native FA2 wrapper. Some training setups retain
         # fp32 norm weights, which can promote Q/K despite BF16 autocast.
@@ -496,7 +515,7 @@ def shared_prefix_flash_attention_forward(
 
 
 def register_shared_prefix_attention() -> None:
-    """Register the Qwen3/Llama backend before config/model construction."""
+    """Register the Qwen3/Qwen3-MoE/Llama backend before model construction."""
     from transformers import AttentionInterface
     from transformers.masking_utils import (
         AttentionMaskInterface,

--- a/nemo_rl/models/automodel/shared_prefix.py
+++ b/nemo_rl/models/automodel/shared_prefix.py
@@ -1,0 +1,562 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Train-time shared-prefix execution for Hugging Face Qwen3.
+
+The logical GRPO microbatch remains a normal ``[batch, sequence]`` tensor.  This
+module builds a physical ``[1, compact_tokens]`` representation containing one
+copy of each prompt followed by all responses that share it.  Qwen3 norm, MLP,
+and projections run directly on that compact representation.  The registered
+attention backend preserves the logical causal semantics with two varlen FA2
+calls: prompt self-attention and response-to-(prompt + own response) attention.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+# Deliberately contains no ``flash`` substring. Transformers treats any backend
+# name containing it as a built-in/hub FlashAttention request before dispatch.
+SHARED_PREFIX_ATTENTION = "nemo_zorro_shared_prefix"
+SHARED_PREFIX_GROUP_IDS = "shared_prefix_group_ids"
+SHARED_PREFIX_LENGTHS = "shared_prefix_lengths"
+
+
+@dataclass(frozen=True)
+class SharedPrefixLayout:
+    """Tensor metadata describing one compact shared-prefix microbatch."""
+
+    compact_input_ids: torch.Tensor
+    compact_position_ids: torch.Tensor
+
+    prompt_token_indices: torch.Tensor
+    response_token_indices: torch.Tensor
+    response_kv_indices: torch.Tensor
+
+    prompt_cu_seqlens: torch.Tensor
+    response_cu_seqlens: torch.Tensor
+    response_kv_cu_seqlens: torch.Tensor
+
+    predictor_indices: torch.Tensor
+    response_target_ids: torch.Tensor
+    loss_logprob_scatter_indices: torch.Tensor
+
+    max_prompt_length: int
+    max_response_length: int
+    max_response_kv_length: int
+    original_batch_size: int
+    original_sequence_length: int
+
+    @property
+    def compact_tokens(self) -> int:
+        return int(self.compact_input_ids.shape[1])
+
+    @property
+    def response_tokens(self) -> int:
+        return int(self.response_target_ids.numel())
+
+
+def infer_shared_prefix_response_bounds(
+    token_mask: torch.Tensor,
+    input_lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Infer the prompt start and effective end of one trainable response.
+
+    Each real sequence must have exactly
+    ``prompt(0*) + response(1+) + ignored_tail(0*)`` in its token loss mask.
+    The ignored tail covers terminal environment observations appended by native
+    NeMo-RL rollouts; it is safe to crop because no later trainable token attends
+    to it. Multi-turn ``0*1+0+1+`` masks are rejected rather than silently
+    receiving incorrect shared-prefix semantics.
+    """
+    if token_mask.ndim != 2:
+        raise ValueError(
+            f"token_mask must be rank 2, got shape={tuple(token_mask.shape)}"
+        )
+    if input_lengths.ndim != 1 or input_lengths.shape[0] != token_mask.shape[0]:
+        raise ValueError(
+            "input_lengths must be rank 1 with the same batch size as token_mask"
+        )
+
+    batch_size, sequence_length = token_mask.shape
+    positions = torch.arange(sequence_length, device=token_mask.device).unsqueeze(0)
+    lengths = input_lengths.to(device=token_mask.device, dtype=torch.long)
+    if torch.any(lengths > sequence_length) or torch.any(lengths <= 0):
+        raise ValueError("input_lengths must be in [1, token_mask.shape[1]]")
+
+    mask = token_mask != 0
+    real_tokens = positions < lengths.unsqueeze(1)
+    response_tokens = mask & real_tokens
+    if not torch.all(response_tokens.any(dim=1)):
+        raise ValueError(
+            "every shared-prefix rollout must contain at least one response token"
+        )
+
+    first_response = torch.where(
+        response_tokens,
+        positions.expand(batch_size, -1),
+        sequence_length,
+    ).amin(dim=1)
+    last_response = torch.where(
+        response_tokens,
+        positions.expand(batch_size, -1),
+        -1,
+    ).amax(dim=1)
+    expected_mask = (
+        (positions >= first_response.unsqueeze(1))
+        & (positions <= last_response.unsqueeze(1))
+        & real_tokens
+    )
+    if not torch.equal(mask, expected_mask):
+        raise ValueError(
+            "shared-prefix training currently requires a single contiguous response span"
+        )
+    if torch.any(first_response <= 0):
+        raise ValueError(
+            "every shared-prefix rollout must contain at least one prompt token"
+        )
+    return first_response, last_response + 1
+
+
+def build_shared_prefix_layout(
+    input_ids: torch.Tensor,
+    input_lengths: torch.Tensor,
+    prompt_lengths: torch.Tensor,
+    group_ids: torch.Tensor,
+) -> SharedPrefixLayout:
+    """Build the compact physical layout for one already-formed microbatch."""
+    if input_ids.ndim != 2:
+        raise ValueError(
+            f"input_ids must be rank 2, got shape={tuple(input_ids.shape)}"
+        )
+    batch_size, sequence_length = input_ids.shape
+    for name, tensor in (
+        ("input_lengths", input_lengths),
+        ("prompt_lengths", prompt_lengths),
+        ("group_ids", group_ids),
+    ):
+        if tensor.ndim != 1 or tensor.shape[0] != batch_size:
+            raise ValueError(f"{name} must be rank 1 with batch size {batch_size}")
+    if batch_size == 0:
+        raise ValueError("shared-prefix microbatches cannot be empty")
+
+    device = input_ids.device
+    # Fetch the small row metadata together. When callers construct a layout
+    # directly from CUDA tensors this avoids three separate device syncs.
+    row_metadata = torch.stack(
+        (
+            input_lengths.to(dtype=torch.long),
+            prompt_lengths.to(dtype=torch.long),
+            group_ids.to(dtype=torch.long),
+        ),
+        dim=1,
+    ).to(device="cpu")
+    input_lengths_list = row_metadata[:, 0].tolist()
+    prompt_lengths_list = row_metadata[:, 1].tolist()
+    group_ids_list = row_metadata[:, 2].tolist()
+
+    group_order: list[int] = []
+    rows_by_group: dict[int, list[int]] = {}
+    for row, group_id in enumerate(group_ids_list):
+        if group_id not in rows_by_group:
+            rows_by_group[group_id] = []
+            group_order.append(group_id)
+        rows_by_group[group_id].append(row)
+
+    compact_ids_parts: list[torch.Tensor] = []
+    compact_positions_parts: list[torch.Tensor] = []
+    prompt_indices_parts: list[torch.Tensor] = []
+    response_indices_parts: list[torch.Tensor] = []
+    response_kv_indices_parts: list[torch.Tensor] = []
+    predictor_indices_parts: list[torch.Tensor] = []
+    response_target_parts: list[torch.Tensor] = []
+    loss_scatter_parts: list[torch.Tensor] = []
+
+    prompt_cu = [0]
+    response_cu = [0]
+    response_kv_cu = [0]
+    max_prompt_length = 0
+    max_response_length = 0
+    max_response_kv_length = 0
+    compact_cursor = 0
+    prompt_match_checks: list[torch.Tensor] = []
+
+    for group_id in group_order:
+        rows = rows_by_group[group_id]
+        representative = rows[0]
+        prompt_length = prompt_lengths_list[representative]
+        if not 0 < prompt_length < input_lengths_list[representative]:
+            raise ValueError(
+                "each rollout must have at least one prompt token and one response token"
+            )
+
+        prompt = input_ids[representative, :prompt_length]
+        prompt_start = compact_cursor
+        prompt_end = prompt_start + prompt_length
+        prompt_indices = torch.arange(prompt_start, prompt_end, device=device)
+
+        compact_ids_parts.append(prompt)
+        compact_positions_parts.append(torch.arange(prompt_length, device=device))
+        prompt_indices_parts.append(prompt_indices)
+        prompt_cu.append(prompt_cu[-1] + prompt_length)
+        max_prompt_length = max(max_prompt_length, prompt_length)
+        compact_cursor = prompt_end
+
+        for row in rows:
+            total_length = input_lengths_list[row]
+            row_prompt_length = prompt_lengths_list[row]
+            if not 0 < row_prompt_length < total_length <= sequence_length:
+                raise ValueError(
+                    "each rollout must satisfy 0 < prompt_length < input_length <= sequence_length"
+                )
+            if row_prompt_length != prompt_length:
+                raise ValueError(
+                    f"all rows in shared-prefix group {group_id} must have identical prompts"
+                )
+            if row != representative:
+                # Defer conversion to a Python bool until every row has been
+                # checked, avoiding one CUDA synchronization per rollout.
+                prompt_match_checks.append(
+                    torch.all(input_ids[row, :prompt_length] == prompt)
+                )
+
+            response = input_ids[row, prompt_length:total_length]
+            response_length = total_length - prompt_length
+            response_start = compact_cursor
+            response_end = response_start + response_length
+            response_indices = torch.arange(response_start, response_end, device=device)
+
+            compact_ids_parts.append(response)
+            compact_positions_parts.append(
+                torch.arange(prompt_length, total_length, device=device)
+            )
+            response_indices_parts.append(response_indices)
+            response_kv_indices_parts.append(
+                torch.cat((prompt_indices, response_indices))
+            )
+
+            predictor_indices_parts.append(
+                torch.cat(
+                    (
+                        torch.tensor([prompt_end - 1], device=device),
+                        response_indices[:-1],
+                    )
+                )
+            )
+            response_target_parts.append(response)
+
+            response_positions = torch.arange(
+                prompt_length,
+                total_length,
+                device=device,
+                dtype=torch.long,
+            )
+            loss_scatter_parts.append(
+                row * (sequence_length - 1) + response_positions - 1
+            )
+
+            response_cu.append(response_cu[-1] + response_length)
+            response_kv_length = prompt_length + response_length
+            response_kv_cu.append(response_kv_cu[-1] + response_kv_length)
+            max_response_length = max(max_response_length, response_length)
+            max_response_kv_length = max(max_response_kv_length, response_kv_length)
+            compact_cursor = response_end
+
+    if prompt_match_checks and not torch.stack(prompt_match_checks).all().item():
+        raise ValueError(
+            "all rows in a shared-prefix group must have identical prompts"
+        )
+
+    def _cat(parts: list[torch.Tensor]) -> torch.Tensor:
+        return torch.cat(parts).to(dtype=torch.long)
+
+    return SharedPrefixLayout(
+        compact_input_ids=torch.cat(compact_ids_parts).unsqueeze(0),
+        compact_position_ids=torch.cat(compact_positions_parts).unsqueeze(0),
+        prompt_token_indices=_cat(prompt_indices_parts),
+        response_token_indices=_cat(response_indices_parts),
+        response_kv_indices=_cat(response_kv_indices_parts),
+        prompt_cu_seqlens=torch.tensor(prompt_cu, device=device, dtype=torch.int32),
+        response_cu_seqlens=torch.tensor(response_cu, device=device, dtype=torch.int32),
+        response_kv_cu_seqlens=torch.tensor(
+            response_kv_cu, device=device, dtype=torch.int32
+        ),
+        predictor_indices=_cat(predictor_indices_parts),
+        response_target_ids=_cat(response_target_parts),
+        loss_logprob_scatter_indices=_cat(loss_scatter_parts),
+        max_prompt_length=max_prompt_length,
+        max_response_length=max_response_length,
+        max_response_kv_length=max_response_kv_length,
+        original_batch_size=batch_size,
+        original_sequence_length=sequence_length,
+    )
+
+
+def _flash_attention_functions():
+    try:
+        from flash_attn import flash_attn_func, flash_attn_varlen_func
+    except ImportError as error:  # pragma: no cover - exercised in the GPU environment
+        raise ImportError(
+            "shared-prefix Qwen3 training requires flash-attn with FA2 varlen support"
+        ) from error
+    return flash_attn_func, flash_attn_varlen_func
+
+
+def _standard_flash_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    dropout: float,
+    scaling: float | None,
+    is_causal: bool,
+    kwargs: dict[str, Any],
+) -> torch.Tensor:
+    """Keep ordinary logprob/inference forwards working under the custom backend."""
+    flash_attn_func, flash_attn_varlen_func = _flash_attention_functions()
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+
+    packed_kwargs = kwargs.get("flash_attn_kwargs")
+
+    def _first_not_none(*values: Any) -> Any:
+        return next((value for value in values if value is not None), None)
+
+    def _packed_value(name: str) -> Any:
+        if packed_kwargs is None:
+            return None
+        if isinstance(packed_kwargs, dict):
+            return packed_kwargs.get(name)
+        return getattr(packed_kwargs, name, None)
+
+    cu_q = _first_not_none(
+        _packed_value("cu_seqlens_q"),
+        kwargs.get("cu_seq_lens_q"),
+        kwargs.get("cu_seqlens_q"),
+    )
+    cu_k = _first_not_none(
+        _packed_value("cu_seqlens_k"),
+        kwargs.get("cu_seq_lens_k"),
+        kwargs.get("cu_seqlens_k"),
+    )
+    max_q = _first_not_none(
+        _packed_value("max_seqlen_q"),
+        kwargs.get("max_length_q"),
+        kwargs.get("max_seqlen_q"),
+    )
+    max_k = _first_not_none(
+        _packed_value("max_seqlen_k"),
+        kwargs.get("max_length_k"),
+        kwargs.get("max_seqlen_k"),
+    )
+
+    if cu_q is not None:
+        if any(value is None for value in (cu_k, max_q, max_k)):
+            raise ValueError("packed FA2 requires Q/K cu_seqlens and max lengths")
+        # NeMo-RL's packed metadata may inherit the int64 dtype of
+        # ``input_lengths``. The FA2 varlen ABI requires CUDA int32 cumulative
+        # lengths, matching Transformers' native FlashAttention wrapper.
+        cu_q = cu_q.to(device=query.device, dtype=torch.int32)
+        cu_k = cu_k.to(device=query.device, dtype=torch.int32)
+        return flash_attn_varlen_func(
+            query.reshape(-1, query.shape[-2], query.shape[-1]),
+            key.reshape(-1, key.shape[-2], key.shape[-1]),
+            value.reshape(-1, value.shape[-2], value.shape[-1]),
+            cu_q,
+            cu_k,
+            max_q,
+            max_k,
+            dropout_p=dropout,
+            softmax_scale=scaling,
+            causal=is_causal,
+        ).unsqueeze(0)
+
+    return flash_attn_func(
+        query,
+        key,
+        value,
+        dropout_p=dropout,
+        softmax_scale=scaling,
+        causal=is_causal,
+    )
+
+
+def shared_prefix_flash_attention_forward(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float = 0.0,
+    scaling: float | None = None,
+    sliding_window: int | None = None,
+    shared_prefix_layout: SharedPrefixLayout | None = None,
+    **kwargs: Any,
+) -> tuple[torch.Tensor, None]:
+    """Transformers ``AttentionInterface`` implementation for Qwen3 + FA2."""
+    if query.dtype == torch.float32:
+        # Match Transformers' native FA2 wrapper. Qwen3's fp32 norm weights can
+        # promote Q/K even while the surrounding forward is autocast to BF16.
+        from transformers.integrations.flash_attention import get_target_dtype
+
+        target_dtype = get_target_dtype(query, module)
+        if target_dtype is None:
+            raise ValueError(
+                "shared-prefix FA2 received float32 QKV outside CUDA autocast"
+            )
+        query = query.to(target_dtype)
+        key = key.to(target_dtype)
+        value = value.to(target_dtype)
+
+    if shared_prefix_layout is None:
+        if sliding_window is not None:
+            raise ValueError("the Qwen3 shared-prefix backend requires full attention")
+        output = _standard_flash_attention(
+            query,
+            key,
+            value,
+            dropout=dropout,
+            scaling=scaling,
+            is_causal=(
+                kwargs["is_causal"]
+                if kwargs.get("is_causal") is not None
+                else module.is_causal
+            ),
+            kwargs=kwargs,
+        )
+        return output, None
+
+    if attention_mask is not None:
+        raise ValueError("shared-prefix attention expects attention_mask=None")
+    if sliding_window is not None:
+        raise ValueError(
+            "shared-prefix attention does not support sliding-window Qwen3"
+        )
+    if dropout != 0.0:
+        raise ValueError("shared-prefix attention requires attention_dropout=0")
+    if query.shape[0] != 1:
+        raise ValueError("shared-prefix attention expects a physical batch size of 1")
+    if query.dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError(
+            f"shared-prefix FA2 requires float16 or bfloat16 QKV, got {query.dtype}"
+        )
+
+    _, flash_attn_varlen_func = _flash_attention_functions()
+    query_tokens = query.transpose(1, 2).squeeze(0)
+    key_tokens = key.transpose(1, 2).squeeze(0)
+    value_tokens = value.transpose(1, 2).squeeze(0)
+    layout = shared_prefix_layout
+
+    prompt_output = flash_attn_varlen_func(
+        query_tokens[layout.prompt_token_indices],
+        key_tokens[layout.prompt_token_indices],
+        value_tokens[layout.prompt_token_indices],
+        layout.prompt_cu_seqlens,
+        layout.prompt_cu_seqlens,
+        layout.max_prompt_length,
+        layout.max_prompt_length,
+        dropout_p=0.0,
+        softmax_scale=scaling,
+        causal=True,
+    )
+    response_output = flash_attn_varlen_func(
+        query_tokens[layout.response_token_indices],
+        key_tokens[layout.response_kv_indices],
+        value_tokens[layout.response_kv_indices],
+        layout.response_cu_seqlens,
+        layout.response_kv_cu_seqlens,
+        layout.max_response_length,
+        layout.max_response_kv_length,
+        dropout_p=0.0,
+        softmax_scale=scaling,
+        causal=True,
+    )
+
+    compact_output = torch.empty_like(query_tokens)
+    compact_output = compact_output.index_copy(
+        0, layout.prompt_token_indices, prompt_output
+    )
+    compact_output = compact_output.index_copy(
+        0, layout.response_token_indices, response_output
+    )
+    return compact_output.unsqueeze(0), None
+
+
+def register_shared_prefix_attention() -> None:
+    """Register the Qwen3 backend before config/model construction."""
+    from transformers import AttentionInterface
+    from transformers.masking_utils import (
+        AttentionMaskInterface,
+        flash_attention_mask,
+    )
+
+    AttentionInterface.register(
+        SHARED_PREFIX_ATTENTION,
+        shared_prefix_flash_attention_forward,
+    )
+    # Since Transformers 5.5, causal-mask construction dispatches through a
+    # registry separate from AttentionInterface.  Reuse FA2's mask policy: an
+    # ordinary dense/packed forward receives its 2D padding metadata, while the
+    # compact train forward (attention_mask=None) stays mask-free and implements
+    # causality inside the two FA2 calls below.
+    AttentionMaskInterface.register(
+        SHARED_PREFIX_ATTENTION,
+        flash_attention_mask,
+    )
+
+
+def response_logprobs_from_logits(
+    logits: torch.Tensor,
+    layout: SharedPrefixLayout,
+) -> torch.Tensor:
+    """Select response-target logprobs from predictor-only Qwen3 logits."""
+    if logits.ndim != 3 or logits.shape[0] != 1:
+        raise ValueError(
+            "shared-prefix Qwen3 logits must have shape [1, response_tokens, vocab]"
+        )
+    if logits.shape[1] != layout.response_tokens:
+        raise ValueError(
+            f"expected {layout.response_tokens} predictor logits, got {logits.shape[1]}"
+        )
+    log_probs = torch.nn.functional.log_softmax(logits.squeeze(0).float(), dim=-1)
+    return log_probs.gather(-1, layout.response_target_ids.unsqueeze(-1)).squeeze(-1)
+
+
+def scatter_response_logprobs(
+    response_logprobs: torch.Tensor,
+    layout: SharedPrefixLayout,
+    base: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Restore response logprobs to NeMo-RL's logical dense alignment."""
+    if (
+        response_logprobs.ndim != 1
+        or response_logprobs.numel() != layout.response_tokens
+    ):
+        raise ValueError(
+            f"expected {layout.response_tokens} response logprobs, got shape={tuple(response_logprobs.shape)}"
+        )
+    width = layout.original_sequence_length - 1
+    if base is None:
+        flat = response_logprobs.new_zeros(layout.original_batch_size * width)
+    else:
+        if base.shape != (layout.original_batch_size, width):
+            raise ValueError(
+                "shared-prefix logprob base must match the logical loss shape"
+            )
+        flat = base.detach().clone().reshape(-1)
+    flat = flat.scatter(0, layout.loss_logprob_scatter_indices, response_logprobs)
+    return flat.view(layout.original_batch_size, width)

--- a/nemo_rl/models/automodel/shared_prefix.py
+++ b/nemo_rl/models/automodel/shared_prefix.py
@@ -519,9 +519,67 @@ def register_shared_prefix_attention() -> None:
     )
 
 
+class _ChunkedTargetLogprobs(torch.autograd.Function):
+    """Target-only log-softmax with bounded fp32 activation memory.
+
+    The model already owns the input logits. Forward saves only those logits and
+    the target ids, while each fp32 log-softmax chunk is released immediately.
+    Backward rematerializes one fp32 softmax chunk at a time instead of retaining
+    ``response_tokens * vocab_size`` fp32 activations across the model backward.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        logits: torch.Tensor,
+        targets: torch.Tensor,
+        chunk_size: int,
+    ) -> torch.Tensor:
+        ctx.chunk_size = chunk_size
+        ctx.save_for_backward(logits, targets)
+
+        output = torch.empty(logits.shape[0], device=logits.device, dtype=torch.float32)
+        for start in range(0, logits.shape[0], chunk_size):
+            end = min(start + chunk_size, logits.shape[0])
+            log_probs = torch.nn.functional.log_softmax(
+                logits[start:end].float(), dim=-1
+            )
+            output[start:end] = log_probs.gather(
+                -1, targets[start:end].unsqueeze(-1)
+            ).squeeze(-1)
+            del log_probs
+        return output
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor, None, None]:
+        logits, targets = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        grad_logits = torch.empty_like(logits)
+
+        for start in range(0, logits.shape[0], chunk_size):
+            end = min(start + chunk_size, logits.shape[0])
+            probabilities = torch.softmax(logits[start:end].float(), dim=-1)
+            probabilities.neg_()
+            target_indices = targets[start:end].unsqueeze(-1)
+            probabilities.scatter_add_(
+                -1,
+                target_indices,
+                torch.ones_like(target_indices, dtype=probabilities.dtype),
+            )
+            probabilities.mul_(grad_output[start:end].float().unsqueeze(-1))
+            grad_logits[start:end].copy_(probabilities)
+            del probabilities, target_indices
+
+        return grad_logits, None, None
+
+
 def response_logprobs_from_logits(
     logits: torch.Tensor,
     layout: SharedPrefixLayout,
+    chunk_size: int | None = None,
 ) -> torch.Tensor:
     """Select response-target logprobs from predictor-only Qwen3 logits."""
     if logits.ndim != 3 or logits.shape[0] != 1:
@@ -532,8 +590,16 @@ def response_logprobs_from_logits(
         raise ValueError(
             f"expected {layout.response_tokens} predictor logits, got {logits.shape[1]}"
         )
-    log_probs = torch.nn.functional.log_softmax(logits.squeeze(0).float(), dim=-1)
-    return log_probs.gather(-1, layout.response_target_ids.unsqueeze(-1)).squeeze(-1)
+    logits = logits.squeeze(0)
+    if chunk_size is None:
+        chunk_size = layout.response_tokens
+    if chunk_size <= 0:
+        raise ValueError("shared-prefix logprob_chunk_size must be positive")
+    return _ChunkedTargetLogprobs.apply(
+        logits,
+        layout.response_target_ids,
+        chunk_size,
+    )
 
 
 def scatter_response_logprobs(

--- a/nemo_rl/models/automodel/shared_prefix_moe.py
+++ b/nemo_rl/models/automodel/shared_prefix_moe.py
@@ -1,0 +1,1274 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared-prefix adapters for AutoModel's native Qwen3-MoE implementation.
+
+AutoModel owns expert parallelism, expert checkpoint conversion, and the token
+dispatcher. This module supplies the semantics changed by a compact ZoRRo
+forward plus narrow, source-guarded compatibility fixes for the pinned native
+Qwen3-MoE implementation:
+
+* native Qwen3-MoE attention must use the shared-prefix FA2 layout; and
+* router-wide quantities must count logical tokens, not physical compact tokens.
+
+The adapters are installed on model instances, so ordinary AutoModel models and
+ordinary forwards retain their upstream behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import math
+import re
+import textwrap
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from types import MethodType
+from typing import Any, Iterator, TypeAlias
+
+import torch
+from torch import nn
+
+from nemo_rl.models.automodel.shared_prefix import (
+    SharedPrefixLayout,
+    shared_prefix_flash_attention_forward,
+)
+
+_CUSTOM_QWEN3_MOE_FLAG = "_nemo_shared_prefix_custom_qwen3_moe"
+
+_SourceReplacement: TypeAlias = tuple[str, str, int]
+_MethodPatch: TypeAlias = tuple[
+    Any,
+    type[nn.Module],
+    str,
+    tuple[_SourceReplacement, ...],
+]
+
+
+@dataclass(frozen=True)
+class _EPFreeCheckpointStage:
+    """One grouped-expert tensor staged through rank-local HF placeholders."""
+
+    native_tensor: Any
+    local_tensor: torch.Tensor
+    expert_ids: tuple[int, ...]
+    hf_prefix: str
+    layer_num: str
+    expert_segment: str
+    projection: str
+    expected_shapes: dict[str, torch.Size]
+
+
+def _qwen3_moe_configured_dtype(config: Any) -> torch.dtype:
+    from nemo_automodel.shared.utils import dtype_from_str
+
+    return dtype_from_str(getattr(config, "torch_dtype", None), torch.bfloat16)
+
+
+def enable_qwen3_moe_configured_dtype() -> None:
+    """Backport configured-dtype construction for native Qwen3-MoE.
+
+    The pinned AutoModel revision constructs several native Qwen3-MoE
+    parameters with helper defaults (bf16), even when NeMo-RL requests fp32
+    master weights. FSDP requires a uniform master dtype before it can shard the
+    model, so post-construction casting is too late.
+
+    Patch all affected methods atomically. Every source edit is exact and
+    guarded, and no class is mutated until every replacement has compiled. An
+    upstream source change therefore fails visibly without leaving a partial
+    process-wide patch installed.
+    """
+    from nemo_automodel.components.models.qwen3_moe import layers as layers_module
+    from nemo_automodel.components.models.qwen3_moe import model as model_module
+
+    marker = "_nemo_qwen3_moe_configured_dtype"
+    targets: tuple[_MethodPatch, ...] = (
+        (
+            layers_module,
+            layers_module.Qwen3MoeAttention,
+            "__init__",
+            (
+                (
+                    "        super().__init__()\n",
+                    "        super(Qwen3MoeAttention, self).__init__()\n",
+                    1,
+                ),
+                (
+                    '        attention_bias = getattr(config, "attention_bias", False)\n',
+                    '        attention_bias = getattr(config, "attention_bias", False)\n'
+                    "        dtype = _nemo_qwen3_moe_configured_dtype(config)\n",
+                    1,
+                ),
+                (
+                    "attention_bias\n        )",
+                    "attention_bias, dtype=dtype\n        )",
+                    4,
+                ),
+                (
+                    "self.q_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps)",
+                    "self.q_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps, dtype=dtype)",
+                    1,
+                ),
+                (
+                    "self.k_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps)",
+                    "self.k_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps, dtype=dtype)",
+                    1,
+                ),
+            ),
+        ),
+        (
+            model_module,
+            model_module.Block,
+            "__init__",
+            (
+                (
+                    "        super().__init__()\n",
+                    "        super(Block, self).__init__()\n",
+                    1,
+                ),
+                (
+                    "        self.self_attn = Qwen3MoeAttention(config, backend)\n",
+                    "        self.self_attn = Qwen3MoeAttention(config, backend)\n"
+                    "        dtype = _nemo_qwen3_moe_configured_dtype(config)\n",
+                    1,
+                ),
+                (
+                    "self.mlp = MLP(config.hidden_size, config.intermediate_size, backend.linear)",
+                    "self.mlp = MLP(config.hidden_size, config.intermediate_size, backend.linear, dtype=dtype)",
+                    1,
+                ),
+                (
+                    "self.input_layernorm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps)",
+                    "self.input_layernorm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)",
+                    1,
+                ),
+                (
+                    "backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps\n        )",
+                    "backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps, dtype=dtype\n        )",
+                    1,
+                ),
+            ),
+        ),
+        (
+            model_module,
+            model_module.Qwen3MoeModel,
+            "__init__",
+            (
+                (
+                    "        super().__init__()\n",
+                    "        super(Qwen3MoeModel, self).__init__()\n",
+                    1,
+                ),
+                (
+                    '            raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")\n',
+                    '            raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")\n'
+                    "\n        model_dtype = _nemo_qwen3_moe_configured_dtype(config)\n",
+                    1,
+                ),
+                (
+                    "            softmax_before_topk=True,\n",
+                    "            softmax_before_topk=True,\n"
+                    "            dtype=model_dtype,\n",
+                    1,
+                ),
+                (
+                    "        self.embed_tokens = nn.Embedding(\n"
+                    "            config.vocab_size, config.hidden_size, dtype=get_dtype(config.torch_dtype, torch.bfloat16)\n"
+                    "        )",
+                    "        self.embed_tokens = nn.Embedding(\n"
+                    "            config.vocab_size, config.hidden_size, dtype=model_dtype\n"
+                    "        )",
+                    1,
+                ),
+                (
+                    "self.norm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps)",
+                    "self.norm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps, dtype=model_dtype)",
+                    1,
+                ),
+            ),
+        ),
+        (
+            model_module,
+            model_module.Qwen3MoeForCausalLM,
+            "__init__",
+            (
+                (
+                    "        super().__init__()\n",
+                    "        super(Qwen3MoeForCausalLM, self).__init__()\n",
+                    1,
+                ),
+                (
+                    "        self.model = Qwen3MoeModel(config, backend=self.backend, moe_config=moe_config, moe_overrides=moe_overrides)\n",
+                    "        self.model = Qwen3MoeModel(config, backend=self.backend, moe_config=moe_config, moe_overrides=moe_overrides)\n"
+                    "        model_dtype = _nemo_qwen3_moe_configured_dtype(config)\n",
+                    1,
+                ),
+                (
+                    "self.lm_head = initialize_linear_module(self.backend.linear, config.hidden_size, config.vocab_size, bias=False)",
+                    "self.lm_head = initialize_linear_module(self.backend.linear, config.hidden_size, config.vocab_size, bias=False, dtype=model_dtype)",
+                    1,
+                ),
+                (
+                    "dtype=get_dtype(config.torch_dtype, torch.bfloat16)",
+                    "dtype=model_dtype",
+                    1,
+                ),
+            ),
+        ),
+        (
+            model_module,
+            model_module.Qwen3MoeForCausalLM,
+            "initialize_weights",
+            (
+                (
+                    "        self, buffer_device: torch.device | None = None, dtype: torch.dtype = torch.bfloat16\n",
+                    "        self, buffer_device: torch.device | None = None, dtype: torch.dtype | None = None\n",
+                    1,
+                ),
+                (
+                    '        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")\n',
+                    "        dtype = dtype or _nemo_qwen3_moe_configured_dtype(self.config)\n"
+                    '        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")\n',
+                    1,
+                ),
+            ),
+        ),
+    )
+
+    methods = tuple(getattr(owner, name) for _, owner, name, _ in targets)
+    installed = tuple(bool(getattr(method, marker, False)) for method in methods)
+    if all(installed):
+        return
+    if any(installed):
+        raise RuntimeError(
+            "native Qwen3-MoE configured-dtype backport is only partially installed"
+        )
+
+    compiled: list[tuple[type[nn.Module], str, Any]] = []
+    for (module, owner, name, replacements), original in zip(targets, methods):
+        try:
+            source = inspect.getsource(original)
+        except (OSError, TypeError) as error:
+            raise RuntimeError(
+                f"Cannot inspect AutoModel {owner.__name__}.{name} for the "
+                "Qwen3-MoE configured-dtype backport"
+            ) from error
+
+        patched_source = source
+        for old, new, expected_count in replacements:
+            actual_count = patched_source.count(old)
+            if actual_count != expected_count:
+                raise RuntimeError(
+                    f"AutoModel {owner.__name__}.{name} no longer matches the "
+                    "expected Qwen3-MoE configured-dtype source "
+                    f"({actual_count} matches, expected {expected_count}); "
+                    "remove or update the NeMo-RL backport"
+                )
+            patched_source = patched_source.replace(old, new)
+
+        namespace = {
+            **module.__dict__,
+            "_nemo_qwen3_moe_configured_dtype": _qwen3_moe_configured_dtype,
+        }
+        try:
+            exec(textwrap.dedent(patched_source), namespace)
+        except (NameError, SyntaxError, TypeError) as error:
+            raise RuntimeError(
+                f"Cannot compile AutoModel {owner.__name__}.{name} for the "
+                "Qwen3-MoE configured-dtype backport"
+            ) from error
+        patched = namespace[name]
+        patched.__module__ = original.__module__
+        patched.__qualname__ = original.__qualname__
+        patched.__doc__ = original.__doc__
+        setattr(patched, marker, True)
+        compiled.append((owner, name, patched))
+
+    for owner, name, patched in compiled:
+        setattr(owner, name, patched)
+
+
+def enable_qwen3_moe_ep_router_gradients() -> None:
+    """Backport AutoModel's differentiable EP routing-weight gather.
+
+    AutoModel versions before NVIDIA-NeMo/Automodel#2995 gather routing
+    weights with a detached collective inside ``GroupedExperts.forward``.
+    Replacing the function is deliberately fail-closed: the source guard makes
+    an upstream implementation change visible instead of applying a stale
+    whole-function patch silently.
+    """
+    from nemo_automodel.components.moe import experts as experts_module
+
+    grouped_experts = experts_module.GroupedExperts
+    if getattr(grouped_experts.forward, "_nemo_ep_router_gradients", False):
+        return
+
+    try:
+        source = inspect.getsource(grouped_experts.forward)
+    except (OSError, TypeError) as error:
+        raise RuntimeError(
+            "Cannot inspect AutoModel GroupedExperts.forward for the "
+            "Qwen3-MoE EP router-gradient backport"
+        ) from error
+    old = "weights.float(), differentiable=False"
+    if old not in source:
+        raise RuntimeError(
+            "AutoModel GroupedExperts.forward no longer contains the expected "
+            "detached EP routing-weight gather; remove or update the NeMo-RL "
+            "Qwen3-MoE EP backport"
+        )
+    if source.count(old) != 1:
+        raise RuntimeError(
+            "AutoModel GroupedExperts.forward contains an unexpected number of "
+            "detached EP routing-weight gathers"
+        )
+
+    namespace = dict(experts_module.__dict__)
+    exec(
+        textwrap.dedent(source).replace(
+            old,
+            "weights.float(), differentiable=True",
+        ),
+        namespace,
+    )
+    patched = namespace["forward"]
+    patched.__module__ = grouped_experts.forward.__module__
+    patched.__qualname__ = grouped_experts.forward.__qualname__
+    patched.__doc__ = grouped_experts.forward.__doc__
+    patched._nemo_ep_router_gradients = True
+    grouped_experts.forward = patched
+
+
+def enable_qwen3_moe_checkpoint_wrapper_compatibility() -> None:
+    """Make native Qwen3-MoE's MLP dispatch transparent to AC wrappers.
+
+    AutoModel's default activation-checkpointing strategy wraps ``Block.mlp``
+    in a ``CheckpointWrapper``.  The pinned native block dispatches dense versus
+    MoE MLPs with a direct ``isinstance(self.mlp, ...)`` check, so the wrapper
+    makes an otherwise valid forward fail before it is called.  Inspect the
+    wrapped module for type dispatch while still calling the wrapper itself.
+    """
+    from nemo_automodel.components.models.qwen3_moe import model as model_module
+
+    block = model_module.Block
+    marker = "_nemo_qwen3_moe_checkpoint_wrapper_compatibility"
+    original = block._mlp
+    if getattr(original, marker, False):
+        return
+
+    try:
+        source = inspect.getsource(original)
+    except (OSError, TypeError) as error:
+        raise RuntimeError(
+            "Cannot inspect AutoModel Block._mlp for the Qwen3-MoE "
+            "checkpoint-wrapper compatibility fix"
+        ) from error
+
+    old = (
+        "        if isinstance(self.mlp, MLP):\n"
+        "            return self.mlp(x)\n"
+        "        else:\n"
+        "            assert isinstance(self.mlp, MoE)\n"
+        "            return self.mlp(x, padding_mask)\n"
+    )
+    new = (
+        "        mlp = self.mlp\n"
+        '        target = getattr(mlp, "_checkpoint_wrapped_module", mlp)\n'
+        "        if isinstance(target, MLP):\n"
+        "            return mlp(x)\n"
+        "        assert isinstance(target, MoE)\n"
+        "        return mlp(x, padding_mask)\n"
+    )
+    if source.count(old) != 1:
+        raise RuntimeError(
+            "AutoModel Block._mlp no longer matches the expected Qwen3-MoE "
+            "checkpoint-wrapper source; remove or update the NeMo-RL fix"
+        )
+
+    namespace = dict(model_module.__dict__)
+    try:
+        exec(textwrap.dedent(source.replace(old, new)), namespace)
+    except (NameError, SyntaxError, TypeError) as error:
+        raise RuntimeError(
+            "Cannot compile AutoModel Block._mlp for the Qwen3-MoE "
+            "checkpoint-wrapper compatibility fix"
+        ) from error
+    patched = namespace["_mlp"]
+    patched.__module__ = original.__module__
+    patched.__qualname__ = original.__qualname__
+    patched.__doc__ = original.__doc__
+    setattr(patched, marker, True)
+    block._mlp = patched
+
+
+def _guard_automodel_source(owner: type[Any], name: str, expected_sha256: str) -> None:
+    """Fail closed when a runtime backport no longer matches its pinned source."""
+    try:
+        source = inspect.getblock(inspect.getsourcelines(getattr(owner, name))[0])
+    except (OSError, TypeError) as error:
+        raise RuntimeError(
+            f"Cannot inspect AutoModel {owner.__name__}.{name} for the "
+            "Qwen3-MoE EP-free checkpoint backport"
+        ) from error
+    digest = hashlib.sha256("".join(source).encode()).hexdigest()
+    if digest != expected_sha256:
+        raise RuntimeError(
+            f"AutoModel {owner.__name__}.{name} no longer matches the pinned "
+            "Qwen3-MoE EP-free checkpoint source; remove or update the "
+            f"NeMo-RL backport (expected {expected_sha256}, got {digest})"
+        )
+
+
+def _torch_chunk_shard_size_and_offset(
+    dim_size: int,
+    num_chunks: int,
+    rank: int,
+) -> tuple[int, int]:
+    """Return the contiguous shard described by pinned DTensor ``Shard``."""
+    full_chunk_size = (dim_size + num_chunks - 1) // num_chunks
+    start = min(dim_size, full_chunk_size * rank)
+    end = min(dim_size, start + full_chunk_size)
+    return end - start, start
+
+
+def _ep_free_expert_ids(tensor: Any, n_experts: int) -> tuple[int, ...] | None:
+    """Return rank-local expert IDs for the one supported EP-free FSDP layout."""
+    from torch.distributed.tensor import DTensor, Shard
+
+    if not isinstance(tensor, DTensor):
+        return None
+    mesh = tensor.device_mesh
+    if "ep" in mesh.mesh_dim_names:
+        return None
+    if mesh.ndim != 1 or len(tensor.placements) != 1:
+        raise ValueError(
+            "Qwen3-MoE EP-free checkpoint staging requires a one-dimensional FSDP mesh"
+        )
+    placement = tensor.placements[0]
+    if not isinstance(placement, Shard) or placement.dim != 0:
+        return None
+    if tensor.shape[0] != n_experts:
+        raise ValueError(
+            f"Qwen3-MoE grouped tensor has {tensor.shape[0]} experts, "
+            f"expected {n_experts}"
+        )
+
+    mesh_size = mesh.size()
+    mesh_rank = mesh.get_local_rank()
+    # DTensor Shard follows torch.chunk semantics: every non-final chunk has
+    # ceil(N / world_size) entries, and trailing ranks can be empty. A balanced
+    # divmod partition gives different expert IDs for uneven expert counts.
+    local_count, start = _torch_chunk_shard_size_and_offset(
+        n_experts, mesh_size, mesh_rank
+    )
+    end = start + local_count
+    if tensor.to_local().shape[0] != local_count:
+        raise ValueError(
+            "Qwen3-MoE EP-free grouped tensor local expert axis does not "
+            f"match its Shard(0) placement ({tensor.to_local().shape[0]} != "
+            f"{local_count})"
+        )
+    return tuple(range(start, end))
+
+
+def _stage_ep_free_expert_tensor(
+    adapter: Any,
+    fqn: str,
+    tensor: Any,
+    *,
+    quantization: bool,
+) -> list[tuple[str, torch.Tensor]] | None:
+    """Create contiguous HF destinations while retaining their grouped target."""
+    expert_segment = adapter._expert_path_segment
+    if not (
+        f".{expert_segment}." in fqn
+        and fqn.endswith((".gate_and_up_projs", ".down_projs"))
+    ):
+        return None
+
+    n_experts = adapter.moe_config.n_routed_experts
+    expert_ids = _ep_free_expert_ids(tensor, n_experts)
+    if expert_ids is None:
+        return None
+    if quantization:
+        raise ValueError(
+            "Qwen3-MoE EP-free staged checkpoint loading does not support "
+            "quantized expert destinations"
+        )
+    if getattr(adapter.backend, "experts", None) == "te":
+        raise ValueError(
+            "Qwen3-MoE EP-free staged checkpoint loading does not support "
+            "Transformer Engine experts"
+        )
+
+    layer_match = re.search(r"layers\.(\d+)", fqn)
+    if layer_match is None:
+        raise ValueError(f"Cannot determine Qwen3-MoE layer from {fqn!r}")
+    layer_num = layer_match.group(1)
+    local_tensor = tensor.to_local()
+    inter_dim = adapter.moe_config.moe_inter_dim
+    hf_prefix = adapter._hf_prefix
+    result: list[tuple[str, torch.Tensor]] = []
+    expected_shapes: dict[str, torch.Size] = {}
+
+    if fqn.endswith(".gate_and_up_projs"):
+        expected_last_dim = inter_dim * (2 if adapter._is_gated_moe else 1)
+        if local_tensor.ndim != 3 or local_tensor.shape[2] != expected_last_dim:
+            raise ValueError(
+                "Qwen3-MoE EP-free gate/up tensor has an unexpected local shape "
+                f"{tuple(local_tensor.shape)}"
+            )
+        projection = "gate_and_up_projs"
+        for local_index, expert_id in enumerate(expert_ids):
+            expert = local_tensor[local_index]
+            if adapter._is_gated_moe:
+                gate_key = (
+                    f"{hf_prefix}layers.{layer_num}.{expert_segment}."
+                    f"{expert_id}.gate_proj.weight"
+                )
+                up_key = (
+                    f"{hf_prefix}layers.{layer_num}.{expert_segment}."
+                    f"{expert_id}.up_proj.weight"
+                )
+                gate = expert[:, :inter_dim].transpose(0, 1).contiguous()
+                up = expert[:, inter_dim:].transpose(0, 1).contiguous()
+                result.extend(((gate_key, gate), (up_key, up)))
+                expected_shapes[gate_key] = gate.shape
+                expected_shapes[up_key] = up.shape
+            else:
+                up_key = (
+                    f"{hf_prefix}layers.{layer_num}.{expert_segment}."
+                    f"{expert_id}.up_proj.weight"
+                )
+                up = expert.transpose(0, 1).contiguous()
+                result.append((up_key, up))
+                expected_shapes[up_key] = up.shape
+    else:
+        if local_tensor.ndim != 3 or local_tensor.shape[1] != inter_dim:
+            raise ValueError(
+                "Qwen3-MoE EP-free down tensor has an unexpected local shape "
+                f"{tuple(local_tensor.shape)}"
+            )
+        projection = "down_projs"
+        for local_index, expert_id in enumerate(expert_ids):
+            key = (
+                f"{hf_prefix}layers.{layer_num}.{expert_segment}."
+                f"{expert_id}.down_proj.weight"
+            )
+            value = local_tensor[local_index].transpose(0, 1).contiguous()
+            result.append((key, value))
+            expected_shapes[key] = value.shape
+
+    stages = getattr(adapter, "_nemo_ep_free_checkpoint_stages", None)
+    if stages is None:
+        stages = {}
+        adapter._nemo_ep_free_checkpoint_stages = stages
+    if fqn in stages:
+        raise RuntimeError(f"Qwen3-MoE checkpoint tensor {fqn!r} was staged twice")
+    stages[fqn] = _EPFreeCheckpointStage(
+        native_tensor=tensor,
+        local_tensor=local_tensor,
+        expert_ids=expert_ids,
+        hf_prefix=hf_prefix,
+        layer_num=layer_num,
+        expert_segment=expert_segment,
+        projection=projection,
+        expected_shapes=expected_shapes,
+    )
+    return result
+
+
+def _restore_ep_free_expert_stages(
+    adapter: Any,
+    hf_state_dict: dict[str, Any],
+    original_from_hf: Any,
+    device_mesh: Any,
+) -> dict[str, Any]:
+    """Validate every staged value, then atomically copy into grouped storage."""
+    stages: dict[str, _EPFreeCheckpointStage] = (
+        getattr(adapter, "_nemo_ep_free_checkpoint_stages", None) or {}
+    )
+    if not stages:
+        return original_from_hf(adapter, hf_state_dict, device_mesh)
+
+    # A staged expert load is specifically the EP-free path; passing a MoE mesh
+    # here would mix two different ownership models.
+    if device_mesh is not None:
+        raise ValueError("Qwen3-MoE EP-free checkpoint stages require device_mesh=None")
+
+    expected_keys = {key for stage in stages.values() for key in stage.expected_shapes}
+    expert_pattern = re.compile(
+        rf"(?:model\.)?(?:language_model\.)?layers\.\d+\."
+        rf"{re.escape(adapter._expert_path_segment)}\.\d+\."
+        r"(?:gate_proj|up_proj|down_proj)\.weight$"
+    )
+    observed_keys = {key for key in hf_state_dict if expert_pattern.fullmatch(key)}
+    if observed_keys != expected_keys:
+        missing = sorted(expected_keys - observed_keys)
+        unexpected = sorted(observed_keys - expected_keys)
+        raise RuntimeError(
+            "Qwen3-MoE rank-local expert checkpoint keys do not match the "
+            f"staged FSDP shard (missing={missing[:5]}, "
+            f"unexpected={unexpected[:5]})"
+        )
+
+    by_layer: dict[tuple[str, str, str], dict[str, _EPFreeCheckpointStage]] = {}
+    for stage in stages.values():
+        group = by_layer.setdefault(
+            (stage.hf_prefix, stage.layer_num, stage.expert_segment), {}
+        )
+        group[stage.projection] = stage
+    for layer, projections in by_layer.items():
+        required = {"gate_and_up_projs", "down_projs"}
+        if set(projections) != required:
+            raise RuntimeError(
+                f"Qwen3-MoE staged layer {layer} is missing grouped projections"
+            )
+        if (
+            projections["gate_and_up_projs"].expert_ids
+            != projections["down_projs"].expert_ids
+        ):
+            raise RuntimeError(
+                f"Qwen3-MoE staged layer {layer} has inconsistent expert IDs"
+            )
+
+    # Validate the complete batch before the first destination write.
+    for stage in stages.values():
+        for key, expected_shape in stage.expected_shapes.items():
+            value = hf_state_dict[key]
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(f"Qwen3-MoE checkpoint value {key!r} is not a tensor")
+            if value.shape != expected_shape:
+                raise ValueError(
+                    f"Qwen3-MoE checkpoint value {key!r} has shape "
+                    f"{tuple(value.shape)}, expected {tuple(expected_shape)}"
+                )
+            if value.dtype != stage.local_tensor.dtype:
+                raise ValueError(
+                    f"Qwen3-MoE checkpoint value {key!r} has dtype {value.dtype}, "
+                    f"expected {stage.local_tensor.dtype}"
+                )
+            if value.device != stage.local_tensor.device:
+                raise ValueError(
+                    f"Qwen3-MoE checkpoint value {key!r} is on {value.device}, "
+                    f"expected {stage.local_tensor.device}"
+                )
+
+    # Let the upstream adapter validate/convert every non-expert value before
+    # mutating grouped expert storage.  This makes adapter failures as well as
+    # expert validation failures transactional with respect to the model.
+    remaining = {
+        key: value for key, value in hf_state_dict.items() if key not in expected_keys
+    }
+    restored = original_from_hf(adapter, remaining, device_mesh)
+
+    with torch.no_grad():
+        for stage in stages.values():
+            inter_dim = adapter.moe_config.moe_inter_dim
+            for local_index, expert_id in enumerate(stage.expert_ids):
+                base = (
+                    f"{stage.hf_prefix}layers.{stage.layer_num}."
+                    f"{stage.expert_segment}.{expert_id}"
+                )
+                destination = stage.local_tensor[local_index]
+                if stage.projection == "gate_and_up_projs":
+                    if adapter._is_gated_moe:
+                        gate = hf_state_dict[f"{base}.gate_proj.weight"]
+                        up = hf_state_dict[f"{base}.up_proj.weight"]
+                        destination[:, :inter_dim].copy_(gate.transpose(0, 1))
+                        destination[:, inter_dim:].copy_(up.transpose(0, 1))
+                    else:
+                        up = hf_state_dict[f"{base}.up_proj.weight"]
+                        destination.copy_(up.transpose(0, 1))
+                else:
+                    down = hf_state_dict[f"{base}.down_proj.weight"]
+                    destination.copy_(down.transpose(0, 1))
+
+    restored.update(
+        {native_key: stage.native_tensor for native_key, stage in stages.items()}
+    )
+    return restored
+
+
+def enable_qwen3_moe_ep_free_checkpoint_adapter() -> None:
+    """Backport rank-local checkpoint loading for Qwen3-MoE without EP.
+
+    AutoModel before #3397 assumes every grouped-expert DTensor has an ``ep``
+    mesh dimension. With EP=1, FSDP instead shards the expert axis over ``dp``.
+    This Qwen-specific staged-copy keeps DCP's rank-local placeholders, validates
+    them as one transaction, and copies them back into the original grouped
+    storage. Regular full tensors used by rollout refit retain the upstream path.
+    """
+    from nemo_automodel.components.models.qwen3_moe.state_dict_adapter import (
+        Qwen3MoeStateDictAdapter,
+    )
+    from nemo_automodel.components.moe.state_dict_mixin import (
+        MoESplitExpertsStateDictMixin,
+    )
+
+    marker = "_nemo_ep_free_checkpoint_adapter"
+    methods = (
+        Qwen3MoeStateDictAdapter.to_hf,
+        Qwen3MoeStateDictAdapter.convert_single_tensor_to_hf,
+        Qwen3MoeStateDictAdapter.from_hf,
+    )
+    installed = tuple(bool(getattr(method, marker, False)) for method in methods)
+    if all(installed):
+        return
+    if any(installed):
+        raise RuntimeError(
+            "Qwen3-MoE EP-free checkpoint backport is only partially installed"
+        )
+    if (
+        Qwen3MoeStateDictAdapter._convert_single_merged_expert_to_hf_split_experts
+        is not MoESplitExpertsStateDictMixin._convert_single_merged_expert_to_hf_split_experts
+        or Qwen3MoeStateDictAdapter._from_hf_w_merged_experts
+        is not MoESplitExpertsStateDictMixin._from_hf_w_merged_experts
+    ):
+        raise RuntimeError(
+            "Qwen3-MoE checkpoint adapter inheritance no longer matches the "
+            "pinned runtime backport"
+        )
+
+    guards = (
+        (
+            Qwen3MoeStateDictAdapter,
+            "to_hf",
+            "bdc81cf7ac72b1b82e700e9039154809947f2ba809b7552325f45689d9f7f58c",
+        ),
+        (
+            Qwen3MoeStateDictAdapter,
+            "convert_single_tensor_to_hf",
+            "2da6c393549c61eb1bbb1fe6bbfe4d01b7534ada9c8b702407b84e0d46b501bb",
+        ),
+        (
+            Qwen3MoeStateDictAdapter,
+            "from_hf",
+            "6917840b85e7b293db44f04a9d23e35bf10ec65baf17859719e3159ed3843548",
+        ),
+        (
+            MoESplitExpertsStateDictMixin,
+            "_convert_single_merged_expert_to_hf_split_experts",
+            "75de160476e9d0b3399b676cf14ede98093a309069cc846a9fda6519e6f9b508",
+        ),
+        (
+            MoESplitExpertsStateDictMixin,
+            "_from_hf_w_merged_experts",
+            "1702d2670caecb433cbb3da177747ad5075096bdf8b775cc5f5333b381cab0ff",
+        ),
+    )
+    for owner, name, digest in guards:
+        _guard_automodel_source(owner, name, digest)
+
+    original_to_hf = Qwen3MoeStateDictAdapter.to_hf
+    original_convert = Qwen3MoeStateDictAdapter.convert_single_tensor_to_hf
+    original_from_hf = Qwen3MoeStateDictAdapter.from_hf
+    original_split = (
+        MoESplitExpertsStateDictMixin._convert_single_merged_expert_to_hf_split_experts
+    )
+    original_merge = MoESplitExpertsStateDictMixin._from_hf_w_merged_experts
+
+    def split(self, fqn, tensor, **kwargs):
+        staged = _stage_ep_free_expert_tensor(
+            self,
+            fqn,
+            tensor,
+            quantization=bool(kwargs.get("quantization", False)),
+        )
+        if staged is not None:
+            return staged
+        return original_split(self, fqn, tensor, **kwargs)
+
+    def convert(self, fqn, tensor, **kwargs):
+        # Per-tensor conversion is the refit API. It normally receives an
+        # already gathered Tensor; reset stale checkpoint staging at the start
+        # of such an independent conversion.
+        if not hasattr(self, "_nemo_ep_free_checkpoint_bulk_conversion"):
+            self._nemo_ep_free_checkpoint_stages = {}
+        return original_convert(self, fqn, tensor, **kwargs)
+
+    def bulk_to_hf(self, state_dict, *args, **kwargs):
+        self._nemo_ep_free_checkpoint_stages = {}
+        self._nemo_ep_free_checkpoint_bulk_conversion = True
+        try:
+            return original_to_hf(self, state_dict, *args, **kwargs)
+        except BaseException:
+            self._nemo_ep_free_checkpoint_stages = {}
+            raise
+        finally:
+            del self._nemo_ep_free_checkpoint_bulk_conversion
+
+    def merge(self, hf_state_dict, device_mesh=None):
+        try:
+            return _restore_ep_free_expert_stages(
+                self, hf_state_dict, original_merge, device_mesh
+            )
+        finally:
+            self._nemo_ep_free_checkpoint_stages = {}
+
+    def from_hf(self, hf_state_dict, device_mesh=None, **kwargs):
+        return original_from_hf(self, hf_state_dict, device_mesh=device_mesh, **kwargs)
+
+    # The Qwen callers remain intact; only their inherited conversion hooks are
+    # specialized. Mark all public entry points so partial process-wide state is
+    # detectable on repeated installation.
+    for function in (bulk_to_hf, convert, from_hf):
+        setattr(function, marker, True)
+    Qwen3MoeStateDictAdapter._convert_single_merged_expert_to_hf_split_experts = split
+    Qwen3MoeStateDictAdapter._from_hf_w_merged_experts = merge
+    Qwen3MoeStateDictAdapter.to_hf = bulk_to_hf
+    Qwen3MoeStateDictAdapter.convert_single_tensor_to_hf = convert
+    Qwen3MoeStateDictAdapter.from_hf = from_hf
+
+
+class _LogicalAuxLossAutoScaler(torch.autograd.Function):
+    """Attach logical router aux loss without an unused saved tensor.
+
+    AutoModel's scaler retains the auxiliary-loss value, although its backward
+    only needs the value's metadata. Non-reentrant activation checkpointing can
+    stop replay before that trailing save and then rejects the unequal saved-
+    tensor count. This equivalent scaler keeps the aux autograd edge and exact
+    backward scale without adding a checkpoint save.
+    """
+
+    @staticmethod
+    def forward(ctx, output: torch.Tensor, aux_loss: torch.Tensor) -> torch.Tensor:
+        ctx.aux_shape = aux_loss.shape
+        ctx.aux_dtype = aux_loss.dtype
+        ctx.aux_device = aux_loss.device
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        from nemo_automodel.components.moe.megatron.moe_utils import (
+            MoEAuxLossAutoScaler,
+        )
+
+        scale = MoEAuxLossAutoScaler.main_loss_backward_scale
+        if scale is None:
+            scale = 1.0
+        aux_gradient = torch.ones(
+            ctx.aux_shape,
+            dtype=ctx.aux_dtype,
+            device=ctx.aux_device,
+        )
+        return grad_output, aux_gradient * scale
+
+
+@dataclass
+class _RouterExecution:
+    logical_token_weights: torch.Tensor | None
+    valid: bool
+    committed: bool = False
+    pending: dict[nn.Module, tuple[torch.Tensor, torch.Tensor | None]] = field(
+        default_factory=dict
+    )
+
+    def record(
+        self,
+        gate: nn.Module,
+        expert_load: torch.Tensor,
+        aux_loss: torch.Tensor | None,
+    ) -> None:
+        # Activation checkpointing replays Gate.forward during backward.  Keep
+        # this bookkeeping tail identical between the original forward and
+        # replay, including the detached snapshot and Python-side write.  The
+        # one-shot ``commit`` guard below, rather than a branch in ``record``,
+        # prevents replayed state from being accumulated twice.
+        snapshot = (expert_load.detach(), _detach_optional(aux_loss))
+        if self.valid:
+            self.pending[gate] = snapshot
+
+    def commit(self) -> None:
+        """Commit forward-only state before any activation-checkpoint replay."""
+        if not self.valid:
+            self.pending.clear()
+            return
+        if self.committed:
+            self.pending.clear()
+            return
+        for gate, (expert_load, aux_loss) in self.pending.items():
+            gate._last_expert_load = expert_load
+            gate._last_aux_loss = aux_loss
+
+            accumulated = getattr(gate, "_nemo_shared_prefix_logical_expert_load", None)
+            gate._nemo_shared_prefix_logical_expert_load = (
+                expert_load.clone()
+                if accumulated is None
+                else accumulated + expert_load
+            )
+            if aux_loss is not None:
+                aux_sum = getattr(gate, "_nemo_shared_prefix_aux_loss_sum", None)
+                gate._nemo_shared_prefix_aux_loss_sum = (
+                    aux_loss.clone() if aux_sum is None else aux_sum + aux_loss
+                )
+                gate._nemo_shared_prefix_aux_loss_count = (
+                    getattr(gate, "_nemo_shared_prefix_aux_loss_count", 0) + 1
+                )
+
+        self.committed = True
+        self.pending.clear()
+
+
+def _detach_optional(value: torch.Tensor | None) -> torch.Tensor | None:
+    return None if value is None else value.detach()
+
+
+_ROUTER_EXECUTION_ATTR = "_nemo_shared_prefix_router_execution"
+_MISSING_ROUTER_EXECUTION = object()
+
+
+@contextmanager
+def shared_prefix_moe_context(
+    model: nn.Module,
+    layout: SharedPrefixLayout | None,
+    *,
+    valid: bool,
+) -> Iterator[_RouterExecution]:
+    """Keep logical router metadata active through forward and backward.
+
+    Store the execution on each Gate rather than only in a ``ContextVar``.
+    Non-reentrant activation checkpoint replay can run from an autograd engine
+    context that does not inherit Python context variables; module state remains
+    visible to the replay and is safe here because each worker processes and
+    backpropagates one microbatch synchronously.
+    """
+    from nemo_automodel.components.moe.layers import Gate
+
+    execution = _RouterExecution(
+        logical_token_weights=(
+            None if layout is None else layout.logical_token_weights
+        ),
+        valid=valid,
+    )
+    previous: list[tuple[nn.Module, object]] = []
+    for module in model.modules():
+        if isinstance(module, Gate):
+            previous.append(
+                (
+                    module,
+                    getattr(
+                        module,
+                        _ROUTER_EXECUTION_ATTR,
+                        _MISSING_ROUTER_EXECUTION,
+                    ),
+                )
+            )
+            setattr(module, _ROUTER_EXECUTION_ATTR, execution)
+    try:
+        yield execution
+    finally:
+        for module, prior_execution in previous:
+            if prior_execution is _MISSING_ROUTER_EXECUTION:
+                delattr(module, _ROUTER_EXECUTION_ATTR)
+            else:
+                setattr(module, _ROUTER_EXECUTION_ATTR, prior_execution)
+
+
+def is_custom_qwen3_moe_shared_prefix(model: nn.Module) -> bool:
+    """Return whether the native Qwen3-MoE adapter is installed."""
+    return bool(getattr(model, _CUSTOM_QWEN3_MOE_FLAG, False))
+
+
+def enable_custom_qwen3_moe_shared_prefix(model: nn.Module) -> None:
+    """Install native-attention and logical-router adapters on one model."""
+    from nemo_automodel.components.models.qwen3_moe.layers import (
+        Qwen3MoeAttention,
+    )
+    from nemo_automodel.components.moe.layers import Gate
+
+    if is_custom_qwen3_moe_shared_prefix(model):
+        return
+
+    attention_count = 0
+    gate_count = 0
+    for module in model.modules():
+        if isinstance(module, Qwen3MoeAttention):
+            module._nemo_shared_prefix_original_forward = module.forward
+            module.forward = MethodType(_custom_qwen3_moe_attention_forward, module)
+            attention_count += 1
+        elif isinstance(module, Gate):
+            module._nemo_shared_prefix_original_forward = module.forward
+            module.forward = MethodType(_logical_router_forward, module)
+            gate_count += 1
+
+    if attention_count == 0 or gate_count == 0:
+        raise TypeError(
+            "native Qwen3-MoE shared-prefix setup found no attention or Gate modules"
+        )
+
+    setattr(model, _CUSTOM_QWEN3_MOE_FLAG, True)
+
+
+def _custom_qwen3_moe_attention_forward(
+    module: nn.Module,
+    x: torch.Tensor,
+    *,
+    freqs_cis: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+    shared_prefix_layout: SharedPrefixLayout | None = None,
+    **attn_kwargs: Any,
+) -> torch.Tensor:
+    """Run native Qwen3-MoE projections with the shared-prefix FA2 core."""
+    packed_kwargs = attn_kwargs.get("flash_attn_kwargs")
+    if shared_prefix_layout is None and packed_kwargs is None:
+        return module._nemo_shared_prefix_original_forward(
+            x,
+            freqs_cis=freqs_cis,
+            attention_mask=attention_mask,
+            **attn_kwargs,
+        )
+    if x.ndim != 3 or x.shape[0] != 1:
+        raise ValueError(
+            "native Qwen3-MoE shared-prefix attention requires [1, tokens, hidden]"
+        )
+    if attention_mask is not None:
+        raise ValueError("native Qwen3-MoE FA2 expects attention_mask=None")
+
+    from nemo_automodel.components.models.gpt_oss.rope_utils import (
+        apply_rotary_emb_qk,
+    )
+
+    batch_size, sequence_length, _ = x.shape
+    query = module.q_proj(x).view(
+        batch_size, sequence_length, module.num_heads, module.head_dim
+    )
+    key = module.k_proj(x).view(
+        batch_size, sequence_length, module.num_kv_heads, module.head_dim
+    )
+    value = module.v_proj(x).view(
+        batch_size, sequence_length, module.num_kv_heads, module.head_dim
+    )
+    query = module.q_norm(query)
+    key = module.k_norm(key)
+    query, key = apply_rotary_emb_qk(
+        query,
+        key,
+        freqs_cis,
+        format="bshd",
+        rope_fusion=module.backend.rope_fusion,
+        cu_seqlens=None,
+        cp_size=1,
+        cp_rank=0,
+    )
+
+    # Transformers' attention interface uses BHSD at its boundary. Reuse the
+    # exact FA2 implementation used by the HF Qwen/Llama path.
+    output, _ = shared_prefix_flash_attention_forward(
+        module,
+        query.transpose(1, 2),
+        key.transpose(1, 2),
+        value.transpose(1, 2),
+        attention_mask=None,
+        dropout=0.0,
+        scaling=module.head_dim**-0.5,
+        shared_prefix_layout=shared_prefix_layout,
+        flash_attn_kwargs=packed_kwargs,
+        is_causal=True,
+    )
+    return module.o_proj(output.flatten(2))
+
+
+def _logical_router_forward(
+    gate: nn.Module,
+    x: torch.Tensor,
+    token_mask: torch.Tensor,
+    cp_mesh: Any,
+):
+    from nemo_automodel.components.moe import layers as moe_layers
+
+    execution = getattr(gate, _ROUTER_EXECUTION_ATTR, None)
+    if execution is None or execution.logical_token_weights is None:
+        return gate._nemo_shared_prefix_original_forward(x, token_mask, cp_mesh)
+    if cp_mesh is not None:
+        raise ValueError("shared-prefix logical router statistics require CP=1")
+    if gate.bias_update_factor != 0:
+        raise ValueError(
+            "native Qwen3-MoE shared-prefix routing does not support dynamic bias"
+        )
+
+    if not gate.training:
+        return gate._nemo_shared_prefix_original_forward(x, token_mask, cp_mesh)
+
+    logical_token_weights = execution.logical_token_weights
+    if logical_token_weights.ndim != 1 or logical_token_weights.numel() != x.shape[0]:
+        raise ValueError(
+            "shared-prefix logical token weights must match the flattened Gate input"
+        )
+    logical_token_weights = logical_token_weights.to(device=x.device)
+
+    captured_load: torch.Tensor | None = None
+
+    def logical_expert_load(
+        module: nn.Module,
+        indices: torch.Tensor,
+        physical_token_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        nonlocal captured_load
+        valid_weights = logical_token_weights * physical_token_mask.to(
+            logical_token_weights.dtype
+        )
+        expert_load = indices.new_zeros((module.n_experts,))
+        contributions = valid_weights.to(indices.dtype).unsqueeze(1).expand_as(indices)
+        expert_load.scatter_add_(0, indices.reshape(-1), contributions.reshape(-1))
+        captured_load = expert_load
+        return expert_load
+
+    def logical_aux_loss(
+        module: nn.Module,
+        original_scores: torch.Tensor,
+        expert_load: torch.Tensor,
+        physical_token_mask: torch.Tensor,
+        logical_cp_mesh: Any,
+    ) -> torch.Tensor:
+        if logical_cp_mesh is not None:
+            raise ValueError("shared-prefix logical router statistics require CP=1")
+        valid_weights = logical_token_weights * physical_token_mask.to(
+            logical_token_weights.dtype
+        )
+        logical_tokens = valid_weights.sum().clamp_min(1)
+        expert_scores = (
+            original_scores * valid_weights.to(original_scores.dtype).unsqueeze(1)
+        ).sum(dim=0)
+        load_fraction = expert_load * module.n_experts / (module.topk * logical_tokens)
+        return torch.sum(load_fraction * (expert_scores / logical_tokens))
+
+    original_compute_expert_load = gate._compute_expert_load
+    original_compute_aux_loss = gate._compute_aux_loss
+    aux_loss_coeff = gate.aux_loss_coeff
+    track_load_balance = gate._track_load_balance
+    original_aux_scaler = moe_layers.MoEAuxLossAutoScaler
+    gate._compute_expert_load = MethodType(logical_expert_load, gate)
+    gate._compute_aux_loss = MethodType(logical_aux_loss, gate)
+    # Force load computation for logical statistics even when the aux
+    # coefficient is zero. Dummy microbatches must not attach an aux gradient:
+    # AutoModel's aux autoscaler deliberately ignores the downstream zero loss.
+    gate._track_load_balance = execution.valid
+    if not execution.valid:
+        gate.aux_loss_coeff = 0.0
+    moe_layers.MoEAuxLossAutoScaler = _LogicalAuxLossAutoScaler
+    try:
+        weights, indices, aux_loss = gate._nemo_shared_prefix_original_forward(
+            x, token_mask, cp_mesh
+        )
+    finally:
+        moe_layers.MoEAuxLossAutoScaler = original_aux_scaler
+        gate._compute_expert_load = original_compute_expert_load
+        gate._compute_aux_loss = original_compute_aux_loss
+        gate.aux_loss_coeff = aux_loss_coeff
+        gate._track_load_balance = track_load_balance
+
+    if execution.valid:
+        if captured_load is None:
+            raise RuntimeError("logical Qwen3-MoE router did not compute expert load")
+        execution.record(gate, captured_load, aux_loss)
+    return weights, indices, aux_loss
+
+
+def reset_shared_prefix_moe_statistics(model: nn.Module) -> None:
+    """Reset logical statistics at the beginning of one ``Policy.train`` call."""
+    if not is_custom_qwen3_moe_shared_prefix(model):
+        return
+    from nemo_automodel.components.moe.layers import Gate
+
+    for module in model.modules():
+        if isinstance(module, Gate):
+            module._nemo_shared_prefix_logical_expert_load = None
+            module._nemo_shared_prefix_aux_loss_sum = None
+            module._nemo_shared_prefix_aux_loss_count = 0
+
+
+def collect_shared_prefix_moe_statistics(
+    model: nn.Module,
+    dp_group: torch.distributed.ProcessGroup,
+) -> dict[str, float]:
+    """Return DP-reduced logical load statistics accumulated over valid MBs."""
+    if not is_custom_qwen3_moe_shared_prefix(model):
+        return {}
+    from nemo_automodel.components.moe.layers import Gate
+
+    cvs: list[float] = []
+    min_utilizations: list[float] = []
+    max_utilizations: list[float] = []
+    dead_fractions: list[float] = []
+    diversities: list[float] = []
+    aux_sum = 0.0
+    aux_count = 0.0
+    logical_tokens = 0.0
+
+    for module in model.modules():
+        if not isinstance(module, Gate):
+            continue
+
+        # Every DP rank must issue the same collectives. A rank can receive only
+        # dummy packing microbatches while another rank has valid tokens, so a
+        # missing local accumulator participates as zeros instead of skipping.
+        local_load = getattr(module, "_nemo_shared_prefix_logical_expert_load", None)
+        load = (
+            torch.zeros(
+                module.n_experts,
+                device=module.weight.device,
+                dtype=torch.int64,
+            )
+            if local_load is None
+            else local_load.detach().clone().to(dtype=torch.int64)
+        )
+        torch.distributed.all_reduce(load, group=dp_group)
+        load_float = load.float()
+        mean = load_float.mean()
+        if mean > 0:
+            utilization = load_float / mean
+            cvs.append((load_float.std(correction=0) / mean).item())
+            min_utilizations.append(utilization.min().item())
+            max_utilizations.append(utilization.max().item())
+            dead_fractions.append((load_float == 0).float().mean().item())
+            distribution = load_float / load_float.sum()
+            nonzero = distribution[distribution > 0]
+            entropy = -(nonzero * nonzero.log()).sum().item()
+            diversities.append(math.exp(entropy) / module.n_experts)
+            logical_tokens += (load_float.sum() / module.topk).item()
+
+        layer_aux_sum = getattr(module, "_nemo_shared_prefix_aux_loss_sum", None)
+        layer_aux_count = getattr(module, "_nemo_shared_prefix_aux_loss_count", 0)
+        reduced = torch.stack(
+            (
+                torch.zeros((), device=module.weight.device, dtype=torch.float32)
+                if layer_aux_sum is None
+                else layer_aux_sum.detach().float(),
+                torch.tensor(
+                    float(layer_aux_count),
+                    device=module.weight.device,
+                    dtype=torch.float32,
+                ),
+            )
+        )
+        torch.distributed.all_reduce(reduced, group=dp_group)
+        if reduced[1] > 0:
+            aux_sum += reduced[0].item()
+            aux_count += reduced[1].item()
+
+    if not cvs:
+        return {}
+    metrics = {
+        "logical_load_cv_mean": sum(cvs) / len(cvs),
+        "logical_expert_utilization_min": min(min_utilizations),
+        "logical_expert_utilization_max": max(max_utilizations),
+        "logical_dead_expert_fraction_mean": sum(dead_fractions) / len(dead_fractions),
+        "logical_expert_diversity_mean": sum(diversities) / len(diversities),
+        "logical_token_layer_events": logical_tokens,
+    }
+    if aux_count:
+        metrics["logical_router_aux_loss_mean"] = aux_sum / aux_count
+    return metrics

--- a/nemo_rl/models/automodel/shared_prefix_moe.py
+++ b/nemo_rl/models/automodel/shared_prefix_moe.py
@@ -931,6 +931,14 @@ class _RouterExecution:
             gate._last_expert_load = expert_load
             gate._last_aux_loss = aux_loss
 
+            if getattr(gate, "bias_update_factor", 0.0) > 0:
+                cumulative_load = gate._cumulative_expert_load
+                gate._cumulative_expert_load = (
+                    expert_load.clone()
+                    if cumulative_load is None
+                    else cumulative_load + expert_load
+                )
+
             accumulated = getattr(gate, "_nemo_shared_prefix_logical_expert_load", None)
             gate._nemo_shared_prefix_logical_expert_load = (
                 expert_load.clone()
@@ -1010,7 +1018,54 @@ def is_custom_qwen3_moe_shared_prefix(model: nn.Module) -> bool:
     return bool(getattr(model, _CUSTOM_QWEN3_MOE_FLAG, False))
 
 
-def enable_custom_qwen3_moe_shared_prefix(model: nn.Module) -> None:
+@torch.no_grad()
+def update_shared_prefix_moe_bias(
+    model: nn.Module,
+    dp_group: torch.distributed.ProcessGroup | None,
+) -> None:
+    """Update correction biases from logical, DP-global expert load.
+
+    AutoModel's native ``Gate.update_bias`` only reduces load when its bias is
+    a DTensor. FSDP keeps this persistent buffer replicated, so use the
+    Policy-owned DP group explicitly and make every rank participate, including
+    ranks that received only dummy packing microbatches.
+    """
+    if not is_custom_qwen3_moe_shared_prefix(model):
+        return
+
+    from nemo_automodel.components.moe.layers import Gate
+
+    for gate in model.modules():
+        if not isinstance(gate, Gate):
+            continue
+
+        factor = float(gate.bias_update_factor)
+        if factor == 0:
+            continue
+
+        correction_bias = gate.e_score_correction_bias
+        local_load = gate._cumulative_expert_load
+        gate._cumulative_expert_load = None
+        if local_load is None:
+            local_load = torch.zeros(
+                gate.n_experts,
+                dtype=torch.float32,
+                device=correction_bias.device,
+            )
+        else:
+            local_load = local_load.to(
+                device=correction_bias.device,
+                dtype=torch.float32,
+            )
+        if torch.distributed.is_initialized() and dp_group is not None:
+            torch.distributed.all_reduce(local_load, group=dp_group)
+        correction_bias.add_(torch.sign(local_load.mean() - local_load) * factor)
+
+
+def enable_custom_qwen3_moe_shared_prefix(
+    model: nn.Module,
+    routing_bias_factor: float = 0.0,
+) -> None:
     """Install native-attention and logical-router adapters on one model."""
     from nemo_automodel.components.models.qwen3_moe.layers import (
         Qwen3MoeAttention,
@@ -1030,6 +1085,19 @@ def enable_custom_qwen3_moe_shared_prefix(model: nn.Module) -> None:
         elif isinstance(module, Gate):
             module._nemo_shared_prefix_original_forward = module.forward
             module.forward = MethodType(_logical_router_forward, module)
+            if routing_bias_factor > 0:
+                # Add this only after loading: it is absent from HF checkpoints.
+                del module.e_score_correction_bias
+                module.register_buffer(
+                    "e_score_correction_bias",
+                    torch.zeros(
+                        module.n_experts,
+                        dtype=torch.float32,
+                        device=module.weight.device,
+                    ),
+                )
+                module.bias_update_factor = routing_bias_factor
+                module.score_func = "softmax_with_bias"
             gate_count += 1
 
     if attention_count == 0 or gate_count == 0:
@@ -1122,10 +1190,11 @@ def _logical_router_forward(
         isinstance(bias_update_factor, bool)
         or not isinstance(bias_update_factor, numbers.Real)
         or not math.isfinite(float(bias_update_factor))
-        or bias_update_factor != 0
+        or bias_update_factor < 0
     ):
         raise ValueError(
-            "native Qwen3-MoE shared-prefix routing does not support dynamic bias"
+            "Qwen3-MoE gate_bias_update_factor must be a finite "
+            "non-negative real number"
         )
 
     execution = getattr(gate, _ROUTER_EXECUTION_ATTR, None)
@@ -1184,6 +1253,7 @@ def _logical_router_forward(
     original_compute_aux_loss = gate._compute_aux_loss
     aux_loss_coeff = gate.aux_loss_coeff
     track_load_balance = gate._track_load_balance
+    original_bias_update_factor = gate.bias_update_factor
     original_aux_scaler = moe_layers.MoEAuxLossAutoScaler
     gate._compute_expert_load = MethodType(logical_expert_load, gate)
     gate._compute_aux_loss = MethodType(logical_aux_loss, gate)
@@ -1193,6 +1263,10 @@ def _logical_router_forward(
     gate._track_load_balance = execution.valid
     if not execution.valid:
         gate.aux_loss_coeff = 0.0
+    # Native Gate.forward accumulates physical load immediately. Stage logical
+    # load in the execution and commit it exactly once before backward instead;
+    # this also prevents activation-checkpoint replay from double counting.
+    gate.bias_update_factor = 0.0
     moe_layers.MoEAuxLossAutoScaler = _LogicalAuxLossAutoScaler
     try:
         weights, indices, aux_loss = gate._nemo_shared_prefix_original_forward(
@@ -1204,6 +1278,7 @@ def _logical_router_forward(
         gate._compute_aux_loss = original_compute_aux_loss
         gate.aux_loss_coeff = aux_loss_coeff
         gate._track_load_balance = track_load_balance
+        gate.bias_update_factor = original_bias_update_factor
 
     if execution.valid:
         if captured_load is None:
@@ -1223,6 +1298,7 @@ def reset_shared_prefix_moe_statistics(model: nn.Module) -> None:
             module._nemo_shared_prefix_logical_expert_load = None
             module._nemo_shared_prefix_aux_loss_sum = None
             module._nemo_shared_prefix_aux_loss_count = 0
+            module._cumulative_expert_load = None
 
 
 def collect_shared_prefix_moe_statistics(

--- a/nemo_rl/models/automodel/shared_prefix_moe.py
+++ b/nemo_rl/models/automodel/shared_prefix_moe.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import math
+import numbers
 import re
 import textwrap
 from contextlib import contextmanager
@@ -78,7 +79,7 @@ def _qwen3_moe_configured_dtype(config: Any) -> torch.dtype:
 
 
 def enable_qwen3_moe_configured_dtype() -> None:
-    """Backport configured-dtype construction for native Qwen3-MoE.
+    """Backport configured-dtype construction and forward boundaries.
 
     The pinned AutoModel revision constructs several native Qwen3-MoE
     parameters with helper defaults (bf16), even when NeMo-RL requests fp32
@@ -223,6 +224,20 @@ def enable_qwen3_moe_configured_dtype() -> None:
                 (
                     "dtype=get_dtype(config.torch_dtype, torch.bfloat16)",
                     "dtype=model_dtype",
+                    1,
+                ),
+            ),
+        ),
+        (
+            model_module,
+            model_module.Qwen3MoeForCausalLM,
+            "forward",
+            (
+                (
+                    "        logits = self.lm_head(hidden) if self.lm_head else hidden\n",
+                    "        if self.lm_head:\n"
+                    "            hidden = hidden.to(dtype=self.lm_head.weight.dtype)\n"
+                    "        logits = self.lm_head(hidden) if self.lm_head else hidden\n",
                     1,
                 ),
             ),
@@ -450,7 +465,7 @@ def _ep_free_expert_ids(tensor: Any, n_experts: int) -> tuple[int, ...] | None:
     if not isinstance(tensor, DTensor):
         return None
     mesh = tensor.device_mesh
-    if "ep" in mesh.mesh_dim_names:
+    if "ep" in (mesh.mesh_dim_names or ()):
         return None
     if mesh.ndim != 1 or len(tensor.placements) != 1:
         raise ValueError(
@@ -844,14 +859,27 @@ class _LogicalAuxLossAutoScaler(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, output: torch.Tensor, aux_loss: torch.Tensor) -> torch.Tensor:
-        ctx.aux_shape = aux_loss.shape
-        ctx.aux_dtype = aux_loss.dtype
-        ctx.aux_device = aux_loss.device
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        output: torch.Tensor,
+        aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.aux_shape = (  # pyrefly: ignore[implicitly-defined-attribute]
+            aux_loss.shape
+        )
+        ctx.aux_dtype = (  # pyrefly: ignore[implicitly-defined-attribute]
+            aux_loss.dtype
+        )
+        ctx.aux_device = (  # pyrefly: ignore[implicitly-defined-attribute]
+            aux_loss.device
+        )
         return output
 
     @staticmethod
-    def backward(ctx, grad_output: torch.Tensor):
+    def backward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        grad_output: torch.Tensor,
+    ):
         from nemo_automodel.components.moe.megatron.moe_utils import (
             MoEAuxLossAutoScaler,
         )
@@ -872,13 +900,13 @@ class _RouterExecution:
     logical_token_weights: torch.Tensor | None
     valid: bool
     committed: bool = False
-    pending: dict[nn.Module, tuple[torch.Tensor, torch.Tensor | None]] = field(
+    pending: dict[Any, tuple[torch.Tensor, torch.Tensor | None]] = field(
         default_factory=dict
     )
 
     def record(
         self,
-        gate: nn.Module,
+        gate: Any,
         expert_load: torch.Tensor,
         aux_loss: torch.Tensor | None,
     ) -> None:
@@ -1013,7 +1041,7 @@ def enable_custom_qwen3_moe_shared_prefix(model: nn.Module) -> None:
 
 
 def _custom_qwen3_moe_attention_forward(
-    module: nn.Module,
+    module: Any,
     x: torch.Tensor,
     *,
     freqs_cis: torch.Tensor,
@@ -1082,22 +1110,29 @@ def _custom_qwen3_moe_attention_forward(
 
 
 def _logical_router_forward(
-    gate: nn.Module,
+    gate: Any,
     x: torch.Tensor,
     token_mask: torch.Tensor,
     cp_mesh: Any,
 ):
     from nemo_automodel.components.moe import layers as moe_layers
 
+    bias_update_factor = gate.bias_update_factor
+    if (
+        isinstance(bias_update_factor, bool)
+        or not isinstance(bias_update_factor, numbers.Real)
+        or not math.isfinite(float(bias_update_factor))
+        or bias_update_factor != 0
+    ):
+        raise ValueError(
+            "native Qwen3-MoE shared-prefix routing does not support dynamic bias"
+        )
+
     execution = getattr(gate, _ROUTER_EXECUTION_ATTR, None)
     if execution is None or execution.logical_token_weights is None:
         return gate._nemo_shared_prefix_original_forward(x, token_mask, cp_mesh)
     if cp_mesh is not None:
         raise ValueError("shared-prefix logical router statistics require CP=1")
-    if gate.bias_update_factor != 0:
-        raise ValueError(
-            "native Qwen3-MoE shared-prefix routing does not support dynamic bias"
-        )
 
     if not gate.training:
         return gate._nemo_shared_prefix_original_forward(x, token_mask, cp_mesh)
@@ -1112,7 +1147,7 @@ def _logical_router_forward(
     captured_load: torch.Tensor | None = None
 
     def logical_expert_load(
-        module: nn.Module,
+        module: Any,
         indices: torch.Tensor,
         physical_token_mask: torch.Tensor,
     ) -> torch.Tensor:
@@ -1127,7 +1162,7 @@ def _logical_router_forward(
         return expert_load
 
     def logical_aux_loss(
-        module: nn.Module,
+        module: Any,
         original_scores: torch.Tensor,
         expert_load: torch.Tensor,
         physical_token_mask: torch.Tensor,

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -632,7 +632,11 @@ class LossPostProcessor:
                     "shared-prefix training does not support train-time top-k/top-p"
                 )
             local_logits = to_local_if_dtensor(logits)
-            response_logprobs = response_logprobs_from_logits(local_logits, layout)
+            response_logprobs = response_logprobs_from_logits(
+                local_logits,
+                layout,
+                chunk_size=self.cfg.get("logprob_chunk_size"),
+            )
             prev_logprobs = data_dict.get("prev_logprobs")
             logprob_base = (
                 prev_logprobs[:, 1:]

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -42,7 +42,7 @@ from nemo_rl.algorithms.logits_sampling_utils import (
     need_top_k_or_top_p_filtering,
 )
 from nemo_rl.algorithms.loss import SequencePackingLossWrapper, prepare_loss_input
-from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType
 from nemo_rl.algorithms.utils import mask_out_neg_inf_logprobs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
@@ -52,6 +52,10 @@ from nemo_rl.distributed.model_utils import (
     get_logprobs_from_vocab_parallel_logits,
 )
 from nemo_rl.models.automodel.data import ProcessedInputs, ProcessedMicrobatch
+from nemo_rl.models.automodel.shared_prefix import (
+    response_logprobs_from_logits,
+    scatter_response_logprobs,
+)
 from nemo_rl.models.policy import PolicyConfig
 
 # Union type for any post-processing function
@@ -111,6 +115,13 @@ def model_forward(
         position_ids=processed_inputs.position_ids,
         use_cache=use_cache,
     )
+
+    if processed_inputs.shared_prefix_layout is not None:
+        layout = processed_inputs.shared_prefix_layout
+        model_args["shared_prefix_layout"] = layout
+        # Qwen3 accepts an arbitrary index tensor here. Repeated prompt-last
+        # indices make one shared hidden state predict each response's first token.
+        model_args["logits_to_keep"] = layout.predictor_indices
 
     # Add flash attention kwargs if applicable
     if processed_inputs.has_flash_attention:
@@ -606,6 +617,40 @@ class LossPostProcessor:
         Returns:
             Tuple of (loss, metrics)
         """
+        layout = processed_inputs.shared_prefix_layout
+        if layout is not None:
+            if self.loss_fn.input_type != LossInputType.LOGPROB:
+                raise ValueError(
+                    "shared-prefix training currently supports logprob losses only"
+                )
+            if getattr(self.loss_fn, "use_fused_linear_logprobs", False):
+                raise ValueError(
+                    "shared-prefix training does not support fused linear logprobs"
+                )
+            if need_top_k_or_top_p_filtering(self.sampling_params):
+                raise ValueError(
+                    "shared-prefix training does not support train-time top-k/top-p"
+                )
+            local_logits = to_local_if_dtensor(logits)
+            response_logprobs = response_logprobs_from_logits(local_logits, layout)
+            prev_logprobs = data_dict.get("prev_logprobs")
+            logprob_base = (
+                prev_logprobs[:, 1:]
+                if isinstance(prev_logprobs, torch.Tensor)
+                else None
+            )
+            next_token_logprobs = scatter_response_logprobs(
+                response_logprobs,
+                layout,
+                base=logprob_base,
+            )
+            return self.loss_fn(
+                data=data_dict,
+                next_token_logprobs=next_token_logprobs,
+                global_valid_seqs=global_valid_seqs,
+                global_valid_toks=global_valid_toks,
+            )
+
         # Handle CP redistribution
         if self.cp_size > 1:
             _, data_dict = prepare_data_for_cp(

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -49,6 +49,7 @@ from nemo_rl.distributed.model_utils import (
     allgather_cp_sharded_tensor,
     cp_load_balanced_to_contiguous,
     distributed_vocab_topk,
+    get_aligned_target_logprobs_from_vocab_parallel_logits,
     get_logprobs_from_vocab_parallel_logits,
 )
 from nemo_rl.models.automodel.data import ProcessedInputs, ProcessedMicrobatch
@@ -631,12 +632,20 @@ class LossPostProcessor:
                 raise ValueError(
                     "shared-prefix training does not support train-time top-k/top-p"
                 )
-            local_logits = to_local_if_dtensor(logits)
-            response_logprobs = response_logprobs_from_logits(
-                local_logits,
-                layout,
-                chunk_size=self.cfg.get("logprob_chunk_size"),
-            )
+            if isinstance(logits, DTensor):
+                response_logprobs = (
+                    get_aligned_target_logprobs_from_vocab_parallel_logits(
+                        logits,
+                        layout.response_target_ids.unsqueeze(0),
+                        chunk_size=self.cfg.get("logprob_chunk_size"),
+                    ).squeeze(0)
+                )
+            else:
+                response_logprobs = response_logprobs_from_logits(
+                    logits,
+                    layout,
+                    chunk_size=self.cfg.get("logprob_chunk_size"),
+                )
             prev_logprobs = data_dict.get("prev_logprobs")
             logprob_base = (
                 prev_logprobs[:, 1:]

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -57,6 +57,10 @@ from nemo_rl.models.automodel.shared_prefix import (
     response_logprobs_from_logits,
     scatter_response_logprobs,
 )
+from nemo_rl.models.automodel.shared_prefix_moe import (
+    is_custom_qwen3_moe_shared_prefix,
+    shared_prefix_moe_context,
+)
 from nemo_rl.models.policy import PolicyConfig
 
 # Union type for any post-processing function
@@ -120,10 +124,12 @@ def model_forward(
     if processed_inputs.shared_prefix_layout is not None:
         layout = processed_inputs.shared_prefix_layout
         model_args["shared_prefix_layout"] = layout
-        # Both supported HF causal LMs accept an arbitrary index tensor here.
-        # Repeated prompt-last indices make one shared hidden state predict each
-        # response's first token.
-        model_args["logits_to_keep"] = layout.predictor_indices
+        if not is_custom_qwen3_moe_shared_prefix(model):
+            # Supported HF causal LMs accept an arbitrary index tensor here.
+            # Repeated prompt-last indices make one shared hidden state predict
+            # every response's first token. AutoModel's native Qwen3-MoE does
+            # not implement this HF argument and is selected after lm_head.
+            model_args["logits_to_keep"] = layout.predictor_indices
 
     # Add flash attention kwargs if applicable
     if processed_inputs.has_flash_attention:
@@ -375,6 +381,15 @@ def forward_with_post_processing_fn(
     logits = extract_logits(model, outputs)
     del outputs
 
+    layout = processed_inputs.shared_prefix_layout
+    if layout is not None and is_custom_qwen3_moe_shared_prefix(model):
+        if logits.ndim != 3 or logits.shape[:2] != (1, layout.compact_tokens):
+            raise ValueError(
+                "native Qwen3-MoE shared-prefix logits must have shape "
+                f"[1, {layout.compact_tokens}, vocab], got {tuple(logits.shape)}"
+            )
+        logits = logits.index_select(1, layout.predictor_indices)
+
     # Apply temperature scaling only for sampling-oriented post-processors
     # Score computations should use unscaled logits
     if isinstance(
@@ -495,6 +510,18 @@ def automodel_forward_backward(
     from contextlib import nullcontext
 
     results = []
+    fsdp_backward_scale = dp_size * cp_size
+    if not forward_only and is_custom_qwen3_moe_shared_prefix(model):
+        # Router auxiliary losses are attached inside AutoModel's Gate, outside
+        # the scalar policy loss below. Match AutoModel's non-PP driver so FSDP's
+        # gradient average does not underweight them.
+        from nemo_automodel.components.moe.megatron.moe_utils import (
+            MoEAuxLossAutoScaler,
+        )
+
+        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(
+            float(fsdp_backward_scale)
+        )
 
     for mb_idx, processed_mb in enumerate(data_iterator):
         # Call optional callback at start of microbatch
@@ -502,6 +529,9 @@ def automodel_forward_backward(
             on_microbatch_start(mb_idx)
 
         processed_inputs = processed_mb.processed_inputs
+        is_dummy = (
+            num_valid_microbatches is not None and mb_idx >= num_valid_microbatches
+        )
 
         # Create train context if factory provided, otherwise use nullcontext
         if train_context_fn is not None:
@@ -509,7 +539,16 @@ def automodel_forward_backward(
         else:
             ctx = nullcontext()
 
-        with ctx:
+        router_ctx = (
+            shared_prefix_moe_context(
+                model,
+                processed_inputs.shared_prefix_layout,
+                valid=not is_dummy,
+            )
+            if is_custom_qwen3_moe_shared_prefix(model)
+            else nullcontext()
+        )
+        with ctx, router_ctx as router_execution:
             # Forward pass with post-processing
             result, metrics, _ = forward_with_post_processing_fn(
                 model=model,
@@ -522,11 +561,12 @@ def automodel_forward_backward(
                 sampling_params=sampling_params,
                 sequence_dim=sequence_dim,
             )
-
-            # Check if this is a dummy batch
-            is_dummy = (
-                num_valid_microbatches is not None and mb_idx >= num_valid_microbatches
-            )
+            # Commit detached statistics exactly once. Activation checkpointing
+            # may replay Gate.forward during backward; the execution remains
+            # active so aux gradients are rebuilt, while the one-shot commit
+            # prevents the replay from double-counting load state.
+            if router_execution is not None:
+                router_execution.commit()
 
             # Scale metrics for aggregation (only for loss)
             if isinstance(post_processing_fn, LossPostProcessor):
@@ -551,7 +591,7 @@ def automodel_forward_backward(
 
                     # when FSDP reduces the gradients over the DP dim, they're automatically averaged
                     # but we want to sum them so we cancel out the average here
-                    loss = result * dp_size * cp_size
+                    loss = result * fsdp_backward_scale
                     loss.backward()
 
         results.append((result, metrics))

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -120,8 +120,9 @@ def model_forward(
     if processed_inputs.shared_prefix_layout is not None:
         layout = processed_inputs.shared_prefix_layout
         model_args["shared_prefix_layout"] = layout
-        # Qwen3 accepts an arbitrary index tensor here. Repeated prompt-last
-        # indices make one shared hidden state predict each response's first token.
+        # Both supported HF causal LMs accept an arbitrary index tensor here.
+        # Repeated prompt-last indices make one shared hidden state predict each
+        # response's first token.
         model_args["logits_to_keep"] = layout.predictor_indices
 
     # Add flash attention kwargs if applicable

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -38,6 +38,33 @@ except ImportError:
     )
 
 
+def _enable_qwen3_moe_routing_bias_refit() -> None:
+    """Plumb Qwen3-MoE's refitted correction bias into vLLM's existing router."""
+    from vllm.model_executor.models import qwen3_moe
+
+    marker = "_nemo_qwen3_moe_routing_bias_refit"
+    original_fused_moe = qwen3_moe.FusedMoE
+    if getattr(original_fused_moe, marker, False):
+        return
+
+    def fused_moe_with_routing_bias(*args, **kwargs):
+        gate = kwargs["gate"]
+        correction_bias = torch.nn.Parameter(
+            torch.zeros(kwargs["num_experts"], dtype=torch.float32),
+            requires_grad=False,
+        )
+        gate.e_score_correction_bias = correction_bias
+        return original_fused_moe(
+            *args, e_score_correction_bias=correction_bias, **kwargs
+        )
+
+    setattr(fused_moe_with_routing_bias, marker, True)
+    qwen3_moe.FusedMoE = fused_moe_with_routing_bias
+
+
+_enable_qwen3_moe_routing_bias_refit()
+
+
 def fix_gemma3_vision_weight_name(key: str) -> str:
     """Re-insert the `vision_model` segment into Gemma3 vision-tower weights.
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -171,9 +171,7 @@ class AutomodelKwargs(TypedDict):
     # auto-detected and set at runtime if not explicitly configured.
     # See: https://github.com/NVIDIA-NeMo/RL/issues/2072
     force_hf: NotRequired[bool]
-    # Overrides for AutoModel's native MoE config. Shared-prefix Qwen3-MoE only
-    # accepts checkpoint-compatible auxiliary-loss overrides; dynamic routing
-    # bias is rejected because Qwen rollout backends do not consume that state.
+    # Numeric overrides for AutoModel's native Qwen3-MoE config.
     moe_overrides: NotRequired[dict[str, float]]
 
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -110,7 +110,10 @@ class AutomodelBackendConfig(TypedDict):
 
     Used when setting the backend in automodel_kwargs in your config.
     Alternatively, pass `force_hf: true` in automodel_kwargs to fall back
-    to the HuggingFace implementation.
+    to the HuggingFace implementation. Shared-prefix native Qwen3-MoE
+    currently requires an explicit ``dispatcher="torch"`` and
+    ``experts="torch"`` or ``experts="torch_mm"`` so behavior does not depend
+    on whether DeepEP happens to be installed in the runtime environment.
     """
 
     # Hydra target class path (e.g., "nemo_automodel.components.models.common.utils.BackendConfig")
@@ -132,10 +135,14 @@ class AutomodelBackendConfig(TypedDict):
     # Use fake balanced gate for testing/debugging MoE
     fake_balanced_gate: NotRequired[bool]
     # Enable HuggingFace state dict adapter for checkpoint saving/loading plus refit support for RL
-    # This should almost always be set to True when using a custom MoE implementation. Set to False only for specific use cases like debugging or performance testing.
+    # This should almost always be True for custom MoE implementations. False
+    # is intended only for narrowly scoped debugging or performance tests.
     enable_hf_state_dict_adapter: NotRequired[bool]
     # Enable FSDP-specific optimizations
     enable_fsdp_optimizations: NotRequired[bool]
+    # Transformer Engine FP8 recipe. Native shared-prefix Qwen3-MoE rejects
+    # this until the Policy train loop owns the matching TE autocast context.
+    te_fp8: NotRequired[dict[str, Any]]
     # Precision for the MoE gate computation (e.g., "float64", "float32")
     gate_precision: NotRequired[str]
 
@@ -164,6 +171,10 @@ class AutomodelKwargs(TypedDict):
     # auto-detected and set at runtime if not explicitly configured.
     # See: https://github.com/NVIDIA-NeMo/RL/issues/2072
     force_hf: NotRequired[bool]
+    # Overrides for AutoModel's native MoE config. Shared-prefix Qwen3-MoE only
+    # accepts checkpoint-compatible auxiliary-loss overrides; dynamic routing
+    # bias is rejected because Qwen rollout backends do not consume that state.
+    moe_overrides: NotRequired[dict[str, float]]
 
 
 class DTensorConfigDisabled(TypedDict):
@@ -183,8 +194,8 @@ class DTensorConfig(TypedDict):
     enabled: Literal[True]
     env_vars: NotRequired[dict[str, str] | None]
     _v2: NotRequired[bool]
-    # Distributed parallelism sizes
-    # data_parallel_size is derived from world_size / (tp * cp * ep)
+    # Distributed parallelism sizes. AutoModel's current FSDP2 mesh derives
+    # data parallelism from world_size / (tp * cp); EP is an overlapping view.
     tensor_parallel_size: int
     context_parallel_size: int
     expert_parallel_size: NotRequired[int]
@@ -535,8 +546,9 @@ class PolicyConfig(TypedDict):
     hf_config_overrides: NotRequired[dict[str, Any]]
     dynamic_batching: DynamicBatchingConfig | DynamicBatchingConfigDisabled
     sequence_packing: NotRequired[SequencePackingConfig | SequencePackingConfigDisabled]
-    # Train Qwen3 or Llama on one physical prompt plus all responses sharing it.
-    # This path is DTensor v2/HF/FA2-only and leaves logprob inference dense.
+    # Train Qwen3, Qwen3-MoE, or Llama on one physical prompt plus all responses
+    # sharing it. Dense models use HF/FA2; Qwen3-MoE EP uses AutoModel's native
+    # grouped experts plus the same FA2 split-attention core.
     shared_prefix_training: NotRequired[bool]
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -535,8 +535,8 @@ class PolicyConfig(TypedDict):
     hf_config_overrides: NotRequired[dict[str, Any]]
     dynamic_batching: DynamicBatchingConfig | DynamicBatchingConfigDisabled
     sequence_packing: NotRequired[SequencePackingConfig | SequencePackingConfigDisabled]
-    # Train Qwen3 on one physical prompt plus all responses sharing it. The
-    # first version is DTensor v2/HF/FA2-only and leaves logprob inference dense.
+    # Train Qwen3 or Llama on one physical prompt plus all responses sharing it.
+    # This path is DTensor v2/HF/FA2-only and leaves logprob inference dense.
     shared_prefix_training: NotRequired[bool]
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -535,6 +535,9 @@ class PolicyConfig(TypedDict):
     hf_config_overrides: NotRequired[dict[str, Any]]
     dynamic_batching: DynamicBatchingConfig | DynamicBatchingConfigDisabled
     sequence_packing: NotRequired[SequencePackingConfig | SequencePackingConfigDisabled]
+    # Train Qwen3 on one physical prompt plus all responses sharing it. The
+    # first version is DTensor v2/HF/FA2-only and leaves logprob inference dense.
+    shared_prefix_training: NotRequired[bool]
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int
     # This sets the clipping norm for the DTensorPolicyWorkers (Megatron's is called clip_grad)

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -38,6 +38,10 @@ from nemo_rl.models.generation.interfaces import (
     GenerationInterface,
     GenerationOutputSpec,
 )
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+)
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import (
     ColocatablePolicyInterface,
@@ -514,10 +518,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             self.sequence_packing_args["max_tokens_per_microbatch"] = self.cfg[
                 "sequence_packing"
             ]["train_mb_tokens"]
+            train_packing_args = self.sequence_packing_args
+            if self.cfg.get("shared_prefix_training"):
+                train_packing_args = {
+                    **self.sequence_packing_args,
+                    "shared_prefix_group_ids_key": SHARED_PREFIX_GROUP_IDS,
+                    "shared_prefix_lengths_key": SHARED_PREFIX_LENGTHS,
+                }
             sharded_data, _ = data.shard_by_batch_size(
                 dp_size,
                 batch_size=batch_size,
-                sequence_packing_args=self.sequence_packing_args,
+                sequence_packing_args=train_packing_args,
             )
         else:
             sharded_data = data.shard_by_batch_size(

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -112,6 +112,15 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         megatron_enable = bool(config.get("megatron_cfg", {}).get("enabled", False))
         dtensor_enable = bool(config.get("dtensor_cfg", {}).get("enabled", False))
         draft_enabled = bool(config.get("draft", {}).get("enabled", False))
+        if config.get("shared_prefix_training") and (
+            megatron_enable
+            or not dtensor_enable
+            or not config.get("dtensor_cfg", {}).get("_v2", False)
+        ):
+            raise ValueError(
+                "shared-prefix training requires the DTensor v2 backend and does "
+                "not support Megatron or DTensor v1"
+            )
         if megatron_enable and dtensor_enable:
             raise ValueError(
                 "Configure either Megatron (policy.megatron_cfg.enabled=true) or "

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -54,7 +54,9 @@ from nemo_rl.models.automodel.setup import (
 from nemo_rl.models.automodel.shared_prefix import SHARED_PREFIX_GROUP_IDS
 from nemo_rl.models.automodel.shared_prefix_moe import (
     collect_shared_prefix_moe_statistics,
+    is_custom_qwen3_moe_shared_prefix,
     reset_shared_prefix_moe_statistics,
+    update_shared_prefix_moe_bias,
 )
 from nemo_rl.models.automodel.train import (
     FullLogitsPostProcessor,
@@ -109,15 +111,25 @@ def dtensor_params_generator(
 
         adapted_fqn_tensors = _maybe_adapt_tensor_to_hf(model, name, merged_tensor)
         for adapted_fqn, adapted_tensor in adapted_fqn_tensors:
-            # Convert to target dtype
+            refit_dtype = _refit_tensor_dtype(adapted_fqn, target_dtype)
             yield (
                 adapted_fqn,
-                adapted_tensor.to(target_dtype, non_blocking=True).contiguous(),
+                adapted_tensor.to(refit_dtype, non_blocking=True).contiguous(),
             )
             del adapted_tensor
         del adapted_fqn_tensors
         del merged_tensor
         del full_tensor
+
+
+def _refit_tensor_dtype(
+    name: str,
+    target_dtype: torch.dtype,
+) -> torch.dtype:
+    """Keep routing correction bias in FP32 across rollout refits."""
+    if name == "e_score_correction_bias" or name.endswith(".e_score_correction_bias"):
+        return torch.float32
+    return target_dtype
 
 
 @torch.no_grad()
@@ -385,6 +397,9 @@ class DTensorPolicyWorkerV2Impl(
 
     def _update_moe_gate_bias_if_supported(self) -> None:
         """Update the non-gradient MoE routing bias after the optimizer step."""
+        if is_custom_qwen3_moe_shared_prefix(self.model):
+            update_shared_prefix_moe_bias(self.model, self.dp_mesh.get_group())
+            return
         update_moe_gate_bias = getattr(self.model, "update_moe_gate_bias", None)
         if update_moe_gate_bias is not None:
             update_moe_gate_bias()
@@ -1095,7 +1110,10 @@ class DTensorPolicyWorkerV2Impl(
                 self.model, name, full_tensor
             )
             for adapted_fqn, adapted_tensor in adapted_fqn_tensors:
-                state_dict_info[adapted_fqn] = (adapted_tensor.shape, self.dtype)
+                state_dict_info[adapted_fqn] = (
+                    adapted_tensor.shape,
+                    _refit_tensor_dtype(adapted_fqn, self.dtype),
+                )
 
         return state_dict_info
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -52,6 +52,10 @@ from nemo_rl.models.automodel.setup import (
     validate_and_prepare_config,
 )
 from nemo_rl.models.automodel.shared_prefix import SHARED_PREFIX_GROUP_IDS
+from nemo_rl.models.automodel.shared_prefix_moe import (
+    collect_shared_prefix_moe_statistics,
+    reset_shared_prefix_moe_statistics,
+)
 from nemo_rl.models.automodel.train import (
     FullLogitsPostProcessor,
     LogprobsPostProcessor,
@@ -409,6 +413,7 @@ class DTensorPolicyWorkerV2Impl(
                 "shared-prefix training is enabled, but the training batch has no "
                 "GRPO shared-prefix metadata"
             )
+        reset_shared_prefix_moe_statistics(self.model)
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -581,6 +586,12 @@ class DTensorPolicyWorkerV2Impl(
                 dp_group=self.dp_mesh.get_group(),
                 dtype=self.dtype,
             )
+            moe_metrics = collect_shared_prefix_moe_statistics(
+                self.model,
+                self.dp_mesh.get_group(),
+            )
+            if moe_metrics:
+                metrics["moe_metrics"] = moe_metrics
 
             self.timer.stop("train")
             return metrics

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -51,6 +51,7 @@ from nemo_rl.models.automodel.setup import (
     setup_reference_model_state,
     validate_and_prepare_config,
 )
+from nemo_rl.models.automodel.shared_prefix import SHARED_PREFIX_GROUP_IDS
 from nemo_rl.models.automodel.train import (
     FullLogitsPostProcessor,
     LogprobsPostProcessor,
@@ -400,6 +401,14 @@ class DTensorPolicyWorkerV2Impl(
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
         self.timer.start("train")
+        if (
+            self.cfg.get("shared_prefix_training")
+            and SHARED_PREFIX_GROUP_IDS not in data
+        ):
+            raise ValueError(
+                "shared-prefix training is enabled, but the training batch has no "
+                "GRPO shared-prefix metadata"
+            )
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -147,6 +147,7 @@ project-includes = [
   "nemo_rl/modelopt/registry.py",
   "nemo_rl/models/__init__.py",
   "nemo_rl/models/automodel/__init__.py",
+  "nemo_rl/models/automodel/shared_prefix_moe.py",
   "nemo_rl/models/dtensor/__init__.py",
   "nemo_rl/models/dtensor/parallelize.py",
   "nemo_rl/models/generation/__init__.py",

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -41,6 +41,7 @@ from nemo_rl.algorithms.grpo import (
     compute_and_apply_seq_logprob_error_masking,
     dynamic_sampling,
     grpo_train,
+    setup,
     validate,
 )
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
@@ -568,6 +569,18 @@ def test_raise_if_reward_penalties_enabled_without_nemo_gym_allows_nemo_gym(
     _raise_if_reward_penalties_enabled_without_nemo_gym(
         master_config, enable_nemo_gym=True
     )
+
+
+def test_setup_rejects_shared_prefix_dynamic_sampling_with_loo(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.policy["shared_prefix_training"] = True
+    master_config.grpo["use_dynamic_sampling"] = True
+    master_config.grpo["use_leave_one_out_baseline"] = True
+
+    with pytest.raises(NotImplementedError, match="partial prompt groups"):
+        setup(master_config, MagicMock(), MagicMock(), None)
 
 
 def test_raise_if_message_level_advantage_penalties_enabled_noops_when_unset(

--- a/tests/unit/algorithms/test_grpo_router_replay_async.py
+++ b/tests/unit/algorithms/test_grpo_router_replay_async.py
@@ -20,11 +20,16 @@ import torch
 
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
+    _add_shared_prefix_training_metadata,
     _build_async_grpo_train_data,
     _default_grpo_save_state,
     async_grpo_train,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -107,6 +112,69 @@ def test_build_async_grpo_train_data_preserves_routed_experts_for_r3(
         assert torch.equal(train_data["routed_experts"], routes)
     else:
         assert "routed_experts" not in train_data
+
+
+def test_add_shared_prefix_training_metadata_uses_grpo_prompt_groups():
+    train_data = BatchedDataDict(
+        {
+            "input_ids": torch.tensor(
+                [
+                    [1, 2, 3, 4],
+                    [1, 2, 5, 0],
+                    [6, 7, 8, 9],
+                    [6, 7, 10, 11],
+                ]
+            ),
+            "input_lengths": torch.tensor([4, 3, 4, 4]),
+            "token_mask": torch.tensor(
+                [
+                    [0, 0, 1, 1],
+                    [0, 0, 1, 0],
+                    [0, 0, 1, 1],
+                    [0, 0, 1, 1],
+                ]
+            ),
+        }
+    )
+
+    _add_shared_prefix_training_metadata(
+        train_data,
+        {"shared_prefix_training": True},
+        num_generations_per_prompt=2,
+    )
+
+    assert train_data[SHARED_PREFIX_GROUP_IDS].tolist() == [0, 0, 1, 1]
+    assert train_data[SHARED_PREFIX_LENGTHS].tolist() == [2, 2, 2, 2]
+
+
+def test_add_shared_prefix_training_metadata_crops_terminal_environment_tokens():
+    train_data = BatchedDataDict(
+        {
+            "input_ids": torch.tensor(
+                [
+                    [1, 2, 3, 4, 90, 91],
+                    [1, 2, 5, 6, 92, 0],
+                ]
+            ),
+            "input_lengths": torch.tensor([6, 5], dtype=torch.int32),
+            "token_mask": torch.tensor(
+                [
+                    [0, 0, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 0, 0],
+                ]
+            ),
+        }
+    )
+
+    _add_shared_prefix_training_metadata(
+        train_data,
+        {"shared_prefix_training": True},
+        num_generations_per_prompt=2,
+    )
+
+    assert train_data[SHARED_PREFIX_LENGTHS].tolist() == [2, 2]
+    assert train_data["input_lengths"].dtype == torch.int32
+    assert train_data["input_lengths"].tolist() == [4, 4]
 
 
 def test_async_grpo_r3_rejects_data_plane_until_async_tq_exists():

--- a/tests/unit/algorithms/test_grpo_router_replay_async.py
+++ b/tests/unit/algorithms/test_grpo_router_replay_async.py
@@ -147,7 +147,7 @@ def test_add_shared_prefix_training_metadata_uses_grpo_prompt_groups():
     assert train_data[SHARED_PREFIX_LENGTHS].tolist() == [2, 2, 2, 2]
 
 
-def test_add_shared_prefix_training_metadata_crops_terminal_environment_tokens():
+def test_add_shared_prefix_training_metadata_keeps_terminal_environment_tokens():
     train_data = BatchedDataDict(
         {
             "input_ids": torch.tensor(
@@ -174,7 +174,11 @@ def test_add_shared_prefix_training_metadata_crops_terminal_environment_tokens()
 
     assert train_data[SHARED_PREFIX_LENGTHS].tolist() == [2, 2]
     assert train_data["input_lengths"].dtype == torch.int32
-    assert train_data["input_lengths"].tolist() == [4, 4]
+    # Terminal-environment cropping is disabled for now so that shared-prefix and
+    # the dense/packed baseline consume identical input_lengths; see the disabled
+    # assignment in _add_shared_prefix_training_metadata. Expect [4, 4] again once
+    # the crop is re-enabled.
+    assert train_data["input_lengths"].tolist() == [6, 5]
 
 
 def test_async_grpo_r3_rejects_data_plane_until_async_tq_exists():

--- a/tests/unit/data/packing/test_algorithms.py
+++ b/tests/unit/data/packing/test_algorithms.py
@@ -23,7 +23,101 @@ from nemo_rl.data.packing.algorithms import (
     PackingAlgorithm,
     SequencePacker,
     get_packer,
+    pack_shared_prefix_sequences,
+    shared_prefix_bin_length,
 )
+
+
+def test_shared_prefix_packer_fits_32_outputs_in_one_32k_bin():
+    prompt_length = 8192
+    response_length = 768
+    num_outputs = 32
+    sequence_lengths = [prompt_length + response_length] * num_outputs
+    prompt_lengths = [prompt_length] * num_outputs
+    group_ids = [0] * num_outputs
+
+    bins = pack_shared_prefix_sequences(
+        sequence_lengths,
+        prompt_lengths,
+        group_ids,
+        bin_capacity=32768,
+    )
+
+    assert bins == [list(range(num_outputs))]
+    assert (
+        shared_prefix_bin_length(bins[0], sequence_lengths, prompt_lengths, group_ids)
+        == 32768
+    )
+
+
+def test_shared_prefix_packer_recomputes_only_when_group_must_split():
+    bins = pack_shared_prefix_sequences(
+        sequence_lengths=[60] * 4,
+        prompt_lengths=[40] * 4,
+        group_ids=[0] * 4,
+        bin_capacity=100,
+        min_bin_count=4,
+        bin_count_multiple=4,
+    )
+
+    assert len(bins) == 4
+    assert sorted(index for bin_indices in bins for index in bin_indices) == list(
+        range(4)
+    )
+    assert all(
+        shared_prefix_bin_length(
+            bin_indices,
+            [60] * 4,
+            [40] * 4,
+            [0] * 4,
+        )
+        <= 100
+        for bin_indices in bins
+    )
+    # Four DP-required bins each pay one 40-token prompt plus one response.
+    assert (
+        sum(
+            shared_prefix_bin_length(
+                bin_indices,
+                [60] * 4,
+                [40] * 4,
+                [0] * 4,
+            )
+            for bin_indices in bins
+        )
+        == 240
+    )
+
+
+def test_shared_prefix_packer_balances_dp_required_bins():
+    bins = pack_shared_prefix_sequences(
+        sequence_lengths=[60] * 32,
+        prompt_lengths=[40] * 32,
+        group_ids=[0] * 32,
+        bin_capacity=1000,
+        min_bin_count=8,
+        bin_count_multiple=8,
+    )
+
+    assert len(bins) == 8
+    assert sorted(len(bin_indices) for bin_indices in bins) == [4] * 8
+
+
+def test_shared_prefix_packer_does_not_split_group_to_fill_another_tail():
+    # A costs 85. B's two rows cost 10 + 5 + 5 = 20 together. Splitting B to
+    # fill A's 15-token tail would unnecessarily recompute B's prompt.
+    sequence_lengths = [85, 15, 15]
+    prompt_lengths = [80, 10, 10]
+    group_ids = [0, 1, 1]
+
+    bins = pack_shared_prefix_sequences(
+        sequence_lengths,
+        prompt_lengths,
+        group_ids,
+        bin_capacity=100,
+    )
+
+    assert bins == [[0], [1, 2]]
 
 
 def validate_solution(

--- a/tests/unit/distributed/test_batched_data_dict.py
+++ b/tests/unit/distributed/test_batched_data_dict.py
@@ -20,6 +20,112 @@ from nemo_rl.distributed.batched_data_dict import (
     DynamicBatchingArgs,
     SequencePackingArgs,
 )
+from nemo_rl.models.automodel.shared_prefix import build_shared_prefix_layout
+
+
+def test_shared_prefix_sequence_packing_uses_compact_32k_cost():
+    num_outputs = 32
+    prompt_length = 8192
+    response_length = 768
+    sequence_length = prompt_length + response_length
+    input_ids = torch.arange(sequence_length).repeat(num_outputs, 1)
+    batch = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": torch.full((num_outputs,), sequence_length),
+            "shared_prefix_lengths": torch.full((num_outputs,), prompt_length),
+            "shared_prefix_group_ids": torch.zeros(num_outputs, dtype=torch.long),
+        }
+    )
+    packing_args = SequencePackingArgs(
+        max_tokens_per_microbatch=32768,
+        input_key="input_ids",
+        input_lengths_key="input_lengths",
+        algorithm="modified_first_fit_decreasing",
+        sequence_length_pad_multiple=1,
+        shared_prefix_lengths_key="shared_prefix_lengths",
+        shared_prefix_group_ids_key="shared_prefix_group_ids",
+    )
+
+    shards, _ = batch.shard_by_batch_size(
+        shards=1,
+        batch_size=num_outputs,
+        sequence_packing_args=packing_args,
+    )
+    microbatches = list(shards[0].make_microbatch_iterator_for_packable_sequences())
+
+    assert len(microbatches) == 1
+    assert microbatches[0].size == num_outputs
+    layout = build_shared_prefix_layout(
+        microbatches[0]["input_ids"],
+        microbatches[0]["input_lengths"],
+        microbatches[0]["shared_prefix_lengths"],
+        microbatches[0]["shared_prefix_group_ids"],
+    )
+    assert layout.compact_tokens == 32768
+    assert shards[0].micro_batch_lengths == [[32768]]
+
+
+def test_shared_prefix_sequence_packing_does_not_charge_alignment_padding():
+    batch = BatchedDataDict(
+        {
+            "input_ids": torch.ones((2, 65), dtype=torch.long),
+            "input_lengths": torch.tensor([65, 65]),
+            "shared_prefix_lengths": torch.tensor([64, 64]),
+            "shared_prefix_group_ids": torch.tensor([0, 0]),
+        }
+    )
+    packing_args = SequencePackingArgs(
+        max_tokens_per_microbatch=66,
+        input_key="input_ids",
+        input_lengths_key="input_lengths",
+        algorithm="modified_first_fit_decreasing",
+        sequence_length_pad_multiple=64,
+        shared_prefix_lengths_key="shared_prefix_lengths",
+        shared_prefix_group_ids_key="shared_prefix_group_ids",
+    )
+
+    shards, indices = batch.shard_by_batch_size(
+        shards=1,
+        batch_size=2,
+        sequence_packing_args=packing_args,
+    )
+
+    assert indices == [0, 1]
+    assert shards[0].micro_batch_indices == [[[0, 2]]]
+    assert shards[0].micro_batch_lengths == [[66]]
+
+
+def test_shared_prefix_sequence_packing_recomputes_group_across_global_batches():
+    batch = BatchedDataDict(
+        {
+            "input_ids": torch.ones((4, 60), dtype=torch.long),
+            "input_lengths": torch.full((4,), 60),
+            "shared_prefix_lengths": torch.full((4,), 40),
+            "shared_prefix_group_ids": torch.zeros(4, dtype=torch.long),
+        }
+    )
+    packing_args = SequencePackingArgs(
+        max_tokens_per_microbatch=100,
+        input_key="input_ids",
+        input_lengths_key="input_lengths",
+        algorithm="modified_first_fit_decreasing",
+        sequence_length_pad_multiple=1,
+        shared_prefix_lengths_key="shared_prefix_lengths",
+        shared_prefix_group_ids_key="shared_prefix_group_ids",
+    )
+
+    shards, _ = batch.shard_by_batch_size(
+        shards=1,
+        batch_size=2,
+        sequence_packing_args=packing_args,
+    )
+
+    # The prompt group crosses the two optimizer global batches. Each batch
+    # therefore owns a separate compact bin and pays its 40-token prompt once.
+    assert shards[0].elem_counts_per_gb == [2, 2]
+    assert shards[0].micro_batch_indices == [[[0, 2]], [[0, 2]]]
+    assert shards[0].micro_batch_lengths == [[80], [80]]
 
 
 def test_shard_by_batch_size_basic():

--- a/tests/unit/distributed/test_distributed_logprob.py
+++ b/tests/unit/distributed/test_distributed_logprob.py
@@ -23,6 +23,8 @@ import functools
 
 import pytest
 import torch
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
 
 from nemo_rl.distributed.model_utils import (
     ChunkedDistributedEntropy,
@@ -30,6 +32,7 @@ from nemo_rl.distributed.model_utils import (
     ChunkedDistributedLogprob,
     DistributedLogprob,
     _compute_distributed_log_softmax,
+    get_aligned_target_logprobs_from_vocab_parallel_logits,
     get_next_token_logprobs_from_logits,
 )
 
@@ -140,6 +143,64 @@ def _run_logprob_forward_and_backward(rank, world_size, tp_size, chunk_size):
     )
 
 
+def _run_aligned_dtensor_logprob(
+    rank, world_size, tp_size, chunk_size, dtype, atol, rtol
+):
+    """Test aligned DTensor targets against a full-vocabulary reference."""
+    tp_mesh = init_device_mesh(
+        "cuda",
+        (tp_size,),
+        mesh_dim_names=("tp",),
+    )
+    full_vocab_size = 128
+    vocab_part_size = full_vocab_size // tp_size
+    target_ids = []
+    for shard in range(tp_size):
+        target_ids.extend([shard * vocab_part_size, (shard + 1) * vocab_part_size - 1])
+    target = torch.tensor([target_ids], device="cuda", dtype=torch.long)
+
+    torch.manual_seed(123)
+    full_logits = torch.randn(
+        1,
+        target.shape[1],
+        full_vocab_size,
+        device="cuda",
+        dtype=dtype,
+        requires_grad=True,
+    )
+    vocab_start_index = rank * vocab_part_size
+    vocab_end_index = (rank + 1) * vocab_part_size
+    local_logits = (
+        full_logits.detach()[..., vocab_start_index:vocab_end_index]
+        .clone()
+        .requires_grad_()
+    )
+    vocab_parallel_logits = DTensor.from_local(
+        local_logits,
+        device_mesh=tp_mesh,
+        placements=[Shard(-1)],
+        run_check=False,
+    )
+    weights = torch.linspace(-1.0, 1.0, target.shape[1], device="cuda")
+
+    actual = get_aligned_target_logprobs_from_vocab_parallel_logits(
+        vocab_parallel_logits,
+        target,
+        chunk_size=chunk_size,
+    )
+    expected = _torch_baseline_logprob(full_logits.float(), target)
+    actual_loss = (actual * weights).sum()
+    expected_loss = (expected * weights).sum()
+    actual_grad = torch.autograd.grad(actual_loss, local_logits)[0]
+    expected_grad = torch.autograd.grad(expected_loss, full_logits)[0][
+        ..., vocab_start_index:vocab_end_index
+    ]
+
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_loss, expected_loss, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_grad, expected_grad, atol=atol, rtol=rtol)
+
+
 def _run_log_softmax(rank, world_size, tp_size):
     """Test _compute_distributed_log_softmax against PyTorch baseline."""
     tp_group = torch.distributed.new_group(ranks=list(range(tp_size)))
@@ -240,6 +301,37 @@ def test_distributed_logprob_forward_and_backward(
 ):
     test_fn = functools.partial(
         _run_logprob_forward_and_backward, tp_size=tp_size, chunk_size=chunk_size
+    )
+    distributed_test_runner(test_fn, world_size=tp_size)
+
+
+@pytest.mark.parametrize(
+    "tp_size,chunk_size,dtype,atol,rtol",
+    [
+        (1, None, torch.bfloat16, 5e-3, 5e-3),
+        (2, None, torch.float32, 1e-4, 1e-4),
+        (2, None, torch.bfloat16, 5e-3, 5e-3),
+        (2, 1, torch.float32, 1e-4, 1e-4),
+        (2, 3, torch.bfloat16, 5e-3, 5e-3),
+        (4, 3, torch.float32, 1e-4, 1e-4),
+        (4, 64, torch.bfloat16, 5e-3, 5e-3),
+    ],
+)
+def test_aligned_dtensor_logprob_forward_and_backward(
+    distributed_test_runner,
+    tp_size,
+    chunk_size,
+    dtype,
+    atol,
+    rtol,
+):
+    test_fn = functools.partial(
+        _run_aligned_dtensor_logprob,
+        tp_size=tp_size,
+        chunk_size=chunk_size,
+        dtype=dtype,
+        atol=atol,
+        rtol=rtol,
     )
     distributed_test_runner(test_fn, world_size=tp_size)
 

--- a/tests/unit/models/automodel/test_automodel_data.py
+++ b/tests/unit/models/automodel/test_automodel_data.py
@@ -27,6 +27,10 @@ from nemo_rl.models.automodel.data import (
     process_global_batch,
     process_microbatch,
 )
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+)
 
 
 @pytest.fixture
@@ -380,6 +384,81 @@ class TestProcessMicrobatch:
         assert result.position_ids is not None
         assert "cu_seqlens" in result.flash_attn_kwargs
         assert result.vlm_kwargs == {}
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="process_microbatch requires CUDA"
+    )
+    def test_shared_prefix_compaction(self, mock_tokenizer):
+        mb = BatchedDataDict(
+            {
+                "input_ids": torch.tensor(
+                    [
+                        [10, 11, 12, 21, 22],
+                        [10, 11, 12, 31, 0],
+                    ]
+                ),
+                "input_lengths": torch.tensor([5, 4]),
+                SHARED_PREFIX_LENGTHS: torch.tensor([3, 3]),
+                SHARED_PREFIX_GROUP_IDS: torch.tensor([0, 0]),
+            }
+        )
+        cfg = {
+            "dtensor_cfg": {"sequence_parallel": False},
+            "sequence_packing": {"train_mb_tokens": 32},
+            "shared_prefix_training": True,
+        }
+
+        result = process_microbatch(
+            mb=mb,
+            tokenizer=mock_tokenizer,
+            enable_seq_packing=True,
+            cfg=cfg,
+            cp_size=1,
+        )
+
+        assert result.input_ids.cpu().tolist() == [[10, 11, 12, 21, 22, 31]]
+        assert result.position_ids.cpu().tolist() == [[0, 1, 2, 3, 4, 3]]
+        assert result.shared_prefix_layout is not None
+        assert result.flash_attn_kwargs == {}
+
+    @pytest.mark.parametrize(
+        "metadata,enabled,match",
+        [
+            ({SHARED_PREFIX_GROUP_IDS: torch.tensor([0])}, True, "both metadata"),
+            (
+                {
+                    SHARED_PREFIX_GROUP_IDS: torch.tensor([0]),
+                    SHARED_PREFIX_LENGTHS: torch.tensor([1]),
+                },
+                False,
+                "is disabled",
+            ),
+        ],
+    )
+    def test_shared_prefix_metadata_requires_enabled_complete_pair(
+        self, mock_tokenizer, metadata, enabled, match
+    ):
+        mb = BatchedDataDict(
+            {
+                "input_ids": torch.tensor([[10, 11]]),
+                "input_lengths": torch.tensor([2]),
+                **metadata,
+            }
+        )
+        cfg = {
+            "dtensor_cfg": {"sequence_parallel": False},
+            "sequence_packing": {"train_mb_tokens": 8},
+            "shared_prefix_training": enabled,
+        }
+
+        with pytest.raises(ValueError, match=match):
+            process_microbatch(
+                mb=mb,
+                tokenizer=mock_tokenizer,
+                enable_seq_packing=True,
+                cfg=cfg,
+                cp_size=1,
+            )
 
     def test_with_multimodal_inputs(self, mock_tokenizer):
         # Create test microbatch with multimodal data

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -32,7 +32,6 @@ from nemo_rl.models.automodel.setup import (
     ModelAndOptimizerState,
     RuntimeConfig,
     _maybe_set_force_hf,
-    _prewarm_native_shared_prefix_moe_world,
     get_tokenizer,
     setup_distributed,
     setup_model_and_optimizer,
@@ -642,6 +641,20 @@ class TestValidateAndPrepareConfig:
             with pytest.raises(ValueError, match=expected_error):
                 validate_and_prepare_config(mock_config, None, 0)
 
+    @pytest.mark.parametrize(
+        "bias_update_factor",
+        [
+            1.0e-3,
+            -1.0e-3,
+            True,
+            False,
+            None,
+            float("nan"),
+            float("inf"),
+            -float("inf"),
+            "x",
+        ],
+    )
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
@@ -652,6 +665,7 @@ class TestValidateAndPrepareConfig:
         mock_autoconfig_class,
         mock_config,
         mock_autoconfig,
+        bias_update_factor,
     ):
         """Reject dynamic bias that cannot be refit into Qwen rollout models."""
         mock_autoconfig.model_type = "qwen3_moe"
@@ -676,7 +690,7 @@ class TestValidateAndPrepareConfig:
                 "sequence_parallel": False,
                 "automodel_kwargs": {
                     **_native_qwen3_moe_kwargs(),
-                    "moe_overrides": {"gate_bias_update_factor": 1.0e-3},
+                    "moe_overrides": {"gate_bias_update_factor": bias_update_factor},
                 },
             }
         )
@@ -709,6 +723,39 @@ class TestValidateAndPrepareConfig:
         result = validate_and_prepare_config(mock_config, None, 0)
 
         assert isinstance(result, RuntimeConfig)
+
+    @pytest.mark.parametrize(
+        "unsupported_override",
+        [
+            {"score_func": "softmax_with_bias"},
+            {"force_e_score_correction_bias": True},
+        ],
+    )
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_rejects_correction_bias_overrides(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+        unsupported_override,
+    ):
+        """Do not allow correction-bias state or score semantics to bypass validation."""
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+            automodel_kwargs=_native_qwen3_moe_kwargs(
+                moe_overrides=unsupported_override
+            ),
+        )
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        with pytest.raises(ValueError, match="only supports checkpoint-compatible"):
+            validate_and_prepare_config(mock_config, None, 0)
 
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
@@ -1353,7 +1400,13 @@ class TestSetupDistributed:
         mock_config["dtensor_cfg"]["expert_parallel_size"] = 4
         mock_config["dtensor_cfg"]["automodel_kwargs"] = {"force_hf": False}
 
-        with pytest.raises(ValueError, match="expert_parallel_size"):
+        with (
+            patch(
+                "nemo_rl.models.automodel.setup.torch.cuda.current_device",
+                return_value=3,
+            ),
+            pytest.raises(ValueError, match="expert_parallel_size"),
+        ):
             setup_distributed(mock_config, mock_runtime_config)
 
     @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
@@ -1387,29 +1440,26 @@ class TestSetupDistributed:
         mock_moe_config.assert_not_called()
         mock_create_mesh.assert_not_called()
 
-    @patch("nemo_rl.models.automodel.setup._prewarm_native_shared_prefix_moe_world")
     @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
     @patch("nemo_rl.models.automodel.setup.create_device_mesh")
     @patch("nemo_rl.models.automodel.setup.FSDP2Config")
     @patch("nemo_rl.models.automodel.setup.torch.distributed")
-    def test_setup_distributed_prewarms_native_shared_prefix_ep(
+    def test_setup_distributed_binds_native_shared_prefix_ep_to_cuda_device(
         self,
         mock_torch_dist,
         mock_fsdp2_config,
         mock_create_mesh,
         mock_moe_config,
-        mock_prewarm,
         mock_config,
         mock_runtime_config,
         mock_device_mesh,
     ):
-        """Native EP communicator is initialized before model/FSDP setup."""
+        """Native EP binds the default NCCL process group to its CUDA device."""
         events = []
         mock_torch_dist.init_process_group.side_effect = lambda **_: events.append(
             "init"
         )
         mock_torch_dist.get_world_size.return_value = 8
-        mock_prewarm.side_effect = lambda _: events.append("prewarm")
         mock_fsdp2_config.return_value = MagicMock()
         mock_moe_config.return_value = MagicMock()
         mock_moe_config.return_value.ignore_router_for_ac = False
@@ -1427,29 +1477,34 @@ class TestSetupDistributed:
             }
         )
 
-        setup_distributed(mock_config, mock_runtime_config)
+        with patch(
+            "nemo_rl.models.automodel.setup.torch.cuda.current_device",
+            return_value=3,
+        ):
+            setup_distributed(mock_config, mock_runtime_config)
 
-        mock_prewarm.assert_called_once_with(8)
-        assert events[:3] == ["init", "prewarm", "mesh"]
+        mock_torch_dist.init_process_group.assert_called_once_with(
+            backend="nccl",
+            device_id=torch.device("cuda", 3),
+        )
+        assert events[:2] == ["init", "mesh"]
         assert mock_moe_config.return_value.ignore_router_for_ac is False
 
-    @patch("nemo_rl.models.automodel.setup._prewarm_native_shared_prefix_moe_world")
     @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
     @patch("nemo_rl.models.automodel.setup.create_device_mesh")
     @patch("nemo_rl.models.automodel.setup.FSDP2Config")
     @patch("nemo_rl.models.automodel.setup.torch.distributed")
-    def test_setup_distributed_skips_world_prewarm_without_ep_shard(
+    def test_setup_distributed_binds_native_shared_prefix_ep_without_ep_shard(
         self,
         mock_torch_dist,
         mock_fsdp2_config,
         mock_create_mesh,
         mock_moe_config,
-        mock_prewarm,
         mock_config,
         mock_runtime_config,
         mock_device_mesh,
     ):
-        """EP=world has no overlapping EP-shard communicator to order."""
+        """EP=world still binds the default NCCL group to its CUDA device."""
         mock_torch_dist.get_world_size.return_value = 4
         mock_fsdp2_config.return_value = MagicMock()
         mock_moe_config.return_value = MagicMock()
@@ -1463,9 +1518,16 @@ class TestSetupDistributed:
             }
         )
 
-        setup_distributed(mock_config, mock_runtime_config)
+        with patch(
+            "nemo_rl.models.automodel.setup.torch.cuda.current_device",
+            return_value=3,
+        ):
+            setup_distributed(mock_config, mock_runtime_config)
 
-        mock_prewarm.assert_not_called()
+        mock_torch_dist.init_process_group.assert_called_once_with(
+            backend="nccl",
+            device_id=torch.device("cuda", 3),
+        )
 
     @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
     @patch("nemo_rl.models.automodel.setup.create_device_mesh")
@@ -1501,42 +1563,6 @@ class TestSetupDistributed:
 
         mock_moe_config.assert_called_once_with(ignore_router_for_ac=True)
         assert mock_moe_config.return_value.ignore_router_for_ac is True
-
-
-def test_prewarm_native_shared_prefix_moe_world_uses_default_group():
-    """Prewarm initializes default NCCL before overlapping meshes exist."""
-    with (
-        patch(
-            "nemo_rl.models.automodel.setup.torch.cuda.current_device",
-            return_value=3,
-        ),
-        patch("nemo_rl.models.automodel.setup.torch.zeros") as mock_zeros,
-        patch("nemo_rl.models.automodel.setup.torch.empty") as mock_empty,
-        patch(
-            "nemo_rl.models.automodel.setup.torch.distributed.all_gather_into_tensor"
-        ) as mock_all_gather,
-        patch(
-            "nemo_rl.models.automodel.setup.torch.cuda.synchronize"
-        ) as mock_synchronize,
-    ):
-        token = MagicMock()
-        gathered = MagicMock()
-        mock_zeros.return_value = token
-        mock_empty.return_value = gathered
-        _prewarm_native_shared_prefix_moe_world(8)
-
-    mock_zeros.assert_called_once_with(
-        1,
-        dtype=torch.int64,
-        device=torch.device("cuda", 3),
-    )
-    mock_empty.assert_called_once_with(
-        8,
-        dtype=torch.int64,
-        device=torch.device("cuda", 3),
-    )
-    mock_all_gather.assert_called_once_with(gathered, token)
-    mock_synchronize.assert_called_once_with(torch.device("cuda", 3))
 
 
 @pytest.mark.automodel

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -289,6 +289,58 @@ class TestValidateAndPrepareConfig:
         result = validate_and_prepare_config(mock_config, None, 0)
         assert result.attn_impl is None
 
+    @pytest.mark.parametrize(
+        "tp_size,cp_size,sequence_parallel,expected_error",
+        [
+            (2, 1, False, None),
+            (2, 2, False, "requires CP=1 and sequence_parallel=false"),
+            (2, 1, True, "requires CP=1 and sequence_parallel=false"),
+        ],
+        ids=["tp2", "cp2", "sequence_parallel"],
+    )
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_parallelism_validation(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+        tp_size,
+        cp_size,
+        sequence_parallel,
+        expected_error,
+    ):
+        """Shared-prefix training accepts TP but still rejects CP and SP."""
+        mock_autoconfig.model_type = "qwen3"
+        mock_autoconfig.architectures = ["Qwen3ForCausalLM"]
+        mock_autoconfig.layer_types = ["full_attention"]
+        mock_autoconfig.attention_dropout = 0.0
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        mock_config["shared_prefix_training"] = True
+        mock_config["sequence_packing"]["enabled"] = True
+        mock_config["dynamic_batching"] = {"enabled": False}
+        mock_config["dtensor_cfg"].update(
+            {
+                "_v2": True,
+                "tensor_parallel_size": tp_size,
+                "context_parallel_size": cp_size,
+                "sequence_parallel": sequence_parallel,
+                "automodel_kwargs": {"force_hf": True},
+            }
+        )
+
+        if expected_error is None:
+            result = validate_and_prepare_config(mock_config, None, 0)
+            assert isinstance(result, RuntimeConfig)
+        else:
+            with pytest.raises(ValueError, match=expected_error):
+                validate_and_prepare_config(mock_config, None, 0)
+
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -290,13 +290,42 @@ class TestValidateAndPrepareConfig:
         assert result.attn_impl is None
 
     @pytest.mark.parametrize(
-        "tp_size,cp_size,sequence_parallel,expected_error",
+        "model_type,architecture,tp_size,cp_size,sequence_parallel,expected_error",
         [
-            (2, 1, False, None),
-            (2, 2, False, "requires CP=1 and sequence_parallel=false"),
-            (2, 1, True, "requires CP=1 and sequence_parallel=false"),
+            ("qwen3", "Qwen3ForCausalLM", 2, 1, False, None),
+            ("llama", "LlamaForCausalLM", 2, 1, False, None),
+            (
+                "mistral",
+                "MistralForCausalLM",
+                2,
+                1,
+                False,
+                "currently supports Qwen3 and Llama, got mistral",
+            ),
+            (
+                "qwen3",
+                "Qwen3ForCausalLM",
+                2,
+                2,
+                False,
+                "requires CP=1 and sequence_parallel=false",
+            ),
+            (
+                "qwen3",
+                "Qwen3ForCausalLM",
+                2,
+                1,
+                True,
+                "requires CP=1 and sequence_parallel=false",
+            ),
         ],
-        ids=["tp2", "cp2", "sequence_parallel"],
+        ids=[
+            "qwen3_tp2",
+            "llama_tp2",
+            "unsupported_model",
+            "cp2",
+            "sequence_parallel",
+        ],
     )
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
@@ -308,14 +337,16 @@ class TestValidateAndPrepareConfig:
         mock_autoconfig_class,
         mock_config,
         mock_autoconfig,
+        model_type,
+        architecture,
         tp_size,
         cp_size,
         sequence_parallel,
         expected_error,
     ):
-        """Shared-prefix training accepts TP but still rejects CP and SP."""
-        mock_autoconfig.model_type = "qwen3"
-        mock_autoconfig.architectures = ["Qwen3ForCausalLM"]
+        """Shared-prefix training accepts Qwen3/Llama TP and rejects other modes."""
+        mock_autoconfig.model_type = model_type
+        mock_autoconfig.architectures = [architecture]
         mock_autoconfig.layer_types = ["full_attention"]
         mock_autoconfig.attention_dropout = 0.0
         mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -644,7 +644,6 @@ class TestValidateAndPrepareConfig:
     @pytest.mark.parametrize(
         "bias_update_factor",
         [
-            1.0e-3,
             -1.0e-3,
             True,
             False,
@@ -667,7 +666,7 @@ class TestValidateAndPrepareConfig:
         mock_autoconfig,
         bias_update_factor,
     ):
-        """Reject dynamic bias that cannot be refit into Qwen rollout models."""
+        """Reject malformed dynamic-bias update factors."""
         mock_autoconfig.model_type = "qwen3_moe"
         mock_autoconfig.architectures = ["Qwen3MoeForCausalLM"]
         mock_autoconfig.layer_types = ["full_attention"]
@@ -695,8 +694,45 @@ class TestValidateAndPrepareConfig:
             }
         )
 
-        with pytest.raises(ValueError, match="dynamic routing bias is not supported"):
+        with pytest.raises(ValueError, match="finite non-negative"):
             validate_and_prepare_config(mock_config, None, 0)
+
+    @pytest.mark.parametrize(
+        "generation_backend,expected_error",
+        [("vllm", None), ("sglang", "backend='vllm' only")],
+    )
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_enables_dynamic_bias(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+        generation_backend,
+        expected_error,
+    ):
+        """Require a rollout backend that consumes the refitted bias."""
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+            automodel_kwargs=_native_qwen3_moe_kwargs(
+                moe_overrides={"gate_bias_update_factor": 1.0e-3}
+            ),
+        )
+        mock_config["generation"]["backend"] = generation_backend
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        if expected_error:
+            with pytest.raises(ValueError, match=expected_error):
+                validate_and_prepare_config(mock_config, None, 0)
+        else:
+            assert isinstance(
+                validate_and_prepare_config(mock_config, None, 0), RuntimeConfig
+            )
 
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
@@ -2266,7 +2302,7 @@ class TestSetupModelAndOptimizer:
         else:
             mock_enable_ep_free_checkpoint_adapter.assert_not_called()
             mock_enable_ep_router_gradients.assert_called_once_with()
-        mock_enable_custom_qwen3_moe.assert_called_once_with(mock_model)
+        mock_enable_custom_qwen3_moe.assert_called_once_with(mock_model, 0.0)
         model_kwargs = mock_runtime_config.model_class.from_pretrained.call_args.kwargs
         assert model_kwargs["force_hf"] is False
         assert model_kwargs["moe_overrides"] == {"gate_bias_update_factor": 0.0}

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -32,12 +32,63 @@ from nemo_rl.models.automodel.setup import (
     ModelAndOptimizerState,
     RuntimeConfig,
     _maybe_set_force_hf,
+    _prewarm_native_shared_prefix_moe_world,
     get_tokenizer,
     setup_distributed,
     setup_model_and_optimizer,
     setup_reference_model_state,
     validate_and_prepare_config,
 )
+
+
+def _native_qwen3_moe_kwargs(**extra):
+    """Return the explicit backend required by native shared-prefix Qwen3-MoE."""
+    return {
+        "force_hf": False,
+        "backend": {
+            "_target_": ("nemo_automodel.components.models.common.utils.BackendConfig"),
+            "dispatcher": "torch",
+            "experts": "torch_mm",
+        },
+        **extra,
+    }
+
+
+def _configure_native_shared_prefix_qwen3_moe(
+    mock_config,
+    mock_autoconfig,
+    *,
+    expert_parallel_size=2,
+    automodel_kwargs=None,
+):
+    """Populate the minimum valid native shared-prefix Qwen3-MoE config."""
+    mock_autoconfig.model_type = "qwen3_moe"
+    mock_autoconfig.architectures = ["Qwen3MoeForCausalLM"]
+    mock_autoconfig.layer_types = ["full_attention"]
+    mock_autoconfig.attention_dropout = 0.0
+    mock_autoconfig.output_router_logits = False
+    mock_autoconfig.sliding_window = None
+    mock_autoconfig.num_experts = 8
+    mock_autoconfig.router_aux_loss_coef = 0.0
+
+    mock_config["shared_prefix_training"] = True
+    mock_config["sequence_packing"]["enabled"] = True
+    mock_config["dynamic_batching"] = {"enabled": False}
+    mock_config["dtensor_cfg"].update(
+        {
+            "_v2": True,
+            "tensor_parallel_size": 1,
+            "expert_parallel_size": expert_parallel_size,
+            "context_parallel_size": 1,
+            "sequence_parallel": False,
+            "dp_replicate_size": 1,
+            "automodel_kwargs": (
+                _native_qwen3_moe_kwargs()
+                if automodel_kwargs is None
+                else automodel_kwargs
+            ),
+        }
+    )
 
 
 def test_token_classification_backport_still_required():
@@ -290,41 +341,251 @@ class TestValidateAndPrepareConfig:
         assert result.attn_impl is None
 
     @pytest.mark.parametrize(
-        "model_type,architecture,tp_size,cp_size,sequence_parallel,expected_error",
+        (
+            "model_type,architecture,dtensor_overrides,automodel_kwargs,"
+            "model_overrides,expected_error"
+        ),
         [
-            ("qwen3", "Qwen3ForCausalLM", 2, 1, False, None),
-            ("llama", "LlamaForCausalLM", 2, 1, False, None),
-            (
+            pytest.param(
+                "qwen3",
+                "Qwen3ForCausalLM",
+                {"tensor_parallel_size": 2},
+                {"force_hf": True},
+                {},
+                None,
+                id="qwen3_tp2",
+            ),
+            pytest.param(
+                "llama",
+                "LlamaForCausalLM",
+                {"tensor_parallel_size": 2},
+                {"force_hf": True},
+                {},
+                None,
+                id="llama_tp2",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                None,
+                id="qwen3_moe_ep2_custom",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2, "cpu_offload": True},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                "cpu_offload=false",
+                id="qwen3_moe_cpu_offload",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {"force_hf": True},
+                {"num_experts": 8},
+                "requires force_hf=false",
+                id="qwen3_moe_ep2_force_hf",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {},
+                {"num_experts": 8},
+                "force_hf=false",
+                id="qwen3_moe_ep2_force_hf_unspecified",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "enable_deepep": True,
+                    },
+                },
+                {"num_experts": 8},
+                "enable_deepep=false",
+                id="qwen3_moe_deprecated_deepep_override",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "fake_balanced_gate": True,
+                    },
+                },
+                {"num_experts": 8},
+                "fake_balanced_gate=false",
+                id="qwen3_moe_fake_balanced_gate",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "fake_balanced_gate": 1,
+                    },
+                },
+                {"num_experts": 8},
+                "fake_balanced_gate must be boolean",
+                id="qwen3_moe_fake_balanced_gate_integer",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "enable_hf_state_dict_adapter": False,
+                    },
+                },
+                {"num_experts": 8},
+                "enable_hf_state_dict_adapter=true",
+                id="qwen3_moe_state_dict_adapter_disabled",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "enable_hf_state_dict_adapter": 0,
+                    },
+                },
+                {"num_experts": 8},
+                "enable_hf_state_dict_adapter must be boolean",
+                id="qwen3_moe_state_dict_adapter_integer",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "te_fp8": {"recipe": "current"},
+                    },
+                },
+                {"num_experts": 8},
+                "te_fp8=null",
+                id="qwen3_moe_te_fp8",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                {
+                    **_native_qwen3_moe_kwargs(),
+                    "backend": {
+                        **_native_qwen3_moe_kwargs()["backend"],
+                        "gate_precision": "int64",
+                    },
+                },
+                {"num_experts": 8},
+                "gate_precision must be a floating-point dtype",
+                id="qwen3_moe_integer_gate_precision",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                None,
+                id="qwen3_moe_ep1_custom",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2, "tensor_parallel_size": 2},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                "requires TP=1",
+                id="qwen3_moe_ep2_tp2",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2, "dp_replicate_size": 2},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                "requires dp_replicate_size=1",
+                id="qwen3_moe_ep2_dp_replicate2",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 3},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8},
+                "must be divisible by expert_parallel_size",
+                id="qwen3_moe_ep3_nondivisible_experts",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {"expert_parallel_size": 2},
+                _native_qwen3_moe_kwargs(),
+                {"num_experts": 8, "output_router_logits": True},
+                "requires output_router_logits=false",
+                id="qwen3_moe_router_aux_output",
+            ),
+            pytest.param(
+                "qwen3_moe",
+                "Qwen3MoeForCausalLM",
+                {},
+                {"force_hf": True},
+                {"num_experts": 8, "sliding_window": 4096},
+                "supports full attention only",
+                id="qwen3_moe_sliding_window",
+            ),
+            pytest.param(
                 "mistral",
                 "MistralForCausalLM",
-                2,
-                1,
-                False,
-                "currently supports Qwen3 and Llama, got mistral",
+                {"tensor_parallel_size": 2},
+                {"force_hf": True},
+                {},
+                "currently supports Qwen3, Qwen3-MoE, and Llama, got mistral",
+                id="unsupported_model",
             ),
-            (
+            pytest.param(
                 "qwen3",
                 "Qwen3ForCausalLM",
-                2,
-                2,
-                False,
+                {"tensor_parallel_size": 2, "context_parallel_size": 2},
+                {"force_hf": True},
+                {},
                 "requires CP=1 and sequence_parallel=false",
+                id="cp2",
             ),
-            (
+            pytest.param(
                 "qwen3",
                 "Qwen3ForCausalLM",
-                2,
-                1,
-                True,
+                {"tensor_parallel_size": 2, "sequence_parallel": True},
+                {"force_hf": True},
+                {},
                 "requires CP=1 and sequence_parallel=false",
+                id="sequence_parallel",
             ),
-        ],
-        ids=[
-            "qwen3_tp2",
-            "llama_tp2",
-            "unsupported_model",
-            "cp2",
-            "sequence_parallel",
         ],
     )
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
@@ -339,16 +600,22 @@ class TestValidateAndPrepareConfig:
         mock_autoconfig,
         model_type,
         architecture,
-        tp_size,
-        cp_size,
-        sequence_parallel,
+        dtensor_overrides,
+        automodel_kwargs,
+        model_overrides,
         expected_error,
     ):
-        """Shared-prefix training accepts Qwen3/Llama TP and rejects other modes."""
+        """Shared-prefix training accepts safe TP/EP layouts and rejects unsafe modes."""
         mock_autoconfig.model_type = model_type
         mock_autoconfig.architectures = [architecture]
         mock_autoconfig.layer_types = ["full_attention"]
         mock_autoconfig.attention_dropout = 0.0
+        mock_autoconfig.output_router_logits = False
+        mock_autoconfig.sliding_window = None
+        for name, value in model_overrides.items():
+            setattr(mock_autoconfig, name, value)
+        if model_type == "qwen3_moe":
+            mock_autoconfig.router_aux_loss_coef = 0.0
         mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
         mock_resolve_class.return_value = Mock
 
@@ -358,12 +625,15 @@ class TestValidateAndPrepareConfig:
         mock_config["dtensor_cfg"].update(
             {
                 "_v2": True,
-                "tensor_parallel_size": tp_size,
-                "context_parallel_size": cp_size,
-                "sequence_parallel": sequence_parallel,
-                "automodel_kwargs": {"force_hf": True},
+                "tensor_parallel_size": 1,
+                "expert_parallel_size": 1,
+                "context_parallel_size": 1,
+                "sequence_parallel": False,
+                "dp_replicate_size": 1,
+                "automodel_kwargs": automodel_kwargs,
             }
         )
+        mock_config["dtensor_cfg"].update(dtensor_overrides)
 
         if expected_error is None:
             result = validate_and_prepare_config(mock_config, None, 0)
@@ -371,6 +641,173 @@ class TestValidateAndPrepareConfig:
         else:
             with pytest.raises(ValueError, match=expected_error):
                 validate_and_prepare_config(mock_config, None, 0)
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_dynamic_bias_validation(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """Reject dynamic bias that cannot be refit into Qwen rollout models."""
+        mock_autoconfig.model_type = "qwen3_moe"
+        mock_autoconfig.architectures = ["Qwen3MoeForCausalLM"]
+        mock_autoconfig.layer_types = ["full_attention"]
+        mock_autoconfig.attention_dropout = 0.0
+        mock_autoconfig.output_router_logits = False
+        mock_autoconfig.sliding_window = None
+        mock_autoconfig.num_experts = 8
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        mock_config["shared_prefix_training"] = True
+        mock_config["sequence_packing"]["enabled"] = True
+        mock_config["dynamic_batching"] = {"enabled": False}
+        mock_config["dtensor_cfg"].update(
+            {
+                "_v2": True,
+                "tensor_parallel_size": 1,
+                "expert_parallel_size": 2,
+                "context_parallel_size": 1,
+                "sequence_parallel": False,
+                "automodel_kwargs": {
+                    **_native_qwen3_moe_kwargs(),
+                    "moe_overrides": {"gate_bias_update_factor": 1.0e-3},
+                },
+            }
+        )
+
+        with pytest.raises(ValueError, match="dynamic routing bias is not supported"):
+            validate_and_prepare_config(mock_config, None, 0)
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_allows_disabled_dynamic_bias_override(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """An explicit zero keeps Qwen's native auxiliary-loss router."""
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+            automodel_kwargs=_native_qwen3_moe_kwargs(
+                moe_overrides={"gate_bias_update_factor": 0.0}
+            ),
+        )
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        result = validate_and_prepare_config(mock_config, None, 0)
+
+        assert isinstance(result, RuntimeConfig)
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_missing_aux_coefficient_defaults_to_zero(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """Match AutoModel's zero aux-loss fallback for older checkpoints."""
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+        )
+        del mock_autoconfig.router_aux_loss_coef
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        result = validate_and_prepare_config(mock_config, None, 0)
+
+        assert isinstance(result, RuntimeConfig)
+
+    @pytest.mark.parametrize(
+        "expert_parallel_size",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(True, id="bool"),
+        ],
+    )
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_rejects_invalid_ep_size(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+        expert_parallel_size,
+    ):
+        """Reject EP sizes that would crash or silently normalize in mesh setup."""
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+            expert_parallel_size=expert_parallel_size,
+        )
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        with pytest.raises(ValueError, match="expert_parallel_size"):
+            validate_and_prepare_config(mock_config, None, 0)
+
+    @pytest.mark.parametrize(
+        "coefficient",
+        [
+            pytest.param(None, id="none"),
+            pytest.param("0.1", id="string"),
+            pytest.param(True, id="bool"),
+            pytest.param(-0.1, id="negative"),
+            pytest.param(float("nan"), id="nan"),
+            pytest.param(float("inf"), id="inf"),
+        ],
+    )
+    @pytest.mark.parametrize("source", ["override", "model_config"])
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_shared_prefix_qwen3_moe_rejects_invalid_effective_aux_coefficient(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+        source,
+        coefficient,
+    ):
+        """Validate both override and model-config router aux coefficients."""
+        automodel_kwargs = _native_qwen3_moe_kwargs()
+        if source == "override":
+            automodel_kwargs["moe_overrides"] = {"aux_loss_coeff": coefficient}
+        else:
+            mock_autoconfig.router_aux_loss_coef = coefficient
+        _configure_native_shared_prefix_qwen3_moe(
+            mock_config,
+            mock_autoconfig,
+            automodel_kwargs=automodel_kwargs,
+        )
+        if source == "model_config":
+            mock_autoconfig.router_aux_loss_coef = coefficient
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        with pytest.raises(ValueError, match="aux_loss_coeff"):
+            validate_and_prepare_config(mock_config, None, 0)
 
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
@@ -893,6 +1330,213 @@ class TestSetupDistributed:
 
         with pytest.raises(ValueError, match="dp_replicate_size"):
             setup_distributed(mock_config, mock_runtime_config)
+
+    @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
+    @patch("nemo_rl.models.automodel.setup.create_device_mesh")
+    @patch("nemo_rl.models.automodel.setup.FSDP2Config")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed")
+    def test_setup_distributed_ep_requires_divisible_world_size(
+        self,
+        mock_torch_dist,
+        mock_fsdp2_config,
+        mock_create_mesh,
+        mock_moe_config,
+        mock_config,
+        mock_runtime_config,
+    ):
+        """The overlapping EP mesh still must evenly partition world ranks."""
+        mock_torch_dist.get_world_size.return_value = 6
+        mock_fsdp2_config.return_value = MagicMock()
+        mock_moe_config.return_value = MagicMock()
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_config["shared_prefix_training"] = True
+        mock_config["dtensor_cfg"]["expert_parallel_size"] = 4
+        mock_config["dtensor_cfg"]["automodel_kwargs"] = {"force_hf": False}
+
+        with pytest.raises(ValueError, match="expert_parallel_size"):
+            setup_distributed(mock_config, mock_runtime_config)
+
+    @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
+    @patch("nemo_rl.models.automodel.setup.create_device_mesh")
+    @patch("nemo_rl.models.automodel.setup.FSDP2Config")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed")
+    def test_setup_distributed_native_moe_rejects_single_gpu(
+        self,
+        mock_torch_dist,
+        mock_fsdp2_config,
+        mock_create_mesh,
+        mock_moe_config,
+        mock_config,
+        mock_runtime_config,
+    ):
+        """Single-rank AutoModel skips the mixed precision required by FA2."""
+        mock_torch_dist.get_world_size.return_value = 1
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_config["shared_prefix_training"] = True
+        mock_config["dtensor_cfg"].update(
+            {
+                "expert_parallel_size": 1,
+                "automodel_kwargs": {"force_hf": False},
+            }
+        )
+
+        with pytest.raises(ValueError, match="world_size > 1"):
+            setup_distributed(mock_config, mock_runtime_config)
+
+        mock_fsdp2_config.assert_not_called()
+        mock_moe_config.assert_not_called()
+        mock_create_mesh.assert_not_called()
+
+    @patch("nemo_rl.models.automodel.setup._prewarm_native_shared_prefix_moe_world")
+    @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
+    @patch("nemo_rl.models.automodel.setup.create_device_mesh")
+    @patch("nemo_rl.models.automodel.setup.FSDP2Config")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed")
+    def test_setup_distributed_prewarms_native_shared_prefix_ep(
+        self,
+        mock_torch_dist,
+        mock_fsdp2_config,
+        mock_create_mesh,
+        mock_moe_config,
+        mock_prewarm,
+        mock_config,
+        mock_runtime_config,
+        mock_device_mesh,
+    ):
+        """Native EP communicator is initialized before model/FSDP setup."""
+        events = []
+        mock_torch_dist.init_process_group.side_effect = lambda **_: events.append(
+            "init"
+        )
+        mock_torch_dist.get_world_size.return_value = 8
+        mock_prewarm.side_effect = lambda _: events.append("prewarm")
+        mock_fsdp2_config.return_value = MagicMock()
+        mock_moe_config.return_value = MagicMock()
+        mock_moe_config.return_value.ignore_router_for_ac = False
+        mock_moe_mesh = MagicMock()
+        mock_create_mesh.side_effect = lambda *_, **__: (
+            events.append("mesh") or (mock_device_mesh, mock_moe_mesh)
+        )
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_config["shared_prefix_training"] = True
+        mock_config["dtensor_cfg"].update(
+            {
+                "expert_parallel_size": 4,
+                "activation_checkpointing": True,
+                "automodel_kwargs": {"force_hf": False},
+            }
+        )
+
+        setup_distributed(mock_config, mock_runtime_config)
+
+        mock_prewarm.assert_called_once_with(8)
+        assert events[:3] == ["init", "prewarm", "mesh"]
+        assert mock_moe_config.return_value.ignore_router_for_ac is False
+
+    @patch("nemo_rl.models.automodel.setup._prewarm_native_shared_prefix_moe_world")
+    @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
+    @patch("nemo_rl.models.automodel.setup.create_device_mesh")
+    @patch("nemo_rl.models.automodel.setup.FSDP2Config")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed")
+    def test_setup_distributed_skips_world_prewarm_without_ep_shard(
+        self,
+        mock_torch_dist,
+        mock_fsdp2_config,
+        mock_create_mesh,
+        mock_moe_config,
+        mock_prewarm,
+        mock_config,
+        mock_runtime_config,
+        mock_device_mesh,
+    ):
+        """EP=world has no overlapping EP-shard communicator to order."""
+        mock_torch_dist.get_world_size.return_value = 4
+        mock_fsdp2_config.return_value = MagicMock()
+        mock_moe_config.return_value = MagicMock()
+        mock_create_mesh.return_value = (mock_device_mesh, MagicMock())
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_config["shared_prefix_training"] = True
+        mock_config["dtensor_cfg"].update(
+            {
+                "expert_parallel_size": 4,
+                "automodel_kwargs": {"force_hf": False},
+            }
+        )
+
+        setup_distributed(mock_config, mock_runtime_config)
+
+        mock_prewarm.assert_not_called()
+
+    @patch("nemo_rl.models.automodel.setup.MoEParallelizerConfig")
+    @patch("nemo_rl.models.automodel.setup.create_device_mesh")
+    @patch("nemo_rl.models.automodel.setup.FSDP2Config")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed")
+    def test_setup_distributed_native_moe_keeps_router_checkpoint_setting(
+        self,
+        mock_torch_dist,
+        mock_fsdp2_config,
+        mock_create_mesh,
+        mock_moe_config,
+        mock_config,
+        mock_runtime_config,
+        mock_device_mesh,
+    ):
+        """Native shared-prefix setup preserves the recipe's AC strategy."""
+        mock_torch_dist.get_world_size.return_value = 2
+        mock_fsdp2_config.return_value = MagicMock()
+        mock_moe_config.return_value.ignore_router_for_ac = True
+        mock_create_mesh.return_value = (mock_device_mesh, None)
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_config["shared_prefix_training"] = True
+        mock_config["dtensor_cfg"].update(
+            {
+                "expert_parallel_size": 1,
+                "activation_checkpointing": True,
+                "moe_parallelizer": {"ignore_router_for_ac": True},
+                "automodel_kwargs": {"force_hf": False},
+            }
+        )
+
+        setup_distributed(mock_config, mock_runtime_config)
+
+        mock_moe_config.assert_called_once_with(ignore_router_for_ac=True)
+        assert mock_moe_config.return_value.ignore_router_for_ac is True
+
+
+def test_prewarm_native_shared_prefix_moe_world_uses_default_group():
+    """Prewarm initializes default NCCL before overlapping meshes exist."""
+    with (
+        patch(
+            "nemo_rl.models.automodel.setup.torch.cuda.current_device",
+            return_value=3,
+        ),
+        patch("nemo_rl.models.automodel.setup.torch.zeros") as mock_zeros,
+        patch("nemo_rl.models.automodel.setup.torch.empty") as mock_empty,
+        patch(
+            "nemo_rl.models.automodel.setup.torch.distributed.all_gather_into_tensor"
+        ) as mock_all_gather,
+        patch(
+            "nemo_rl.models.automodel.setup.torch.cuda.synchronize"
+        ) as mock_synchronize,
+    ):
+        token = MagicMock()
+        gathered = MagicMock()
+        mock_zeros.return_value = token
+        mock_empty.return_value = gathered
+        _prewarm_native_shared_prefix_moe_world(8)
+
+    mock_zeros.assert_called_once_with(
+        1,
+        dtype=torch.int64,
+        device=torch.device("cuda", 3),
+    )
+    mock_empty.assert_called_once_with(
+        8,
+        dtype=torch.int64,
+        device=torch.device("cuda", 3),
+    )
+    mock_all_gather.assert_called_once_with(gathered, token)
+    mock_synchronize.assert_called_once_with(torch.device("cuda", 3))
 
 
 @pytest.mark.automodel
@@ -1518,6 +2162,97 @@ class TestSetupModelAndOptimizer:
 
         assert result.is_moe_model is True
 
+    @patch("nemo_rl.models.automodel.setup.enable_custom_qwen3_moe_shared_prefix")
+    @patch("nemo_rl.models.automodel.setup.enable_qwen3_moe_ep_free_checkpoint_adapter")
+    @patch("nemo_rl.models.automodel.setup.enable_qwen3_moe_configured_dtype")
+    @patch(
+        "nemo_rl.models.automodel.setup.enable_qwen3_moe_checkpoint_wrapper_compatibility"
+    )
+    @patch("nemo_rl.models.automodel.setup.enable_qwen3_moe_ep_router_gradients")
+    @patch("nemo_rl.models.automodel.setup._maybe_set_force_hf")
+    @patch("nemo_rl.models.automodel.setup.torch.optim.lr_scheduler.LambdaLR")
+    @patch("nemo_rl.models.automodel.setup.torch.distributed.get_rank")
+    @patch("nemo_rl.models.automodel.setup.get_class")
+    @pytest.mark.parametrize("expert_parallel_size", [1, 2])
+    @pytest.mark.parametrize("activation_checkpointing", [False, True])
+    def test_qwen3_moe_ep_uses_custom_model_adapter(
+        self,
+        mock_get_class,
+        mock_get_rank,
+        mock_lambda_lr,
+        mock_maybe_set_force_hf,
+        mock_enable_ep_router_gradients,
+        mock_enable_checkpoint_wrapper_compatibility,
+        mock_enable_configured_dtype,
+        mock_enable_ep_free_checkpoint_adapter,
+        mock_enable_custom_qwen3_moe,
+        mock_config,
+        mock_runtime_config,
+        mock_distributed_context,
+        mock_checkpoint_manager,
+        mock_tokenizer,
+        expert_parallel_size,
+        activation_checkpointing,
+    ):
+        """Install only the native compatibility patches needed by each EP mode."""
+        mock_get_rank.return_value = 0
+        mock_lambda_lr.return_value = MagicMock()
+        mock_config["shared_prefix_training"] = True
+        source_automodel_kwargs = _native_qwen3_moe_kwargs(
+            moe_overrides={"gate_bias_update_factor": 0.0}
+        )
+        mock_config["dtensor_cfg"].update(
+            {
+                "expert_parallel_size": expert_parallel_size,
+                "activation_checkpointing": activation_checkpointing,
+                "automodel_kwargs": source_automodel_kwargs,
+            }
+        )
+
+        mock_model = MagicMock()
+        mock_model.state_dict.return_value = {
+            "model.layers.0.mlp.experts.weight": torch.zeros(4, 4, 4)
+        }
+        mock_model.config = MagicMock()
+        mock_model.config.pad_token_id = 0
+        mock_runtime_config.model_class.from_pretrained.return_value = mock_model
+        mock_runtime_config.model_config.model_type = "qwen3_moe"
+        mock_runtime_config.model_config.architectures = ["Qwen3MoeForCausalLM"]
+        mock_get_class.return_value = MagicMock(return_value=MagicMock())
+
+        result = setup_model_and_optimizer(
+            config=mock_config,
+            tokenizer=mock_tokenizer,
+            runtime_config=mock_runtime_config,
+            distributed_context=mock_distributed_context,
+            checkpoint_manager=mock_checkpoint_manager,
+        )
+
+        mock_maybe_set_force_hf.assert_called_once()
+        mock_enable_configured_dtype.assert_called_once_with()
+        if activation_checkpointing:
+            mock_enable_checkpoint_wrapper_compatibility.assert_called_once_with()
+        else:
+            mock_enable_checkpoint_wrapper_compatibility.assert_not_called()
+        if expert_parallel_size == 1:
+            mock_enable_ep_free_checkpoint_adapter.assert_called_once_with()
+            mock_enable_ep_router_gradients.assert_not_called()
+        else:
+            mock_enable_ep_free_checkpoint_adapter.assert_not_called()
+            mock_enable_ep_router_gradients.assert_called_once_with()
+        mock_enable_custom_qwen3_moe.assert_called_once_with(mock_model)
+        model_kwargs = mock_runtime_config.model_class.from_pretrained.call_args.kwargs
+        assert model_kwargs["force_hf"] is False
+        assert model_kwargs["moe_overrides"] == {"gate_bias_update_factor": 0.0}
+        assert source_automodel_kwargs == _native_qwen3_moe_kwargs(
+            moe_overrides={"gate_bias_update_factor": 0.0}
+        )
+        assert model_kwargs["moe_config"] is (
+            None if expert_parallel_size == 1 else mock_distributed_context.moe_config
+        )
+        assert model_kwargs["torch_dtype"] == "float32"
+        assert result.is_moe_model is True
+
     @patch("nemo_rl.models.automodel.setup.torch.distributed.get_rank")
     @patch("nemo_rl.models.automodel.setup.get_class")
     def test_setup_model_with_cp_raises_for_vlm(
@@ -1684,7 +2419,15 @@ class TestSetupModelAndOptimizer:
             "backend": {
                 "_target_": "some.backend.Class",
                 "param1": "value1",
-            }
+            },
+            "attn_implementation": "eager",
+        }
+        original_automodel_kwargs = {
+            "backend": {
+                "_target_": "some.backend.Class",
+                "param1": "value1",
+            },
+            "attn_implementation": "eager",
         }
 
         setup_model_and_optimizer(
@@ -1697,6 +2440,9 @@ class TestSetupModelAndOptimizer:
 
         mock_resolve_target.assert_called_once_with("some.backend.Class")
         mock_backend_class.assert_called_once_with(param1="value1")
+        assert (
+            mock_config["dtensor_cfg"]["automodel_kwargs"] == original_automodel_kwargs
+        )
 
     @patch("nemo_rl.models.automodel.setup.torch.optim.lr_scheduler.LambdaLR")
     @patch("nemo_rl.models.automodel.setup.torch.distributed.get_rank")

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -25,6 +25,7 @@ except ImportError:
     pytest.skip("nemo_automodel not available", allow_module_level=True)
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
 from nemo_rl.algorithms.loss.interfaces import LossInputType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.models.automodel.data import (
@@ -32,6 +33,11 @@ from nemo_rl.models.automodel.data import (
     ProcessedMicrobatch,
     check_sequence_dim,
     make_processed_microbatch_iterator,
+)
+from nemo_rl.models.automodel.shared_prefix import (
+    build_shared_prefix_layout,
+    response_logprobs_from_logits,
+    scatter_response_logprobs,
 )
 from nemo_rl.models.automodel.train import (
     LogprobsPostProcessor,
@@ -171,6 +177,27 @@ class TestModelForward:
         mock_model.assert_called_once()
         call_kwargs = mock_model.call_args[1]
         assert "flash_attn_kwargs" in call_kwargs
+
+    def test_forward_with_shared_prefix_layout(self, mock_model):
+        input_ids = torch.tensor([[1, 2, 3], [1, 2, 4]])
+        layout = build_shared_prefix_layout(
+            input_ids,
+            input_lengths=torch.tensor([3, 3]),
+            prompt_lengths=torch.tensor([2, 2]),
+            group_ids=torch.tensor([0, 0]),
+        )
+        processed_inputs = ProcessedInputs(
+            input_ids=layout.compact_input_ids,
+            position_ids=layout.compact_position_ids,
+            seq_len=layout.compact_tokens,
+            shared_prefix_layout=layout,
+        )
+
+        model_forward(mock_model, processed_inputs)
+
+        call_kwargs = mock_model.call_args.kwargs
+        assert call_kwargs["shared_prefix_layout"] is layout
+        assert torch.equal(call_kwargs["logits_to_keep"], layout.predictor_indices)
 
     def test_forward_with_multimodal(self, mock_model, processed_inputs_multimodal):
         result = model_forward(mock_model, processed_inputs_multimodal)
@@ -452,6 +479,232 @@ class TestLossPostProcessor:
         mock_wrapper_class.assert_called_once()
         # Verify the wrapper was called instead of raw loss_fn
         mock_wrapper_instance.assert_called_once()
+
+    @pytest.mark.parametrize("force_on_policy_ratio", [False, True])
+    def test_shared_prefix_clipped_pg_loss_parity(
+        self,
+        force_on_policy_ratio,
+        base_cfg,
+        mock_device_mesh,
+        mock_cp_mesh,
+        mock_tp_mesh,
+    ):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is required by the dense next-token logprob path")
+
+        device = torch.device("cuda")
+        input_ids = torch.tensor(
+            [
+                [10, 11, 12, 21, 22],
+                [40, 41, 51, 52, 53],
+                [10, 11, 12, 31, 0],
+                [40, 41, 61, 62, 0],
+            ],
+            device=device,
+        )
+        input_lengths = torch.tensor([5, 5, 4, 4], device=device)
+        prompt_lengths = torch.tensor([3, 2, 3, 2], device=device)
+        group_ids = torch.tensor([7, 9, 7, 9], device=device)
+        layout = build_shared_prefix_layout(
+            input_ids,
+            input_lengths=input_lengths,
+            prompt_lengths=prompt_lengths,
+            group_ids=group_ids,
+        )
+
+        token_mask = torch.tensor(
+            [
+                [0, 0, 0, 1, 1],
+                [0, 0, 1, 1, 1],
+                [0, 0, 0, 1, 0],
+                [0, 0, 1, 1, 0],
+            ],
+            device=device,
+        )
+        sample_mask = torch.ones(4, device=device)
+        active_mask = token_mask[:, 1:].bool()
+
+        torch.manual_seed(1234)
+        vocab_size = 64
+        dense_logits = torch.randn(
+            4,
+            5,
+            vocab_size,
+            device=device,
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+        compact_logits = (
+            dense_logits.detach()[:, :-1]
+            .reshape(-1, vocab_size)
+            .index_select(0, layout.loss_logprob_scatter_indices)
+            .clone()
+            .unsqueeze(0)
+            .requires_grad_()
+        )
+
+        with torch.no_grad():
+            dense_current_logprobs = (
+                torch.log_softmax(dense_logits[:, :-1], dim=-1)
+                .gather(-1, input_ids[:, 1:].unsqueeze(-1))
+                .squeeze(-1)
+            )
+
+        # Full-shape fields deliberately contain finite non-zero values outside
+        # the response mask. ClippedPGLossFn owns the [:, 1:] shift and masking.
+        advantages = torch.full((4, 5), 3.0, device=device)
+        advantages[:, 1:] = torch.tensor(
+            [1.0, -0.75, 0.5, -1.25], device=device
+        ).unsqueeze(-1)
+
+        desired_ratios = torch.tensor([1.5, 0.5, 1.1, 0.9], device=device).unsqueeze(-1)
+        desired_log_ratios = desired_ratios.log().expand(-1, 4)
+        prev_shifted = torch.full((4, 4), -2.5, device=device)
+        prev_shifted[active_mask] = (
+            dense_current_logprobs.detach() - desired_log_ratios
+        )[active_mask]
+
+        generation_shifted = torch.full((4, 4), -3.0, device=device)
+        generation_offsets = torch.tensor(
+            [-0.10, 0.15, -0.20, 0.05], device=device
+        ).unsqueeze(-1)
+        generation_shifted[active_mask] = (prev_shifted + generation_offsets)[
+            active_mask
+        ]
+
+        reference_shifted = torch.full((4, 4), -3.5, device=device)
+        reference_offsets = torch.tensor(
+            [0.20, -0.25, 0.30, -0.15], device=device
+        ).unsqueeze(-1)
+        reference_shifted[active_mask] = (
+            dense_current_logprobs.detach() + reference_offsets
+        )[active_mask]
+
+        def _prepend(values: torch.Tensor, first_value: float) -> torch.Tensor:
+            return torch.cat(
+                (
+                    torch.full((values.shape[0], 1), first_value, device=device),
+                    values,
+                ),
+                dim=1,
+            )
+
+        data_tensors = {
+            "input_ids": input_ids,
+            "input_lengths": input_lengths,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "advantages": advantages,
+            "prev_logprobs": _prepend(prev_shifted, -2.0),
+            "generation_logprobs": _prepend(generation_shifted, -2.0),
+            "reference_policy_logprobs": _prepend(reference_shifted, -2.0),
+        }
+
+        def _data_copy() -> BatchedDataDict:
+            return BatchedDataDict(
+                {name: value.clone() for name, value in data_tensors.items()}
+            )
+
+        dense_processed_inputs = ProcessedInputs(
+            input_ids=input_ids,
+            seq_len=input_ids.shape[1],
+        )
+        shared_processed_inputs = ProcessedInputs(
+            input_ids=layout.compact_input_ids,
+            position_ids=layout.compact_position_ids,
+            seq_len=layout.compact_tokens,
+            shared_prefix_layout=layout,
+        )
+
+        loss_cfg = ClippedPGLossConfig(
+            reference_policy_kl_penalty=0.07,
+            force_on_policy_ratio=force_on_policy_ratio,
+        )
+        processor_cfg = base_cfg
+        dense_processor = LossPostProcessor(
+            loss_fn=ClippedPGLossFn(loss_cfg),
+            cfg=processor_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+            dp_size=1,
+            enable_seq_packing=False,
+        )
+        shared_processor = LossPostProcessor(
+            loss_fn=ClippedPGLossFn(loss_cfg),
+            cfg=processor_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+            dp_size=1,
+            enable_seq_packing=True,
+        )
+
+        global_valid_seqs = sample_mask.sum()
+        global_valid_toks = (token_mask[:, 1:] * sample_mask.unsqueeze(-1)).sum()
+
+        dense_loss, dense_metrics = dense_processor(
+            logits=dense_logits,
+            data_dict=_data_copy(),
+            processed_inputs=dense_processed_inputs,
+            global_valid_seqs=global_valid_seqs,
+            global_valid_toks=global_valid_toks,
+        )
+        shared_loss, shared_metrics = shared_processor(
+            logits=compact_logits,
+            data_dict=_data_copy(),
+            processed_inputs=shared_processed_inputs,
+            global_valid_seqs=global_valid_seqs,
+            global_valid_toks=global_valid_toks,
+        )
+
+        with torch.no_grad():
+            compact_current_logprobs = scatter_response_logprobs(
+                response_logprobs_from_logits(compact_logits, layout),
+                layout,
+                base=prev_shifted,
+            )
+        torch.testing.assert_close(
+            compact_current_logprobs[active_mask],
+            dense_current_logprobs[active_mask],
+        )
+        torch.testing.assert_close(shared_loss, dense_loss)
+        assert shared_metrics.keys() == dense_metrics.keys()
+        for metric_name in dense_metrics:
+            assert shared_metrics[metric_name] == pytest.approx(
+                dense_metrics[metric_name], rel=1e-6, abs=1e-6
+            )
+
+        if force_on_policy_ratio:
+            assert shared_metrics["probs_ratio"] == pytest.approx(1.0)
+            assert shared_metrics["probs_ratio_min"] == pytest.approx(1.0)
+            assert shared_metrics["probs_ratio_max"] == pytest.approx(1.0)
+
+        dense_loss.backward()
+        shared_loss.backward()
+        dense_grad = dense_logits.grad[:, :-1].reshape(-1, vocab_size)
+        selected_dense_grad = dense_grad.index_select(
+            0, layout.loss_logprob_scatter_indices
+        )
+        torch.testing.assert_close(
+            compact_logits.grad.squeeze(0),
+            selected_dense_grad,
+        )
+
+        selected_positions = torch.zeros(
+            dense_grad.shape[0], device=device, dtype=torch.bool
+        )
+        selected_positions[layout.loss_logprob_scatter_indices] = True
+        torch.testing.assert_close(
+            dense_grad[~selected_positions],
+            torch.zeros_like(dense_grad[~selected_positions]),
+        )
+        torch.testing.assert_close(
+            dense_logits.grad[:, -1],
+            torch.zeros_like(dense_logits.grad[:, -1]),
+        )
 
     def test_loss_processor_initialization(
         self,

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -620,7 +620,7 @@ class TestLossPostProcessor:
             reference_policy_kl_penalty=0.07,
             force_on_policy_ratio=force_on_policy_ratio,
         )
-        processor_cfg = base_cfg
+        processor_cfg = {**base_cfg, "logprob_chunk_size": 3}
         dense_processor = LossPostProcessor(
             loss_fn=ClippedPGLossFn(loss_cfg),
             cfg=processor_cfg,
@@ -662,7 +662,7 @@ class TestLossPostProcessor:
 
         with torch.no_grad():
             compact_current_logprobs = scatter_response_logprobs(
-                response_logprobs_from_logits(compact_logits, layout),
+                response_logprobs_from_logits(compact_logits, layout, chunk_size=3),
                 layout,
                 base=prev_shifted,
             )

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -64,6 +64,7 @@ def mock_tokenizer():
 @pytest.fixture
 def mock_model():
     model = MagicMock()
+    model._nemo_shared_prefix_custom_qwen3_moe = False
     model.return_value = MagicMock(logits=torch.randn(4, 64, 32000))
     return model
 
@@ -198,6 +199,28 @@ class TestModelForward:
         call_kwargs = mock_model.call_args.kwargs
         assert call_kwargs["shared_prefix_layout"] is layout
         assert torch.equal(call_kwargs["logits_to_keep"], layout.predictor_indices)
+
+    def test_native_qwen3_moe_forward_omits_hf_logits_to_keep(self, mock_model):
+        input_ids = torch.tensor([[1, 2, 3], [1, 2, 4]])
+        layout = build_shared_prefix_layout(
+            input_ids,
+            input_lengths=torch.tensor([3, 3]),
+            prompt_lengths=torch.tensor([2, 2]),
+            group_ids=torch.tensor([0, 0]),
+        )
+        processed_inputs = ProcessedInputs(
+            input_ids=layout.compact_input_ids,
+            position_ids=layout.compact_position_ids,
+            seq_len=layout.compact_tokens,
+            shared_prefix_layout=layout,
+        )
+        mock_model._nemo_shared_prefix_custom_qwen3_moe = True
+
+        model_forward(mock_model, processed_inputs)
+
+        call_kwargs = mock_model.call_args.kwargs
+        assert call_kwargs["shared_prefix_layout"] is layout
+        assert "logits_to_keep" not in call_kwargs
 
     def test_forward_with_multimodal(self, mock_model, processed_inputs_multimodal):
         result = model_forward(mock_model, processed_inputs_multimodal)

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -406,22 +406,35 @@ def test_split_attention_matches_logical_dense_attention_and_gradients():
 
 @pytest.mark.automodel
 @pytest.mark.parametrize("activation_checkpointing", [False, True])
+@pytest.mark.parametrize("model_family", ["qwen3", "llama"])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA GPU")
-def test_tiny_qwen3_fa2_logits_and_gradients_match_dense(activation_checkpointing):
+def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
+    activation_checkpointing,
+    model_family,
+):
     pytest.importorskip("flash_attn")
-    from transformers import Qwen3Config, Qwen3ForCausalLM
+
+    if model_family == "qwen3":
+        from transformers import Qwen3Config as ModelConfig
+        from transformers import Qwen3ForCausalLM as ModelForCausalLM
+    else:
+        from transformers import LlamaConfig as ModelConfig
+        from transformers import LlamaForCausalLM as ModelForCausalLM
 
     register_shared_prefix_attention()
-    dense_config = Qwen3Config(
+    dense_config = ModelConfig(
         vocab_size=128,
         hidden_size=64,
         intermediate_size=128,
         num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=2,
-        head_dim=16,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=8,
         max_position_embeddings=64,
         attention_dropout=0.0,
+        tie_word_embeddings=False,
+        pad_token_id=0,
+        eos_token_id=1,
         use_cache=False,
     )
     dense_config._attn_implementation = "flash_attention_2"
@@ -429,8 +442,8 @@ def test_tiny_qwen3_fa2_logits_and_gradients_match_dense(activation_checkpointin
     shared_config._attn_implementation = SHARED_PREFIX_ATTENTION
 
     torch.manual_seed(42)
-    dense_model = Qwen3ForCausalLM(dense_config).cuda().train()
-    shared_model = Qwen3ForCausalLM(shared_config).cuda().train()
+    dense_model = ModelForCausalLM(dense_config).cuda().train()
+    shared_model = ModelForCausalLM(shared_config).cuda().train()
     shared_model.load_state_dict(dense_model.state_dict())
     if activation_checkpointing:
         dense_model.gradient_checkpointing_enable()
@@ -454,6 +467,20 @@ def test_tiny_qwen3_fa2_logits_and_gradients_match_dense(activation_checkpointin
         prompt_lengths,
         group_ids,
     )
+    assert layout.predictor_indices.tolist() == [
+        2,
+        3,
+        4,
+        2,
+        6,
+        7,
+        11,
+        12,
+        13,
+        11,
+        15,
+        16,
+    ]
 
     with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
         dense_logits = dense_model(input_ids=input_ids, use_cache=False).logits

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -14,7 +14,7 @@
 
 import copy
 import math
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -117,6 +117,23 @@ def test_build_shared_prefix_layout_exact_mapping():
     assert layout.compact_position_ids.tolist() == [
         [0, 1, 2, 3, 4, 3, 0, 1, 2, 3, 4, 2, 3]
     ]
+    assert layout.logical_token_weights.tolist() == [
+        2,
+        2,
+        2,
+        1,
+        1,
+        1,
+        2,
+        2,
+        1,
+        1,
+        1,
+        1,
+        1,
+    ]
+    assert layout.logical_token_weights.dtype == torch.long
+    assert layout.logical_token_weights.sum() == 18
     assert layout.prompt_token_indices.tolist() == [0, 1, 2, 6, 7]
     assert layout.response_token_indices.tolist() == [3, 4, 5, 8, 9, 10, 11, 12]
     assert layout.prompt_cu_seqlens.tolist() == [0, 3, 5]
@@ -126,6 +143,661 @@ def test_build_shared_prefix_layout_exact_mapping():
     assert layout.response_target_ids.tolist() == [21, 22, 31, 51, 52, 53, 61, 62]
     assert layout.loss_logprob_scatter_indices.tolist() == [2, 3, 10, 5, 6, 7, 13, 14]
     assert layout.compact_tokens == 13
+
+
+def test_shared_prefix_moe_router_matches_logical_dense_tokens():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.config import MoEConfig
+    from nemo_automodel.components.moe.layers import Gate
+    from nemo_automodel.components.moe.megatron.moe_utils import (
+        MoEAuxLossAutoScaler,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        _logical_router_forward,
+        shared_prefix_moe_context,
+    )
+
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    compact_x = (
+        torch.linspace(
+            -1.0,
+            1.0,
+            layout.compact_tokens * 3,
+            dtype=torch.float32,
+        )
+        .reshape(layout.compact_tokens, 3)
+        .requires_grad_()
+    )
+    dense_gather = torch.tensor(
+        [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 0, 1, 2, 5, 6, 7, 11, 12]
+    )
+    dense_x = compact_x.detach()[dense_gather].requires_grad_()
+
+    config = MoEConfig(
+        n_routed_experts=4,
+        n_shared_experts=0,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.03125,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=3,
+        inter_dim=8,
+        moe_inter_dim=8,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+    dense_gate = Gate(config, gate_precision=torch.float32).train()
+    with torch.no_grad():
+        dense_gate.weight.copy_(
+            torch.tensor(
+                [
+                    [0.50, -0.20, 0.10],
+                    [-0.40, 0.30, 0.20],
+                    [0.20, 0.60, -0.50],
+                    [-0.10, -0.40, 0.70],
+                ]
+            )
+        )
+    compact_gate = copy.deepcopy(dense_gate)
+    dense_gate._track_load_balance = True
+    compact_gate._track_load_balance = True
+    compact_gate._nemo_shared_prefix_original_forward = compact_gate.forward
+    compact_gate.forward = MethodType(_logical_router_forward, compact_gate)
+
+    dense_weights, dense_indices, dense_aux_loss = dense_gate(
+        dense_x,
+        torch.ones(dense_x.shape[0], dtype=torch.bool),
+        None,
+    )
+    with shared_prefix_moe_context(compact_gate, layout, valid=True) as execution:
+        compact_weights, compact_indices, compact_aux_loss = compact_gate(
+            compact_x,
+            torch.ones(compact_x.shape[0], dtype=torch.bool),
+            None,
+        )
+        execution.commit()
+
+    assert torch.equal(compact_indices[dense_gather], dense_indices)
+    torch.testing.assert_close(compact_weights[dense_gather], dense_weights)
+    torch.testing.assert_close(compact_aux_loss, dense_aux_loss)
+    assert torch.equal(compact_gate._last_expert_load, dense_gate._last_expert_load)
+    # A non-unit scale catches aux-loss adapters that silently drop the main
+    # loss normalization used by AutoModel's forward/backward driver.
+    with patch.object(
+        MoEAuxLossAutoScaler,
+        "main_loss_backward_scale",
+        torch.tensor(0.375),
+    ):
+        dense_weights.sum().backward()
+        compact_weights[dense_gather].sum().backward()
+    torch.testing.assert_close(compact_gate.weight.grad, dense_gate.weight.grad)
+    expected_compact_input_grad = torch.zeros_like(compact_x)
+    expected_compact_input_grad.index_add_(0, dense_gather, dense_x.grad)
+    torch.testing.assert_close(compact_x.grad, expected_compact_input_grad)
+
+
+def test_shared_prefix_moe_context_is_module_scoped_and_restored():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.config import MoEConfig
+    from nemo_automodel.components.moe.layers import Gate
+
+    from nemo_rl.models.automodel import shared_prefix_moe
+
+    config = MoEConfig(
+        n_routed_experts=2,
+        n_shared_experts=0,
+        n_activated_experts=1,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=2,
+        inter_dim=4,
+        moe_inter_dim=4,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+    gate = Gate(config, gate_precision=torch.float32)
+    model = torch.nn.Sequential(gate)
+    outer_layout = SimpleNamespace(logical_token_weights=torch.tensor([2, 1]))
+    inner_layout = SimpleNamespace(logical_token_weights=torch.tensor([3, 4]))
+    attribute = shared_prefix_moe._ROUTER_EXECUTION_ATTR
+
+    assert not hasattr(gate, attribute)
+    with shared_prefix_moe.shared_prefix_moe_context(
+        model, outer_layout, valid=True
+    ) as outer_execution:
+        assert getattr(gate, attribute) is outer_execution
+        with shared_prefix_moe.shared_prefix_moe_context(
+            model, inner_layout, valid=False
+        ) as inner_execution:
+            assert getattr(gate, attribute) is inner_execution
+        assert getattr(gate, attribute) is outer_execution
+    assert not hasattr(gate, attribute)
+
+
+def test_logical_aux_autoscaler_uses_no_saved_tensors_and_preserves_gradient():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.megatron.moe_utils import (
+        MoEAuxLossAutoScaler,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        _LogicalAuxLossAutoScaler,
+    )
+
+    output = torch.tensor([1.0, -2.0], requires_grad=True)
+    aux_loss = torch.tensor(0.75, dtype=torch.float64, requires_grad=True)
+    saved_tensors = []
+
+    def pack(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+        attached = _LogicalAuxLossAutoScaler.apply(output, aux_loss)
+
+    assert saved_tensors == []
+    with patch.object(
+        MoEAuxLossAutoScaler,
+        "main_loss_backward_scale",
+        torch.tensor(0.375),
+    ):
+        attached.sum().backward()
+
+    torch.testing.assert_close(output.grad, torch.ones_like(output))
+    torch.testing.assert_close(aux_loss.grad, torch.tensor(0.375, dtype=torch.float64))
+
+
+def test_router_execution_replay_does_not_double_commit_statistics():
+    from nemo_rl.models.automodel import shared_prefix_moe
+
+    gate = torch.nn.Module()
+    execution = shared_prefix_moe._RouterExecution(
+        logical_token_weights=torch.ones(2, dtype=torch.long),
+        valid=True,
+    )
+    first_load = torch.tensor([3.0, 1.0], requires_grad=True)
+    first_aux = torch.tensor(0.25, requires_grad=True)
+
+    with patch.object(
+        shared_prefix_moe,
+        "_detach_optional",
+        wraps=shared_prefix_moe._detach_optional,
+    ) as detach_optional:
+        execution.record(gate, first_load, first_aux)
+        execution.commit()
+
+        committed_load = gate._nemo_shared_prefix_logical_expert_load.clone()
+        committed_aux = gate._nemo_shared_prefix_aux_loss_sum.clone()
+        assert gate._nemo_shared_prefix_aux_loss_count == 1
+
+        # Model activation checkpointing replays Gate.forward after commit.
+        # Snapshot construction and the pending write stay isomorphic to the
+        # original forward, while commit remains one-shot.
+        replay_load = torch.tensor([1.0, 3.0], requires_grad=True)
+        replay_aux = torch.tensor(0.75, requires_grad=True)
+        execution.record(gate, replay_load, replay_aux)
+        assert detach_optional.call_count == 2
+        assert gate in execution.pending
+        assert execution.pending[gate][0].grad_fn is None
+        assert execution.pending[gate][1].grad_fn is None
+
+        execution.commit()
+
+    assert execution.pending == {}
+    torch.testing.assert_close(
+        gate._nemo_shared_prefix_logical_expert_load, committed_load
+    )
+    torch.testing.assert_close(gate._nemo_shared_prefix_aux_loss_sum, committed_aux)
+    assert gate._nemo_shared_prefix_aux_loss_count == 1
+
+
+@pytest.mark.parametrize(
+    ("n_experts", "world_size", "expected_ids"),
+    [
+        (7, 2, ((0, 1, 2, 3), (4, 5, 6))),
+        (7, 4, ((0, 1), (2, 3), (4, 5), (6,))),
+        (3, 4, ((0,), (1,), (2,), ())),
+    ],
+)
+def test_torch_chunk_expert_ownership(
+    n_experts: int,
+    world_size: int,
+    expected_ids: tuple[tuple[int, ...], ...],
+) -> None:
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        _torch_chunk_shard_size_and_offset,
+    )
+
+    actual_ids = []
+    for rank in range(world_size):
+        local_count, start = _torch_chunk_shard_size_and_offset(
+            n_experts, world_size, rank
+        )
+        actual_ids.append(tuple(range(start, start + local_count)))
+
+    assert tuple(actual_ids) == expected_ids
+
+
+def test_qwen3_moe_ep_router_gradient_backport_is_idempotent():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.experts import GroupedExperts
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_ep_router_gradients,
+    )
+
+    original_forward = GroupedExperts.forward
+    try:
+        enable_qwen3_moe_ep_router_gradients()
+        patched_forward = GroupedExperts.forward
+        assert patched_forward is not original_forward
+        assert patched_forward._nemo_ep_router_gradients is True
+        enable_qwen3_moe_ep_router_gradients()
+        assert GroupedExperts.forward is patched_forward
+    finally:
+        GroupedExperts.forward = original_forward
+
+
+def test_qwen3_moe_ep_router_gradient_backport_fails_closed():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.experts import GroupedExperts
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_ep_router_gradients,
+    )
+
+    original_forward = GroupedExperts.forward
+    with (
+        patch(
+            "nemo_rl.models.automodel.shared_prefix_moe.inspect.getsource",
+            return_value="def forward(self):\n    return None\n",
+        ),
+        pytest.raises(RuntimeError, match="detached EP routing-weight gather"),
+    ):
+        enable_qwen3_moe_ep_router_gradients()
+
+    assert GroupedExperts.forward is original_forward
+
+
+def test_qwen3_moe_checkpoint_wrapper_compatibility_preserves_wrapper_call():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.qwen3_moe.model import Block
+    from nemo_automodel.components.moe.config import MoEConfig
+    from nemo_automodel.components.moe.layers import MLP, MoE
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+        checkpoint_wrapper,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_checkpoint_wrapper_compatibility,
+    )
+
+    config = MoEConfig(
+        n_routed_experts=2,
+        n_shared_experts=0,
+        n_activated_experts=1,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=4,
+        inter_dim=8,
+        moe_inter_dim=6,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    original = Block._mlp
+    try:
+        enable_qwen3_moe_checkpoint_wrapper_compatibility()
+        patched = Block._mlp
+        enable_qwen3_moe_checkpoint_wrapper_compatibility()
+        assert Block._mlp is patched
+
+        block = object.__new__(Block)
+        torch.nn.Module.__init__(block)
+        dense = MLP(4, 8, "torch", dtype=torch.float32)
+        block.mlp = checkpoint_wrapper(dense)
+        dense_input = torch.randn(2, 3, 4)
+        torch.testing.assert_close(
+            block._mlp(dense_input, None),
+            dense(dense_input),
+        )
+
+        moe = MoE(config, backend)
+        block.mlp = checkpoint_wrapper(moe)
+        moe_input = torch.randn(2, 3, 4)
+        padding_mask = torch.zeros(2, 3, dtype=torch.bool)
+        torch.testing.assert_close(
+            block._mlp(moe_input, padding_mask),
+            moe(moe_input, padding_mask),
+        )
+    finally:
+        Block._mlp = original
+
+
+def test_qwen3_moe_checkpoint_wrapper_compatibility_fails_closed():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.models.qwen3_moe.model import Block
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_checkpoint_wrapper_compatibility,
+    )
+
+    original = Block._mlp
+    with (
+        patch(
+            "nemo_rl.models.automodel.shared_prefix_moe.inspect.getsource",
+            return_value="def _mlp(self, x, padding_mask):\n    return x\n",
+        ),
+        pytest.raises(RuntimeError, match="checkpoint-wrapper source"),
+    ):
+        enable_qwen3_moe_checkpoint_wrapper_compatibility()
+
+    assert Block._mlp is original
+
+
+def _qwen3_moe_dtype_backport_methods():
+    from nemo_automodel.components.models.qwen3_moe.layers import (
+        Qwen3MoeAttention,
+    )
+    from nemo_automodel.components.models.qwen3_moe.model import (
+        Block,
+        Qwen3MoeForCausalLM,
+        Qwen3MoeModel,
+    )
+
+    return (
+        (Qwen3MoeAttention, "__init__"),
+        (Block, "__init__"),
+        (Qwen3MoeModel, "__init__"),
+        (Qwen3MoeForCausalLM, "__init__"),
+        (Qwen3MoeForCausalLM, "initialize_weights"),
+    )
+
+
+def test_qwen3_moe_configured_dtype_backport_constructs_fp32_on_cpu():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.qwen3_moe.model import (
+        Qwen3MoeForCausalLM,
+    )
+    from transformers.models.qwen3_moe.configuration_qwen3_moe import (
+        Qwen3MoeConfig,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_configured_dtype,
+    )
+
+    targets = _qwen3_moe_dtype_backport_methods()
+    originals = tuple(getattr(owner, name) for owner, name in targets)
+    try:
+        enable_qwen3_moe_configured_dtype()
+        config = Qwen3MoeConfig(
+            vocab_size=64,
+            hidden_size=16,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            num_hidden_layers=2,
+            intermediate_size=32,
+            moe_intermediate_size=16,
+            num_experts=4,
+            num_experts_per_tok=2,
+            decoder_sparse_step=1,
+            mlp_only_layers=[0],
+            max_position_embeddings=32,
+            rms_norm_eps=1e-6,
+            rope_theta=5000.0,
+            router_aux_loss_coef=0.01,
+            use_sliding_window=False,
+        )
+        config.torch_dtype = torch.float32
+        backend = BackendConfig(
+            linear="torch",
+            attn="sdpa",
+            rms_norm="torch",
+            experts="torch",
+            dispatcher="torch",
+            fake_balanced_gate=False,
+            enable_hf_state_dict_adapter=False,
+        )
+
+        # The pinned model only stores this device in its RoPE helper during
+        # construction; avoid CUDA initialization so this remains a CPU test.
+        with patch.object(torch.cuda, "current_device", return_value=0):
+            model = Qwen3MoeForCausalLM(config, backend=backend)
+        assert model.model.moe_config.dtype == torch.float32
+        assert all(parameter.dtype == torch.float32 for parameter in model.parameters())
+
+        model.initialize_weights(buffer_device=torch.device("cpu"))
+        assert all(parameter.dtype == torch.float32 for parameter in model.parameters())
+    finally:
+        for (owner, name), original in zip(targets, originals):
+            setattr(owner, name, original)
+
+
+def test_qwen3_moe_configured_dtype_backport_is_idempotent():
+    pytest.importorskip("nemo_automodel")
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_configured_dtype,
+    )
+
+    targets = _qwen3_moe_dtype_backport_methods()
+    originals = tuple(getattr(owner, name) for owner, name in targets)
+    try:
+        enable_qwen3_moe_configured_dtype()
+        patched = tuple(getattr(owner, name) for owner, name in targets)
+        assert patched != originals
+        assert all(
+            "__class__" not in method.__code__.co_freevars for method in patched[:4]
+        )
+        assert all(
+            method._nemo_qwen3_moe_configured_dtype is True for method in patched
+        )
+
+        enable_qwen3_moe_configured_dtype()
+        assert tuple(getattr(owner, name) for owner, name in targets) == patched
+    finally:
+        for (owner, name), original in zip(targets, originals):
+            setattr(owner, name, original)
+
+
+def test_qwen3_moe_configured_dtype_backport_fails_without_partial_mutation():
+    pytest.importorskip("nemo_automodel")
+    from nemo_rl.models.automodel import shared_prefix_moe
+
+    targets = _qwen3_moe_dtype_backport_methods()
+    originals = tuple(getattr(owner, name) for owner, name in targets)
+    real_getsource = shared_prefix_moe.inspect.getsource
+
+    def mismatched_third_method(method):
+        if method is originals[2]:
+            return "def __init__(self):\n    pass\n"
+        return real_getsource(method)
+
+    try:
+        with (
+            patch.object(
+                shared_prefix_moe.inspect,
+                "getsource",
+                side_effect=mismatched_third_method,
+            ),
+            pytest.raises(RuntimeError, match="no longer matches"),
+        ):
+            shared_prefix_moe.enable_qwen3_moe_configured_dtype()
+
+        assert tuple(getattr(owner, name) for owner, name in targets) == originals
+    finally:
+        for (owner, name), original in zip(targets, originals):
+            setattr(owner, name, original)
+
+
+def test_shared_prefix_moe_bf16_fp32_gate_aux_matches_expanded_tokens():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.config import MoEConfig
+    from nemo_automodel.components.moe.layers import Gate
+    from nemo_automodel.components.moe.megatron.moe_utils import (
+        MoEAuxLossAutoScaler,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        _logical_router_forward,
+        shared_prefix_moe_context,
+    )
+
+    # The logical total (515) is not exactly representable in BF16. This catches
+    # implementations that accidentally cast load/count normalization to the
+    # router-probability dtype instead of preserving the dense FP32 semantics.
+    multiplicity = torch.tensor([129, 128, 127, 66, 65], dtype=torch.long)
+    compact_x = torch.tensor(
+        [
+            [0.25, -0.50, 0.75],
+            [-0.80, 0.20, 0.45],
+            [0.60, 0.15, -0.35],
+            [-0.10, 0.90, 0.30],
+            [0.55, -0.25, -0.65],
+        ],
+        dtype=torch.bfloat16,
+    )
+    dense_x = compact_x.repeat_interleave(multiplicity, dim=0)
+    config = MoEConfig(
+        n_routed_experts=4,
+        n_shared_experts=0,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.125,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=3,
+        inter_dim=8,
+        moe_inter_dim=8,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.bfloat16,
+    )
+    dense_gate = Gate(config, gate_precision=torch.float32).train()
+    with torch.no_grad():
+        dense_gate.weight.copy_(
+            torch.tensor(
+                [
+                    [0.50, -0.20, 0.10],
+                    [-0.40, 0.30, 0.20],
+                    [0.20, 0.60, -0.50],
+                    [-0.10, -0.40, 0.70],
+                ],
+                dtype=torch.bfloat16,
+            )
+        )
+    compact_gate = copy.deepcopy(dense_gate)
+    compact_gate._nemo_shared_prefix_original_forward = compact_gate.forward
+    compact_gate.forward = MethodType(_logical_router_forward, compact_gate)
+    token_mask = torch.ones(compact_x.shape[0], dtype=torch.bool)
+    dense_mask = torch.ones(dense_x.shape[0], dtype=torch.bool)
+    layout = SimpleNamespace(logical_token_weights=multiplicity)
+
+    dense_weights, dense_indices, dense_aux = dense_gate(dense_x, dense_mask, None)
+    with shared_prefix_moe_context(compact_gate, layout, valid=True) as execution:
+        compact_weights, compact_indices, compact_aux = compact_gate(
+            compact_x, token_mask, None
+        )
+        execution.commit()
+
+    assert torch.equal(
+        compact_indices.repeat_interleave(multiplicity, dim=0), dense_indices
+    )
+    torch.testing.assert_close(
+        compact_weights.repeat_interleave(multiplicity, dim=0), dense_weights
+    )
+    torch.testing.assert_close(compact_aux, dense_aux, rtol=3e-3, atol=3e-4)
+    with patch.object(
+        MoEAuxLossAutoScaler,
+        "main_loss_backward_scale",
+        torch.tensor(1.0),
+    ):
+        (dense_weights.sum() * 0.0).backward()
+        (compact_weights.sum() * 0.0).backward()
+    torch.testing.assert_close(
+        compact_gate.weight.grad,
+        dense_gate.weight.grad,
+        rtol=2e-2,
+        atol=2e-3,
+    )
+
+
+def test_shared_prefix_moe_single_expert_statistics_are_finite():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.moe.config import MoEConfig
+    from nemo_automodel.components.moe.layers import Gate
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        collect_shared_prefix_moe_statistics,
+    )
+
+    config = MoEConfig(
+        n_routed_experts=1,
+        n_shared_experts=0,
+        n_activated_experts=1,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=2,
+        inter_dim=4,
+        moe_inter_dim=4,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+    gate = Gate(config, gate_precision=torch.float32)
+    gate._nemo_shared_prefix_logical_expert_load = torch.tensor([7])
+    stats_model = torch.nn.Module()
+    stats_model.add_module("gate", gate)
+    stats_model._nemo_shared_prefix_custom_qwen3_moe = True
+
+    with patch("torch.distributed.all_reduce"):
+        stats = collect_shared_prefix_moe_statistics(stats_model, None)
+
+    assert math.isfinite(stats["logical_load_cv_mean"])
+    assert stats["logical_load_cv_mean"] == 0.0
+    assert stats["logical_expert_utilization_min"] == 1.0
+    assert stats["logical_expert_utilization_max"] == 1.0
+    assert stats["logical_dead_expert_fraction_mean"] == 0.0
+    assert stats["logical_expert_diversity_mean"] == 1.0
+    assert stats["logical_token_layer_events"] == 7.0
+    assert all(math.isfinite(value) for value in stats.values())
 
 
 def test_build_shared_prefix_layout_rejects_false_groups():
@@ -406,7 +1078,7 @@ def test_split_attention_matches_logical_dense_attention_and_gradients():
 
 @pytest.mark.automodel
 @pytest.mark.parametrize("activation_checkpointing", [False, True])
-@pytest.mark.parametrize("model_family", ["qwen3", "llama"])
+@pytest.mark.parametrize("model_family", ["qwen3", "llama", "qwen3_moe"])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA GPU")
 def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
     activation_checkpointing,
@@ -417,12 +1089,15 @@ def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
     if model_family == "qwen3":
         from transformers import Qwen3Config as ModelConfig
         from transformers import Qwen3ForCausalLM as ModelForCausalLM
-    else:
+    elif model_family == "llama":
         from transformers import LlamaConfig as ModelConfig
         from transformers import LlamaForCausalLM as ModelForCausalLM
+    else:
+        from transformers import Qwen3MoeConfig as ModelConfig
+        from transformers import Qwen3MoeForCausalLM as ModelForCausalLM
 
     register_shared_prefix_attention()
-    dense_config = ModelConfig(
+    config_kwargs = dict(
         vocab_size=128,
         hidden_size=64,
         intermediate_size=128,
@@ -437,6 +1112,18 @@ def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
         eos_token_id=1,
         use_cache=False,
     )
+    if model_family == "qwen3_moe":
+        config_kwargs.update(
+            moe_intermediate_size=64,
+            decoder_sparse_step=1,
+            mlp_only_layers=[],
+            num_experts=2,
+            num_experts_per_tok=2,
+            norm_topk_prob=False,
+            use_sliding_window=False,
+            output_router_logits=False,
+        )
+    dense_config = ModelConfig(**config_kwargs)
     dense_config._attn_implementation = "flash_attention_2"
     shared_config = copy.deepcopy(dense_config)
     shared_config._attn_implementation = SHARED_PREFIX_ATTENTION
@@ -512,6 +1199,7 @@ def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
     shared_loss.backward()
 
     torch.testing.assert_close(shared_loss, dense_loss, atol=5e-2, rtol=2e-3)
+    moe_gradients: dict[str, torch.Tensor] = {}
     for (dense_name, dense_parameter), (shared_name, shared_parameter) in zip(
         dense_model.named_parameters(),
         shared_model.named_parameters(),
@@ -525,6 +1213,16 @@ def test_tiny_causal_lm_fa2_logits_and_gradients_match_dense(
             atol=7e-2,
             rtol=7e-2,
             msg=lambda message, name=dense_name: f"{name}: {message}",
+        )
+        if ".mlp.gate.weight" in dense_name or ".mlp.experts." in dense_name:
+            moe_gradients[dense_name] = shared_parameter.grad
+
+    if model_family == "qwen3_moe":
+        assert any(".mlp.gate.weight" in name for name in moe_gradients)
+        assert any(".mlp.experts.gate_up_proj" in name for name in moe_gradients)
+        assert any(".mlp.experts.down_proj" in name for name in moe_gradients)
+        assert all(
+            gradient.abs().sum().item() > 0 for gradient in moe_gradients.values()
         )
 
     dense_optimizer = torch.optim.AdamW(dense_model.parameters(), lr=1e-4)

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -482,6 +482,7 @@ def test_qwen3_moe_checkpoint_wrapper_compatibility_preserves_wrapper_call():
         block = object.__new__(Block)
         torch.nn.Module.__init__(block)
         dense = MLP(4, 8, "torch", dtype=torch.float32)
+        dense.init_weights(torch.device("cpu"))
         block.mlp = checkpoint_wrapper(dense)
         dense_input = torch.randn(2, 3, 4)
         torch.testing.assert_close(
@@ -490,6 +491,7 @@ def test_qwen3_moe_checkpoint_wrapper_compatibility_preserves_wrapper_call():
         )
 
         moe = MoE(config, backend)
+        moe.init_weights(torch.device("cpu"))
         block.mlp = checkpoint_wrapper(moe)
         moe_input = torch.randn(2, 3, 4)
         padding_mask = torch.zeros(2, 3, dtype=torch.bool)

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -156,6 +156,7 @@ def test_shared_prefix_moe_router_matches_logical_dense_tokens():
     from nemo_rl.models.automodel.shared_prefix_moe import (
         _logical_router_forward,
         shared_prefix_moe_context,
+        update_shared_prefix_moe_bias,
     )
 
     layout = build_shared_prefix_layout(*_interleaved_rollouts())
@@ -181,9 +182,10 @@ def test_shared_prefix_moe_router_matches_logical_dense_tokens():
         n_expert_groups=1,
         n_limited_groups=1,
         train_gate=True,
-        gate_bias_update_factor=0.0,
+        gate_bias_update_factor=0.125,
         aux_loss_coeff=0.03125,
-        score_func="softmax",
+        score_func="softmax_with_bias",
+        force_e_score_correction_bias=True,
         route_scale=1.0,
         dim=3,
         inter_dim=8,
@@ -209,6 +211,7 @@ def test_shared_prefix_moe_router_matches_logical_dense_tokens():
     compact_gate._track_load_balance = True
     compact_gate._nemo_shared_prefix_original_forward = compact_gate.forward
     compact_gate.forward = MethodType(_logical_router_forward, compact_gate)
+    compact_gate._nemo_shared_prefix_custom_qwen3_moe = True
 
     dense_weights, dense_indices, dense_aux_loss = dense_gate(
         dense_x,
@@ -221,6 +224,9 @@ def test_shared_prefix_moe_router_matches_logical_dense_tokens():
             torch.ones(compact_x.shape[0], dtype=torch.bool),
             None,
         )
+        execution.commit()
+        committed_load = compact_gate._cumulative_expert_load.clone()
+        compact_gate(compact_x, torch.ones(compact_x.shape[0], dtype=torch.bool), None)
         execution.commit()
 
     assert torch.equal(compact_indices[dense_gather], dense_indices)
@@ -240,6 +246,16 @@ def test_shared_prefix_moe_router_matches_logical_dense_tokens():
     expected_compact_input_grad = torch.zeros_like(compact_x)
     expected_compact_input_grad.index_add_(0, dense_gather, dense_x.grad)
     torch.testing.assert_close(compact_x.grad, expected_compact_input_grad)
+    torch.testing.assert_close(compact_gate._cumulative_expert_load, committed_load)
+    torch.testing.assert_close(
+        compact_gate._cumulative_expert_load, dense_gate._cumulative_expert_load
+    )
+    dense_gate.update_bias()
+    update_shared_prefix_moe_bias(compact_gate, dp_group=None)
+    torch.testing.assert_close(
+        compact_gate.e_score_correction_bias, dense_gate.e_score_correction_bias
+    )
+    assert compact_gate._cumulative_expert_load is None
 
 
 def test_shared_prefix_moe_context_is_module_scoped_and_restored():
@@ -289,7 +305,6 @@ def test_shared_prefix_moe_context_is_module_scoped_and_restored():
 @pytest.mark.parametrize(
     "bias_update_factor",
     [
-        1.0e-3,
         -1.0e-3,
         True,
         False,
@@ -300,7 +315,7 @@ def test_shared_prefix_moe_context_is_module_scoped_and_restored():
         "x",
     ],
 )
-def test_shared_prefix_moe_router_rejects_dynamic_bias_without_layout(
+def test_shared_prefix_moe_router_rejects_invalid_bias_without_layout(
     bias_update_factor,
 ):
     pytest.importorskip("nemo_automodel")
@@ -313,7 +328,7 @@ def test_shared_prefix_moe_router_rejects_dynamic_bias_without_layout(
         ),
     )
 
-    with pytest.raises(ValueError, match="does not support dynamic bias"):
+    with pytest.raises(ValueError, match="finite non-negative"):
         _logical_router_forward(
             gate,
             torch.zeros(1, 2),

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -1,0 +1,458 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_ATTENTION,
+    build_shared_prefix_layout,
+    infer_shared_prefix_response_bounds,
+    register_shared_prefix_attention,
+    scatter_response_logprobs,
+    shared_prefix_flash_attention_forward,
+)
+
+
+def _interleaved_rollouts():
+    input_ids = torch.tensor(
+        [
+            [10, 11, 12, 21, 22],
+            [40, 41, 51, 52, 53],
+            [10, 11, 12, 31, 0],
+            [40, 41, 61, 62, 0],
+        ]
+    )
+    input_lengths = torch.tensor([5, 5, 4, 4])
+    prompt_lengths = torch.tensor([3, 2, 3, 2])
+    group_ids = torch.tensor([7, 9, 7, 9])
+    return input_ids, input_lengths, prompt_lengths, group_ids
+
+
+def test_infer_response_bounds_finds_prompt_lengths():
+    _, input_lengths, prompt_lengths, _ = _interleaved_rollouts()
+    token_mask = torch.tensor(
+        [
+            [0, 0, 0, 1, 1],
+            [0, 0, 1, 1, 1],
+            [0, 0, 0, 1, 0],
+            [0, 0, 1, 1, 0],
+        ]
+    )
+
+    actual, effective_input_lengths = infer_shared_prefix_response_bounds(
+        token_mask, input_lengths
+    )
+
+    assert torch.equal(actual, prompt_lengths)
+    assert torch.equal(effective_input_lengths, input_lengths)
+
+
+def test_infer_response_bounds_crops_terminal_environment_observation():
+    token_mask = torch.tensor(
+        [
+            [0, 0, 1, 1, 0, 0],
+            [0, 0, 1, 0, 0, 0],
+        ]
+    )
+    input_lengths = torch.tensor([6, 4])
+
+    prompt_lengths, effective_input_lengths = infer_shared_prefix_response_bounds(
+        token_mask, input_lengths
+    )
+
+    assert prompt_lengths.tolist() == [2, 2]
+    assert effective_input_lengths.tolist() == [4, 3]
+
+
+def test_register_shared_prefix_attention_registers_attention_and_mask():
+    from transformers import AttentionInterface
+    from transformers.masking_utils import AttentionMaskInterface
+
+    register_shared_prefix_attention()
+
+    assert (
+        AttentionInterface()[SHARED_PREFIX_ATTENTION]
+        is shared_prefix_flash_attention_forward
+    )
+    assert SHARED_PREFIX_ATTENTION in AttentionMaskInterface()
+
+
+@pytest.mark.parametrize(
+    "token_mask,match",
+    [
+        (torch.tensor([[0, 1, 0, 1]]), "single contiguous response span"),
+        (torch.tensor([[0, 0, 0, 0]]), "at least one response token"),
+        (torch.tensor([[1, 1, 1, 1]]), "at least one prompt token"),
+    ],
+)
+def test_infer_response_bounds_rejects_unsupported_masks(token_mask, match):
+    with pytest.raises(ValueError, match=match):
+        infer_shared_prefix_response_bounds(token_mask, torch.tensor([4]))
+
+
+def test_build_shared_prefix_layout_exact_mapping():
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+
+    assert layout.compact_input_ids.tolist() == [
+        [10, 11, 12, 21, 22, 31, 40, 41, 51, 52, 53, 61, 62]
+    ]
+    assert layout.compact_position_ids.tolist() == [
+        [0, 1, 2, 3, 4, 3, 0, 1, 2, 3, 4, 2, 3]
+    ]
+    assert layout.prompt_token_indices.tolist() == [0, 1, 2, 6, 7]
+    assert layout.response_token_indices.tolist() == [3, 4, 5, 8, 9, 10, 11, 12]
+    assert layout.prompt_cu_seqlens.tolist() == [0, 3, 5]
+    assert layout.response_cu_seqlens.tolist() == [0, 2, 3, 6, 8]
+    assert layout.response_kv_cu_seqlens.tolist() == [0, 5, 9, 14, 18]
+    assert layout.predictor_indices.tolist() == [2, 3, 2, 7, 8, 9, 7, 11]
+    assert layout.response_target_ids.tolist() == [21, 22, 31, 51, 52, 53, 61, 62]
+    assert layout.loss_logprob_scatter_indices.tolist() == [2, 3, 10, 5, 6, 7, 13, 14]
+    assert layout.compact_tokens == 13
+
+
+def test_build_shared_prefix_layout_rejects_false_groups():
+    input_ids, input_lengths, prompt_lengths, group_ids = _interleaved_rollouts()
+    input_ids[2, 1] = 99
+
+    with pytest.raises(ValueError, match="identical prompts"):
+        build_shared_prefix_layout(
+            input_ids,
+            input_lengths,
+            prompt_lengths,
+            group_ids,
+        )
+
+
+def test_scatter_response_logprobs_preserves_dense_loss_alignment():
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    response_logprobs = torch.arange(1, 9, dtype=torch.float32, requires_grad=True)
+
+    dense = scatter_response_logprobs(response_logprobs, layout)
+
+    torch.testing.assert_close(
+        dense,
+        torch.tensor(
+            [
+                [0, 0, 1, 2],
+                [0, 4, 5, 6],
+                [0, 0, 3, 0],
+                [0, 7, 8, 0],
+            ],
+            dtype=torch.float32,
+        ),
+    )
+    dense.sum().backward()
+    torch.testing.assert_close(response_logprobs.grad, torch.ones(8))
+
+
+def test_scatter_response_logprobs_preserves_inactive_base_values():
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    response_logprobs = torch.arange(1, 9, dtype=torch.float32)
+    base = torch.full((4, 4), -7.0)
+
+    dense = scatter_response_logprobs(response_logprobs, layout, base=base)
+
+    assert torch.equal(dense[0, :2], torch.tensor([-7.0, -7.0]))
+    assert dense[2, 3] == -7.0
+    assert dense[3, 3] == -7.0
+
+
+def _reference_varlen_attention(
+    query,
+    key,
+    value,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    *,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+):
+    del max_seqlen_q, max_seqlen_k
+    assert dropout_p == 0.0
+    assert cu_seqlens_q.dtype == torch.int32
+    assert cu_seqlens_k.dtype == torch.int32
+    outputs = []
+    for sequence in range(cu_seqlens_q.numel() - 1):
+        q_start, q_end = cu_seqlens_q[sequence : sequence + 2].tolist()
+        k_start, k_end = cu_seqlens_k[sequence : sequence + 2].tolist()
+        q = query[q_start:q_end].transpose(0, 1).float()
+        k = key[k_start:k_end].transpose(0, 1).float()
+        v = value[k_start:k_end].transpose(0, 1).float()
+        scale = (
+            softmax_scale if softmax_scale is not None else 1 / math.sqrt(q.shape[-1])
+        )
+        scores = torch.matmul(q, k.transpose(-1, -2)) * scale
+        if causal:
+            q_positions = torch.arange(q.shape[-2]).unsqueeze(-1)
+            k_positions = torch.arange(k.shape[-2]).unsqueeze(0)
+            causal_mask = k_positions <= q_positions + k.shape[-2] - q.shape[-2]
+            scores = scores.masked_fill(~causal_mask, torch.finfo(scores.dtype).min)
+        probabilities = torch.softmax(scores, dim=-1)
+        outputs.append(torch.matmul(probabilities, v).transpose(0, 1))
+    return torch.cat(outputs).to(query.dtype)
+
+
+def test_custom_backend_preserves_dense_packed_attention_and_gradients():
+    """The train-only backend must leave prev/ref packed forwards unchanged."""
+
+    torch.manual_seed(31)
+    query = torch.randn(1, 2, 7, 8, dtype=torch.bfloat16, requires_grad=True)
+    key = torch.randn_like(query, requires_grad=True)
+    value = torch.randn_like(query, requires_grad=True)
+    expected_query = query.detach().clone().requires_grad_()
+    expected_key = key.detach().clone().requires_grad_()
+    expected_value = value.detach().clone().requires_grad_()
+    # Exercise the dtype emitted by NeMo-RL's packed logprob path. The custom
+    # backend must normalize it to FA2's int32 ABI.
+    cu_seqlens = torch.tensor([0, 3, 7], dtype=torch.int64)
+    packed_kwargs = SimpleNamespace(
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens.clone(),
+        max_seqlen_q=4,
+        max_seqlen_k=4,
+    )
+
+    module = torch.nn.Module()
+    module.is_causal = True
+    with patch(
+        "nemo_rl.models.automodel.shared_prefix._flash_attention_functions",
+        return_value=(None, _reference_varlen_attention),
+    ):
+        actual, _ = shared_prefix_flash_attention_forward(
+            module,
+            query,
+            key,
+            value,
+            attention_mask=None,
+            flash_attn_kwargs=packed_kwargs,
+        )
+
+    expected = _reference_varlen_attention(
+        expected_query.transpose(1, 2).reshape(-1, 2, 8),
+        expected_key.transpose(1, 2).reshape(-1, 2, 8),
+        expected_value.transpose(1, 2).reshape(-1, 2, 8),
+        cu_seqlens.to(dtype=torch.int32),
+        cu_seqlens.to(dtype=torch.int32),
+        4,
+        4,
+        causal=True,
+    ).unsqueeze(0)
+    weights = torch.linspace(0.25, 1.25, actual.numel()).reshape_as(actual)
+    actual_loss = (actual.float() * weights).sum()
+    expected_loss = (expected.float() * weights).sum()
+    actual_grads = torch.autograd.grad(actual_loss, (query, key, value))
+    expected_grads = torch.autograd.grad(
+        expected_loss,
+        (expected_query, expected_key, expected_value),
+    )
+
+    torch.testing.assert_close(actual, expected)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        torch.testing.assert_close(actual_grad, expected_grad)
+
+
+def test_split_attention_matches_logical_dense_attention_and_gradients():
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    torch.manual_seed(1234)
+    compact_q = torch.randn(1, 2, layout.compact_tokens, 8, dtype=torch.bfloat16)
+    compact_k = torch.randn_like(compact_q)
+    compact_v = torch.randn_like(compact_q)
+    compact_q.requires_grad_()
+    compact_k.requires_grad_()
+    compact_v.requires_grad_()
+
+    dense_gather = torch.tensor(
+        [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 0, 1, 2, 5, 6, 7, 11, 12]
+    )
+    dense_cu = torch.tensor([0, 5, 10, 14, 18], dtype=torch.int32)
+    dense_predictors = torch.tensor([2, 3, 12, 6, 7, 8, 15, 16])
+    weights = torch.linspace(0.25, 2.0, 8).view(-1, 1, 1)
+
+    def logical_dense_loss(q, k, v):
+        dense_output = _reference_varlen_attention(
+            q.transpose(1, 2).squeeze(0)[dense_gather],
+            k.transpose(1, 2).squeeze(0)[dense_gather],
+            v.transpose(1, 2).squeeze(0)[dense_gather],
+            dense_cu,
+            dense_cu,
+            5,
+            5,
+            causal=True,
+        )
+        return (dense_output[dense_predictors].float() * weights).sum()
+
+    dense_loss = logical_dense_loss(compact_q, compact_k, compact_v)
+    dense_grads = torch.autograd.grad(
+        dense_loss,
+        (compact_q, compact_k, compact_v),
+    )
+
+    with patch(
+        "nemo_rl.models.automodel.shared_prefix._flash_attention_functions",
+        return_value=(None, _reference_varlen_attention),
+    ):
+        compact_output, _ = shared_prefix_flash_attention_forward(
+            torch.nn.Identity(),
+            compact_q,
+            compact_k,
+            compact_v,
+            attention_mask=None,
+            shared_prefix_layout=layout,
+        )
+    compact_loss = (
+        compact_output.squeeze(0)[layout.predictor_indices].float() * weights
+    ).sum()
+    compact_grads = torch.autograd.grad(
+        compact_loss,
+        (compact_q, compact_k, compact_v),
+    )
+
+    torch.testing.assert_close(compact_loss, dense_loss, atol=2e-2, rtol=2e-3)
+    for compact_grad, dense_grad in zip(compact_grads, dense_grads):
+        torch.testing.assert_close(compact_grad, dense_grad, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.automodel
+@pytest.mark.parametrize("activation_checkpointing", [False, True])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA GPU")
+def test_tiny_qwen3_fa2_logits_and_gradients_match_dense(activation_checkpointing):
+    pytest.importorskip("flash_attn")
+    from transformers import Qwen3Config, Qwen3ForCausalLM
+
+    register_shared_prefix_attention()
+    dense_config = Qwen3Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        attention_dropout=0.0,
+        use_cache=False,
+    )
+    dense_config._attn_implementation = "flash_attention_2"
+    shared_config = copy.deepcopy(dense_config)
+    shared_config._attn_implementation = SHARED_PREFIX_ATTENTION
+
+    torch.manual_seed(42)
+    dense_model = Qwen3ForCausalLM(dense_config).cuda().train()
+    shared_model = Qwen3ForCausalLM(shared_config).cuda().train()
+    shared_model.load_state_dict(dense_model.state_dict())
+    if activation_checkpointing:
+        dense_model.gradient_checkpointing_enable()
+        shared_model.gradient_checkpointing_enable()
+
+    input_ids = torch.tensor(
+        [
+            [5, 6, 7, 20, 21, 22],
+            [8, 9, 10, 30, 31, 32],
+            [5, 6, 7, 23, 24, 25],
+            [8, 9, 10, 33, 34, 35],
+        ],
+        device="cuda",
+    )
+    lengths = torch.full((4,), 6, device="cuda")
+    prompt_lengths = torch.full((4,), 3, device="cuda")
+    group_ids = torch.tensor([0, 1, 0, 1], device="cuda")
+    layout = build_shared_prefix_layout(
+        input_ids,
+        lengths,
+        prompt_lengths,
+        group_ids,
+    )
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        dense_logits = dense_model(input_ids=input_ids, use_cache=False).logits
+        shared_logits = shared_model(
+            input_ids=layout.compact_input_ids,
+            position_ids=layout.compact_position_ids,
+            use_cache=False,
+            shared_prefix_layout=layout,
+            logits_to_keep=layout.predictor_indices,
+        ).logits
+        dense_response_logits = dense_logits[:, :-1].reshape(-1, 128)[
+            layout.loss_logprob_scatter_indices
+        ]
+
+    torch.testing.assert_close(
+        shared_logits.squeeze(0).float(),
+        dense_response_logits.float(),
+        atol=5e-2,
+        rtol=2e-2,
+    )
+
+    targets = layout.response_target_ids.unsqueeze(-1)
+    weights = torch.linspace(0.5, 1.5, layout.response_tokens, device="cuda")
+    dense_logprobs = torch.log_softmax(dense_response_logits.float(), dim=-1)
+    dense_loss = (dense_logprobs.gather(-1, targets).squeeze(-1) * weights).sum()
+    shared_logprobs = torch.log_softmax(shared_logits.squeeze(0).float(), dim=-1)
+    shared_loss = (shared_logprobs.gather(-1, targets).squeeze(-1) * weights).sum()
+    dense_loss.backward()
+    shared_loss.backward()
+
+    torch.testing.assert_close(shared_loss, dense_loss, atol=5e-2, rtol=2e-3)
+    for (dense_name, dense_parameter), (shared_name, shared_parameter) in zip(
+        dense_model.named_parameters(),
+        shared_model.named_parameters(),
+    ):
+        assert dense_name == shared_name
+        assert dense_parameter.grad is not None, dense_name
+        assert shared_parameter.grad is not None, shared_name
+        torch.testing.assert_close(
+            shared_parameter.grad,
+            dense_parameter.grad,
+            atol=7e-2,
+            rtol=7e-2,
+            msg=lambda message, name=dense_name: f"{name}: {message}",
+        )
+
+    dense_optimizer = torch.optim.AdamW(dense_model.parameters(), lr=1e-4)
+    shared_optimizer = torch.optim.AdamW(shared_model.parameters(), lr=1e-4)
+    dense_optimizer.step()
+    shared_optimizer.step()
+    for (dense_name, dense_parameter), (shared_name, shared_parameter) in zip(
+        dense_model.named_parameters(),
+        shared_model.named_parameters(),
+    ):
+        assert dense_name == shared_name
+        torch.testing.assert_close(
+            shared_parameter,
+            dense_parameter,
+            atol=2e-4,
+            rtol=2e-4,
+            msg=lambda message, name=dense_name: f"{name}: {message}",
+        )
+        dense_state = dense_optimizer.state[dense_parameter]
+        shared_state = shared_optimizer.state[shared_parameter]
+        for state_name in ("exp_avg", "exp_avg_sq"):
+            torch.testing.assert_close(
+                shared_state[state_name],
+                dense_state[state_name],
+                atol=7e-3,
+                rtol=8e-2,
+                msg=lambda message, name=dense_name, state=state_name: (
+                    f"{name}.{state}: {message}"
+                ),
+            )

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -286,6 +286,42 @@ def test_shared_prefix_moe_context_is_module_scoped_and_restored():
     assert not hasattr(gate, attribute)
 
 
+@pytest.mark.parametrize(
+    "bias_update_factor",
+    [
+        1.0e-3,
+        -1.0e-3,
+        True,
+        False,
+        None,
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        "x",
+    ],
+)
+def test_shared_prefix_moe_router_rejects_dynamic_bias_without_layout(
+    bias_update_factor,
+):
+    pytest.importorskip("nemo_automodel")
+    from nemo_rl.models.automodel.shared_prefix_moe import _logical_router_forward
+
+    gate = SimpleNamespace(
+        bias_update_factor=bias_update_factor,
+        _nemo_shared_prefix_original_forward=lambda *_: pytest.fail(
+            "dynamic bias reached the original Gate forward"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not support dynamic bias"):
+        _logical_router_forward(
+            gate,
+            torch.zeros(1, 2),
+            torch.ones(1, dtype=torch.bool),
+            None,
+        )
+
+
 def test_logical_aux_autoscaler_uses_no_saved_tensors_and_preserves_gradient():
     pytest.importorskip("nemo_automodel")
     from nemo_automodel.components.moe.megatron.moe_utils import (
@@ -482,7 +518,8 @@ def test_qwen3_moe_checkpoint_wrapper_compatibility_preserves_wrapper_call():
         block = object.__new__(Block)
         torch.nn.Module.__init__(block)
         dense = MLP(4, 8, "torch", dtype=torch.float32)
-        dense.init_weights(torch.device("cpu"))
+        with torch.no_grad():
+            dense.init_weights(torch.device("cpu"))
         block.mlp = checkpoint_wrapper(dense)
         dense_input = torch.randn(2, 3, 4)
         torch.testing.assert_close(
@@ -491,7 +528,8 @@ def test_qwen3_moe_checkpoint_wrapper_compatibility_preserves_wrapper_call():
         )
 
         moe = MoE(config, backend)
-        moe.init_weights(torch.device("cpu"))
+        with torch.no_grad():
+            moe.init_weights(torch.device("cpu"))
         block.mlp = checkpoint_wrapper(moe)
         moe_input = torch.randn(2, 3, 4)
         padding_mask = torch.zeros(2, 3, dtype=torch.bool)
@@ -539,6 +577,7 @@ def _qwen3_moe_dtype_backport_methods():
         (Block, "__init__"),
         (Qwen3MoeModel, "__init__"),
         (Qwen3MoeForCausalLM, "__init__"),
+        (Qwen3MoeForCausalLM, "forward"),
         (Qwen3MoeForCausalLM, "initialize_weights"),
     )
 
@@ -626,6 +665,57 @@ def test_qwen3_moe_configured_dtype_backport_is_idempotent():
 
         enable_qwen3_moe_configured_dtype()
         assert tuple(getattr(owner, name) for owner, name in targets) == patched
+    finally:
+        for (owner, name), original in zip(targets, originals):
+            setattr(owner, name, original)
+
+
+def test_qwen3_moe_configured_dtype_backport_casts_lm_head_input():
+    pytest.importorskip("nemo_automodel")
+    from nemo_automodel.components.models.qwen3_moe.model import (
+        Qwen3MoeForCausalLM,
+    )
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_configured_dtype,
+    )
+
+    class _HiddenState(torch.nn.Module):
+        def __init__(self, hidden):
+            super().__init__()
+            self.hidden = hidden
+
+        def forward(self, *args, **kwargs):
+            return self.hidden
+
+    targets = _qwen3_moe_dtype_backport_methods()
+    originals = tuple(getattr(owner, name) for owner, name in targets)
+    try:
+        enable_qwen3_moe_configured_dtype()
+        hidden = torch.randn(2, 3, 4, dtype=torch.float32, requires_grad=True)
+        model = object.__new__(Qwen3MoeForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.model = _HiddenState(hidden)
+        model.lm_head = torch.nn.Linear(
+            4,
+            5,
+            bias=False,
+            dtype=torch.bfloat16,
+        )
+
+        logits = model(torch.zeros(2, 3, dtype=torch.long))
+        expected = torch.nn.functional.linear(
+            hidden.to(torch.bfloat16),
+            model.lm_head.weight,
+        )
+        torch.testing.assert_close(logits, expected)
+        assert logits.dtype == torch.bfloat16
+
+        logits.float().sum().backward()
+        assert hidden.grad is not None
+        assert model.lm_head.weight.grad is not None
+        assert torch.isfinite(hidden.grad).all()
+        assert torch.isfinite(model.lm_head.weight.grad).all()
     finally:
         for (owner, name), original in zip(targets, originals):
             setattr(owner, name, original)

--- a/tests/unit/models/automodel/test_shared_prefix.py
+++ b/tests/unit/models/automodel/test_shared_prefix.py
@@ -25,6 +25,7 @@ from nemo_rl.models.automodel.shared_prefix import (
     build_shared_prefix_layout,
     infer_shared_prefix_response_bounds,
     register_shared_prefix_attention,
+    response_logprobs_from_logits,
     scatter_response_logprobs,
     shared_prefix_flash_attention_forward,
 )
@@ -172,6 +173,77 @@ def test_scatter_response_logprobs_preserves_inactive_base_values():
     assert torch.equal(dense[0, :2], torch.tensor([-7.0, -7.0]))
     assert dense[2, 3] == -7.0
     assert dense[3, 3] == -7.0
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 64])
+def test_chunked_response_logprobs_match_dense_values_and_gradients(chunk_size):
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    torch.manual_seed(17)
+    actual_logits = torch.randn(
+        1,
+        layout.response_tokens,
+        128,
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    expected_logits = actual_logits.detach().clone().requires_grad_()
+    weights = torch.linspace(-1.0, 1.0, layout.response_tokens)
+
+    actual = response_logprobs_from_logits(
+        actual_logits,
+        layout,
+        chunk_size=chunk_size,
+    )
+    expected = (
+        torch.log_softmax(expected_logits.squeeze(0), dim=-1)
+        .gather(-1, layout.response_target_ids.unsqueeze(-1))
+        .squeeze(-1)
+    )
+
+    actual_loss = (actual * weights).sum()
+    expected_loss = (expected * weights).sum()
+    actual_grad = torch.autograd.grad(actual_loss, actual_logits)[0]
+    expected_grad = torch.autograd.grad(expected_loss, expected_logits)[0]
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_loss, expected_loss)
+    torch.testing.assert_close(actual_grad, expected_grad)
+
+
+def test_chunked_response_logprobs_do_not_save_fp32_vocab_activations():
+    layout = build_shared_prefix_layout(*_interleaved_rollouts())
+    logits = torch.randn(
+        1,
+        layout.response_tokens,
+        128,
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    saved_tensors = []
+
+    def pack_hook(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        response_logprobs_from_logits(logits, layout, chunk_size=3).sum().backward()
+
+    assert any(
+        tensor.dtype == torch.bfloat16
+        and tensor.shape == (layout.response_tokens, logits.shape[-1])
+        for tensor in saved_tensors
+    )
+    assert any(
+        tensor.dtype == torch.long and tensor.shape == (layout.response_tokens,)
+        for tensor in saved_tensors
+    )
+    assert not any(
+        tensor.dtype == torch.float32
+        and tensor.ndim == 2
+        and tensor.shape[-1] == logits.shape[-1]
+        for tensor in saved_tensors
+    )
+    assert logits.grad is not None
 
 
 def _reference_varlen_attention(

--- a/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
+++ b/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
@@ -42,7 +42,12 @@ pytestmark = [
 ]
 
 
-def _config(*, aux_loss_coeff: float, n_routed_experts: int = 4):
+def _config(
+    *,
+    aux_loss_coeff: float,
+    n_routed_experts: int = 4,
+    gate_bias_update_factor: float = 0.0,
+):
     from nemo_automodel.components.moe.config import MoEConfig
 
     return MoEConfig(
@@ -52,9 +57,10 @@ def _config(*, aux_loss_coeff: float, n_routed_experts: int = 4):
         n_expert_groups=1,
         n_limited_groups=1,
         train_gate=True,
-        gate_bias_update_factor=0.0,
+        gate_bias_update_factor=gate_bias_update_factor,
         aux_loss_coeff=aux_loss_coeff,
-        score_func="softmax",
+        score_func=("softmax_with_bias" if gate_bias_update_factor > 0 else "softmax"),
+        force_e_score_correction_bias=gate_bias_update_factor > 0,
         route_scale=1.0,
         dim=4,
         inter_dim=8,
@@ -221,6 +227,7 @@ def test_ep4_matches_dense_main_and_logical_router_gradients():
         collect_shared_prefix_moe_statistics,
         enable_qwen3_moe_ep_router_gradients,
         shared_prefix_moe_context,
+        update_shared_prefix_moe_bias,
     )
 
     local_rank = int(os.environ["LOCAL_RANK"])
@@ -308,7 +315,10 @@ def test_ep4_matches_dense_main_and_logical_router_gradients():
         # exclusively injected by the router auxiliary loss. Sending the
         # compact weights through EP also verifies that the routing-weight
         # all-gather preserves this autograd edge.
-        aux_config = _config(aux_loss_coeff=0.125)
+        aux_config = _config(
+            aux_loss_coeff=0.125,
+            gate_bias_update_factor=0.0625,
+        )
         logical_gate = _make_gate(aux_config, device)
         dense_aux_gate = copy.deepcopy(logical_gate)
         _install_logical_router(logical_gate)
@@ -370,6 +380,24 @@ def test_ep4_matches_dense_main_and_logical_router_gradients():
             rtol=4e-5,
             atol=4e-6,
         )
+
+        expected_global_load = dense_aux_gate._cumulative_expert_load.clone().float()
+        dist.all_reduce(expected_global_load)
+        expected_bias = (
+            torch.sign(expected_global_load.mean() - expected_global_load)
+            * aux_config.gate_bias_update_factor
+        )
+        bias_model = torch.nn.Module()
+        bias_model.add_module("gate", logical_gate)
+        bias_model._nemo_shared_prefix_custom_qwen3_moe = True
+        update_shared_prefix_moe_bias(bias_model, dist.group.WORLD)
+        torch.testing.assert_close(
+            logical_gate.e_score_correction_bias,
+            expected_bias,
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert logical_gate._cumulative_expert_load is None
 
         # DP statistics collectives must remain aligned when packing gives one
         # rank only dummy microbatches. Simulate that by retaining accumulators

--- a/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
+++ b/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
@@ -228,7 +228,11 @@ def test_ep4_matches_dense_main_and_logical_router_gradients():
     device = torch.device("cuda", local_rank)
     initialized_here = not dist.is_initialized()
     if initialized_here:
-        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=2))
+        dist.init_process_group(
+            backend="nccl",
+            timeout=timedelta(minutes=2),
+            device_id=device,
+        )
 
     original_aux_scale = MoEAuxLossAutoScaler.main_loss_backward_scale
     try:
@@ -447,9 +451,6 @@ def test_ep4_ep_shard2_matches_dense_post_scaled_main_and_aux_gradients():
     from torch.distributed.tensor import DTensor, Shard
     from torch.distributed.tensor.parallel import parallelize_module
 
-    from nemo_rl.models.automodel.setup import (
-        _prewarm_native_shared_prefix_moe_world,
-    )
     from nemo_rl.models.automodel.shared_prefix_moe import (
         enable_qwen3_moe_ep_router_gradients,
         shared_prefix_moe_context,
@@ -460,14 +461,17 @@ def test_ep4_ep_shard2_matches_dense_post_scaled_main_and_aux_gradients():
     device = torch.device("cuda", local_rank)
     initialized_here = not dist.is_initialized()
     if initialized_here:
-        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=2))
+        dist.init_process_group(
+            backend="nccl",
+            timeout=timedelta(minutes=2),
+            device_id=device,
+        )
 
     original_aux_scale = MoEAuxLossAutoScaler.main_loss_backward_scale
     try:
         rank = dist.get_rank()
         world_size = dist.get_world_size()
         assert world_size == 8
-        _prewarm_native_shared_prefix_moe_world(world_size)
         enable_qwen3_moe_ep_router_gradients()
 
         # This is the same overlapping interpretation used by NeMo-RL:

--- a/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
+++ b/tests/unit/models/automodel/test_shared_prefix_ep_distributed.py
@@ -1,0 +1,605 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU oracle tests for native Qwen3-MoE expert parallelism.
+
+Run this file under ``torchrun --nproc-per-node=4`` for EP=4 or under
+``torchrun --nproc-per-node=8`` for EP=4 with an EP-shard dimension of two.
+Ordinary pytest runs skip it because the differentiable routing-weight gather
+only exists for EP > 1.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from datetime import timedelta
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+_WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
+pytestmark = [
+    pytest.mark.automodel,
+    pytest.mark.skipif(
+        _WORLD_SIZE not in {4, 8} or "LOCAL_RANK" not in os.environ,
+        reason="requires torchrun with four or eight ranks",
+    ),
+]
+
+
+def _config(*, aux_loss_coeff: float, n_routed_experts: int = 4):
+    from nemo_automodel.components.moe.config import MoEConfig
+
+    return MoEConfig(
+        n_routed_experts=n_routed_experts,
+        n_shared_experts=0,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=aux_loss_coeff,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=4,
+        inter_dim=8,
+        moe_inter_dim=6,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+
+
+def _make_gate(config, device):
+    from nemo_automodel.components.moe.layers import Gate
+
+    gate = Gate(config, gate_precision=torch.float32).to(device).train()
+    with torch.no_grad():
+        if config.n_routed_experts == 4:
+            value = torch.tensor(
+                [
+                    [1.20, -0.25, 0.10, 0.05],
+                    [-0.35, 1.10, 0.20, -0.15],
+                    [0.15, -0.30, 1.05, 0.25],
+                    [-0.20, 0.15, -0.40, 1.25],
+                ],
+                device=device,
+            )
+        else:
+            indices = torch.arange(
+                config.n_routed_experts * config.dim,
+                device=device,
+                dtype=torch.float32,
+            ).reshape(config.n_routed_experts, config.dim)
+            value = 0.7 * torch.sin(indices * 0.37 + 0.2) + 0.4 * torch.cos(
+                indices * 0.13 - 0.1
+            )
+        gate.weight.copy_(value)
+    return gate
+
+
+def _make_experts(config, device):
+    from nemo_automodel.components.moe.experts import GroupedExperts
+
+    experts = GroupedExperts(config).to(device).train()
+    # This tiny numerical oracle validates EP/FSDP/autograd semantics rather
+    # than Inductor.  The pinned implementation wraps this four-op activation
+    # in several separately compiled custom-autograd kernels; eight ranks each
+    # launching a 32-worker max-autotune pool obscures collective failures and
+    # can exceed the short-job limit before the first EP forward completes.
+    # Keep production's compiled activation unchanged and use the exact eager
+    # forward math here; ordinary autograd supplies the same derivatives.
+    experts.expert_activation_grouped = _eager_weighted_swiglu
+    with torch.no_grad():
+        for parameter_index, parameter in enumerate(experts.parameters()):
+            values = torch.arange(
+                parameter.numel(), device=device, dtype=torch.float32
+            ).reshape(parameter.shape)
+            parameter.copy_(0.07 * torch.sin(values * 0.17 + parameter_index * 0.31))
+    return experts
+
+
+def _eager_weighted_swiglu(
+    value: torch.Tensor,
+    weights: torch.Tensor,
+    fp8_input_store: bool = False,
+) -> torch.Tensor:
+    assert not fp8_input_store
+    gate, up = torch.chunk(value, 2, dim=-1)
+    return (F.silu(gate) * up * weights).to(value.dtype)
+
+
+def _global_inputs(device):
+    # Unequal per-rank token counts exercise the variable-length EP gather.
+    local_lengths = [2, 3, 4, 5]
+    values = torch.arange(sum(local_lengths) * 4, device=device, dtype=torch.float32)
+    x = (0.65 * torch.sin(values * 0.23) + 0.35 * torch.cos(values * 0.11)).reshape(
+        -1, 4
+    )
+    targets = torch.cos(values.reshape(-1, 4) * 0.19 + 0.4)
+    return x, targets, local_lengths
+
+
+def _global_inputs_ep_shard(device):
+    # Both EP-shard replicas receive distinct data, and every EP group still
+    # contains unequal local token counts.
+    local_lengths = [2, 3, 4, 5, 3, 2, 5, 4]
+    values = torch.arange(sum(local_lengths) * 4, device=device, dtype=torch.float32)
+    x = (0.55 * torch.sin(values * 0.21) + 0.45 * torch.cos(values * 0.09)).reshape(
+        -1, 4
+    )
+    targets = torch.sin(values.reshape(-1, 4) * 0.17 + 0.35)
+    return x, targets, local_lengths
+
+
+def _local_dtensor(tensor):
+    from torch.distributed.tensor import DTensor
+
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _full_dtensor(tensor):
+    from torch.distributed.tensor import DTensor
+
+    return tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
+
+
+def _install_logical_router(gate):
+    from nemo_rl.models.automodel.shared_prefix_moe import _logical_router_forward
+
+    gate._nemo_shared_prefix_original_forward = gate.forward
+    gate.forward = MethodType(_logical_router_forward, gate)
+
+
+def _production_w8_meshes():
+    """Construct exactly the DP and overlapping EP views used by NeMo-RL."""
+    from nemo_automodel.components.distributed.config import FSDP2Config
+    from nemo_automodel.components.distributed.mesh_utils import (
+        create_device_mesh,
+        get_submesh,
+    )
+
+    device_mesh, moe_mesh = create_device_mesh(
+        FSDP2Config(backend="nccl"),
+        dp_replicate_size=1,
+        tp_size=1,
+        pp_size=1,
+        cp_size=1,
+        ep_size=4,
+        world_size=8,
+    )
+    assert device_mesh is not None
+    assert moe_mesh is not None
+    # ``MeshContext._dp_axis_names()`` passes only ``dp_shard_cp`` to the
+    # native MoE parallelizer for this topology.  The flattened ``dp`` view is
+    # a convenient logical data mesh, but it is not the root FSDP mesh used by
+    # production when EP introduces an overlapping ``ep_shard`` dimension.
+    return get_submesh(device_mesh, ("dp_shard_cp",)), moe_mesh
+
+
+class _TinyMoE(torch.nn.Module):
+    def __init__(self, gate, experts):
+        super().__init__()
+        self.gate = gate
+        self.experts = experts
+
+    def forward(self, x, token_mask):
+        weights, indices, aux_loss = self.gate(x, token_mask, None)
+        output = self.experts(x, token_mask, weights, indices)
+        return output, indices, aux_loss
+
+
+@pytest.mark.skipif(_WORLD_SIZE != 4, reason="requires exactly four ranks")
+def test_ep4_matches_dense_main_and_logical_router_gradients():
+    pytest.importorskip("nemo_automodel")
+    if not torch.cuda.is_available() or torch.cuda.device_count() < 4:
+        pytest.skip("requires four visible CUDA devices")
+
+    from nemo_automodel.components.moe.megatron.moe_utils import (
+        MoEAuxLossAutoScaler,
+    )
+    from nemo_automodel.components.moe.parallelizer import ExpertParallel
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor.parallel import parallelize_module
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        collect_shared_prefix_moe_statistics,
+        enable_qwen3_moe_ep_router_gradients,
+        shared_prefix_moe_context,
+    )
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    initialized_here = not dist.is_initialized()
+    if initialized_here:
+        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=2))
+
+    original_aux_scale = MoEAuxLossAutoScaler.main_loss_backward_scale
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        assert world_size == 4
+        enable_qwen3_moe_ep_router_gradients()
+        ep_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("ep",))
+
+        # Main-loss oracle: all ranks independently evaluate the full dense MoE,
+        # while EP owns one expert per rank and receives a different token count.
+        main_config = _config(aux_loss_coeff=0.0)
+        dense_gate = _make_gate(main_config, device)
+        ep_gate = copy.deepcopy(dense_gate)
+        dense_experts = _make_experts(main_config, device)
+        ep_experts = copy.deepcopy(dense_experts)
+        parallelize_module(ep_experts, ep_mesh, ExpertParallel())
+
+        global_x_values, global_targets, local_lengths = _global_inputs(device)
+        start = sum(local_lengths[:rank])
+        stop = start + local_lengths[rank]
+        local_x = global_x_values[start:stop].clone().requires_grad_(True)
+        dense_x = global_x_values.clone().requires_grad_(True)
+        local_mask = torch.ones(local_x.shape[0], device=device, dtype=torch.bool)
+        dense_mask = torch.ones(dense_x.shape[0], device=device, dtype=torch.bool)
+
+        ep_weights, ep_indices, _ = ep_gate(local_x, local_mask, None)
+        ep_output = ep_experts(local_x, local_mask, ep_weights, ep_indices)
+        dense_weights, dense_indices, _ = dense_gate(dense_x, dense_mask, None)
+        dense_output = dense_experts(dense_x, dense_mask, dense_weights, dense_indices)
+
+        assert torch.equal(ep_indices, dense_indices[start:stop])
+        torch.testing.assert_close(
+            ep_weights, dense_weights[start:stop], rtol=2e-6, atol=2e-6
+        )
+        torch.testing.assert_close(
+            ep_output, dense_output[start:stop], rtol=2e-5, atol=2e-6
+        )
+
+        (ep_output * global_targets[start:stop]).sum().backward()
+        (dense_output * global_targets).sum().backward()
+
+        # Gate parameters are replicated in this focused harness. Summing their
+        # rank-local gradients is the DDP/FSDP reduction used by a real policy.
+        assert ep_gate.weight.grad is not None
+        dist.all_reduce(ep_gate.weight.grad, op=dist.ReduceOp.SUM)
+        assert ep_gate.weight.grad.norm() > 0
+        torch.testing.assert_close(
+            ep_gate.weight.grad, dense_gate.weight.grad, rtol=3e-5, atol=3e-6
+        )
+        torch.testing.assert_close(
+            local_x.grad, dense_x.grad[start:stop], rtol=4e-5, atol=4e-6
+        )
+
+        experts_per_rank = main_config.n_routed_experts // world_size
+        expert_start = rank * experts_per_rank
+        expert_stop = expert_start + experts_per_rank
+        for (ep_name, ep_parameter), (dense_name, dense_parameter) in zip(
+            ep_experts.named_parameters(), dense_experts.named_parameters()
+        ):
+            assert ep_name == dense_name
+            assert ep_parameter.grad is not None
+            torch.testing.assert_close(
+                _local_dtensor(ep_parameter.grad),
+                dense_parameter.grad[expert_start:expert_stop],
+                rtol=4e-5,
+                atol=4e-6,
+            )
+
+        # Logical-router oracle: repeat compact tokens according to their
+        # multiplicity, then compare that ordinary dense aux loss with the
+        # ZoRRo adapter. The zero downstream loss ensures any Gate gradient is
+        # exclusively injected by the router auxiliary loss. Sending the
+        # compact weights through EP also verifies that the routing-weight
+        # all-gather preserves this autograd edge.
+        aux_config = _config(aux_loss_coeff=0.125)
+        logical_gate = _make_gate(aux_config, device)
+        dense_aux_gate = copy.deepcopy(logical_gate)
+        _install_logical_router(logical_gate)
+        logical_gate._track_load_balance = True
+        dense_aux_gate._track_load_balance = True
+
+        compact_x = local_x.detach().clone().requires_grad_(True)
+        multiplicity = (
+            torch.arange(compact_x.shape[0], device=device, dtype=torch.long) % 3
+            + rank
+            + 1
+        )
+        layout = SimpleNamespace(logical_token_weights=multiplicity)
+        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(
+            0.625, device=device
+        )
+        with shared_prefix_moe_context(logical_gate, layout, valid=True) as execution:
+            logical_weights, logical_indices, logical_aux = logical_gate(
+                compact_x, local_mask, None
+            )
+            execution.commit()
+        logical_output = ep_experts(
+            compact_x, local_mask, logical_weights, logical_indices
+        )
+
+        expanded_x = (
+            compact_x.detach()
+            .repeat_interleave(multiplicity, dim=0)
+            .requires_grad_(True)
+        )
+        expanded_mask = torch.ones(expanded_x.shape[0], device=device, dtype=torch.bool)
+        oracle_weights, oracle_indices, oracle_aux = dense_aux_gate(
+            expanded_x, expanded_mask, None
+        )
+
+        assert torch.equal(
+            logical_indices.repeat_interleave(multiplicity, dim=0), oracle_indices
+        )
+        torch.testing.assert_close(
+            logical_weights.repeat_interleave(multiplicity, dim=0),
+            oracle_weights,
+            rtol=2e-6,
+            atol=2e-6,
+        )
+        torch.testing.assert_close(logical_aux, oracle_aux, rtol=2e-6, atol=2e-6)
+        assert torch.equal(
+            logical_gate._last_expert_load, dense_aux_gate._last_expert_load
+        )
+
+        (logical_output.sum() * 0.0).backward()
+        (oracle_weights.sum() * 0.0).backward()
+        assert logical_gate.weight.grad is not None
+        dist.all_reduce(logical_gate.weight.grad, op=dist.ReduceOp.SUM)
+        dist.all_reduce(dense_aux_gate.weight.grad, op=dist.ReduceOp.SUM)
+        assert logical_gate.weight.grad.norm() > 0
+        torch.testing.assert_close(
+            logical_gate.weight.grad,
+            dense_aux_gate.weight.grad,
+            rtol=4e-5,
+            atol=4e-6,
+        )
+
+        # DP statistics collectives must remain aligned when packing gives one
+        # rank only dummy microbatches. Simulate that by retaining accumulators
+        # on even ranks only and compare against an explicit global reduction.
+        expected_load = logical_gate._nemo_shared_prefix_logical_expert_load.clone()
+        expected_aux = logical_gate._nemo_shared_prefix_aux_loss_sum.clone()
+        expected_aux_count = logical_gate._nemo_shared_prefix_aux_loss_count
+        if rank % 2:
+            expected_load.zero_()
+            expected_aux.zero_()
+            expected_aux_count = 0
+            logical_gate._nemo_shared_prefix_logical_expert_load = None
+            logical_gate._nemo_shared_prefix_aux_loss_sum = None
+            logical_gate._nemo_shared_prefix_aux_loss_count = 0
+        dist.all_reduce(expected_load)
+        expected_aux_pair = torch.stack(
+            (
+                expected_aux,
+                expected_aux.new_tensor(float(expected_aux_count)),
+            )
+        )
+        dist.all_reduce(expected_aux_pair)
+
+        stats_model = torch.nn.Module()
+        stats_model.add_module("gate", logical_gate)
+        stats_model._nemo_shared_prefix_custom_qwen3_moe = True
+        stats = collect_shared_prefix_moe_statistics(stats_model, dist.group.WORLD)
+        assert stats["logical_token_layer_events"] == pytest.approx(
+            (expected_load.sum() / aux_config.n_activated_experts).item()
+        )
+        assert stats["logical_router_aux_loss_mean"] == pytest.approx(
+            (expected_aux_pair[0] / expected_aux_pair[1]).item()
+        )
+
+        # Dummy microbatches still execute collectives on all EP ranks, but
+        # they must attach no aux gradient and commit no logical statistics.
+        dummy_gate = _make_gate(aux_config, device)
+        _install_logical_router(dummy_gate)
+        dummy_x = local_x.detach().clone().requires_grad_(True)
+        with shared_prefix_moe_context(dummy_gate, layout, valid=False) as execution:
+            dummy_weights, dummy_indices, dummy_aux = dummy_gate(
+                dummy_x, local_mask, None
+            )
+            execution.commit()
+        dummy_output = ep_experts(dummy_x, local_mask, dummy_weights, dummy_indices)
+        (dummy_output.sum() * 0.0).backward()
+
+        assert dummy_aux is None
+        assert execution.pending == {}
+        assert dummy_gate._last_expert_load is None
+        assert (
+            getattr(dummy_gate, "_nemo_shared_prefix_logical_expert_load", None) is None
+        )
+        assert dummy_gate.weight.grad is not None
+        torch.testing.assert_close(
+            dummy_gate.weight.grad, torch.zeros_like(dummy_gate.weight.grad)
+        )
+    finally:
+        MoEAuxLossAutoScaler.main_loss_backward_scale = original_aux_scale
+        if initialized_here and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(_WORLD_SIZE != 8, reason="requires exactly eight ranks")
+def test_ep4_ep_shard2_matches_dense_post_scaled_main_and_aux_gradients():
+    """Exercise the production W=8, EP=4, EP-shard=2 gradient topology."""
+    pytest.importorskip("nemo_automodel")
+    if not torch.cuda.is_available() or torch.cuda.device_count() < 8:
+        pytest.skip("requires eight visible CUDA devices")
+
+    from nemo_automodel.components.moe.megatron.moe_utils import (
+        MoEAuxLossAutoScaler,
+    )
+    from nemo_automodel.components.moe.parallelizer import ExpertParallel
+    from nemo_automodel.components.training.utils import (
+        scale_grads_and_clip_grad_norm,
+    )
+    from torch.distributed.fsdp import fully_shard
+    from torch.distributed.tensor import DTensor, Shard
+    from torch.distributed.tensor.parallel import parallelize_module
+
+    from nemo_rl.models.automodel.setup import (
+        _prewarm_native_shared_prefix_moe_world,
+    )
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_ep_router_gradients,
+        shared_prefix_moe_context,
+    )
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    initialized_here = not dist.is_initialized()
+    if initialized_here:
+        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=2))
+
+    original_aux_scale = MoEAuxLossAutoScaler.main_loss_backward_scale
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        assert world_size == 8
+        _prewarm_native_shared_prefix_moe_world(world_size)
+        enable_qwen3_moe_ep_router_gradients()
+
+        # This is the same overlapping interpretation used by NeMo-RL:
+        # all eight ranks are DP data ranks, while the native experts view them
+        # as two EP replicas, each containing four expert-parallel ranks.
+        dp_mesh, moe_mesh = _production_w8_meshes()
+
+        config = _config(aux_loss_coeff=0.125, n_routed_experts=8)
+        dense_model = _TinyMoE(
+            _make_gate(config, device), _make_experts(config, device)
+        ).train()
+        ep_model = copy.deepcopy(dense_model).train()
+        _install_logical_router(dense_model.gate)
+        _install_logical_router(ep_model.gate)
+
+        # Production order: shard expert dimension across EP first; FSDP-shard
+        # each local expert's hidden dimension across replica groups second;
+        # finally FSDP the shared Gate over the complete DP mesh while ignoring
+        # the already-managed expert parameters.
+        parallelize_module(ep_model.experts, moe_mesh["ep"], ExpertParallel())
+        fully_shard(
+            ep_model.experts,
+            mesh=moe_mesh["ep_shard"],
+            shard_placement_fn=lambda _: Shard(1),
+            reshard_after_forward=False,
+        )
+        fully_shard(
+            ep_model,
+            mesh=dp_mesh,
+            ignored_params=set(ep_model.experts.parameters()),
+            reshard_after_forward=False,
+        )
+
+        global_x, global_targets, local_lengths = _global_inputs_ep_shard(device)
+        offsets = [0]
+        for local_length in local_lengths:
+            offsets.append(offsets[-1] + local_length)
+
+        # The logical aux objective is normalized per rank/microbatch and is
+        # nonlinear, so the EP=1 oracle accumulates the eight local objectives
+        # rather than computing one aux loss from concatenated tokens.
+        dense_loss = global_x.new_zeros(())
+        dense_inputs = []
+        dense_outputs = []
+        dense_aux_losses = []
+        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(1.0, device=device)
+        for data_rank, (start, stop) in enumerate(zip(offsets[:-1], offsets[1:])):
+            dense_x = global_x[start:stop].clone().requires_grad_(True)
+            dense_mask = torch.ones(dense_x.shape[0], device=device, dtype=torch.bool)
+            multiplicity = (
+                torch.arange(dense_x.shape[0], device=device, dtype=torch.long) % 3
+                + data_rank
+                + 1
+            )
+            layout = SimpleNamespace(logical_token_weights=multiplicity)
+            with shared_prefix_moe_context(
+                dense_model, layout, valid=True
+            ) as execution:
+                dense_output, _, dense_aux = dense_model(dense_x, dense_mask)
+                execution.commit()
+            assert dense_aux is not None
+            dense_inputs.append(dense_x)
+            dense_outputs.append(dense_output.detach())
+            dense_aux_losses.append(dense_aux.detach())
+            dense_loss = dense_loss + (dense_output * global_targets[start:stop]).sum()
+        dense_loss.backward()
+
+        start, stop = offsets[rank], offsets[rank + 1]
+        local_x = global_x[start:stop].clone().requires_grad_(True)
+        local_mask = torch.ones(local_x.shape[0], device=device, dtype=torch.bool)
+        multiplicity = (
+            torch.arange(local_x.shape[0], device=device, dtype=torch.long) % 3
+            + rank
+            + 1
+        )
+        layout = SimpleNamespace(logical_token_weights=multiplicity)
+        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(
+            float(world_size), device=device
+        )
+        with shared_prefix_moe_context(ep_model, layout, valid=True) as execution:
+            ep_output, _, ep_aux = ep_model(local_x, local_mask)
+            execution.commit()
+        assert ep_aux is not None
+        torch.testing.assert_close(ep_aux, dense_aux_losses[rank])
+        torch.testing.assert_close(ep_output, dense_outputs[rank], rtol=3e-5, atol=3e-6)
+
+        # Policy.train multiplies the already globally normalized local main
+        # loss by W before backward. The logical aux autoscaler uses the same W.
+        # FSDP averages shared gradients over W and expert gradients over the
+        # two EP-shard replicas; the existing post-scale divides expert grads by
+        # W / EP-shard = 4, leaving the same global sum as the dense oracle.
+        ((ep_output * global_targets[start:stop]).sum() * world_size).backward()
+        scale_grads_and_clip_grad_norm(
+            max_grad_norm=None,
+            model_parts=[ep_model],
+            pp_enabled=False,
+            moe_mesh=moe_mesh,
+            ep_axis_name="ep",
+            dp_group_size=world_size,
+        )
+
+        assert local_x.grad is not None
+        torch.testing.assert_close(
+            local_x.grad / world_size,
+            dense_inputs[rank].grad,
+            rtol=5e-5,
+            atol=5e-6,
+        )
+
+        dense_parameters = dict(dense_model.named_parameters())
+        ep_parameters = dict(ep_model.named_parameters())
+        assert ep_parameters.keys() == dense_parameters.keys()
+        for name in sorted(ep_parameters):
+            ep_parameter = ep_parameters[name]
+            dense_parameter = dense_parameters[name]
+            assert ep_parameter.grad is not None, name
+            assert dense_parameter.grad is not None, name
+            if name.startswith("experts."):
+                assert isinstance(ep_parameter, DTensor), name
+                assert "ep" in ep_parameter.device_mesh.mesh_dim_names, name
+                assert "ep_shard" in ep_parameter.device_mesh.mesh_dim_names, name
+            ep_grad = _full_dtensor(ep_parameter.grad)
+            torch.testing.assert_close(
+                ep_grad,
+                dense_parameter.grad,
+                rtol=6e-5,
+                atol=6e-6,
+                msg=lambda message, parameter_name=name: (
+                    f"post-scaled gradient mismatch for {parameter_name}: {message}"
+                ),
+            )
+    finally:
+        MoEAuxLossAutoScaler.main_loss_backward_scale = original_aux_scale
+        if initialized_here and dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/unit/models/automodel/test_shared_prefix_moe_adapter_distributed.py
+++ b/tests/unit/models/automodel/test_shared_prefix_moe_adapter_distributed.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed oracle for the EP-free Qwen3-MoE checkpoint adapter.
+
+Run with either of the following commands::
+
+    torchrun --standalone --nproc-per-node=2 -m pytest -q \
+        tests/unit/models/automodel/test_shared_prefix_moe_adapter_distributed.py
+    torchrun --standalone --nproc-per-node=4 -m pytest -q \
+        tests/unit/models/automodel/test_shared_prefix_moe_adapter_distributed.py
+
+The production adapter deliberately stages checkpoint values in ordinary
+rank-local placeholders.  DCP fills those placeholders, and ``from_hf`` copies
+the fully validated values into the original FSDP DTensor storage.  This test
+simulates that DCP write without needing a filesystem checkpoint.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+_WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
+pytestmark = [
+    pytest.mark.automodel,
+    pytest.mark.skipif(
+        _WORLD_SIZE not in {2, 4} or "RANK" not in os.environ,
+        reason="requires torchrun with two or four ranks",
+    ),
+]
+
+_N_EXPERTS = 7
+_HIDDEN = 6
+_INTER = 2
+_GATE_UP_KEY = "model.layers.0.mlp.experts.gate_and_up_projs"
+_DOWN_KEY = "model.layers.0.mlp.experts.down_projs"
+_EXPERT_KEY = re.compile(
+    r"model\.layers\.0\.mlp\.experts\.(?P<expert>\d+)\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\.weight$"
+)
+
+
+def _adapter():
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.qwen3_moe.state_dict_adapter import (
+        Qwen3MoeStateDictAdapter,
+    )
+    from nemo_automodel.components.moe.config import MoEConfig
+
+    moe_config = MoEConfig(
+        n_routed_experts=_N_EXPERTS,
+        n_shared_experts=0,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        dim=_HIDDEN,
+        inter_dim=2 * _INTER,
+        moe_inter_dim=_INTER,
+        norm_topk_prob=False,
+        softmax_before_topk=True,
+        dtype=torch.float32,
+    )
+    backend = BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch_fp32",
+        rope_fusion=False,
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+    )
+    return Qwen3MoeStateDictAdapter(
+        config=SimpleNamespace(),
+        moe_config=moe_config,
+        backend=backend,
+        dtype=torch.float32,
+    )
+
+
+def _grouped_values(offset: float = 0.0) -> tuple[torch.Tensor, torch.Tensor]:
+    gate_up = torch.arange(
+        _N_EXPERTS * _HIDDEN * 2 * _INTER,
+        dtype=torch.float32,
+    ).reshape(_N_EXPERTS, _HIDDEN, 2 * _INTER)
+    down = torch.arange(
+        _N_EXPERTS * _INTER * _HIDDEN,
+        dtype=torch.float32,
+    ).reshape(_N_EXPERTS, _INTER, _HIDDEN)
+    return gate_up + offset, down + 2.0 * offset
+
+
+def _local_expert_ids(rank: int, world_size: int) -> tuple[int, ...]:
+    # DTensor's Shard placement follows torch.chunk rather than balanced
+    # divmod slices. Seven experts deliberately exercises uneven shards in
+    # both supported world sizes.
+    chunk_size = math.ceil(_N_EXPERTS / world_size)
+    start = min(rank * chunk_size, _N_EXPERTS)
+    stop = min(start + chunk_size, _N_EXPERTS)
+    return tuple(range(start, stop))
+
+
+def _expert_ids(hf_state_dict: dict[str, torch.Tensor]) -> tuple[int, ...]:
+    ids = {
+        int(match.group("expert"))
+        for key in hf_state_dict
+        if (match := _EXPERT_KEY.fullmatch(key)) is not None
+    }
+    return tuple(sorted(ids))
+
+
+def _copy_checkpoint_values_into_placeholders(
+    hf_state_dict: dict[str, torch.Tensor],
+    gate_up: torch.Tensor,
+    down: torch.Tensor,
+) -> None:
+    """Simulate DCP's in-place writes into adapter-created destinations."""
+    for key, placeholder in hf_state_dict.items():
+        match = _EXPERT_KEY.fullmatch(key)
+        if match is None:
+            continue
+        expert = int(match.group("expert"))
+        projection = match.group("projection")
+        if projection == "gate_proj":
+            checkpoint_value = gate_up[expert, :, :_INTER].T
+        elif projection == "up_proj":
+            checkpoint_value = gate_up[expert, :, _INTER:].T
+        else:
+            checkpoint_value = down[expert].T
+        placeholder.copy_(checkpoint_value)
+
+
+def _assert_all_placeholders_are_contiguous(
+    hf_state_dict: dict[str, torch.Tensor],
+) -> None:
+    expert_placeholders = [
+        value for key, value in hf_state_dict.items() if _EXPERT_KEY.fullmatch(key)
+    ]
+    assert expert_placeholders
+    assert all(value.is_contiguous() for value in expert_placeholders)
+
+
+def _assert_hf_expert_values(
+    hf_state_dict: dict[str, torch.Tensor],
+    gate_up: torch.Tensor,
+    down: torch.Tensor,
+) -> None:
+    """Verify native-to-HF save conversion before simulating a DCP load."""
+    for key, value in hf_state_dict.items():
+        match = _EXPERT_KEY.fullmatch(key)
+        if match is None:
+            continue
+        expert = int(match.group("expert"))
+        projection = match.group("projection")
+        if projection == "gate_proj":
+            expected = gate_up[expert, :, :_INTER].T
+        elif projection == "up_proj":
+            expected = gate_up[expert, :, _INTER:].T
+        else:
+            expected = down[expert].T
+        torch.testing.assert_close(value, expected, rtol=0.0, atol=0.0)
+
+
+def _assert_regular_refit_conversion_does_not_stage(adapter=None) -> None:
+    """A refit converts a gathered ordinary Tensor, not an FSDP local shard."""
+    adapter = _adapter() if adapter is None else adapter
+    source_gate_up, source_down = _grouped_values(offset=300.0)
+
+    hf_state_dict = dict(
+        adapter.convert_single_tensor_to_hf(_GATE_UP_KEY, source_gate_up)
+    )
+    hf_state_dict.update(adapter.convert_single_tensor_to_hf(_DOWN_KEY, source_down))
+
+    assert _expert_ids(hf_state_dict) == tuple(range(_N_EXPERTS))
+    _assert_all_placeholders_are_contiguous(hf_state_dict)
+
+    target_gate_up, target_down = _grouped_values(offset=700.0)
+    _copy_checkpoint_values_into_placeholders(
+        hf_state_dict,
+        target_gate_up,
+        target_down,
+    )
+    restored = adapter.from_hf(hf_state_dict)
+
+    torch.testing.assert_close(
+        restored[_GATE_UP_KEY], target_gate_up, rtol=0.0, atol=0.0
+    )
+    torch.testing.assert_close(restored[_DOWN_KEY], target_down, rtol=0.0, atol=0.0)
+
+
+def test_ep_free_checkpoint_adapter_staged_copy_oracle() -> None:
+    from torch.distributed._tensor import Shard, distribute_tensor
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from nemo_rl.models.automodel.shared_prefix_moe import (
+        enable_qwen3_moe_ep_free_checkpoint_adapter,
+    )
+
+    owns_process_group = not dist.is_initialized()
+    if owns_process_group:
+        dist.init_process_group("gloo", timeout=timedelta(minutes=3))
+
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        mesh = DeviceMesh(
+            "cpu",
+            torch.arange(world_size),
+            mesh_dim_names=("dp",),
+        )
+        enable_qwen3_moe_ep_free_checkpoint_adapter()
+
+        initial_gate_up, initial_down = _grouped_values(offset=10.0)
+        target_gate_up, target_down = _grouped_values(offset=1000.0)
+
+        native_gate_up = distribute_tensor(initial_gate_up, mesh, [Shard(0)])
+        native_down = distribute_tensor(initial_down, mesh, [Shard(0)])
+        adapter = _adapter()
+        hf_state_dict = adapter.to_hf(
+            {
+                _GATE_UP_KEY: native_gate_up,
+                _DOWN_KEY: native_down,
+            }
+        )
+
+        assert _expert_ids(hf_state_dict) == _local_expert_ids(rank, world_size)
+        _assert_all_placeholders_are_contiguous(hf_state_dict)
+        _assert_hf_expert_values(hf_state_dict, initial_gate_up, initial_down)
+
+        # The staged-copy design must not mutate model storage until every
+        # checkpoint key has been validated by from_hf.
+        local_gate_up_before = native_gate_up.to_local().clone()
+        local_down_before = native_down.to_local().clone()
+        _copy_checkpoint_values_into_placeholders(
+            hf_state_dict,
+            target_gate_up,
+            target_down,
+        )
+        torch.testing.assert_close(
+            native_gate_up.to_local(), local_gate_up_before, rtol=0.0, atol=0.0
+        )
+        torch.testing.assert_close(
+            native_down.to_local(), local_down_before, rtol=0.0, atol=0.0
+        )
+
+        restored = adapter.from_hf(hf_state_dict)
+        assert restored[_GATE_UP_KEY] is native_gate_up
+        assert restored[_DOWN_KEY] is native_down
+        torch.testing.assert_close(
+            native_gate_up.full_tensor(), target_gate_up, rtol=0.0, atol=0.0
+        )
+        torch.testing.assert_close(
+            native_down.full_tensor(), target_down, rtol=0.0, atol=0.0
+        )
+
+        # A rollout refit can reuse the checkpoint adapter after a previous
+        # bulk conversion was abandoned before ``from_hf``.  The first regular
+        # full-Tensor conversion must discard that stale rank-local staging.
+        adapter.to_hf(
+            {
+                _GATE_UP_KEY: native_gate_up,
+                _DOWN_KEY: native_down,
+            }
+        )
+        _assert_regular_refit_conversion_does_not_stage(adapter)
+
+        # Missing-key validation must happen before any projection is copied.
+        failing_gate_up = distribute_tensor(initial_gate_up, mesh, [Shard(0)])
+        failing_down = distribute_tensor(initial_down, mesh, [Shard(0)])
+        failing_adapter = _adapter()
+        incomplete = failing_adapter.to_hf(
+            {
+                _GATE_UP_KEY: failing_gate_up,
+                _DOWN_KEY: failing_down,
+            }
+        )
+        _copy_checkpoint_values_into_placeholders(
+            incomplete,
+            target_gate_up,
+            target_down,
+        )
+        missing_expert = _local_expert_ids(rank, world_size)[0]
+        del incomplete[f"model.layers.0.mlp.experts.{missing_expert}.up_proj.weight"]
+        failing_gate_up_before = failing_gate_up.to_local().clone()
+        failing_down_before = failing_down.to_local().clone()
+
+        with pytest.raises(
+            (RuntimeError, ValueError),
+            match=r"(?i)(missing|expected|checkpoint|expert)",
+        ):
+            failing_adapter.from_hf(incomplete)
+
+        torch.testing.assert_close(
+            failing_gate_up.to_local(),
+            failing_gate_up_before,
+            rtol=0.0,
+            atol=0.0,
+        )
+        torch.testing.assert_close(
+            failing_down.to_local(), failing_down_before, rtol=0.0, atol=0.0
+        )
+
+        # NeMo-RL's refit path calls full_tensor() before adapting each tensor.
+        # Its ordinary full-Tensor conversion must therefore retain all experts
+        # and the original from_hf rebuild semantics on every DP rank.
+        _assert_regular_refit_conversion_does_not_stage()
+    finally:
+        if owns_process_group:
+            dist.destroy_process_group()

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -79,11 +79,31 @@ def test_dtensor_v2_prepare_for_training_restores_optimizer(monkeypatch):
 def test_dtensor_v2_update_moe_gate_bias_called_when_supported():
     worker = object.__new__(DTensorPolicyWorkerV2Impl)
     worker.model = MagicMock()
+    worker.model._nemo_shared_prefix_custom_qwen3_moe = False
     worker.model.update_moe_gate_bias = MagicMock()
 
     DTensorPolicyWorkerV2Impl._update_moe_gate_bias_if_supported(worker)
 
     worker.model.update_moe_gate_bias.assert_called_once_with()
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+@patch(
+    "nemo_rl.models.policy.workers.dtensor_policy_worker_v2."
+    "update_shared_prefix_moe_bias"
+)
+def test_dtensor_v2_updates_shared_prefix_moe_bias_with_dp_group(mock_update):
+    worker = object.__new__(DTensorPolicyWorkerV2Impl)
+    worker.model = nn.Linear(1, 1)
+    worker.model._nemo_shared_prefix_custom_qwen3_moe = True
+    dp_group = object()
+    worker.dp_mesh = MagicMock()
+    worker.dp_mesh.get_group.return_value = dp_group
+
+    DTensorPolicyWorkerV2Impl._update_moe_gate_bias_if_supported(worker)
+
+    mock_update.assert_called_once_with(worker.model, dp_group)
 
 
 @pytest.mark.automodel
@@ -685,6 +705,18 @@ class TestDTensorParamsGenerator:
             assert tensor.dtype == target_dtype, (
                 f"Tensor {name} should be converted to {target_dtype}"
             )
+
+    def test_correction_bias_stays_float32(self):
+        """Routing decisions must not quantize the correction bias on refit."""
+        model = nn.Module()
+        model.register_buffer(
+            "e_score_correction_bias",
+            torch.tensor([0.125, -0.25], dtype=torch.float32),
+        )
+
+        results = dict(dtensor_params_generator(model, torch.bfloat16))
+
+        assert results["e_score_correction_bias"].dtype == torch.float32
 
     def test_contiguous_output(self):
         """Test that output tensors are contiguous."""

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -349,6 +349,26 @@ def test_dtensor_dp_replicate_size_requires_v2(
     mock_ray_worker_group.assert_not_called()
 
 
+@pytest.mark.parametrize("backend", ["dtensor_v1", "megatron"])
+@patch("nemo_rl.models.policy.lm_policy.RayWorkerGroup")
+def test_shared_prefix_training_requires_dtensor_v2(
+    mock_ray_worker_group,
+    backend,
+):
+    cluster = create_mock_cluster(world_size=1)
+    tokenizer = create_mock_tokenizer()
+    if backend == "dtensor_v1":
+        config = create_dtensor_config("unused-model", tp=1)
+    else:
+        config = create_megatron_config("unused-model", tp=1)
+    config["shared_prefix_training"] = True
+
+    with pytest.raises(ValueError, match="requires the DTensor v2 backend"):
+        Policy(cluster=cluster, config=config, tokenizer=tokenizer)
+
+    mock_ray_worker_group.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "world_size,tp,pp,cp,should_pass,expected_error_type,description",
     [

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -63,9 +63,9 @@ def _save_tiny_qwen3(model_path) -> None:
         hidden_size=64,
         intermediate_size=128,
         num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=2,
-        head_dim=16,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=8,
         max_position_embeddings=128,
         attention_dropout=0.0,
         tie_word_embeddings=False,
@@ -92,10 +92,10 @@ def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
             3 + group * prompt_length,
             3 + (group + 1) * prompt_length,
         )
-        input_ids[row, prompt_length : prompt_length + response_length] = (
-            torch.arange(40 + row * response_length, 40 + (row + 1) * response_length)
-            % 85
-            + 3
+        response_start = 4 + (row % 4) * 32 + (row // 4) * response_length
+        input_ids[row, prompt_length : prompt_length + response_length] = torch.arange(
+            response_start,
+            response_start + response_length,
         )
         input_ids[
             row,
@@ -141,8 +141,9 @@ def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
     [
         (4, 1, 4, 2, 1, 36),
         (2, 2, 1, 8, 2, 112),
+        (4, 4, 1, 8, 2, 112),
     ],
-    ids=["dp4_tp1", "dp1_tp2"],
+    ids=["dp4_tp1", "dp1_tp2", "dp1_tp4"],
 )
 def test_shared_prefix_policy_train_fsdp2(
     tmp_path,
@@ -216,8 +217,8 @@ def test_shared_prefix_policy_train_fsdp2(
         train_data["generation_logprobs"] = before.clone()
         train_data["reference_policy_logprobs"] = before.clone()
 
-        # DP=4 forces four compact bins; TP=2 keeps all rollouts in one DP bin
-        # and replicates that physical layout across its two tensor-parallel ranks.
+        # DP=4 forces four compact bins; TP-only cases keep all rollouts in one
+        # DP bin and replicate that physical layout across tensor-parallel ranks.
         shards = policy._shard_for_train(train_data, batch_size=8)
         assert len(shards) == dp_size
         for shard in shards:

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Four-GPU integration smoke for Qwen3 shared-prefix ``Policy.train``."""
+"""Multi-GPU integration smokes for Qwen3 shared-prefix ``Policy.train``."""
 
 import sys
 
@@ -136,8 +136,25 @@ def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
 
 @pytest.mark.automodel
 @pytest.mark.timeout(420)
-def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
-    """Exercise dense LP -> compact FSDP2 train -> dense LP on four DP ranks."""
+@pytest.mark.parametrize(
+    "world_size,tp_size,dp_size,shard_size,groups_per_shard,compact_tokens",
+    [
+        (4, 1, 4, 2, 1, 36),
+        (2, 2, 1, 8, 2, 112),
+    ],
+    ids=["dp4_tp1", "dp1_tp2"],
+)
+def test_shared_prefix_policy_train_fsdp2(
+    tmp_path,
+    monkeypatch,
+    world_size,
+    tp_size,
+    dp_size,
+    shard_size,
+    groups_per_shard,
+    compact_tokens,
+):
+    """Exercise dense LP -> compact FSDP2 train -> dense LP with DP or TP."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
     monkeypatch.setenv("TOKENIZERS_PARALLELISM", "false")
@@ -149,6 +166,7 @@ def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
     _save_tiny_qwen3(model_path)
     config = create_test_config(
         model_name=str(model_path),
+        tp=tp_size,
         dtensor_v2=True,
         precision="bfloat16",
         sequence_packing_enabled=True,
@@ -173,9 +191,9 @@ def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
 
     cluster = RayVirtualCluster(
         name="shared_prefix_policy_train",
-        bundle_ct_per_node_list=[4],
+        bundle_ct_per_node_list=[world_size],
         use_gpus=True,
-        num_gpus_per_node=4,
+        num_gpus_per_node=world_size,
         max_colocated_worker_groups=1,
     )
     policy = None
@@ -188,31 +206,32 @@ def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
             cluster=cluster,
             name_prefix="shared_prefix_policy",
         )
-        assert policy.data_parallel_size == 4
+        assert policy.data_parallel_size == dp_size
 
         dense_data, train_data = _make_rollouts()
-        assert train_data["input_lengths"].tolist() == [24] * 8
+        assert train_data["input_lengths"].tolist() == [26] * 8
         policy.prepare_for_lp_inference()
         before = policy.get_logprobs(dense_data)["logprobs"]
         train_data["prev_logprobs"] = before.clone()
         train_data["generation_logprobs"] = before.clone()
         train_data["reference_policy_logprobs"] = before.clone()
 
-        # The 128-token batch would fit in one shared bin. DP=4 forces four
-        # nonempty bins: two responses per bin, and each split group recomputes
-        # its 16-token prompt exactly once on each receiving rank.
+        # DP=4 forces four compact bins; TP=2 keeps all rollouts in one DP bin
+        # and replicates that physical layout across its two tensor-parallel ranks.
         shards = policy._shard_for_train(train_data, batch_size=8)
-        assert len(shards) == 4
+        assert len(shards) == dp_size
         for shard in shards:
-            assert shard.size == 2
-            assert torch.unique(shard[SHARED_PREFIX_GROUP_IDS]).numel() == 1
+            assert shard.size == shard_size
+            assert (
+                torch.unique(shard[SHARED_PREFIX_GROUP_IDS]).numel() == groups_per_shard
+            )
             layout = build_shared_prefix_layout(
                 shard["input_ids"],
                 shard["input_lengths"],
                 shard[SHARED_PREFIX_LENGTHS],
                 shard[SHARED_PREFIX_GROUP_IDS],
             )
-            assert layout.compact_tokens == 32
+            assert layout.compact_tokens == compact_tokens
 
         policy.prepare_for_training()
         result = policy.train(
@@ -222,7 +241,7 @@ def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
         assert torch.isfinite(result["loss"]).all()
         assert torch.isfinite(result["grad_norm"]).all()
         assert result["grad_norm"].item() > 0
-        assert len(result["all_mb_metrics"]["loss"]) == 4
+        assert len(result["all_mb_metrics"]["loss"]) == dp_size
 
         policy.prepare_for_lp_inference()
         after = policy.get_logprobs(dense_data)["logprobs"]

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -356,6 +356,7 @@ def test_shared_prefix_policy_train_native_qwen3_moe(
         activation_checkpointing=True,
         automodel_kwargs={
             "force_hf": False,
+            "moe_overrides": {"gate_bias_update_factor": 0.0625},
             "backend": {
                 "_target_": (
                     "nemo_automodel.components.models.common.utils.BackendConfig"
@@ -370,6 +371,7 @@ def test_shared_prefix_policy_train_native_qwen3_moe(
         },
     )
     config["shared_prefix_training"] = True
+    config["generation"]["backend"] = "vllm"
     config["train_global_batch_size"] = 8
     config["train_micro_batch_size"] = 2
     config["logprob_batch_size"] = 2
@@ -445,6 +447,27 @@ def test_shared_prefix_policy_train_native_qwen3_moe(
         assert not _any_parameter_changed(
             before_parameters, after_aux_parameters, ".mlp.experts."
         )
+        correction_bias_names = {
+            name
+            for snapshot in after_aux_parameters
+            for name in snapshot
+            if name.endswith(".e_score_correction_bias")
+        }
+        assert len(correction_bias_names) == 1
+        correction_bias_name = correction_bias_names.pop()
+        assert any(
+            not torch.equal(before[correction_bias_name], after[correction_bias_name])
+            for before, after in zip(before_parameters, after_aux_parameters)
+        )
+        reference_bias = after_aux_parameters[0][correction_bias_name]
+        assert reference_bias.dtype == torch.float32
+        for rank_snapshot in after_aux_parameters[1:]:
+            torch.testing.assert_close(
+                rank_snapshot[correction_bias_name],
+                reference_bias,
+                rtol=0.0,
+                atol=0.0,
+            )
 
         moe_metrics = aux_only_result["moe_metrics"]
         assert moe_metrics["logical_token_layer_events"] == pytest.approx(8 * 26)

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -21,12 +21,15 @@ import torch
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
+from torch.distributed.tensor import DTensor
 from transformers import (
     LlamaConfig,
     LlamaForCausalLM,
     PreTrainedTokenizerFast,
     Qwen3Config,
     Qwen3ForCausalLM,
+    Qwen3MoeConfig,
+    Qwen3MoeForCausalLM,
 )
 
 from nemo_rl.algorithms.grpo import _add_shared_prefix_training_metadata
@@ -45,13 +48,17 @@ from nemo_rl.models.automodel.shared_prefix import (
 from nemo_rl.models.policy.lm_policy import Policy
 from tests.unit.models.policy.test_dtensor_worker_v2 import create_test_config
 
-
 _DTENSOR_V2_ACTOR = (
     "nemo_rl.models.policy.workers.dtensor_policy_worker_v2.DTensorPolicyWorkerV2"
 )
 
 
-def _save_tiny_causal_lm(model_path, model_family: str) -> None:
+def _save_tiny_causal_lm(
+    model_path,
+    model_family: str,
+    *,
+    num_hidden_layers: int = 2,
+) -> None:
     vocab = {"<pad>": 0, "<eos>": 1, "<unk>": 2}
     vocab.update({f"token_{index}": index for index in range(3, 128)})
     tokenizer_backend = Tokenizer(WordLevel(vocab=vocab, unk_token="<unk>"))
@@ -68,7 +75,7 @@ def _save_tiny_causal_lm(model_path, model_family: str) -> None:
         vocab_size=128,
         hidden_size=64,
         intermediate_size=128,
-        num_hidden_layers=2,
+        num_hidden_layers=num_hidden_layers,
         num_attention_heads=8,
         num_key_value_heads=4,
         head_dim=8,
@@ -81,8 +88,23 @@ def _save_tiny_causal_lm(model_path, model_family: str) -> None:
     )
     if model_family == "qwen3":
         model = Qwen3ForCausalLM(Qwen3Config(**config_kwargs))
-    else:
+    elif model_family == "llama":
         model = LlamaForCausalLM(LlamaConfig(**config_kwargs))
+    else:
+        model = Qwen3MoeForCausalLM(
+            Qwen3MoeConfig(
+                **config_kwargs,
+                moe_intermediate_size=64,
+                decoder_sparse_step=1,
+                mlp_only_layers=[],
+                num_experts=4,
+                num_experts_per_tok=2,
+                norm_topk_prob=False,
+                router_aux_loss_coef=0.03125,
+                use_sliding_window=False,
+                output_router_logits=False,
+            )
+        )
     model.save_pretrained(model_path)
     tokenizer.save_pretrained(model_path)
 
@@ -141,6 +163,34 @@ def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
         num_generations_per_prompt=4,
     )
     return dense_data, train_data
+
+
+def _snapshot_local_moe_parameters(policy: Policy) -> list[dict[str, torch.Tensor]]:
+    """Copy each rank's local router/expert shards for update assertions."""
+    state_dicts = policy.run_all_workers_single_data("return_state_dict")
+    snapshots = []
+    for state_dict in state_dicts:
+        local_state = {}
+        for name, tensor in state_dict.items():
+            if ".mlp.gate." not in name and ".mlp.experts." not in name:
+                continue
+            local_tensor = tensor.to_local() if isinstance(tensor, DTensor) else tensor
+            local_state[name] = local_tensor.detach().cpu().clone()
+        snapshots.append(local_state)
+    return snapshots
+
+
+def _any_parameter_changed(
+    before: list[dict[str, torch.Tensor]],
+    after: list[dict[str, torch.Tensor]],
+    name_fragment: str,
+) -> bool:
+    return any(
+        not torch.equal(before_rank[name], after_rank[name])
+        for before_rank, after_rank in zip(before, after)
+        for name in before_rank
+        if name_fragment in name
+    )
 
 
 @pytest.mark.automodel
@@ -272,6 +322,166 @@ def test_shared_prefix_policy_train_fsdp2(
         response_mask = train_data["token_mask"].bool()
         max_response_delta = (after - before).abs()[response_mask].max()
         assert max_response_delta.item() > 1e-6
+    finally:
+        if policy is not None:
+            policy.shutdown()
+        cluster.shutdown()
+
+
+@pytest.mark.automodel
+@pytest.mark.timeout(420)
+@pytest.mark.parametrize("expert_parallel_size", [1, 4], ids=["ep1", "ep4"])
+def test_shared_prefix_policy_train_native_qwen3_moe(
+    tmp_path,
+    monkeypatch,
+    expert_parallel_size,
+):
+    """Train native Qwen3-MoE with logical aux/load semantics under EP."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "false")
+    monkeypatch.setitem(ACTOR_ENVIRONMENT_REGISTRY, _DTENSOR_V2_ACTOR, sys.executable)
+
+    model_path = tmp_path / "tiny_qwen3_moe_native_shared_prefix"
+    # One layer makes an aux-only step reach the router but not an earlier
+    # layer's experts, so the parameter-update assertions are unambiguous.
+    _save_tiny_causal_lm(model_path, "qwen3_moe", num_hidden_layers=1)
+    config = create_test_config(
+        model_name=str(model_path),
+        tp=1,
+        dtensor_v2=True,
+        precision="bfloat16",
+        expert_parallel_size=expert_parallel_size,
+        sequence_packing_enabled=True,
+        activation_checkpointing=True,
+        automodel_kwargs={
+            "force_hf": False,
+            "backend": {
+                "_target_": (
+                    "nemo_automodel.components.models.common.utils.BackendConfig"
+                ),
+                "attn": "sdpa",
+                "linear": "torch",
+                "rms_norm": "torch_fp32",
+                "rope_fusion": False,
+                "experts": "torch_mm",
+                "dispatcher": "torch",
+            },
+        },
+    )
+    config["shared_prefix_training"] = True
+    config["train_global_batch_size"] = 8
+    config["train_micro_batch_size"] = 2
+    config["logprob_batch_size"] = 2
+    config["learning_rate"] = 1e-2
+    config["optimizer"]["kwargs"]["lr"] = 1e-2
+    config["optimizer"]["kwargs"]["weight_decay"] = 0.0
+    config["dynamic_batching"]["enabled"] = False
+    config["sequence_packing"].update(
+        {
+            "train_mb_tokens": 128,
+            "logprob_mb_tokens": 128,
+            "algorithm": "modified_first_fit_decreasing",
+        }
+    )
+    config["make_sequence_length_divisible_by"] = 1
+
+    cluster = RayVirtualCluster(
+        name=f"shared_prefix_native_qwen3_moe_ep{expert_parallel_size}",
+        bundle_ct_per_node_list=[4],
+        use_gpus=True,
+        num_gpus_per_node=4,
+        max_colocated_worker_groups=1,
+    )
+    policy = None
+    try:
+        policy = Policy(
+            tokenizer=get_tokenizer(config["tokenizer"]),
+            config=config,
+            init_optimizer=True,
+            init_reference_model=False,
+            cluster=cluster,
+            name_prefix=f"shared_prefix_native_moe_ep{expert_parallel_size}",
+        )
+        # EP overlaps DP: every rank still consumes a distinct rollout shard.
+        assert policy.data_parallel_size == 4
+
+        initial_state_dicts = policy.run_all_workers_single_data("return_state_dict")
+        for state_dict in initial_state_dicts:
+            moe_parameters = {
+                name: tensor
+                for name, tensor in state_dict.items()
+                if ".mlp.gate." in name or ".mlp.experts." in name
+            }
+            assert moe_parameters
+            assert all(
+                tensor.dtype == torch.float32 for tensor in moe_parameters.values()
+            )
+
+        dense_data, train_data = _make_rollouts()
+        policy.prepare_for_lp_inference()
+        before_logprobs = policy.get_logprobs(dense_data)["logprobs"]
+        train_data["prev_logprobs"] = before_logprobs.clone()
+        train_data["generation_logprobs"] = before_logprobs.clone()
+        train_data["reference_policy_logprobs"] = before_logprobs.clone()
+
+        policy.prepare_for_training()
+        before_parameters = _snapshot_local_moe_parameters(policy)
+        assert all(snapshot for snapshot in before_parameters)
+        train_data["advantages"].zero_()
+        aux_only_result = policy.train(
+            train_data,
+            ClippedPGLossFn(ClippedPGLossConfig(reference_policy_kl_penalty=0.0)),
+        )
+        after_aux_parameters = _snapshot_local_moe_parameters(policy)
+
+        assert torch.isfinite(aux_only_result["loss"]).all()
+        assert aux_only_result["loss"].item() == pytest.approx(0.0, abs=1e-7)
+        assert torch.isfinite(aux_only_result["grad_norm"]).all()
+        assert aux_only_result["grad_norm"].item() > 0
+        assert _any_parameter_changed(
+            before_parameters, after_aux_parameters, ".mlp.gate."
+        )
+        assert not _any_parameter_changed(
+            before_parameters, after_aux_parameters, ".mlp.experts."
+        )
+
+        moe_metrics = aux_only_result["moe_metrics"]
+        assert moe_metrics["logical_token_layer_events"] == pytest.approx(8 * 26)
+        assert moe_metrics["logical_router_aux_loss_mean"] > 0
+        assert 0 <= moe_metrics["logical_dead_expert_fraction_mean"] <= 1
+        assert 0 < moe_metrics["logical_expert_diversity_mean"] <= 1
+        assert moe_metrics["logical_expert_utilization_min"] >= 0
+        assert moe_metrics["logical_expert_utilization_max"] > 0
+        assert all(
+            torch.isfinite(torch.tensor(value)) for value in moe_metrics.values()
+        )
+
+        policy.prepare_for_lp_inference()
+        before_main_logprobs = policy.get_logprobs(dense_data)["logprobs"]
+        train_data["prev_logprobs"] = before_main_logprobs.clone()
+        train_data["generation_logprobs"] = before_main_logprobs.clone()
+        train_data["reference_policy_logprobs"] = before_main_logprobs.clone()
+        train_data["advantages"] = train_data["token_mask"].clone()
+        policy.prepare_for_training()
+        before_main_parameters = _snapshot_local_moe_parameters(policy)
+        result = policy.train(
+            train_data,
+            ClippedPGLossFn(ClippedPGLossConfig(reference_policy_kl_penalty=0.01)),
+        )
+        after_parameters = _snapshot_local_moe_parameters(policy)
+
+        assert torch.isfinite(result["loss"]).all()
+        assert torch.isfinite(result["grad_norm"]).all()
+        assert result["grad_norm"].item() > 0
+        assert _any_parameter_changed(
+            before_main_parameters, after_parameters, ".mlp.experts."
+        )
+
+        policy.prepare_for_lp_inference()
+        after_logprobs = policy.get_logprobs(dense_data)["logprobs"]
+        response_mask = train_data["token_mask"].bool()
+        assert (after_logprobs - before_logprobs).abs()[response_mask].max() > 1e-6
     finally:
         if policy is not None:
             policy.shutdown()

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Four-GPU integration smoke for Qwen3 shared-prefix ``Policy.train``."""
+
+import sys
+
+import pytest
+import torch
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import PreTrainedTokenizerFast, Qwen3Config, Qwen3ForCausalLM
+
+from nemo_rl.algorithms.grpo import _add_shared_prefix_training_metadata
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.ray_actor_environment_registry import (
+    ACTOR_ENVIRONMENT_REGISTRY,
+)
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.automodel.shared_prefix import (
+    SHARED_PREFIX_GROUP_IDS,
+    SHARED_PREFIX_LENGTHS,
+    build_shared_prefix_layout,
+)
+from nemo_rl.models.policy.lm_policy import Policy
+from tests.unit.models.policy.test_dtensor_worker_v2 import create_test_config
+
+
+_DTENSOR_V2_ACTOR = (
+    "nemo_rl.models.policy.workers.dtensor_policy_worker_v2.DTensorPolicyWorkerV2"
+)
+
+
+def _save_tiny_qwen3(model_path) -> None:
+    vocab = {"<pad>": 0, "<eos>": 1, "<unk>": 2}
+    vocab.update({f"token_{index}": index for index in range(3, 128)})
+    tokenizer_backend = Tokenizer(WordLevel(vocab=vocab, unk_token="<unk>"))
+    tokenizer_backend.pre_tokenizer = Whitespace()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_backend,
+        pad_token="<pad>",
+        eos_token="<eos>",
+        unk_token="<unk>",
+    )
+
+    torch.manual_seed(7)
+    config = Qwen3Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=128,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+        pad_token_id=0,
+        eos_token_id=1,
+        use_cache=False,
+    )
+    model = Qwen3ForCausalLM(config)
+    model.save_pretrained(model_path)
+    tokenizer.save_pretrained(model_path)
+
+
+def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
+    batch_size = 8
+    prompt_length = 16
+    response_length = 8
+    environment_length = 2
+    sequence_length = 32
+
+    input_ids = torch.zeros(batch_size, sequence_length, dtype=torch.long)
+    for row in range(batch_size):
+        group = row // 4
+        input_ids[row, :prompt_length] = torch.arange(
+            3 + group * prompt_length,
+            3 + (group + 1) * prompt_length,
+        )
+        input_ids[row, prompt_length : prompt_length + response_length] = (
+            torch.arange(40 + row * response_length, 40 + (row + 1) * response_length)
+            % 85
+            + 3
+        )
+        input_ids[
+            row,
+            prompt_length + response_length : prompt_length
+            + response_length
+            + environment_length,
+        ] = torch.tensor([125, 126])
+
+    input_lengths = torch.full(
+        (batch_size,),
+        prompt_length + response_length + environment_length,
+        dtype=torch.int32,
+    )
+    token_mask = torch.zeros(batch_size, sequence_length)
+    token_mask[:, prompt_length : prompt_length + response_length] = 1
+    dense_data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": input_lengths,
+        }
+    )
+    train_data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": input_lengths,
+            "token_mask": token_mask,
+            "sample_mask": torch.ones(batch_size),
+            "advantages": token_mask.clone(),
+        }
+    )
+    _add_shared_prefix_training_metadata(
+        train_data,
+        {"shared_prefix_training": True},
+        num_generations_per_prompt=4,
+    )
+    return dense_data, train_data
+
+
+@pytest.mark.automodel
+@pytest.mark.timeout(420)
+def test_shared_prefix_policy_train_fsdp2_four_gpus(tmp_path, monkeypatch):
+    """Exercise dense LP -> compact FSDP2 train -> dense LP on four DP ranks."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "false")
+    # The cluster test image already contains the Automodel runtime. Avoid building
+    # a second uv actor environment so this test isolates the training path.
+    monkeypatch.setitem(ACTOR_ENVIRONMENT_REGISTRY, _DTENSOR_V2_ACTOR, sys.executable)
+
+    model_path = tmp_path / "tiny_qwen3_shared_prefix"
+    _save_tiny_qwen3(model_path)
+    config = create_test_config(
+        model_name=str(model_path),
+        dtensor_v2=True,
+        precision="bfloat16",
+        sequence_packing_enabled=True,
+        activation_checkpointing=True,
+        automodel_kwargs={"force_hf": True},
+    )
+    config["shared_prefix_training"] = True
+    config["train_global_batch_size"] = 8
+    config["train_micro_batch_size"] = 2
+    config["logprob_batch_size"] = 2
+    config["learning_rate"] = 1e-2
+    config["optimizer"]["kwargs"]["lr"] = 1e-2
+    config["dynamic_batching"]["enabled"] = False
+    config["sequence_packing"].update(
+        {
+            "train_mb_tokens": 128,
+            "logprob_mb_tokens": 128,
+            "algorithm": "modified_first_fit_decreasing",
+        }
+    )
+    config["make_sequence_length_divisible_by"] = 1
+
+    cluster = RayVirtualCluster(
+        name="shared_prefix_policy_train",
+        bundle_ct_per_node_list=[4],
+        use_gpus=True,
+        num_gpus_per_node=4,
+        max_colocated_worker_groups=1,
+    )
+    policy = None
+    try:
+        policy = Policy(
+            tokenizer=get_tokenizer(config["tokenizer"]),
+            config=config,
+            init_optimizer=True,
+            init_reference_model=False,
+            cluster=cluster,
+            name_prefix="shared_prefix_policy",
+        )
+        assert policy.data_parallel_size == 4
+
+        dense_data, train_data = _make_rollouts()
+        assert train_data["input_lengths"].tolist() == [24] * 8
+        policy.prepare_for_lp_inference()
+        before = policy.get_logprobs(dense_data)["logprobs"]
+        train_data["prev_logprobs"] = before.clone()
+        train_data["generation_logprobs"] = before.clone()
+        train_data["reference_policy_logprobs"] = before.clone()
+
+        # The 128-token batch would fit in one shared bin. DP=4 forces four
+        # nonempty bins: two responses per bin, and each split group recomputes
+        # its 16-token prompt exactly once on each receiving rank.
+        shards = policy._shard_for_train(train_data, batch_size=8)
+        assert len(shards) == 4
+        for shard in shards:
+            assert shard.size == 2
+            assert torch.unique(shard[SHARED_PREFIX_GROUP_IDS]).numel() == 1
+            layout = build_shared_prefix_layout(
+                shard["input_ids"],
+                shard["input_lengths"],
+                shard[SHARED_PREFIX_LENGTHS],
+                shard[SHARED_PREFIX_GROUP_IDS],
+            )
+            assert layout.compact_tokens == 32
+
+        policy.prepare_for_training()
+        result = policy.train(
+            train_data,
+            ClippedPGLossFn(ClippedPGLossConfig(reference_policy_kl_penalty=0.01)),
+        )
+        assert torch.isfinite(result["loss"]).all()
+        assert torch.isfinite(result["grad_norm"]).all()
+        assert result["grad_norm"].item() > 0
+        assert len(result["all_mb_metrics"]["loss"]) == 4
+
+        policy.prepare_for_lp_inference()
+        after = policy.get_logprobs(dense_data)["logprobs"]
+        response_mask = train_data["token_mask"].bool()
+        max_response_delta = (after - before).abs()[response_mask].max()
+        assert max_response_delta.item() > 1e-6
+    finally:
+        if policy is not None:
+            policy.shutdown()
+        cluster.shutdown()

--- a/tests/unit/models/policy/test_shared_prefix_policy_train.py
+++ b/tests/unit/models/policy/test_shared_prefix_policy_train.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Multi-GPU integration smokes for Qwen3 shared-prefix ``Policy.train``."""
+"""Multi-GPU integration smokes for shared-prefix ``Policy.train``."""
 
 import sys
 
@@ -21,7 +21,13 @@ import torch
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
-from transformers import PreTrainedTokenizerFast, Qwen3Config, Qwen3ForCausalLM
+from transformers import (
+    LlamaConfig,
+    LlamaForCausalLM,
+    PreTrainedTokenizerFast,
+    Qwen3Config,
+    Qwen3ForCausalLM,
+)
 
 from nemo_rl.algorithms.grpo import _add_shared_prefix_training_metadata
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
@@ -45,7 +51,7 @@ _DTENSOR_V2_ACTOR = (
 )
 
 
-def _save_tiny_qwen3(model_path) -> None:
+def _save_tiny_causal_lm(model_path, model_family: str) -> None:
     vocab = {"<pad>": 0, "<eos>": 1, "<unk>": 2}
     vocab.update({f"token_{index}": index for index in range(3, 128)})
     tokenizer_backend = Tokenizer(WordLevel(vocab=vocab, unk_token="<unk>"))
@@ -58,7 +64,7 @@ def _save_tiny_qwen3(model_path) -> None:
     )
 
     torch.manual_seed(7)
-    config = Qwen3Config(
+    config_kwargs = dict(
         vocab_size=128,
         hidden_size=64,
         intermediate_size=128,
@@ -73,7 +79,10 @@ def _save_tiny_qwen3(model_path) -> None:
         eos_token_id=1,
         use_cache=False,
     )
-    model = Qwen3ForCausalLM(config)
+    if model_family == "qwen3":
+        model = Qwen3ForCausalLM(Qwen3Config(**config_kwargs))
+    else:
+        model = LlamaForCausalLM(LlamaConfig(**config_kwargs))
     model.save_pretrained(model_path)
     tokenizer.save_pretrained(model_path)
 
@@ -137,17 +146,31 @@ def _make_rollouts() -> tuple[BatchedDataDict, BatchedDataDict]:
 @pytest.mark.automodel
 @pytest.mark.timeout(420)
 @pytest.mark.parametrize(
-    "world_size,tp_size,dp_size,shard_size,groups_per_shard,compact_tokens",
+    (
+        "model_family,world_size,tp_size,dp_size,shard_size,groups_per_shard,"
+        "compact_tokens"
+    ),
     [
-        (4, 1, 4, 2, 1, 36),
-        (2, 2, 1, 8, 2, 112),
-        (4, 4, 1, 8, 2, 112),
+        ("qwen3", 4, 1, 4, 2, 1, 36),
+        ("qwen3", 2, 2, 1, 8, 2, 112),
+        ("qwen3", 4, 4, 1, 8, 2, 112),
+        ("llama", 4, 1, 4, 2, 1, 36),
+        ("llama", 2, 2, 1, 8, 2, 112),
+        ("llama", 4, 4, 1, 8, 2, 112),
     ],
-    ids=["dp4_tp1", "dp1_tp2", "dp1_tp4"],
+    ids=[
+        "qwen3_dp4_tp1",
+        "qwen3_dp1_tp2",
+        "qwen3_dp1_tp4",
+        "llama_dp4_tp1",
+        "llama_dp1_tp2",
+        "llama_dp1_tp4",
+    ],
 )
 def test_shared_prefix_policy_train_fsdp2(
     tmp_path,
     monkeypatch,
+    model_family,
     world_size,
     tp_size,
     dp_size,
@@ -163,8 +186,8 @@ def test_shared_prefix_policy_train_fsdp2(
     # a second uv actor environment so this test isolates the training path.
     monkeypatch.setitem(ACTOR_ENVIRONMENT_REGISTRY, _DTENSOR_V2_ACTOR, sys.executable)
 
-    model_path = tmp_path / "tiny_qwen3_shared_prefix"
-    _save_tiny_qwen3(model_path)
+    model_path = tmp_path / f"tiny_{model_family}_shared_prefix"
+    _save_tiny_causal_lm(model_path, model_family)
     config = create_test_config(
         model_name=str(model_path),
         tp=tp_size,
@@ -191,7 +214,7 @@ def test_shared_prefix_policy_train_fsdp2(
     config["make_sequence_length_divisible_by"] = 1
 
     cluster = RayVirtualCluster(
-        name="shared_prefix_policy_train",
+        name=f"shared_prefix_policy_train_{model_family}",
         bundle_ct_per_node_list=[world_size],
         use_gpus=True,
         num_gpus_per_node=world_size,
@@ -205,7 +228,7 @@ def test_shared_prefix_policy_train_fsdp2(
             init_optimizer=True,
             init_reference_model=False,
             cluster=cluster,
-            name_prefix="shared_prefix_policy",
+            name_prefix=f"shared_prefix_policy_{model_family}",
         )
         assert policy.data_parallel_size == dp_size
 

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -297,6 +297,8 @@ policy:
     algorithm: "modified_first_fit_decreasing"
     sequence_length_round: 64
 
+  shared_prefix_training: False
+
   # makes the training sequence length divisible by the tensor parallel size
   # this is useful for sequence parallel training
   make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}


### PR DESCRIPTION
# What does this PR do ?

**Forwards a GRPO group's shared prompt once instead of once per rollout.**

Every rollout in a GRPO group shares the same prompt, so today the prompt's
forward pass is recomputed for each completion in the group. This
deduplicates it: the shared prefix is forwarded once and reused across the
group's completions.

- `nemo_rl/models/automodel/shared_prefix.py` — the shared-prefix forward path.
- `nemo_rl/models/automodel/shared_prefix_moe.py` — Qwen3 MoE expert-parallel
  variant, including logical routing bias.
- `nemo_rl/data/packing/algorithms.py` — shared-prefix-aware sequence packing.
- Chunked shared-prefix target logprobs, TP support, and the plumbing through
  `automodel/setup.py`, `train.py`, `batched_data_dict.py`, `model_utils.py`,
  `lm_policy.py` and `dtensor_policy_worker_v2.py`.
- ~5000 lines of unit tests, including distributed EP and TP cases.

# Issues

None filed yet. Happy to open one to hold the design discussion if that is
preferred over discussing it here.

# Usage

Off by default; training behavior is unchanged unless it is enabled. Requires
DTensor v2 and sequence packing.

```yaml
policy:
  # Dense Qwen3/Llama use force_hf=true; native Qwen3-MoE EP uses force_hf=false.
  shared_prefix_training: True
```

Bin packing charges each prompt once per group/bin; logprob inference stays
dense. See `examples/configs/grpo_math_1B.yaml` in this PR.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — ~5000 lines under `tests/unit/models/automodel/` and `tests/unit/models/policy/`, including distributed EP/TP cases
- [ ] Did you run the unit tests and functional tests locally? — **not against current `main`.** The distributed tests need multi-GPU.
- [ ] Did you add or update any necessary documentation? — **no.** Not written yet, pending direction on whether this belongs in tree.