### PR TITLE
fix(async): do not let the vLLM prefix cache go stale across weight updates

### DIFF
--- a/docs/guides/async-grpo.md
+++ b/docs/guides/async-grpo.md
@@ -43,7 +43,7 @@ grpo:
     max_trajectory_age_steps: 1  # Maximum age, in training steps, for trajectories
     max_generation_failures: 0  # Consecutive worker failures to tolerate
     in_flight_weight_updates: false  # Enable for faster weight synchronization
-    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after weight-updates
+    recompute_kv_cache_after_weight_updates: true  # Preempt+recompute in-flight requests and clear the prefix cache on refit (see below)
 ```
 
 ### Complete Example Config
@@ -72,7 +72,7 @@ grpo:
     max_trajectory_age_steps: 1
     max_generation_failures: 0  # Consecutive worker failures to tolerate
     in_flight_weight_updates: false  # Enable for faster weight synchronization
-    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after weight-updates
+    recompute_kv_cache_after_weight_updates: true  # Preempt+recompute in-flight requests and clear the prefix cache on refit (see below)
 
 cluster:
   num_nodes: 2
@@ -223,7 +223,7 @@ If no `replay_buffer.pt` file is found in the latest checkpoint directory, train
 
 4. **In-Flight Weight Updates**: Enable `in_flight_weight_updates: true` to refit without waiting for the longest in-flight generation to finish. Except for managed Dynamo, the collector requests a generation pause and resume from every async backend around the weight transfer. Async vLLM implements this contract while preserving request state. A backend that does not implement the hook emits a warning once per backend type per process and refits without a collector-side pause or drain; SGLang is in this group today and instead relies on the pause its own weight synchronizer performs around the transfer. Managed Dynamo always drains active trajectories before refit. vLLM requires `async_engine: true`; the Megatron backend is always async-engine.
 
-5. **Recompute KV Cache After Weight Updates**: Set `recompute_kv_cache_after_weight_updates: true` to invalidate reusable KV/prefix caches when weights change. On the native async vLLM in-flight path, caches are cleared while generation is paused, so preserved requests recompute their KV after resuming. Other refit paths keep their existing post-update invalidation behavior. When false, in-flight requests retain their pre-update KV cache. On the Megatron generation backend, this must agree with `policy.generation.mcore_generation_config.kv_cache_management_mode`; setup errors on a mismatch.
+5. **Recompute KV Cache After Weight Updates**: `recompute_kv_cache_after_weight_updates` (default `true`) decides what happens to requests that are *in flight* during an in-flight refit. With `true`, vLLM is paused with `clear_cache=True`: in-flight requests are preempted, the prefix cache is reset, and the preserved requests re-prefill with the new weights after resuming. With `false` (Magistral-style), in-flight requests keep their pre-update KV, **and the prefix cache is not invalidated either**: every later request that shares a prefix with an earlier one (same prompt, shared system prompt, multi-sample groups spanning a refit) is served KV/state computed by whichever weights first filled that block. That staleness is unbounded within the job and grows the train-vs-rollout logprob mismatch step over step; the collector prints a warning once when this combination is active with prefix caching enabled. Only choose `false` with `policy.generation.vllm_cfg.enable_prefix_caching: false`, or when prompts never share prefixes across steps. Refits that drain generation first (`in_flight_weight_updates: false`, or backends without a pause hook) always invalidate the caches after the update regardless of this flag, since nothing is using them at that point. On the Megatron generation backend, this must agree with `policy.generation.mcore_generation_config.kv_cache_management_mode`; setup errors on a mismatch.
 
 ## Why Importance Sampling Correction Is Required for Async
 

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import functools
 import threading as _threading
 import time
 from collections import defaultdict, deque
@@ -78,6 +79,33 @@ from nemo_rl.utils.multimodal_payload_metrics import (
     print_multimodal_payload_metrics,
 )
 from nemo_rl.utils.timer import ThreadSafeTimer
+
+
+def _prefix_caching_may_be_enabled(generation_cfg: dict[str, Any]) -> bool:
+    """Whether the vLLM prefix cache is (or defaults to) enabled.
+
+    ``vllm_cfg.enable_prefix_caching`` unset resolves to True on Ampere+ GPUs in
+    ``vllm_worker._resolve_enable_prefix_caching``; mirror that without touching CUDA.
+    """
+    vllm_cfg = generation_cfg.get("vllm_cfg") or {}
+    value = vllm_cfg.get("enable_prefix_caching")
+    return True if value is None else bool(value)
+
+
+@functools.lru_cache(maxsize=None)
+def _warn_stale_prefix_cache_once(backend: str) -> None:
+    print(
+        f"⚠️ {backend} in-flight weight update with "
+        "recompute_kv_cache_after_weight_updates=false and prefix caching enabled: "
+        "the prefix cache is NOT invalidated across weight updates, so any later "
+        "request that shares a prefix with an earlier one is served KV/state "
+        "computed by older weights. This staleness is unbounded within the job "
+        "(it is not limited to in-flight requests) and grows the train-vs-rollout "
+        "logprob mismatch step over step. Set "
+        "grpo.async_grpo.recompute_kv_cache_after_weight_updates=true (default) or "
+        "policy.generation.vllm_cfg.enable_prefix_caching=false.",
+        flush=True,
+    )
 
 TokenizerType = PreTrainedTokenizerBase
 _MAX_NEMO_GYM_STREAM_RETRIES = 3
@@ -1073,6 +1101,8 @@ class AsyncTrajectoryCollector:
 
         if is_async_engine and in_flight_weight_updates:
             clear_cache = self.async_config.recompute_kv_cache_after_weight_updates
+            if not clear_cache and _prefix_caching_may_be_enabled(generation_cfg):
+                _warn_stale_prefix_cache_once(backend)
             self._generation_pause_requested_for_refit = True
             print(f"⏸️ Requesting {backend} generation pause before refit")
             self._generation_paused_for_refit = (
@@ -1117,10 +1147,17 @@ class AsyncTrajectoryCollector:
             self._refit_pause_cleared.set()
             return
 
-        # Invalidate&recompute vLLM caches after the weight updates (in-flight or not) if
-        # recompute_kv_cache_after_weight_updates is True (AREAL-style implementation).
-        # Otherwise, keep using the stale KV caches (Magistral-style implementation).
-        if self.async_config.recompute_kv_cache_after_weight_updates:
+        # No in-flight pause was requested for this refit, so generation was drained
+        # first and nothing is using the KV cache: invalidating it is free. Always do
+        # it. (A backend that lacks the pause hook still goes through the pause
+        # request above and keeps the legacy behaviour below.) A prefix cache that
+        # survives a weight update serves later requests KV/state computed by old
+        # weights, without bound, which silently grows the train-vs-rollout
+        # logprob mismatch. `recompute_kv_cache_after_weight_updates` only decides
+        # what happens to requests that were *in flight* during an in-flight refit
+        # (preempt and recompute vs. keep their pre-update KV, Magistral-style).
+        drained = not self._generation_pause_requested_for_refit
+        if drained or self.async_config.recompute_kv_cache_after_weight_updates:
             try:
                 print(
                     "🔄 Invalidating generation backend KV caches after weight update"

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1214,6 +1214,19 @@ def setup(
     # `kv_cache_management_mode="recompute"`; the loop-level flag must agree.
     if generation_config["backend"] == "megatron":
         async_grpo_config = grpo_config.async_grpo
+        if (
+            async_grpo_config is not None
+            and "recompute_kv_cache_after_weight_updates"
+            not in async_grpo_config.model_fields_set
+        ):
+            # The flag's default (true) is chosen for vLLM, where it also governs
+            # prefix-cache invalidation. Megatron generation expresses the same
+            # choice engine-side via kv_cache_management_mode, so when the user
+            # left the flag unset, follow the engine mode instead of erroring.
+            async_grpo_config.recompute_kv_cache_after_weight_updates = (
+                generation_config["mcore_generation_config"]["kv_cache_management_mode"]
+                == "recompute"
+            )
         recompute_kv_cache = bool(
             async_grpo_config is not None
             and async_grpo_config.recompute_kv_cache_after_weight_updates

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -261,8 +261,12 @@ class AsyncGRPOConfig(BaseModel, extra="allow"):
     # Does the weight synchronization as soon as the training is done
     # without waiting for the pending generations to finish.
     in_flight_weight_updates: bool = False
-    # Recomputes the KV cache after weight updates.
-    recompute_kv_cache_after_weight_updates: bool = False
+    # In-flight refits: preempt in-flight requests and recompute their KV with the
+    # new weights (also clears the prefix cache). False keeps their pre-update KV
+    # (Magistral-style) AND leaves the prefix cache stale across weight updates,
+    # which grows train-vs-rollout mismatch when prompts share prefixes; the
+    # collector warns in that case. Drained refits always invalidate caches.
+    recompute_kv_cache_after_weight_updates: bool = True
 
 
 class RewardPenaltyTokenIdsConfig(BaseModel, extra="allow"):

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -140,8 +140,12 @@ class AsyncPPOConfig(BaseModel, extra="allow"):
     warmup_generation_lead_steps: int | None = Field(default=None, ge=1)
     # Allows weight updates while rollout requests are still in flight.
     in_flight_weight_updates: bool = False
-    # Recomputes the KV cache after weight updates.
-    recompute_kv_cache_after_weight_updates: bool = False
+    # In-flight refits: preempt in-flight requests and recompute their KV with the
+    # new weights (also clears the prefix cache). False keeps their pre-update KV
+    # (Magistral-style) AND leaves the prefix cache stale across weight updates,
+    # which grows train-vs-rollout mismatch when prompts share prefixes; the
+    # collector warns in that case. Drained refits always invalidate caches.
+    recompute_kv_cache_after_weight_updates: bool = True
     # Drops partial restored targets; replacement rollouts use subsequent prompts.
     drop_incomplete_targets_on_restore: bool = False
 

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -38,6 +38,7 @@ from nemo_rl.algorithms.async_utils import (
 )
 from nemo_rl.algorithms.async_utils.replay_buffer import ReplayBufferImpl
 from nemo_rl.algorithms.async_utils.trajectory_collector import (
+    _warn_stale_prefix_cache_once,
     _stamped_task_indices,
     _unanimous_task_index,
 )
@@ -2763,17 +2764,67 @@ class TestAsyncTrajectoryCollector:
 
         collector.policy_generation.invalidate_kv_cache.assert_called_once_with()
 
-    def test_resume_after_refit_skips_cache_invalidation_when_recompute_disabled(self):
-        """Test resume after refit skips cache invalidation when recompute is disabled."""
+    def test_drained_refit_invalidates_cache_even_when_recompute_disabled(self):
+        """A drained refit (no in-flight pause requested) always invalidates the
+        prefix/KV cache: nothing is using it, and a cache that survives a weight
+        update serves later requests KV computed by old weights."""
         collector = self.create_local_collector()
+        async_cfg = collector.master_config.grpo.async_grpo
+        async_cfg.in_flight_weight_updates = False
+        async_cfg.recompute_kv_cache_after_weight_updates = False
+        collector.policy_generation.invalidate_kv_cache = mock.Mock(return_value=True)
+        collector.wait_for_pending_generations = mock.Mock()
+
+        collector.prepare_for_refit()
+        collector.resume_after_refit()
+
+        collector.policy_generation.invalidate_kv_cache.assert_called_once_with()
+        assert collector._refit_pause_cleared.is_set()
+
+    def test_in_flight_refit_without_recompute_keeps_cache_and_warns_once(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With in-flight updates and recompute disabled the cache is kept
+        (Magistral-style) and the collector warns once that the prefix cache
+        will go stale across weight updates."""
+        _warn_stale_prefix_cache_once.cache_clear()
+        collector = self.create_local_collector()
+        collector.master_config.policy["generation"] = {
+            "backend": "vllm",
+            "vllm_cfg": {"async_engine": True},  # enable_prefix_caching unset -> on
+        }
         async_cfg = collector.master_config.grpo.async_grpo
         async_cfg.in_flight_weight_updates = True
         async_cfg.recompute_kv_cache_after_weight_updates = False
         collector.policy_generation.invalidate_kv_cache = mock.Mock(return_value=True)
 
-        collector.resume_after_refit()
+        for _ in range(2):
+            collector.prepare_for_refit()
+            collector.resume_after_refit()
 
         collector.policy_generation.invalidate_kv_cache.assert_not_called()
+        assert collector.policy_generation.pause_generation_for_refit_calls == [False, False]
+        output = capsys.readouterr().out
+        assert output.count("prefix cache is NOT invalidated across weight updates") == 1
+        _warn_stale_prefix_cache_once.cache_clear()
+
+    def test_in_flight_refit_without_recompute_does_not_warn_when_prefix_caching_off(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _warn_stale_prefix_cache_once.cache_clear()
+        collector = self.create_local_collector()
+        collector.master_config.policy["generation"] = {
+            "backend": "vllm",
+            "vllm_cfg": {"async_engine": True, "enable_prefix_caching": False},
+        }
+        async_cfg = collector.master_config.grpo.async_grpo
+        async_cfg.in_flight_weight_updates = True
+        async_cfg.recompute_kv_cache_after_weight_updates = False
+
+        collector.prepare_for_refit()
+        collector.resume_after_refit()
+
+        assert "prefix cache is NOT invalidated" not in capsys.readouterr().out
 
     def test_dynamo_cache_invalidation_failure_is_fatal_and_unblocks_waiters(self):
         collector = self.create_local_collector()


### PR DESCRIPTION
# What does this PR do ?

Stops the vLLM prefix cache from silently going stale across weight updates in async GRPO/PPO.

With async rollouts and vLLM prefix caching enabled (the default on Ampere+), `recompute_kv_cache_after_weight_updates=false` did more than keep *in-flight* requests on their pre-update KV: it also left the **prefix cache** untouched across refits. Any later request that shares a prefix with an earlier one (same prompt, shared system prompt, a multi-sample group spanning a refit) was served KV/state computed by whichever weights first filled that block, with no bound on how old those weights were. The trainer scores with the current weights, so the train-vs-rollout logprob mismatch grew step over step within a job and reset only on engine restart. The docs described the flag as affecting in-flight requests only.

### Evidence

Nemotron-H MoE (Nano 3.5), async GRPO, `in_flight_weight_updates=true`, flag `false`, prefix caching default-on, ~49k-token prompts where same-instance rows share ~85% of their context and recur 3–20 steps apart. Logs show `Successfully reset prefix cache` exactly at engine start and at generation finish, never across the 17 refits in between, so every later request sharing a prefix with an earlier one was served KV/Mamba state computed by weights up to 17 steps old while the trainer scored it with current weights. A controlled A/B from the same checkpoint with `enable_prefix_caching=false` confirmed the mechanism is not what drove the *growth* of that run's masked-sequence count (that turned out to be a policy-side format collapse, unrelated to caching), so this PR is a correctness fix for silent staleness rather than the cause of a specific regression. The staleness itself is unbounded by construction and the docs described the flag as affecting in-flight requests only.

### Changes

- `AsyncTrajectoryCollector.resume_after_refit`: refits that drained generation first (no in-flight pause requested) now **always** invalidate the KV/prefix cache after the update, regardless of the flag. Nothing is using the cache at that point, so this is free. The flag now only decides what happens to requests that were in flight during an in-flight refit (preempt and recompute vs. keep pre-update KV, Magistral-style).
- `AsyncTrajectoryCollector.prepare_for_refit`: in-flight refit with the flag `false` and prefix caching enabled prints a one-time warning explaining the unbounded staleness and how to fix it (`recompute_kv_cache_after_weight_updates=true` or `vllm_cfg.enable_prefix_caching=false`).
- Default of `recompute_kv_cache_after_weight_updates` flipped to `true` in `AsyncGRPOConfig` and the PPO async config. Recipes that set it explicitly are unchanged. Cost for in-flight users who relied on the old default: in-flight requests re-prefill once per refit (vLLM `pause_generation(mode="keep", clear_cache=True)` preempts them and resets the block pool).
- `docs/guides/async-grpo.md`: describe both effects of the flag; example snippets use `true`.
- Tests (`tests/unit/algorithms/test_async_utils.py`): drained refit invalidates even with the flag `false`; in-flight + `false` warns exactly once and keeps the cache; no warning when prefix caching is off. Existing keep-pause and legacy-fallback tests unchanged.

If maintainers prefer not to change the default for the performance recipes, the first two changes plus the docs stand alone; the default flip is the last commit hunk in `grpo.py`/`ppo.py`.


### Megatron generation backend

The second commit keeps the existing `kv_cache_management_mode` consistency check intact under the new default: when the flag is left unset and `policy.generation.backend=megatron`, it is derived from the engine-side mode (`recompute` → true, `persist`/`offload` → false) instead of erroring. Explicit disagreement still raises as before.

# Issues

Root-caused while investigating growing train/inference mismatch in a long-context async GRPO run; no existing issue.

# Usage

```yaml
grpo:
  async_grpo:
    in_flight_weight_updates: true
    recompute_kv_cache_after_weight_updates: true   # new default
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (3 added, 1 rewritten in `tests/unit/algorithms/test_async_utils.py`)
- [x] Did you run the unit tests and functional tests locally? `tests/unit/algorithms/test_async_utils.py`: 118 passed; `tests/unit/algorithms/test_grpo.py` + `test_ppo.py -k 'async or recompute or kv_cache or refit or config or setup'`: 107 passed; `tests/unit/single_controller/test_refit_recovery.py` + `tests/unit/models/generation/test_swe1_dynamo_config.py`: 37 passed (run inside the NeMo RL container).
- [x] Did you add or update any necessary documentation? (`docs/guides/async-grpo.md`)

# Additional Information
* Found while root-causing a growing train-vs-rollout logprob mismatch; the cache staleness was one of the candidates and is real, though the run's growth was ultimately a policy-side effect.
