### PR TITLE
fix: avoid NaN in JSD metric when logprobs underflow to zero

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Any, NotRequired, Optional, TypedDict, TypeVar
 
 import torch
@@ -445,8 +446,10 @@ class ClippedPGLossFn(LossFunction):
         # Jensen-Shannon divergence
         # M = 0.5 * (P_train + P_gen)
         # JSD = 0.5 * KL(P_train || M) + 0.5 * KL(P_gen || M)
-        log_mixture = torch.log(
-            0.5 * torch.exp(prev_logprobs) + 0.5 * torch.exp(generation_logprobs)
+        # Use logaddexp instead of log(0.5 * exp(a) + 0.5 * exp(b)) so this stays
+        # finite when both logprobs underflow to zero in fp32.
+        log_mixture = torch.logaddexp(prev_logprobs, generation_logprobs) - math.log(
+            2.0
         )
         # KL(P_train || M)
         kl_prev_to_mixture = (

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
+import math
 
 import pytest
 import torch
@@ -589,6 +590,36 @@ def test_clipped_pg_loss_reinforce_mode():
         **loss_input,
     )
     torch.testing.assert_close(actual_loss, expected_loss)
+
+
+def test_clipped_pg_loss_js_divergence_error_stays_finite_on_underflow():
+    """Tests that js_divergence_error stays finite when logprobs underflow to zero.
+
+    Building the mixture as log(0.5*exp(a) + 0.5*exp(b)) collapses to log(0)
+    once both logprobs underflow in fp32 (roughly below -88), and the KL
+    terms downstream turn that into inf - inf = NaN.
+    """
+    device = "cpu"
+    data, _, _, _ = _setup_clipped_pg_test_data(batch_size=1, seq_len=2, device=device)
+
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.0)
+    loss_fn = ClippedPGLossFn(cfg)
+
+    # exp(-200) underflows to exactly 0.0 in fp32.
+    underflowing_logprob = torch.tensor([[-200.0]], device=device)
+    data["prev_logprobs"][:, 1:] = underflowing_logprob
+    data["generation_logprobs"][:, 1:] = underflowing_logprob
+
+    _, metrics = loss_fn(
+        next_token_logprobs=underflowing_logprob,
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(data["sample_mask"] * data["token_mask"]),
+    )
+
+    assert math.isfinite(metrics["js_divergence_error"]), (
+        f"js_divergence_error should stay finite under logprob underflow, got {metrics['js_divergence_error']}"
+    )
 
 
 def test_clipped_pg_loss_force_on_policy_ratio():


### PR DESCRIPTION
# What does this PR do ?

Fixes a NaN in the `js_divergence_error` training metric when logprobs underflow to zero.

# Issues

Our JSD metric builds the mixture distribution as `log(0.5*exp(a) + 0.5*exp(b))`. Once a logprob drops low enough that `exp()` underflows to 0 in fp32, this becomes `log(0)` and the KL terms downstream turn into `inf - inf`, i.e. NaN. Switched to `torch.logaddexp`, which stays stable in that regime.

Only affects the logged metric, not gradients/training - but a NaN there makes debugging confusing.

# Usage

No usage change.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
