### PR TITLE
feat: add a JSD option to the distillation loss

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -14,8 +14,9 @@ distillation:
     seed: 42
 
 loss_fn:
-    kl_type: "mixed" # forward, reverse, mixed
+    kl_type: "mixed" # forward, reverse, mixed, jsd
     mixed_kl_weight: 0.5 # when kl_type is "mixed", this is the weight of the forward KL
+    jsd_beta: 0.5 # when kl_type is "jsd", interpolates forward KL (0) to reverse KL (1); 0.5 is the symmetric JSD
     zero_outside_topk: false # zero out the teacher logits outside the top k when calculate forward KL loss
 
 checkpointing:

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Any, NotRequired, Optional, TypedDict, TypeVar
 
 import torch
@@ -1111,6 +1112,11 @@ class DistillationLossConfig(BaseModel, extra="allow"):
     kl_type: str = "mixed"
     mixed_kl_weight: float = 0.5
     zero_outside_topk: bool = False
+    # Interpolation coefficient for kl_type="jsd" (generalized Jensen-Shannon
+    # divergence, see Eq. 1 of https://huggingface.co/papers/2306.13649):
+    # beta=0 reduces to forward KL, beta=1 to reverse KL, beta=0.5 (default)
+    # gives the symmetric JSD. Unused for other kl_type values.
+    jsd_beta: float = 0.5
 
 
 class DistillationLossDataDict(TypedDict):
@@ -1132,12 +1138,14 @@ class DistillationLossFn(LossFunction):
         self.kl_type = cfg.kl_type
         self.mixed_kl_weight = cfg.mixed_kl_weight
         self.zero_outside_topk = cfg.zero_outside_topk
+        self.jsd_beta = cfg.jsd_beta
         self.log_infinitesimal = -100
 
-        assert self.kl_type in ["forward", "reverse", "mixed"], "Invalid KL type"
+        assert self.kl_type in ["forward", "reverse", "mixed", "jsd"], "Invalid KL type"
         assert self.mixed_kl_weight >= 0 and self.mixed_kl_weight <= 1, (
             "Invalid mixed KL weight"
         )
+        assert self.jsd_beta >= 0 and self.jsd_beta <= 1, "Invalid JSD beta"
 
     def __call__(
         self,
@@ -1152,8 +1160,14 @@ class DistillationLossFn(LossFunction):
         student_probs = student_topk_logprobs.exp()  # [B, S-1, k]
         teacher_probs = teacher_topk_logprobs.exp()  # [B, S-1, k]
 
+        # jsd is forward KL at beta=0 and reverse KL at beta=1, so the topk
+        # correction below is skipped/unscaled the same way forward/reverse are.
+        is_forward_like = self.kl_type == "forward" or (
+            self.kl_type == "jsd" and self.jsd_beta <= 0.0
+        )
+
         loss_correction_term = torch.zeros_like(student_probs[..., 0])  # [B, S-1]
-        if self.zero_outside_topk and self.kl_type != "forward":
+        if self.zero_outside_topk and not is_forward_like:
             H_rest = H_all - (student_probs * student_topk_logprobs).sum(-1)
             P_rest = 1 - (student_probs.sum(-1))
             # The entropy and prob of the rest of the tokens [B, S-1]
@@ -1162,6 +1176,8 @@ class DistillationLossFn(LossFunction):
                 loss_correction_term = loss_correction_term * (
                     1.0 - self.mixed_kl_weight
                 )
+            elif self.kl_type == "jsd" and self.jsd_beta < 1.0:
+                loss_correction_term = loss_correction_term * (1.0 - self.jsd_beta)
 
         if self.kl_type == "forward":
             per_token_kl = teacher_probs * (
@@ -1171,14 +1187,42 @@ class DistillationLossFn(LossFunction):
             per_token_kl = student_probs * (
                 student_topk_logprobs - teacher_topk_logprobs
             )
-        else:
-            # mixed KL
+        elif self.kl_type == "mixed":
             kl_forward = teacher_probs * (teacher_topk_logprobs - student_topk_logprobs)
             kl_reverse = student_probs * (student_topk_logprobs - teacher_topk_logprobs)
             per_token_kl = (
                 self.mixed_kl_weight * kl_forward
                 + (1.0 - self.mixed_kl_weight) * kl_reverse
             )
+        else:
+            # Generalized Jensen-Shannon divergence (Eq. 1 of
+            # https://huggingface.co/papers/2306.13649): beta * KL(teacher || M)
+            # + (1 - beta) * KL(student || M), M = beta * teacher + (1 - beta) * student.
+            # beta=0/1 degenerate to plain forward/reverse KL, since M collapses
+            # onto student/teacher and the mixture-weighted term above vanishes.
+            beta = self.jsd_beta
+            if beta <= 0.0:
+                per_token_kl = teacher_probs * (
+                    teacher_topk_logprobs - student_topk_logprobs
+                )
+            elif beta >= 1.0:
+                per_token_kl = student_probs * (
+                    student_topk_logprobs - teacher_topk_logprobs
+                )
+            else:
+                mixture_topk_logprobs = torch.logaddexp(
+                    student_topk_logprobs + math.log1p(-beta),
+                    teacher_topk_logprobs + math.log(beta),
+                )
+                kl_teacher_to_mixture = teacher_probs * (
+                    teacher_topk_logprobs - mixture_topk_logprobs
+                )
+                kl_student_to_mixture = student_probs * (
+                    student_topk_logprobs - mixture_topk_logprobs
+                )
+                per_token_kl = (
+                    beta * kl_teacher_to_mixture + (1.0 - beta) * kl_student_to_mixture
+                )
 
         per_token_kl = per_token_kl.sum(dim=-1) + loss_correction_term  # [B, S-1]
 

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -2191,7 +2191,7 @@ def setup_distillation_test_data(batch_size=2, seq_len=4, vocab_size=8, topk=64)
     return data, student_logits
 
 
-@pytest.mark.parametrize("kl_type", ["forward", "reverse", "mixed"])
+@pytest.mark.parametrize("kl_type", ["forward", "reverse", "mixed", "jsd"])
 @pytest.mark.parametrize("zero_outside_topk", [True, False])
 def test_distillation_loss_different_settings(kl_type, zero_outside_topk):
     """Test different distillation loss settings."""
@@ -2201,6 +2201,7 @@ def test_distillation_loss_different_settings(kl_type, zero_outside_topk):
         DistillationLossConfig(
             kl_type=kl_type,
             mixed_kl_weight=0.3,
+            jsd_beta=0.3,
             zero_outside_topk=zero_outside_topk,
         )
     )
@@ -2215,7 +2216,9 @@ def test_distillation_loss_different_settings(kl_type, zero_outside_topk):
         **loss_input,
     )
 
-    # Verify loss
+    # Verify loss. jsd's exact value isn't pinned like the others above (no
+    # hand-derivable closed form for random top-k data) -- its correctness is
+    # covered by the boundary/symmetry/gradient tests below instead.
     if zero_outside_topk:
         if kl_type == "forward":
             assert torch.allclose(loss, torch.tensor(-0.9636520743370056))
@@ -2230,6 +2233,9 @@ def test_distillation_loss_different_settings(kl_type, zero_outside_topk):
             assert torch.allclose(loss, torch.tensor(0.5811167359352112))
         elif kl_type == "mixed":
             assert torch.allclose(loss, torch.tensor(0.5802732110023499))
+    if kl_type == "jsd":
+        assert not torch.isnan(loss)
+        assert not torch.isinf(loss)
 
     # Verify metrics dictionary
     assert isinstance(metrics, dict)
@@ -2381,6 +2387,101 @@ def test_distillation_loss_edge_cases():
     )
     assert not torch.isnan(loss)
     assert not torch.isinf(loss)
+
+
+@pytest.mark.parametrize("zero_outside_topk", [True, False])
+def test_distillation_loss_jsd_matches_forward_reverse_at_boundaries(
+    zero_outside_topk,
+):
+    """kl_type="jsd" must reduce to forward KL at beta=0 and reverse KL at beta=1."""
+    data, student_logits = setup_distillation_test_data()
+
+    def run(kl_type, jsd_beta=0.5):
+        loss_fn = DistillationLossFn(
+            DistillationLossConfig(
+                kl_type=kl_type,
+                jsd_beta=jsd_beta,
+                zero_outside_topk=zero_outside_topk,
+            )
+        )
+        loss_input, loss_data = prepare_loss_input(student_logits, data, loss_fn)
+        loss, _ = loss_fn(
+            data=loss_data,
+            global_valid_seqs=torch.sum(loss_data["sample_mask"]),
+            global_valid_toks=torch.sum(
+                loss_data["sample_mask"].unsqueeze(-1) * loss_data["token_mask"]
+            ),
+            **loss_input,
+        )
+        return loss
+
+    torch.testing.assert_close(
+        run("jsd", jsd_beta=0.0), run("forward"), atol=1e-5, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        run("jsd", jsd_beta=1.0), run("reverse"), atol=1e-5, rtol=1e-4
+    )
+
+
+def test_distillation_loss_jsd_symmetric_beta():
+    """Generalized JSD at beta=0.5 is symmetric: swapping student <-> teacher
+    top-k distributions must give the same loss (forward/reverse KL are not).
+    """
+    data, student_logits = setup_distillation_test_data()
+
+    loss_fn = DistillationLossFn(
+        DistillationLossConfig(kl_type="jsd", jsd_beta=0.5, zero_outside_topk=False)
+    )
+    loss_input, data = prepare_loss_input(student_logits, data, loss_fn)
+    loss, _ = loss_fn(
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(
+            data["sample_mask"].unsqueeze(-1) * data["token_mask"]
+        ),
+        **loss_input,
+    )
+
+    swapped_input = dict(loss_input)
+    swapped_input["student_topk_logprobs"], swapped_input["teacher_topk_logprobs"] = (
+        loss_input["teacher_topk_logprobs"],
+        loss_input["student_topk_logprobs"],
+    )
+    swapped_loss, _ = loss_fn(
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(
+            data["sample_mask"].unsqueeze(-1) * data["token_mask"]
+        ),
+        **swapped_input,
+    )
+
+    torch.testing.assert_close(loss, swapped_loss, atol=1e-5, rtol=1e-4)
+
+
+def test_distillation_loss_jsd_gradient_flow():
+    """Test gradient flow through the generalized JSD branch."""
+    data, student_logits = setup_distillation_test_data()
+    student_logits.requires_grad_(True)
+
+    loss_fn = DistillationLossFn(
+        DistillationLossConfig(kl_type="jsd", jsd_beta=0.5, zero_outside_topk=False)
+    )
+    loss_input, data = prepare_loss_input(student_logits, data, loss_fn)
+    loss, _ = loss_fn(
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(
+            data["sample_mask"].unsqueeze(-1) * data["token_mask"]
+        ),
+        **loss_input,
+    )
+    loss.backward()
+
+    assert student_logits.grad is not None
+    assert not torch.allclose(
+        student_logits.grad, torch.zeros_like(student_logits.grad)
+    )
 
 
 def test_distillation_loss_fn_initialization():

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -14,8 +14,9 @@ distillation:
     seed: 42
 
 loss_fn:
-    kl_type: "mixed" # forward, reverse, mixed
+    kl_type: "mixed" # forward, reverse, mixed, jsd
     mixed_kl_weight: 0.5 # when kl_type is "mixed", this is the weight of the forward KL
+    jsd_beta: 0.5 # when kl_type is "jsd", interpolates forward KL (0) to reverse KL (1); 0.5 is the symmetric JSD
     zero_outside_topk: false # zero out the teacher logits outside the top k when calculate forward KL loss
 
 checkpointing:


### PR DESCRIPTION
# What does this PR do ?

Adds a Jensen-Shannon divergence option to the distillation loss, alongside the existing forward/reverse/mixed KL choices.

# Issues

The distillation loss currently only supports forward KL, reverse KL, or a fixed linear blend of the two. This adds `kl_type="jsd"` with a `jsd_beta` weight: beta=0 is forward KL, beta=1 is reverse KL, and 0.5 (default) gives the symmetric, bounded Jensen-Shannon divergence - a genuinely different loss shape than blending two KL terms, since both sides are measured against a shared mixture distribution instead of each other directly.

# Usage

```yaml
loss_fn:
    kl_type: "jsd"
    jsd_beta: 0.5
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* No GPU available in my environment to run the full test suite (the existing distillation tests are GPU-gated); I validated the math directly against the CPU loss function instead. Would appreciate a CI run / second pair of eyes on the new tests.
