### PR TITLE
feat(grpo): add wall-clock time-efficiency reward for NeMo-Gym rollouts

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -50,8 +50,9 @@ grpo:
   # Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts (training only):
   #   reward = reward - lambda_time * (openhands_run_time / 60)
   # lambda_time 1/60 makes a 60-minute rollout cost exactly 1.0. apply_to "all"
-  # deducts from every rollout, including failures; "correct" deducts from
-  # resolved rollouts only. floor clamps the post-deduction reward; null disables.
+  # deducts from every rollout, including failures; "correct" deducts only from
+  # resolved rollouts whose reward survived the reward-zeroing penalties. floor
+  # clamps the post-deduction reward; null disables. Requires the NeMo-Gym path.
   # Pair with a tight advantage_clip_low/high (e.g. -3/3) when normalize_rewards
   # is true, otherwise a narrow group reward spread amplifies this small term.
   time_efficiency:

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -47,6 +47,18 @@ grpo:
     source_max: 1.0
     target_min: 0.0
     target_max: 1.0
+  # Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts (training only):
+  #   reward = reward - lambda_time * (openhands_run_time / 60)
+  # lambda_time 1/60 makes a 60-minute rollout cost exactly 1.0. apply_to "all"
+  # deducts from every rollout, including failures; "correct" deducts from
+  # resolved rollouts only. floor clamps the post-deduction reward; null disables.
+  # Pair with a tight advantage_clip_low/high (e.g. -3/3) when normalize_rewards
+  # is true, otherwise a narrow group reward spread amplifies this small term.
+  time_efficiency:
+    enabled: false
+    lambda_time: 0.016666666666666666  # 1/60 per minute
+    apply_to: "all"  # "all" | "correct"
+    floor: null
   seq_logprob_error_threshold: null
   # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.
   invalid_tool_call_advantage: null

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -51,8 +51,10 @@ grpo:
   #   reward = reward - lambda_time * (openhands_run_time / 60)
   # lambda_time 1/60 makes a 60-minute rollout cost exactly 1.0. apply_to "all"
   # deducts from every rollout, including failures; "correct" deducts only from
-  # resolved rollouts whose reward survived the reward-zeroing penalties. floor
-  # clamps the post-deduction reward; null disables. Requires the NeMo-Gym path.
+  # resolved rollouts whose reward survived the reward-zeroing penalties. Rows the
+  # env flags mask_sample (e.g. timeouts) are not charged while
+  # env.should_mask_flagged_samples is on. floor clamps the post-deduction
+  # reward; null disables. Requires the NeMo-Gym path.
   # Pair with a tight advantage_clip_low/high (e.g. -3/3) when normalize_rewards
   # is true, otherwise a narrow group reward spread amplifies this small term.
   time_efficiency:

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -53,14 +53,20 @@ grpo:
   # deducts from every rollout, including failures; "correct" deducts only from
   # resolved rollouts whose reward survived the reward-zeroing penalties. Rows the
   # env flags mask_sample (e.g. timeouts) are not charged while
-  # env.should_mask_flagged_samples is on. floor clamps the post-deduction
-  # reward; null disables. Requires the NeMo-Gym path.
+  # env.should_mask_flagged_samples is on. lambda_call_bonus > 0 adds a bonus
+  # lambda_call_bonus * min(calls / call_bonus_ref, 1) for well-formed tool calls
+  # (pays for exploring; calibrate call_bonus_ref to the untrained checkpoint's
+  # mean calls per solved task, read from time_efficiency/calls/mean at step 1,
+  # and use apply_to "correct" with it). floor clamps the adjusted reward; null
+  # disables. Requires the NeMo-Gym path.
   # Pair with a tight advantage_clip_low/high (e.g. -3/3) when normalize_rewards
   # is true, otherwise a narrow group reward spread amplifies this small term.
   time_efficiency:
     enabled: false
     lambda_time: 0.016666666666666666  # 1/60 per minute
     apply_to: "all"  # "all" | "correct"
+    lambda_call_bonus: 0.0  # e.g. 0.10 with call_bonus_ref set
+    call_bonus_ref: null  # required when lambda_call_bonus > 0
     floor: null
   seq_logprob_error_threshold: null
   # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -1300,6 +1300,11 @@ class AsyncTrajectoryCollector:
                 ),
                 reward_penalty_config=self.master_config.reward_penalties,
                 length_penalty_config=self.master_config.grpo.model_dump(),
+                time_efficiency_config=(
+                    self.master_config.grpo.time_efficiency
+                    if isinstance(self.master_config, GRPOMasterConfig)
+                    else None
+                ),
                 thinking_tags=get_nemo_gym_thinking_tags(self.master_config.env),
                 mask_env_flagged_samples=should_mask_flagged_samples(
                     self.master_config.env

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -151,6 +151,7 @@ from nemo_rl.utils.multimodal_payload_metrics import (
     print_multimodal_payload_metrics,
 )
 from nemo_rl.utils.nsys import maybe_gpu_profile_step
+from nemo_rl.utils.time_efficiency import TimeEfficiencyConfig
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
 from nemo_rl.weight_sync.checkpoint_engine_config import (
@@ -352,6 +353,11 @@ class GRPOConfig(BaseModel, extra="allow"):
     batch_multiplier: float = 1.0
     reward_shaping: RewardShapingConfig = Field(default_factory=RewardShapingConfig)
     reward_scaling: RewardScalingConfig = Field(default_factory=RewardScalingConfig)
+    # Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts:
+    # reward -= lambda_time * openhands_run_time / 60. Applied to training
+    # rollouts only; validation reports the raw env reward.
+    # See nemo_rl/utils/time_efficiency.py.
+    time_efficiency: TimeEfficiencyConfig = Field(default_factory=TimeEfficiencyConfig)
     # By default advantages are calculated on CPU. Setting this flag to true leverages GPU for their computation.
     calculate_advantages_on_gpu: bool = False
     # Sequence-level logprob error masking for training stability. If set, mask sequences with mult_prob_error exceeding this threshold (same scale as token_mult_prob_error metric, e.g., 1.5)
@@ -3141,6 +3147,7 @@ def grpo_train(
                             effort_config=_get_effort_config(master_config),
                             reward_penalty_config=master_config.reward_penalties,
                             length_penalty_config=master_config.grpo.model_dump(),
+                            time_efficiency_config=master_config.grpo.time_efficiency,
                             thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                             mask_env_flagged_samples=should_mask_flagged_samples(
                                 master_config.env
@@ -4065,11 +4072,11 @@ def validate(
                     greedy=False,
                     effort_config=_get_effort_config(master_config),
                     reward_penalty_config=master_config.reward_penalties,
-                    # No length_penalty_config here: validation metrics
-                    # (accuracy/pass_k) must reflect the raw env reward, and the
-                    # adjustment code groups by the TRAINING stride
-                    # (num_generations_per_prompt), which does not match
-                    # val_num_generations_per_prompt.
+                    # No length_penalty_config or time_efficiency_config here:
+                    # validation metrics (accuracy/pass_k) must reflect the raw
+                    # env reward, and the length adjustment code groups by the
+                    # TRAINING stride (num_generations_per_prompt), which does
+                    # not match val_num_generations_per_prompt.
                     thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                     mask_env_flagged_samples=should_mask_flagged_samples(
                         master_config.env

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -354,9 +354,9 @@ class GRPOConfig(BaseModel, extra="allow"):
     reward_shaping: RewardShapingConfig = Field(default_factory=RewardShapingConfig)
     reward_scaling: RewardScalingConfig = Field(default_factory=RewardScalingConfig)
     # Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts:
-    # reward -= lambda_time * openhands_run_time / 60. Applied to training
-    # rollouts only; validation reports the raw env reward.
-    # See nemo_rl/utils/time_efficiency.py.
+    # reward -= lambda_time * openhands_run_time / 60, applied after the other
+    # reward shapers. Training rollouts only; validation reports the raw env
+    # reward. See nemo_rl/utils/time_efficiency.py.
     time_efficiency: TimeEfficiencyConfig = Field(default_factory=TimeEfficiencyConfig)
     # By default advantages are calculated on CPU. Setting this flag to true leverages GPU for their computation.
     calculate_advantages_on_gpu: bool = False
@@ -805,6 +805,9 @@ def setup(
     # NeMo Gym is initialized inside setup() (rather than by the caller) so its
     # spinup can overlap with vLLM model loading via deferred model load.
     _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=enable_nemo_gym
+    )
+    _raise_if_time_efficiency_enabled_without_nemo_gym(
         master_config, enable_nemo_gym=enable_nemo_gym
     )
     nemo_gym_actor = None
@@ -2054,6 +2057,22 @@ def _raise_if_reward_penalties_enabled_without_nemo_gym(
         "reward_penalties require the NeMo-Gym path "
         "(env.should_use_nemo_gym=true); they are not supported with the native "
         "generation path."
+    )
+
+
+def _raise_if_time_efficiency_enabled_without_nemo_gym(
+    master_config: MasterConfig,
+    *,
+    enable_nemo_gym: bool,
+) -> None:
+    """Validate the time-efficiency reward is only used with NeMo-Gym."""
+    if enable_nemo_gym or not master_config.grpo.time_efficiency.enabled:
+        return
+
+    raise ValueError(
+        "grpo.time_efficiency requires the NeMo-Gym path "
+        "(env.should_use_nemo_gym=true); openhands_run_time is only emitted by "
+        "Gym agents, so the deduction would be a silent no-op elsewhere."
     )
 
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -294,6 +294,7 @@ def validate_sync(
                     finish_generation=False,
                     task_to_env_override=val_task_to_env,
                     carry_keys=["total_reward", "turn_roles", "turn_contents"],
+                    is_validation=True,
                 )
             )
             roles = driver_carry["turn_roles"]

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -78,6 +78,10 @@ from nemo_rl.utils.multimodal_payload_metrics import (
     collect_multimodal_payload_metrics,
     print_multimodal_payload_metrics,
 )
+from nemo_rl.utils.time_efficiency import (
+    TimeEfficiencyConfig,
+    apply_time_efficiency_reward,
+)
 from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
@@ -2284,6 +2288,7 @@ async def run_async_nemo_gym_rollout(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     length_penalty_config: dict[str, Any] | BaseModel | None = None,
+    time_efficiency_config: Optional[TimeEfficiencyConfig] = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mask_env_flagged_samples: bool = True,
     returns_entire_batch: bool = False,
@@ -2316,6 +2321,8 @@ async def run_async_nemo_gym_rollout(
         effort_config: Optional configuration for effort-based reward shaping.
         reward_penalty_config: Optional reward-penalty configuration.
         length_penalty_config: Optional GRPO config block for length adjustments.
+        time_efficiency_config: Optional ``grpo.time_efficiency`` block; deducts
+            a price for each rollout's agent wall time from its reward.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
         mask_env_flagged_samples: Whether to carry env-driven ``mask_sample``
             flags in the rollout batch for loss masking.
@@ -2492,6 +2499,7 @@ async def run_async_nemo_gym_rollout(
                         effort_config=effort_config,
                         reward_penalty_config=reward_penalty_config,
                         length_penalty_config=length_penalty_config,
+                        time_efficiency_config=time_efficiency_config,
                         thinking_tags=thinking_tags,
                         mask_env_flagged_samples=mask_env_flagged_samples,
                     )
@@ -2530,6 +2538,7 @@ def run_nemo_gym_rollout_sync(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     length_penalty_config: dict[str, Any] | BaseModel | None = None,
+    time_efficiency_config: Optional[TimeEfficiencyConfig] = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     sampling_params: Optional[GenerationSamplingParams] = None,
     mask_env_flagged_samples: bool = True,
@@ -2557,6 +2566,8 @@ def run_nemo_gym_rollout_sync(
         greedy: Must be ``False`` because this path does not support greedy mode.
         effort_config: Optional configuration for effort-based reward shaping.
         reward_penalty_config: Optional reward-penalty configuration.
+        time_efficiency_config: Optional ``grpo.time_efficiency`` block; deducts
+            a price for each rollout's agent wall time from its reward.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
         sampling_params: Sampling profile stamped onto every NeMo-Gym row.
             ``None`` uses the train profile from ``generation_config``;
@@ -2595,6 +2606,7 @@ def run_nemo_gym_rollout_sync(
             effort_config=effort_config,
             reward_penalty_config=reward_penalty_config,
             length_penalty_config=length_penalty_config,
+            time_efficiency_config=time_efficiency_config,
             thinking_tags=thinking_tags,
             mask_env_flagged_samples=mask_env_flagged_samples,
             returns_entire_batch=True,
@@ -2622,10 +2634,17 @@ def _postprocess_single_nemo_gym_group(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     length_penalty_config: dict[str, Any] | BaseModel | None = None,
+    time_efficiency_config: Optional[TimeEfficiencyConfig] = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mask_env_flagged_samples: bool = True,
 ) -> NemoGymRolloutResult:
     """Postprocess one complete prompt group from the NeMo-Gym stream."""
+    # Wall-clock time-efficiency reward. Runs first so the reward-zeroing
+    # penalties below can still zero a rollout after the deduction.
+    time_efficiency_stats = apply_time_efficiency_reward(
+        results, time_efficiency_config
+    )
+
     # Length-based reward shaping for low-effort prompts
     shaping = _apply_effort_shaping(results, nemo_gym_rows, effort_config)
     length_rewards_low = shaping.length_rewards_low
@@ -2796,6 +2815,10 @@ def _postprocess_single_nemo_gym_group(
                 )
 
         rollout_metrics.update(per_agent_metrics)
+
+    # Surface the time-efficiency term as W&B curves next to reward so the
+    # deduction can be watched against accuracy.
+    rollout_metrics.update(time_efficiency_stats)
 
     # Necessary for downstream nemo rl logging/printing.
     rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -2566,6 +2566,7 @@ def run_nemo_gym_rollout_sync(
         greedy: Must be ``False`` because this path does not support greedy mode.
         effort_config: Optional configuration for effort-based reward shaping.
         reward_penalty_config: Optional reward-penalty configuration.
+        length_penalty_config: Optional GRPO config block for length adjustments.
         time_efficiency_config: Optional ``grpo.time_efficiency`` block; deducts
             a price for each rollout's agent wall time from its reward.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
@@ -2639,12 +2640,6 @@ def _postprocess_single_nemo_gym_group(
     mask_env_flagged_samples: bool = True,
 ) -> NemoGymRolloutResult:
     """Postprocess one complete prompt group from the NeMo-Gym stream."""
-    # Wall-clock time-efficiency reward. Runs first so the reward-zeroing
-    # penalties below can still zero a rollout after the deduction.
-    time_efficiency_stats = apply_time_efficiency_reward(
-        results, time_efficiency_config
-    )
-
     # Length-based reward shaping for low-effort prompts
     shaping = _apply_effort_shaping(results, nemo_gym_rows, effort_config)
     length_rewards_low = shaping.length_rewards_low
@@ -2677,6 +2672,14 @@ def _postprocess_single_nemo_gym_group(
             apply_group_length_penalties(
                 results, {"grpo": grpo_config}, tokenizer=tokenizer
             )
+
+    # Wall-clock time-efficiency reward. Runs LAST: the shapers above assume a
+    # binary env reward (effort shaping multiplies it, the length penalties gate
+    # on a 0/1 reward, the reward penalties reset it to 0), so the continuous
+    # deduction only composes with them when applied after them.
+    time_efficiency_stats = apply_time_efficiency_reward(
+        results, time_efficiency_config
+    )
 
     # Prepare for the rollout metrics calculation below. Not strictly necessary here, but good to have parity with `run_async_multi_turn_rollout`
     with timer.time(f"{timer_prefix}/prepare_for_metrics_calculation"):

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -2673,12 +2673,23 @@ def _postprocess_single_nemo_gym_group(
                 results, {"grpo": grpo_config}, tokenizer=tokenizer
             )
 
+    # Env/agent mask flag: flagged samples are dropped from the loss but still
+    # count for advantages. env.should_mask_flagged_samples=false skips this.
+    mask_sample_flags = (
+        _extract_mask_sample_flags(results) if mask_env_flagged_samples else None
+    )
+
     # Wall-clock time-efficiency reward. Runs LAST: the shapers above assume a
     # binary env reward (effort shaping multiplies it, the length penalties gate
     # on a 0/1 reward, the reward penalties reset it to 0), so the continuous
-    # deduction only composes with them when applied after them.
+    # deduction only composes with them when applied after them. Rows the
+    # trainer drops from the loss are not charged (same flags as final_batch).
     time_efficiency_stats = apply_time_efficiency_reward(
-        results, time_efficiency_config
+        results,
+        time_efficiency_config,
+        mask_sample=(
+            mask_sample_flags.tolist() if mask_sample_flags is not None else None
+        ),
     )
 
     # Prepare for the rollout metrics calculation below. Not strictly necessary here, but good to have parity with `run_async_multi_turn_rollout`
@@ -2883,10 +2894,8 @@ def _postprocess_single_nemo_gym_group(
             final_batch[identity_key] = torch.tensor(
                 [int(value) for value in identity_values], dtype=torch.long
             )
-    # Env/agent mask flag: flagged samples are dropped from the loss but still
-    # count for advantages. env.should_mask_flagged_samples=false skips this.
-    if mask_env_flagged_samples:
-        final_batch["mask_sample"] = _extract_mask_sample_flags(results)
+    if mask_sample_flags is not None:
+        final_batch["mask_sample"] = mask_sample_flags
 
     if length_rewards_low:
         rollout_metrics["mean_length_reward_low"] = sum(length_rewards_low) / len(

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -260,6 +260,7 @@ class SyncRolloutActor:
                 and cfg.env["nemo_gym"].get("effort_levels") is not None
                 else None,
                 reward_penalty_config=cfg.reward_penalties,
+                time_efficiency_config=cfg.grpo.time_efficiency,
                 thinking_tags=get_nemo_gym_thinking_tags(cfg.env),
                 deduplicate_multimodal_data=cfg.grpo.deduplicate_multimodal_data,
                 debug_payload_metrics=cfg.grpo.debug_payload_metrics,

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -145,6 +145,7 @@ class SyncRolloutActor:
         finish_generation: bool = True,
         task_to_env_override: Optional[dict[str, EnvironmentInterface]] = None,
         carry_keys: Optional[list[str]] = None,
+        is_validation: bool = False,
     ) -> tuple[
         KVBatchMeta,
         dict[str, Any],
@@ -203,6 +204,11 @@ class SyncRolloutActor:
                 (training uses this). Validation passes a slim list
                 (e.g. ``["total_reward"]``) to avoid wasting Ray transfer
                 on fields it doesn't consume.
+            is_validation: ``True`` for validation rollouts. Skips the
+                training-only ``grpo.time_efficiency`` reward so validation
+                accuracy reflects the raw env reward, mirroring
+                ``grpo.validate()``. Effort shaping and reward penalties are
+                applied in both modes (pre-existing behavior).
 
         Returns:
             ``(meta, driver_carry, rollout_metrics, generation_logger_metrics)``
@@ -260,7 +266,9 @@ class SyncRolloutActor:
                 and cfg.env["nemo_gym"].get("effort_levels") is not None
                 else None,
                 reward_penalty_config=cfg.reward_penalties,
-                time_efficiency_config=cfg.grpo.time_efficiency,
+                time_efficiency_config=(
+                    None if is_validation else cfg.grpo.time_efficiency
+                ),
                 thinking_tags=get_nemo_gym_thinking_tags(cfg.env),
                 deduplicate_multimodal_data=cfg.grpo.deduplicate_multimodal_data,
                 debug_payload_metrics=cfg.grpo.debug_payload_metrics,

--- a/nemo_rl/utils/time_efficiency.py
+++ b/nemo_rl/utils/time_efficiency.py
@@ -19,9 +19,9 @@ Charges each rollout for the time its agent loop ran::
     reward_i = reward_i - lambda_time * (openhands_run_time_i / 60)
 
 ``openhands_run_time`` (seconds) is emitted by the Gym ``swe_agents`` server
-for every rollout. It covers the agent loop only and excludes container
-spin-up, final evaluation and Ray queueing, so it is the part of wall time the
-policy can actually influence. With the default ``lambda_time = 1/60`` a
+for every rollout. It spans the agent container from launch to exit, so it
+excludes final evaluation and Ray queueing but *includes* apptainer spin-up,
+which the policy cannot influence. With the default ``lambda_time = 1/60`` a
 60-minute rollout costs exactly 1.0: one hour of compute is priced at one
 solved task.
 
@@ -49,7 +49,8 @@ class TimeEfficiencyConfig(BaseModel, extra="allow"):
         apply_to: ``"all"`` deducts from every rollout, including failures, so
             failed rollouts also receive a gradient from their wall time; a
             slow correct rollout can then score below a fast incorrect one.
-            ``"correct"`` deducts from resolved rollouts only.
+            ``"correct"`` deducts only from rollouts that are resolved and
+            still carry a positive reward after the reward-zeroing penalties.
         floor: Lower clamp on the post-deduction reward so one pathologically
             slow rollout cannot dominate its group. ``None`` disables.
     """
@@ -79,17 +80,21 @@ def apply_time_efficiency_reward(
 ) -> dict[str, float]:
     """Deduct the wall-time price from each ``result["full_result"]["reward"]`` in place.
 
-    Runs before the reward-zeroing penalties in the NeMo-Gym postprocess so
-    those can still zero a rollout after the deduction.
+    Runs last in the NeMo-Gym postprocess, after effort shaping, the
+    reward-zeroing penalties and the length penalties: those assume a binary
+    env reward, so the continuous deduction only composes with them when it is
+    applied after them.
 
     Args:
-        results: One prompt group of NeMo-Gym rollout results.
+        results: The NeMo-Gym rollout results to adjust: one prompt group on
+            the async collector path, the whole batch in
+            ``run_nemo_gym_rollout_sync``.
         config: The ``grpo.time_efficiency`` block. ``None`` or
             ``enabled=False`` leaves ``results`` untouched.
 
     Returns:
-        Group-level metrics under the ``time_efficiency/`` prefix, or an empty
-        dict when the feature is disabled or ``results`` is empty.
+        Metrics under the ``time_efficiency/`` prefix computed over ``results``,
+        or an empty dict when the feature is disabled or ``results`` is empty.
     """
     if config is None or not config.enabled or not results:
         return {}
@@ -98,7 +103,9 @@ def apply_time_efficiency_reward(
     deductions: list[float] = []
     for result, rollout_min in zip(results, minutes):
         full_result = result["full_result"]
-        if config.apply_to == "correct" and not full_result.get("resolved"):
+        if config.apply_to == "correct" and not (
+            full_result.get("resolved") and full_result.get("reward")
+        ):
             deductions.append(0.0)
             continue
         base = float(full_result.get("reward") or 0.0)
@@ -108,12 +115,17 @@ def apply_time_efficiency_reward(
         deductions.append(base - new)
         full_result["reward"] = new
 
+    # ``<name>/<stat>`` keys so aggregate_rollout_metrics maxes the ``/max``
+    # entries across prompt groups instead of averaging them.
     return {
-        "time_efficiency/minutes_mean": sum(minutes) / len(minutes),
-        "time_efficiency/minutes_max": max(minutes),
-        "time_efficiency/deduction_mean": sum(deductions) / len(deductions),
-        "time_efficiency/deduction_max": max(deductions),
-        # 1.0 when wall times differ within the group, i.e. the term can still
-        # produce a gradient after group normalization.
-        "time_efficiency/group_has_signal": float(max(minutes) > min(minutes)),
+        "time_efficiency/minutes/mean": sum(minutes) / len(minutes),
+        "time_efficiency/minutes/max": max(minutes),
+        "time_efficiency/deduction/mean": sum(deductions) / len(deductions),
+        "time_efficiency/deduction/max": max(deductions),
+        # 1.0 when the deduction differs within the group (skipped rollouts
+        # count as 0), i.e. the term can still produce a gradient after group
+        # normalization. 1e-6 absorbs float noise from ``base - new``.
+        "time_efficiency/group_has_signal": float(
+            max(deductions) - min(deductions) > 1e-6
+        ),
     }

--- a/nemo_rl/utils/time_efficiency.py
+++ b/nemo_rl/utils/time_efficiency.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts.
+
+Charges each rollout for the time its agent loop ran::
+
+    reward_i = reward_i - lambda_time * (openhands_run_time_i / 60)
+
+``openhands_run_time`` (seconds) is emitted by the Gym ``swe_agents`` server
+for every rollout. It covers the agent loop only and excludes container
+spin-up, final evaluation and Ray queueing, so it is the part of wall time the
+policy can actually influence. With the default ``lambda_time = 1/60`` a
+60-minute rollout costs exactly 1.0: one hour of compute is priced at one
+solved task.
+
+Because the deduction is a small continuous term added to a binary reward, it
+should be paired with a tight ``grpo.advantage_clip_low/high`` (e.g. -3/3) when
+``grpo.normalize_rewards`` is on; otherwise a group whose rewards differ only
+by wall time is normalized by a tiny spread and its advantages explode.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class TimeEfficiencyConfig(BaseModel, extra="allow"):
+    """User-facing ``grpo.time_efficiency`` block.
+
+    Attributes:
+        enabled: Master switch. When ``False`` rewards are untouched and no
+            metrics are emitted.
+        lambda_time: Deduction per minute of agent wall time. ``1/60`` makes a
+            60-minute rollout cost exactly 1.0.
+        apply_to: ``"all"`` deducts from every rollout, including failures, so
+            failed rollouts also receive a gradient from their wall time; a
+            slow correct rollout can then score below a fast incorrect one.
+            ``"correct"`` deducts from resolved rollouts only.
+        floor: Lower clamp on the post-deduction reward so one pathologically
+            slow rollout cannot dominate its group. ``None`` disables.
+    """
+
+    enabled: bool = False
+    lambda_time: float = 1.0 / 60.0
+    apply_to: Literal["all", "correct"] = "all"
+    floor: float | None = None
+
+
+def rollout_minutes(result: dict[str, Any]) -> float:
+    """Return the agent-loop wall time of one rollout in minutes.
+
+    A missing, ``None``, negative or non-numeric ``openhands_run_time`` counts
+    as 0 so an absent timing never silently penalizes a rollout.
+    """
+    seconds = result["full_result"].get("openhands_run_time")
+    try:
+        return max(float(seconds), 0.0) / 60.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def apply_time_efficiency_reward(
+    results: list[dict[str, Any]],
+    config: TimeEfficiencyConfig | None,
+) -> dict[str, float]:
+    """Deduct the wall-time price from each ``result["full_result"]["reward"]`` in place.
+
+    Runs before the reward-zeroing penalties in the NeMo-Gym postprocess so
+    those can still zero a rollout after the deduction.
+
+    Args:
+        results: One prompt group of NeMo-Gym rollout results.
+        config: The ``grpo.time_efficiency`` block. ``None`` or
+            ``enabled=False`` leaves ``results`` untouched.
+
+    Returns:
+        Group-level metrics under the ``time_efficiency/`` prefix, or an empty
+        dict when the feature is disabled or ``results`` is empty.
+    """
+    if config is None or not config.enabled or not results:
+        return {}
+
+    minutes = [rollout_minutes(result) for result in results]
+    deductions: list[float] = []
+    for result, rollout_min in zip(results, minutes):
+        full_result = result["full_result"]
+        if config.apply_to == "correct" and not full_result.get("resolved"):
+            deductions.append(0.0)
+            continue
+        base = float(full_result.get("reward") or 0.0)
+        new = base - config.lambda_time * rollout_min
+        if config.floor is not None:
+            new = max(new, config.floor)
+        deductions.append(base - new)
+        full_result["reward"] = new
+
+    return {
+        "time_efficiency/minutes_mean": sum(minutes) / len(minutes),
+        "time_efficiency/minutes_max": max(minutes),
+        "time_efficiency/deduction_mean": sum(deductions) / len(deductions),
+        "time_efficiency/deduction_max": max(deductions),
+        # 1.0 when wall times differ within the group, i.e. the term can still
+        # produce a gradient after group normalization.
+        "time_efficiency/group_has_signal": float(max(minutes) > min(minutes)),
+    }

--- a/nemo_rl/utils/time_efficiency.py
+++ b/nemo_rl/utils/time_efficiency.py
@@ -33,6 +33,7 @@ by wall time is normalized by a tiny spread and its advantages explode.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -49,6 +50,13 @@ class TimeEfficiencyConfig(BaseModel, extra="allow"):
         apply_to: ``"all"`` deducts from every rollout, including failures, so
             failed rollouts also receive a gradient from their wall time; a
             slow correct rollout can then score below a fast incorrect one.
+            Rollouts the env flags with ``mask_sample`` (``swe_agents`` flags
+            timeouts, i.e. the group's longest rollouts) are exempt while
+            ``env.should_mask_flagged_samples`` is on: they are dropped from
+            the loss, so charging them could only drag their siblings' group
+            baseline down. They still enter the baseline at their raw 0.0,
+            which tilts it slightly the other way. With the flag off those
+            rows train and are charged.
             ``"correct"`` deducts only from rollouts that are resolved and
             still carry a positive reward after the reward-zeroing penalties.
         floor: Lower clamp on the post-deduction reward so one pathologically
@@ -77,6 +85,8 @@ def rollout_minutes(result: dict[str, Any]) -> float:
 def apply_time_efficiency_reward(
     results: list[dict[str, Any]],
     config: TimeEfficiencyConfig | None,
+    *,
+    mask_sample: Sequence[bool] | None = None,
 ) -> dict[str, float]:
     """Deduct the wall-time price from each ``result["full_result"]["reward"]`` in place.
 
@@ -91,20 +101,39 @@ def apply_time_efficiency_reward(
             ``run_nemo_gym_rollout_sync``.
         config: The ``grpo.time_efficiency`` block. ``None`` or
             ``enabled=False`` leaves ``results`` untouched.
+        mask_sample: Per-row env ``mask_sample`` flags, one per result, as
+            produced by the caller's loss-mask extraction. Flagged rows are not
+            charged (their deduction is 0). ``None`` charges every row; pass it
+            when ``env.should_mask_flagged_samples`` is off, since those rows
+            then train.
 
     Returns:
         Metrics under the ``time_efficiency/`` prefix computed over ``results``,
         or an empty dict when the feature is disabled or ``results`` is empty.
+        Skipped rows count toward the means with a 0 deduction;
+        ``group_has_signal`` is computed over the rows that train.
+
+    Raises:
+        ValueError: If ``mask_sample`` is given with a length other than
+            ``len(results)``.
     """
     if config is None or not config.enabled or not results:
         return {}
+    if mask_sample is not None and len(mask_sample) != len(results):
+        raise ValueError(
+            f"mask_sample has {len(mask_sample)} entries for {len(results)} results"
+        )
+    masked = (
+        [bool(flag) for flag in mask_sample] if mask_sample else [False] * len(results)
+    )
 
     minutes = [rollout_minutes(result) for result in results]
     deductions: list[float] = []
-    for result, rollout_min in zip(results, minutes):
+    for result, rollout_min, is_masked in zip(results, minutes, masked):
         full_result = result["full_result"]
-        if config.apply_to == "correct" and not (
-            full_result.get("resolved") and full_result.get("reward")
+        if is_masked or (
+            config.apply_to == "correct"
+            and not (full_result.get("resolved") and full_result.get("reward"))
         ):
             deductions.append(0.0)
             continue
@@ -115,6 +144,12 @@ def apply_time_efficiency_reward(
         deductions.append(base - new)
         full_result["reward"] = new
 
+    # Loss-masked rows cannot learn from the term, so the signal metric only
+    # looks at the rows that train.
+    trainable_deductions = [
+        d for d, is_masked in zip(deductions, masked) if not is_masked
+    ]
+
     # ``<name>/<stat>`` keys so aggregate_rollout_metrics maxes the ``/max``
     # entries across prompt groups instead of averaging them.
     return {
@@ -122,10 +157,11 @@ def apply_time_efficiency_reward(
         "time_efficiency/minutes/max": max(minutes),
         "time_efficiency/deduction/mean": sum(deductions) / len(deductions),
         "time_efficiency/deduction/max": max(deductions),
-        # 1.0 when the deduction differs within the group (skipped rollouts
-        # count as 0), i.e. the term can still produce a gradient after group
-        # normalization. 1e-6 absorbs float noise from ``base - new``.
+        # 1.0 when the deduction differs among the trainable rows ("correct"
+        # skips count as 0), i.e. the term can still produce a gradient after
+        # group normalization. 1e-6 absorbs float noise from ``base - new``.
         "time_efficiency/group_has_signal": float(
-            max(deductions) - min(deductions) > 1e-6
+            len(trainable_deductions) > 1
+            and max(trainable_deductions) - min(trainable_deductions) > 1e-6
         ),
     }

--- a/nemo_rl/utils/time_efficiency.py
+++ b/nemo_rl/utils/time_efficiency.py
@@ -14,9 +14,12 @@
 
 """Wall-clock time-efficiency reward for NeMo-Gym agentic rollouts.
 
-Charges each rollout for the time its agent loop ran::
+Charges each rollout for the time its agent loop ran, optionally paying a
+saturating bonus for the tool calls it made::
 
-    reward_i = reward_i - lambda_time * (openhands_run_time_i / 60)
+    reward_i = reward_i
+               + lambda_call_bonus * min(calls_i / call_bonus_ref, 1)   # 0 by default
+               - lambda_time * (openhands_run_time_i / 60)
 
 ``openhands_run_time`` (seconds) is emitted by the Gym ``swe_agents`` server
 for every rollout. It spans the agent container from launch to exit, so it
@@ -36,7 +39,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 
 class TimeEfficiencyConfig(BaseModel, extra="allow"):
@@ -59,14 +62,42 @@ class TimeEfficiencyConfig(BaseModel, extra="allow"):
             rows train and are charged.
             ``"correct"`` deducts only from rollouts that are resolved and
             still carry a positive reward after the reward-zeroing penalties.
-        floor: Lower clamp on the post-deduction reward so one pathologically
-            slow rollout cannot dominate its group. ``None`` disables.
+        lambda_call_bonus: Bonus paid for tool calls, saturating at
+            ``call_bonus_ref`` calls: ``lambda_call_bonus * min(calls /
+            call_bonus_ref, 1)``. Only well-formed ``function_call`` items
+            count, so a malformed call earns nothing. ``0`` (default) disables
+            the bonus and reduces this block to the plain time deduction. The
+            bonus follows the same ``apply_to`` gate as the deduction; paying
+            it on failures (``"all"``) rewards junk calls, so use ``"correct"``
+            with it.
+        call_bonus_ref: Number of calls at which the bonus saturates. Model
+            and task specific: calibrate it to the untrained checkpoint's
+            average calls per solved task (read ``time_efficiency/calls/mean``
+            off step 1). Required when ``lambda_call_bonus > 0``.
+        floor: Lower clamp on the adjusted reward so one pathologically slow
+            rollout cannot dominate its group. ``None`` disables. With the
+            bonus, a correct rollout that runs a 60-minute timeout without
+            earning the bonus lands on exactly 0.0 and ties with the
+            failures; a small positive floor keeps it above them.
     """
 
     enabled: bool = False
     lambda_time: float = 1.0 / 60.0
     apply_to: Literal["all", "correct"] = "all"
+    lambda_call_bonus: float = Field(default=0.0, ge=0.0)
+    call_bonus_ref: float | None = None
     floor: float | None = None
+
+    @model_validator(mode="after")
+    def _check_call_bonus_ref(self) -> "TimeEfficiencyConfig":
+        if self.lambda_call_bonus > 0 and not (
+            self.call_bonus_ref is not None and self.call_bonus_ref > 0
+        ):
+            raise ValueError(
+                "grpo.time_efficiency.call_bonus_ref must be a positive number of "
+                "tool calls when lambda_call_bonus > 0"
+            )
+        return self
 
 
 def rollout_minutes(result: dict[str, Any]) -> float:
@@ -82,13 +113,30 @@ def rollout_minutes(result: dict[str, Any]) -> float:
         return 0.0
 
 
+def rollout_calls(result: dict[str, Any]) -> int:
+    """Return the number of well-formed tool calls the model emitted.
+
+    Counts ``function_call`` items in the Responses output. Calls the
+    environment rejected as malformed never become ``function_call`` items,
+    so they earn no bonus.
+    """
+    output = (result["full_result"].get("response") or {}).get("output")
+    if not isinstance(output, list):
+        return 0
+    return sum(
+        1
+        for item in output
+        if isinstance(item, dict) and item.get("type") == "function_call"
+    )
+
+
 def apply_time_efficiency_reward(
     results: list[dict[str, Any]],
     config: TimeEfficiencyConfig | None,
     *,
     mask_sample: Sequence[bool] | None = None,
 ) -> dict[str, float]:
-    """Deduct the wall-time price from each ``result["full_result"]["reward"]`` in place.
+    """Adjust each ``result["full_result"]["reward"]`` in place for wall time and tool calls.
 
     Runs last in the NeMo-Gym postprocess, after effort shaping, the
     reward-zeroing penalties and the length penalties: those assume a binary
@@ -110,7 +158,13 @@ def apply_time_efficiency_reward(
     Returns:
         Metrics under the ``time_efficiency/`` prefix computed over ``results``,
         or an empty dict when the feature is disabled or ``results`` is empty.
-        Skipped rows count toward the means with a 0 deduction;
+        ``deduction`` is the realized decrease of the reward (net of the call
+        bonus and the floor; negative when the bonus wins), ``bonus`` the raw
+        call bonus, ``calls`` the tool-call count, ``seconds_per_call`` the
+        quantity a call bonus can be gamed on (a collapse alongside rising
+        ``calls/mean`` means cheap-call spam), ``bonus_saturated_frac`` and
+        ``floored_frac`` the calibration signals for ``call_bonus_ref`` and
+        ``floor``. Skipped rows count toward the means with 0;
         ``group_has_signal`` is computed over the rows that train.
 
     Raises:
@@ -128,20 +182,31 @@ def apply_time_efficiency_reward(
     )
 
     minutes = [rollout_minutes(result) for result in results]
+    calls = [rollout_calls(result) for result in results]
     deductions: list[float] = []
-    for result, rollout_min, is_masked in zip(results, minutes, masked):
+    bonuses: list[float] = []
+    floored = 0
+    for result, rollout_min, n_calls, is_masked in zip(results, minutes, calls, masked):
         full_result = result["full_result"]
         if is_masked or (
             config.apply_to == "correct"
             and not (full_result.get("resolved") and full_result.get("reward"))
         ):
             deductions.append(0.0)
+            bonuses.append(0.0)
             continue
         base = float(full_result.get("reward") or 0.0)
-        new = base - config.lambda_time * rollout_min
-        if config.floor is not None:
-            new = max(new, config.floor)
+        bonus = 0.0
+        if config.lambda_call_bonus > 0:
+            # call_bonus_ref is validated to be positive when the bonus is on.
+            assert config.call_bonus_ref is not None
+            bonus = config.lambda_call_bonus * min(n_calls / config.call_bonus_ref, 1.0)
+        new = base + bonus - config.lambda_time * rollout_min
+        if config.floor is not None and new < config.floor:
+            new = config.floor
+            floored += 1
         deductions.append(base - new)
+        bonuses.append(bonus)
         full_result["reward"] = new
 
     # Loss-masked rows cannot learn from the term, so the signal metric only
@@ -152,11 +217,21 @@ def apply_time_efficiency_reward(
 
     # ``<name>/<stat>`` keys so aggregate_rollout_metrics maxes the ``/max``
     # entries across prompt groups instead of averaging them.
+    n = len(results)
     return {
-        "time_efficiency/minutes/mean": sum(minutes) / len(minutes),
+        "time_efficiency/minutes/mean": sum(minutes) / n,
         "time_efficiency/minutes/max": max(minutes),
-        "time_efficiency/deduction/mean": sum(deductions) / len(deductions),
+        "time_efficiency/deduction/mean": sum(deductions) / n,
         "time_efficiency/deduction/max": max(deductions),
+        "time_efficiency/calls/mean": sum(calls) / n,
+        "time_efficiency/bonus/mean": sum(bonuses) / n,
+        "time_efficiency/seconds_per_call": sum(minutes) * 60.0 / max(sum(calls), 1),
+        "time_efficiency/bonus_saturated_frac": (
+            sum(1 for c in calls if c >= config.call_bonus_ref) / n
+            if config.lambda_call_bonus > 0 and config.call_bonus_ref
+            else 0.0
+        ),
+        "time_efficiency/floored_frac": floored / n,
         # 1.0 when the deduction differs among the trainable rows ("correct"
         # skips count as 0), i.e. the term can still produce a gradient after
         # group normalization. 1e-6 absorbs float noise from ``base - new``.

--- a/nemo_rl/utils/time_efficiency.py
+++ b/nemo_rl/utils/time_efficiency.py
@@ -37,7 +37,7 @@ by wall time is normalized by a tiny spread and its advantages explode.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -84,7 +84,7 @@ class TimeEfficiencyConfig(BaseModel, extra="allow"):
     enabled: bool = False
     lambda_time: float = 1.0 / 60.0
     apply_to: Literal["all", "correct"] = "all"
-    lambda_call_bonus: float = Field(default=0.0, ge=0.0)
+    lambda_call_bonus: Annotated[float, Field(ge=0.0)] = 0.0
     call_bonus_ref: float | None = None
     floor: float | None = None
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -244,6 +244,7 @@ project-includes = [
   "nemo_rl/utils/prefetch_venvs.py",
   "nemo_rl/utils/r3_trace.py",
   "nemo_rl/utils/routed_experts_codec.py",
+  "nemo_rl/utils/time_efficiency.py",
   "nemo_rl/utils/timer.py",
   "nemo_rl/utils/venvs.py",
   "nemo_rl/utils/weight_transfer_http.py",

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -45,6 +45,7 @@ from nemo_rl.algorithms.grpo import (
     _maybe_restore_async_replay_buffer_checkpoint,
     _needs_hf_refit_handshake,
     _raise_if_reward_penalties_enabled_without_nemo_gym,
+    _raise_if_time_efficiency_enabled_without_nemo_gym,
     _resolve_logprob_skip_flags,
     _resolve_message_level_advantage_penalties,
     _save_async_replay_buffer_checkpoint,
@@ -95,6 +96,7 @@ from nemo_rl.models.generation.dynamo import DynamoConfig
 from nemo_rl.models.generation.interfaces import should_use_async_rollouts
 from nemo_rl.models.generation.megatron import MegatronGeneration
 from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
+from nemo_rl.utils.time_efficiency import TimeEfficiencyConfig
 from nemo_rl.utils.timer import Timer
 from tests.unit.algorithms.utils import (
     create_mock_batch,
@@ -829,6 +831,42 @@ def test_raise_if_reward_penalties_enabled_without_nemo_gym_allows_nemo_gym(
     )
 
     _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=True
+    )
+
+
+def test_raise_if_time_efficiency_enabled_without_nemo_gym_noops_when_disabled(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.time_efficiency = TimeEfficiencyConfig(enabled=False)
+
+    _raise_if_time_efficiency_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=False
+    )
+
+
+def test_raise_if_time_efficiency_enabled_without_nemo_gym_raises(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.time_efficiency = TimeEfficiencyConfig(enabled=True)
+
+    with pytest.raises(
+        ValueError, match="grpo.time_efficiency requires the NeMo-Gym path"
+    ):
+        _raise_if_time_efficiency_enabled_without_nemo_gym(
+            master_config, enable_nemo_gym=False
+        )
+
+
+def test_raise_if_time_efficiency_enabled_without_nemo_gym_allows_nemo_gym(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.time_efficiency = TimeEfficiencyConfig(enabled=True)
+
+    _raise_if_time_efficiency_enabled_without_nemo_gym(
         master_config, enable_nemo_gym=True
     )
 

--- a/tests/unit/experience/test_time_efficiency_rollouts.py
+++ b/tests/unit/experience/test_time_efficiency_rollouts.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The time-efficiency reward hook inside _postprocess_single_nemo_gym_group."""
+
+import pytest
+import torch
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.rollouts import _postprocess_single_nemo_gym_group
+from nemo_rl.utils.time_efficiency import TimeEfficiencyConfig
+from nemo_rl.utils.timer import Timer
+
+
+class _FakeGeneration:
+    cfg = {"max_total_sequence_length": 100}
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 2
+
+    def encode(self, text, add_special_tokens=False):
+        return {"<think>": [12], "</think>": [13]}[text]
+
+
+def _result(reward, run_time_s, resolved):
+    return {
+        "full_result": {
+            "reward": reward,
+            "openhands_run_time": run_time_s,
+            "resolved": resolved,
+            "response": {"output": []},
+        },
+        "message_log": [
+            {"role": "user", "token_ids": torch.tensor([3, 4])},
+            {"role": "assistant", "token_ids": torch.tensor([1, 2])},
+        ],
+        "input_message_log": [{"role": "user", "token_ids": torch.tensor([3, 4])}],
+    }
+
+
+def _postprocess(results, time_efficiency_config):
+    return _postprocess_single_nemo_gym_group(
+        nemo_gym_rows=[{"agent_ref": {"name": "swe_agents"}} for _ in results],
+        results=results,
+        timer=Timer(),
+        timer_prefix="timing/test",
+        policy_generation=_FakeGeneration(),
+        input_batch=BatchedDataDict({"loss_multiplier": torch.ones(len(results))}),
+        tokenizer=_FakeTokenizer(),
+        log_full_result_tables=False,
+        time_efficiency_config=time_efficiency_config,
+    )
+
+
+def test_deduction_reaches_total_reward_and_metrics():
+    results = [_result(1.0, 1800.0, True), _result(0.0, 3600.0, False)]
+    out = _postprocess(results, TimeEfficiencyConfig(enabled=True))
+
+    # 1.0 - 30/60 = 0.5 and 0.0 - 60/60 = -1.0 -> mean -0.25
+    assert out.rollout_metrics["total_reward/mean"] == pytest.approx(-0.25)
+    assert torch.allclose(out.final_batch["total_reward"], torch.tensor([0.5, -1.0]))
+    assert out.rollout_metrics["time_efficiency/minutes_mean"] == pytest.approx(45.0)
+    assert out.rollout_metrics["time_efficiency/deduction_max"] == pytest.approx(1.0)
+
+
+def test_disabled_leaves_rewards_and_metrics_untouched():
+    results = [_result(1.0, 1800.0, True), _result(0.0, 3600.0, False)]
+    out = _postprocess(results, None)
+
+    assert out.rollout_metrics["total_reward/mean"] == pytest.approx(0.5)
+    assert not any(k.startswith("time_efficiency/") for k in out.rollout_metrics)

--- a/tests/unit/experience/test_time_efficiency_rollouts.py
+++ b/tests/unit/experience/test_time_efficiency_rollouts.py
@@ -51,7 +51,7 @@ def _result(reward, run_time_s, resolved):
     }
 
 
-def _postprocess(results, time_efficiency_config):
+def _postprocess(results, time_efficiency_config, reward_penalty_config=None):
     return _postprocess_single_nemo_gym_group(
         nemo_gym_rows=[{"agent_ref": {"name": "swe_agents"}} for _ in results],
         results=results,
@@ -61,6 +61,7 @@ def _postprocess(results, time_efficiency_config):
         input_batch=BatchedDataDict({"loss_multiplier": torch.ones(len(results))}),
         tokenizer=_FakeTokenizer(),
         log_full_result_tables=False,
+        reward_penalty_config=reward_penalty_config,
         time_efficiency_config=time_efficiency_config,
     )
 
@@ -72,8 +73,35 @@ def test_deduction_reaches_total_reward_and_metrics():
     # 1.0 - 30/60 = 0.5 and 0.0 - 60/60 = -1.0 -> mean -0.25
     assert out.rollout_metrics["total_reward/mean"] == pytest.approx(-0.25)
     assert torch.allclose(out.final_batch["total_reward"], torch.tensor([0.5, -1.0]))
-    assert out.rollout_metrics["time_efficiency/minutes_mean"] == pytest.approx(45.0)
-    assert out.rollout_metrics["time_efficiency/deduction_max"] == pytest.approx(1.0)
+    assert out.rollout_metrics["time_efficiency/minutes/mean"] == pytest.approx(45.0)
+    assert out.rollout_metrics["time_efficiency/deduction/max"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "apply_to, expected_rewards, expected_deduction_max",
+    [("all", [-0.5, -1.0], 1.0), ("correct", [0.0, 0.0], 0.0)],
+)
+def test_deduction_runs_after_reward_zeroing_penalties(
+    apply_to, expected_rewards, expected_deduction_max
+):
+    # Both rollouts have an empty response.output, so penalize_empty_final_answer
+    # zeroes them before the deduction runs. Under "all" the zeroed rollouts are
+    # still charged for their wall time; under "correct" a zeroed rollout counts
+    # as a failure and is not charged.
+    results = [_result(1.0, 1800.0, True), _result(0.0, 3600.0, False)]
+    out = _postprocess(
+        results,
+        TimeEfficiencyConfig(enabled=True, apply_to=apply_to),
+        reward_penalty_config={"penalize_empty_final_answer": True},
+    )
+
+    assert out.rollout_metrics["empty_final_answer_rate"] == pytest.approx(1.0)
+    assert torch.allclose(
+        out.final_batch["total_reward"], torch.tensor(expected_rewards)
+    )
+    assert out.rollout_metrics["time_efficiency/deduction/max"] == pytest.approx(
+        expected_deduction_max
+    )
 
 
 def test_disabled_leaves_rewards_and_metrics_untouched():

--- a/tests/unit/experience/test_time_efficiency_rollouts.py
+++ b/tests/unit/experience/test_time_efficiency_rollouts.py
@@ -35,13 +35,14 @@ class _FakeTokenizer:
         return {"<think>": [12], "</think>": [13]}[text]
 
 
-def _result(reward, run_time_s, resolved):
+def _result(reward, run_time_s, resolved, mask_sample=False):
     return {
         "full_result": {
             "reward": reward,
             "openhands_run_time": run_time_s,
             "resolved": resolved,
             "response": {"output": []},
+            "instance_config": {"mask_sample": mask_sample},
         },
         "message_log": [
             {"role": "user", "token_ids": torch.tensor([3, 4])},
@@ -51,7 +52,12 @@ def _result(reward, run_time_s, resolved):
     }
 
 
-def _postprocess(results, time_efficiency_config, reward_penalty_config=None):
+def _postprocess(
+    results,
+    time_efficiency_config,
+    reward_penalty_config=None,
+    mask_env_flagged_samples=True,
+):
     return _postprocess_single_nemo_gym_group(
         nemo_gym_rows=[{"agent_ref": {"name": "swe_agents"}} for _ in results],
         results=results,
@@ -63,6 +69,7 @@ def _postprocess(results, time_efficiency_config, reward_penalty_config=None):
         log_full_result_tables=False,
         reward_penalty_config=reward_penalty_config,
         time_efficiency_config=time_efficiency_config,
+        mask_env_flagged_samples=mask_env_flagged_samples,
     )
 
 
@@ -102,6 +109,41 @@ def test_deduction_runs_after_reward_zeroing_penalties(
     assert out.rollout_metrics["time_efficiency/deduction/max"] == pytest.approx(
         expected_deduction_max
     )
+
+
+def test_loss_masked_timeout_is_not_charged_when_flag_on():
+    # A swe_agents timeout: unresolved, longest in the group, flagged mask_sample.
+    results = [
+        _result(0.0, 600.0, False),
+        _result(0.0, 600.0, False),
+        _result(0.0, 3600.0, False, mask_sample=True),
+    ]
+    out = _postprocess(results, TimeEfficiencyConfig(enabled=True))
+
+    assert torch.allclose(
+        out.final_batch["total_reward"], torch.tensor([-1 / 6, -1 / 6, 0.0])
+    )
+    assert torch.equal(
+        out.final_batch["mask_sample"], torch.tensor([False, False, True])
+    )
+    assert out.rollout_metrics["time_efficiency/group_has_signal"] == 0.0
+
+
+def test_loss_masked_timeout_is_charged_when_flag_off():
+    results = [
+        _result(0.0, 600.0, False),
+        _result(0.0, 600.0, False),
+        _result(0.0, 3600.0, False, mask_sample=True),
+    ]
+    out = _postprocess(
+        results, TimeEfficiencyConfig(enabled=True), mask_env_flagged_samples=False
+    )
+
+    assert torch.allclose(
+        out.final_batch["total_reward"], torch.tensor([-1 / 6, -1 / 6, -1.0])
+    )
+    assert "mask_sample" not in out.final_batch
+    assert out.rollout_metrics["time_efficiency/group_has_signal"] == 1.0
 
 
 def test_disabled_leaves_rewards_and_metrics_untouched():

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -46,6 +46,11 @@ grpo:
     source_max: 1.0
     target_min: 0.0
     target_max: 1.0
+  time_efficiency:
+    enabled: false
+    lambda_time: 0.016666666666666666
+    apply_to: "all"
+    floor: null
   skip_reference_policy_logprobs_calculation: false
   calculate_advantages_on_gpu: false
   seq_logprob_error_threshold: null

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -50,6 +50,8 @@ grpo:
     enabled: false
     lambda_time: 0.016666666666666666
     apply_to: "all"
+    lambda_call_bonus: 0.0
+    call_bonus_ref: null
     floor: null
   skip_reference_policy_logprobs_calculation: false
   calculate_advantages_on_gpu: false

--- a/tests/unit/utils/test_time_efficiency.py
+++ b/tests/unit/utils/test_time_efficiency.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the wall-clock time-efficiency reward in
+nemo_rl/utils/time_efficiency.py."""
+
+import pytest
+from pydantic import ValidationError
+
+from nemo_rl.utils.time_efficiency import (
+    TimeEfficiencyConfig,
+    apply_time_efficiency_reward,
+    rollout_minutes,
+)
+
+
+def make_result(reward, run_time_s, resolved=True):
+    """Minimal NeMo-Gym rollout result in the shape the module consumes."""
+    return {
+        "full_result": {
+            "reward": reward,
+            "openhands_run_time": run_time_s,
+            "resolved": resolved,
+        }
+    }
+
+
+def rewards(results):
+    return [r["full_result"]["reward"] for r in results]
+
+
+class TestTimeEfficiencyConfig:
+    def test_defaults(self):
+        cfg = TimeEfficiencyConfig()
+        assert cfg.enabled is False
+        assert cfg.lambda_time == pytest.approx(1.0 / 60.0)
+        assert cfg.apply_to == "all"
+        assert cfg.floor is None
+
+    def test_rejects_unknown_apply_to(self):
+        with pytest.raises(ValidationError):
+            TimeEfficiencyConfig(apply_to="solved")
+
+
+class TestRolloutMinutes:
+    @pytest.mark.parametrize(
+        "run_time_s, expected",
+        [
+            (600, 10.0),
+            (90.0, 1.5),
+            ("120", 2.0),
+            (None, 0.0),
+            ("n/a", 0.0),
+            (-30, 0.0),
+        ],
+    )
+    def test_parses_and_guards_bad_values(self, run_time_s, expected):
+        assert rollout_minutes(make_result(1.0, run_time_s)) == pytest.approx(expected)
+
+    def test_missing_key_counts_as_zero(self):
+        assert rollout_minutes({"full_result": {"reward": 1.0}}) == 0.0
+
+
+class TestApplyTimeEfficiencyReward:
+    def test_none_or_disabled_is_a_noop(self):
+        for cfg in (None, TimeEfficiencyConfig(enabled=False)):
+            results = [make_result(1.0, 1800.0), make_result(0.0, 3600.0)]
+            assert apply_time_efficiency_reward(results, cfg) == {}
+            assert rewards(results) == [1.0, 0.0]
+
+    def test_empty_group(self):
+        assert (
+            apply_time_efficiency_reward([], TimeEfficiencyConfig(enabled=True)) == {}
+        )
+
+    def test_deducts_lambda_per_minute_from_every_rollout(self):
+        results = [
+            make_result(1.0, 1800.0, resolved=True),  # 30 min
+            make_result(0.0, 3600.0, resolved=False),  # 60 min
+        ]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True)
+        )
+
+        assert rewards(results) == pytest.approx([0.5, -1.0])
+        assert stats == pytest.approx(
+            {
+                "time_efficiency/minutes_mean": 45.0,
+                "time_efficiency/minutes_max": 60.0,
+                "time_efficiency/deduction_mean": 0.75,
+                "time_efficiency/deduction_max": 1.0,
+                "time_efficiency/group_has_signal": 1.0,
+            }
+        )
+
+    def test_correct_only_leaves_failures_untouched(self):
+        results = [
+            make_result(1.0, 1800.0, resolved=True),
+            make_result(0.0, 3600.0, resolved=False),
+        ]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, apply_to="correct")
+        )
+
+        assert rewards(results) == pytest.approx([0.5, 0.0])
+        # Skipped rollouts still count toward the group means with a 0 deduction.
+        assert stats["time_efficiency/deduction_mean"] == pytest.approx(0.25)
+        assert stats["time_efficiency/minutes_mean"] == pytest.approx(45.0)
+
+    def test_floor_clamps_the_post_deduction_reward(self):
+        results = [make_result(1.0, 5400.0), make_result(0.0, 3600.0)]  # 90 / 60 min
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, floor=0.0)
+        )
+
+        assert rewards(results) == pytest.approx([0.0, 0.0])
+        assert stats["time_efficiency/deduction_max"] == pytest.approx(1.0)
+        assert stats["time_efficiency/deduction_mean"] == pytest.approx(0.5)
+
+    def test_custom_lambda(self):
+        results = [make_result(1.0, 600.0)]  # 10 min
+        apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, lambda_time=0.01)
+        )
+        assert rewards(results) == pytest.approx([0.9])
+
+    def test_missing_timing_costs_nothing(self):
+        results = [{"full_result": {"reward": 1.0, "resolved": True}}]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True)
+        )
+        assert rewards(results) == [1.0]
+        assert stats["time_efficiency/deduction_max"] == 0.0
+
+    def test_none_reward_is_treated_as_zero(self):
+        results = [make_result(None, 1800.0)]
+        apply_time_efficiency_reward(results, TimeEfficiencyConfig(enabled=True))
+        assert rewards(results) == pytest.approx([-0.5])
+
+    def test_group_has_signal_is_zero_for_equal_wall_times(self):
+        results = [make_result(1.0, 600.0), make_result(0.0, 600.0)]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True)
+        )
+        assert stats["time_efficiency/group_has_signal"] == 0.0

--- a/tests/unit/utils/test_time_efficiency.py
+++ b/tests/unit/utils/test_time_efficiency.py
@@ -96,10 +96,10 @@ class TestApplyTimeEfficiencyReward:
         assert rewards(results) == pytest.approx([0.5, -1.0])
         assert stats == pytest.approx(
             {
-                "time_efficiency/minutes_mean": 45.0,
-                "time_efficiency/minutes_max": 60.0,
-                "time_efficiency/deduction_mean": 0.75,
-                "time_efficiency/deduction_max": 1.0,
+                "time_efficiency/minutes/mean": 45.0,
+                "time_efficiency/minutes/max": 60.0,
+                "time_efficiency/deduction/mean": 0.75,
+                "time_efficiency/deduction/max": 1.0,
                 "time_efficiency/group_has_signal": 1.0,
             }
         )
@@ -115,8 +115,22 @@ class TestApplyTimeEfficiencyReward:
 
         assert rewards(results) == pytest.approx([0.5, 0.0])
         # Skipped rollouts still count toward the group means with a 0 deduction.
-        assert stats["time_efficiency/deduction_mean"] == pytest.approx(0.25)
-        assert stats["time_efficiency/minutes_mean"] == pytest.approx(45.0)
+        assert stats["time_efficiency/deduction/mean"] == pytest.approx(0.25)
+        assert stats["time_efficiency/minutes/mean"] == pytest.approx(45.0)
+
+    def test_correct_skips_resolved_rollouts_zeroed_by_a_penalty(self):
+        # A reward-zeroing penalty ran before us: resolved but reward == 0.0 is
+        # treated as a failure and not charged.
+        results = [
+            make_result(0.0, 1800.0, resolved=True),
+            make_result(1.0, 1800.0, resolved=True),
+        ]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, apply_to="correct")
+        )
+
+        assert rewards(results) == pytest.approx([0.0, 0.5])
+        assert stats["time_efficiency/deduction/max"] == pytest.approx(0.5)
 
     def test_floor_clamps_the_post_deduction_reward(self):
         results = [make_result(1.0, 5400.0), make_result(0.0, 3600.0)]  # 90 / 60 min
@@ -125,8 +139,8 @@ class TestApplyTimeEfficiencyReward:
         )
 
         assert rewards(results) == pytest.approx([0.0, 0.0])
-        assert stats["time_efficiency/deduction_max"] == pytest.approx(1.0)
-        assert stats["time_efficiency/deduction_mean"] == pytest.approx(0.5)
+        assert stats["time_efficiency/deduction/max"] == pytest.approx(1.0)
+        assert stats["time_efficiency/deduction/mean"] == pytest.approx(0.5)
 
     def test_custom_lambda(self):
         results = [make_result(1.0, 600.0)]  # 10 min
@@ -141,7 +155,7 @@ class TestApplyTimeEfficiencyReward:
             results, TimeEfficiencyConfig(enabled=True)
         )
         assert rewards(results) == [1.0]
-        assert stats["time_efficiency/deduction_max"] == 0.0
+        assert stats["time_efficiency/deduction/max"] == 0.0
 
     def test_none_reward_is_treated_as_zero(self):
         results = [make_result(None, 1800.0)]
@@ -154,3 +168,29 @@ class TestApplyTimeEfficiencyReward:
             results, TimeEfficiencyConfig(enabled=True)
         )
         assert stats["time_efficiency/group_has_signal"] == 0.0
+
+    def test_group_has_signal_follows_deductions_not_wall_times(self):
+        # "correct" on an all-failed group: wall times differ, nothing deducted.
+        results = [
+            make_result(0.0, 600.0, resolved=False),
+            make_result(0.0, 3600.0, resolved=False),
+        ]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, apply_to="correct")
+        )
+        assert stats["time_efficiency/group_has_signal"] == 0.0
+
+        # floor clamps both rewards to the same value: equal deductions, no signal.
+        results = [make_result(1.0, 5400.0), make_result(1.0, 7200.0)]  # 90 / 120 min
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True, floor=0.0)
+        )
+        assert rewards(results) == pytest.approx([0.0, 0.0])
+        assert stats["time_efficiency/group_has_signal"] == 0.0
+
+        # one second of difference is a signal.
+        results = [make_result(1.0, 600.0), make_result(1.0, 601.0)]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True)
+        )
+        assert stats["time_efficiency/group_has_signal"] == 1.0

--- a/tests/unit/utils/test_time_efficiency.py
+++ b/tests/unit/utils/test_time_efficiency.py
@@ -21,17 +21,22 @@ from pydantic import ValidationError
 from nemo_rl.utils.time_efficiency import (
     TimeEfficiencyConfig,
     apply_time_efficiency_reward,
+    rollout_calls,
     rollout_minutes,
 )
 
 
-def make_result(reward, run_time_s, resolved=True):
+def make_result(reward, run_time_s, resolved=True, calls=0, malformed=0):
     """Minimal NeMo-Gym rollout result in the shape the module consumes."""
+    output = [{"type": "function_call", "name": "bash"} for _ in range(calls)]
+    # Rejected calls surface as plain messages, never as function_call items.
+    output += [{"type": "message", "content": "<tool_call>"} for _ in range(malformed)]
     return {
         "full_result": {
             "reward": reward,
             "openhands_run_time": run_time_s,
             "resolved": resolved,
+            "response": {"output": output},
         }
     }
 
@@ -46,11 +51,42 @@ class TestTimeEfficiencyConfig:
         assert cfg.enabled is False
         assert cfg.lambda_time == pytest.approx(1.0 / 60.0)
         assert cfg.apply_to == "all"
+        assert cfg.lambda_call_bonus == 0.0
+        assert cfg.call_bonus_ref is None
         assert cfg.floor is None
 
     def test_rejects_unknown_apply_to(self):
         with pytest.raises(ValidationError):
             TimeEfficiencyConfig(apply_to="solved")
+
+    def test_rejects_negative_call_bonus(self):
+        with pytest.raises(ValidationError):
+            TimeEfficiencyConfig(lambda_call_bonus=-0.1, call_bonus_ref=56.0)
+
+    @pytest.mark.parametrize("call_bonus_ref", [None, 0.0, -5.0])
+    def test_call_bonus_requires_positive_ref(self, call_bonus_ref):
+        with pytest.raises(ValidationError, match="call_bonus_ref must be a positive"):
+            TimeEfficiencyConfig(lambda_call_bonus=0.1, call_bonus_ref=call_bonus_ref)
+
+    def test_ref_without_bonus_is_allowed(self):
+        TimeEfficiencyConfig(call_bonus_ref=56.0)
+
+
+class TestRolloutCalls:
+    def test_counts_only_function_call_items(self):
+        assert rollout_calls(make_result(1.0, 60.0, calls=3, malformed=2)) == 3
+
+    @pytest.mark.parametrize(
+        "full_result",
+        [
+            {"reward": 1.0},
+            {"reward": 1.0, "response": None},
+            {"reward": 1.0, "response": {"output": None}},
+            {"reward": 1.0, "response": {"output": ["not-a-dict"]}},
+        ],
+    )
+    def test_missing_or_malformed_output_counts_as_zero(self, full_result):
+        assert rollout_calls({"full_result": full_result}) == 0
 
 
 class TestRolloutMinutes:
@@ -100,6 +136,12 @@ class TestApplyTimeEfficiencyReward:
                 "time_efficiency/minutes/max": 60.0,
                 "time_efficiency/deduction/mean": 0.75,
                 "time_efficiency/deduction/max": 1.0,
+                "time_efficiency/calls/mean": 0.0,
+                "time_efficiency/bonus/mean": 0.0,
+                # 90 min of wall time and no calls: max(sum(calls), 1) guards the division.
+                "time_efficiency/seconds_per_call": 5400.0,
+                "time_efficiency/bonus_saturated_frac": 0.0,
+                "time_efficiency/floored_frac": 0.0,
                 "time_efficiency/group_has_signal": 1.0,
             }
         )
@@ -168,6 +210,79 @@ class TestApplyTimeEfficiencyReward:
             results, TimeEfficiencyConfig(enabled=True)
         )
         assert stats["time_efficiency/group_has_signal"] == 0.0
+
+    def test_call_bonus_saturates_at_the_reference(self):
+        # lambda_call_bonus 0.10, ref 50: 25 calls -> +0.05, 50 -> +0.10, 80 -> +0.10.
+        results = [
+            make_result(1.0, 1200.0, calls=25),  # 20 min
+            make_result(1.0, 1200.0, calls=50),
+            make_result(1.0, 1200.0, calls=80),
+        ]
+        cfg = TimeEfficiencyConfig(
+            enabled=True, lambda_call_bonus=0.10, call_bonus_ref=50.0
+        )
+        stats = apply_time_efficiency_reward(results, cfg)
+
+        penalty = 20.0 / 60.0
+        assert rewards(results) == pytest.approx(
+            [1.0 + 0.05 - penalty, 1.0 + 0.10 - penalty, 1.0 + 0.10 - penalty]
+        )
+        assert stats["time_efficiency/calls/mean"] == pytest.approx(155 / 3)
+        assert stats["time_efficiency/bonus/mean"] == pytest.approx(0.25 / 3)
+        assert stats["time_efficiency/bonus_saturated_frac"] == pytest.approx(2 / 3)
+        assert stats["time_efficiency/seconds_per_call"] == pytest.approx(
+            3 * 1200.0 / 155
+        )
+        # deduction is the realized decrease, net of the bonus.
+        assert stats["time_efficiency/deduction/max"] == pytest.approx(penalty - 0.05)
+
+    def test_call_bonus_follows_the_correct_gate(self):
+        # Under "correct" a failure earns neither the bonus nor the deduction,
+        # so junk calls on a failed rollout cannot be rewarded.
+        results = [
+            make_result(0.0, 600.0, resolved=False, calls=200),
+            make_result(1.0, 600.0, resolved=True, calls=10),
+        ]
+        cfg = TimeEfficiencyConfig(
+            enabled=True,
+            apply_to="correct",
+            lambda_call_bonus=0.10,
+            call_bonus_ref=50.0,
+        )
+        apply_time_efficiency_reward(results, cfg)
+        assert rewards(results) == pytest.approx([0.0, 1.0 + 0.02 - 10.0 / 60.0])
+
+    def test_floor_counts_floored_rows_and_lifts_the_full_timeout(self):
+        # A correct 60-min rollout with no calls lands on exactly 0.0 and would
+        # tie with the failures; the floor keeps it above them.
+        results = [
+            make_result(1.0, 3600.0, resolved=True, calls=0),
+            make_result(1.0, 600.0, resolved=True, calls=50),
+            make_result(0.0, 600.0, resolved=False),
+        ]
+        cfg = TimeEfficiencyConfig(
+            enabled=True,
+            apply_to="correct",
+            lambda_call_bonus=0.10,
+            call_bonus_ref=50.0,
+            floor=0.05,
+        )
+        stats = apply_time_efficiency_reward(results, cfg)
+        assert rewards(results) == pytest.approx([0.05, 1.0 + 0.10 - 10.0 / 60.0, 0.0])
+        assert stats["time_efficiency/floored_frac"] == pytest.approx(1 / 3)
+
+    def test_zero_call_bonus_is_the_plain_deduction(self):
+        results = [
+            make_result(1.0, 1800.0, calls=40),
+            make_result(0.0, 3600.0, calls=5),
+        ]
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True)
+        )
+        assert rewards(results) == pytest.approx([0.5, -1.0])
+        assert stats["time_efficiency/bonus/mean"] == 0.0
+        assert stats["time_efficiency/bonus_saturated_frac"] == 0.0
+        assert stats["time_efficiency/calls/mean"] == pytest.approx(22.5)
 
     def test_masked_rows_are_not_charged_when_the_loss_mask_is_on(self):
         # Three trainable failures at equal wall time plus a loss-masked 60-min

--- a/tests/unit/utils/test_time_efficiency.py
+++ b/tests/unit/utils/test_time_efficiency.py
@@ -169,6 +169,46 @@ class TestApplyTimeEfficiencyReward:
         )
         assert stats["time_efficiency/group_has_signal"] == 0.0
 
+    def test_masked_rows_are_not_charged_when_the_loss_mask_is_on(self):
+        # Three trainable failures at equal wall time plus a loss-masked 60-min
+        # timeout (the group's longest rollout by construction).
+        def group():
+            return [
+                make_result(0.0, 600.0, resolved=False),
+                make_result(0.0, 600.0, resolved=False),
+                make_result(0.0, 600.0, resolved=False),
+                make_result(0.0, 3600.0, resolved=False),
+            ]
+
+        results = group()
+        stats = apply_time_efficiency_reward(
+            results,
+            TimeEfficiencyConfig(enabled=True),
+            mask_sample=[False, False, False, True],
+        )
+        # Masked row keeps its raw reward; trainable rows are charged as usual.
+        assert rewards(results) == pytest.approx([-1 / 6, -1 / 6, -1 / 6, 0.0])
+        assert stats["time_efficiency/deduction/max"] == pytest.approx(1 / 6)
+        # The trainable rows have identical deductions, so there is no signal
+        # even though the masked row's 0 deduction differs from theirs.
+        assert stats["time_efficiency/group_has_signal"] == 0.0
+
+        # With the loss mask off those rows train, so they are charged.
+        results = group()
+        stats = apply_time_efficiency_reward(
+            results, TimeEfficiencyConfig(enabled=True), mask_sample=None
+        )
+        assert rewards(results) == pytest.approx([-1 / 6, -1 / 6, -1 / 6, -1.0])
+        assert stats["time_efficiency/deduction/max"] == pytest.approx(1.0)
+        assert stats["time_efficiency/group_has_signal"] == 1.0
+
+    def test_mask_sample_length_mismatch_raises(self):
+        results = [make_result(1.0, 600.0), make_result(1.0, 600.0)]
+        with pytest.raises(ValueError, match="mask_sample has 1 entries"):
+            apply_time_efficiency_reward(
+                results, TimeEfficiencyConfig(enabled=True), mask_sample=[True]
+            )
+
     def test_group_has_signal_follows_deductions_not_wall_times(self):
         # "correct" on an all-failed group: wall times differ, nothing deducted.
         results = [


### PR DESCRIPTION
# What does this PR do ?

Adds an opt-in wall-clock time-efficiency reward (`grpo.time_efficiency`) for NeMo-Gym agentic (SWE) rollouts, ported from the internal `sdd/swe-opencode-superv35` time-efficiency experiments.

```
reward_i = reward_i
           + lambda_call_bonus * min(calls_i / call_bonus_ref, 1)   # 0 by default
           - lambda_time * (openhands_run_time_i / 60)
```

`openhands_run_time` is the wall time of the agent container from launch to exit, reported by the Gym `swe_agents` server (it includes apptainer spin-up and excludes final evaluation and Ray queueing). With the default `lambda_time = 1/60` a 60-minute rollout costs exactly 1.0. `apply_to` selects whether failures are charged too (`"all"`, the original semantics) or only resolved rollouts whose reward survived the reward-zeroing penalties (`"correct"`); `lambda_call_bonus` > 0 (with `call_bonus_ref`) adds the per-tool-call arm from the internal experiments: a saturating bonus for well-formed `function_call` items that pays for exploring, following the same `apply_to` gate (use it with `"correct"`, since paying it on failures rewards junk calls). `floor` optionally clamps the adjusted reward. `time_efficiency/{minutes,deduction}/{mean,max}`, `calls/mean`, `bonus/mean`, `seconds_per_call`, `bonus_saturated_frac`, `floored_frac` and `group_has_signal` are logged next to the reward metrics.

- `nemo_rl/utils/time_efficiency.py`: `TimeEfficiencyConfig` (pydantic `BaseModel`) and `apply_time_efficiency_reward`, mirroring how `length_penalty` lives in utils.
- Threaded explicitly through `run_nemo_gym_rollout_sync`, `run_async_nemo_gym_rollout` and `_postprocess_single_nemo_gym_group`; runs after the other reward shapers (effort shaping, reward-zeroing penalties, length penalties), which all assume a binary env reward, so the continuous deduction composes with them.
- Wired at the training rollout call sites (`grpo_train`, `AsyncTrajectoryCollector`, `SyncRolloutActor`). Validation keeps the raw env reward on both the `grpo.validate()` path and the single-controller `validate_sync` path (`rollout_to_tq(..., is_validation=True)`); the source branch also applied it during validation.
- Rollouts the env flags `mask_sample` (e.g. `swe_agents` timeouts) are not charged while `env.should_mask_flagged_samples` is on: they are dropped from the loss, so charging them could only drag their siblings' group baseline down. With the flag off they train and are charged.
- Enabling it without the NeMo-Gym path raises at setup (mirrors the `reward_penalties` guard), since only Gym agents emit `openhands_run_time`.
- `GRPOConfig.time_efficiency` field; documented in the `grpo_math_1B` exemplar and reference configs. Disabled by default, so existing runs are unaffected.

The SWE e2e config that uses this lives in the post-training pipeline repo rather than here.


# Issues

N/A

# Usage

```
uv run examples/nemo_gym/run_grpo_nemo_gym.py --config <swe-e2e-config.yaml> \
  ++grpo.time_efficiency.enabled=true \
  ++grpo.time_efficiency.lambda_time=0.016666667 \
  ++grpo.time_efficiency.apply_to=all \
  ++grpo.advantage_clip_low=-3 ++grpo.advantage_clip_high=3```

The advantage clip is strongly recommended: with `normalize_rewards` the small continuous term is divided by the group's reward spread and can explode.

Per-tool-call arm (the internal `per_tool_time_efficiency` defaults; `call_bonus_ref` was calibrated on the super-v3.5 base checkpoint and should be re-read from `time_efficiency/calls/mean` at step 1 for another checkpoint):

```bash
  ++grpo.time_efficiency.enabled=true ++grpo.time_efficiency.apply_to=correct \
  ++grpo.time_efficiency.lambda_call_bonus=0.10 ++grpo.time_efficiency.call_bonus_ref=56.0 \
  ++grpo.time_efficiency.floor=0.05
```

The advantage clip is strongly recommended: with `normalize_rewards` the small continuous term is divided by the group's reward spread and can explode.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? `tests/unit/utils/test_time_efficiency.py` (22 tests), `tests/unit/experience/test_time_efficiency_rollouts.py` (ordering vs reward-zeroing penalties under both `apply_to` modes), and setup-guard tests in `tests/unit/algorithms/test_grpo.py`
- [ ] Did you run the unit tests and functional tests locally? Only the pure unit tests, ruff (v0.9.9), and the exemplar/reference config check ran locally (no Python 3.13.14/torch env available on the login node). The torch-dependent test and the rest of the suite need CI.
- [x] Did you add or update any necessary documentation? The new block is documented in the exemplar YAML and on the `BaseModel`; no docs page changes.

# Additional Information
**Differences from the internal implementation** (`sdd/swe-opencode-superv35`, `grpo.time_efficiency` in `_postprocess_single_group`). The reward formula, `lambda_time`, `floor`, and the handling of missing or malformed `openhands_run_time` are unchanged. What differs:

1. **Loss-masked rollouts are not charged** while `env.should_mask_flagged_samples` is on, in both `apply_to` modes. This matters for `"all"`: internally a `swe_agents` timeout (flagged `mask_sample`, always the group's longest rollout) was charged the full deduction even though it is dropped from the loss, which pulled the group ba
seline down for its siblings; here it keeps its raw 0.0. Under `"correct"` a timeout is unresolved and was never charged, so the only change is the rare resolved rollout that Gym flags for max iterations or context window, which is now exempt too. With the flag off, flagged rows train and are charged as before. **For the SWE config
as run, this is the one change that alters training rewards, and only in the `"all"` arm.**
1. **Ordering.** The deduction runs after effort shaping, the reward-zeroing penalties and the length penalties instead of before them, because those assume a binary env reward. Internally a rollout zeroed by a penalty was reset to exactly 0.0 after being charged; here it is charged after zeroing. No effect on the SWE config, which enables none of those shapers.
1. **`"correct"` gate.** Requires `resolved` and a positive post-penalty reward; internally `resolved` alone. Identical for `swe_agents` unless a reward-zeroing penalty is enabled.
1. **Validation is not charged.** Internally the deduction also applied during validation, so `val:total_reward/mean` was accuracy minus the mean deduction. Here validation reports the raw env reward on both the `grpo.validate()` and single-controller `validate_sync` paths, so validation curves are not directly comparable to the internal runs.
1. **Metric names**: `time_efficiency/{minutes,deduction}/{mean,max}` (was `minutes_mean`, `minutes_max`, `deduction_mean`, `deduction_max`), so the async aggregator takes true maxima across groups. `group_has_signal` is keyed on the deductions of trainable rows rather than on raw wall times, so it reads 0 when nothing was actually charged.
1. **Config and wiring.** `grpo.time_efficiency` is a typed `TimeEfficiencyConfig` (an invalid `apply_to` fails at load) threaded explicitly through the rollout functions, instead of an untyped dict read from `master_config` inside the postprocess. Enabling it without the NeMo-Gym path raises at setup, mirroring the `reward_penalties` guard.
1. **Docs.** `openhands_run_time` is documented as spanning the agent container from launch to exit (it includes apptainer spin-up); the internal comments described it as the agent loop only.
8. **Per-tool-call arm.** The internal `per_tool_time_efficiency` block (call bonus plus time deduction) is folded into this same block as `lambda_call_bonus` / `call_bonus_ref`, off by default. `call_bonus_ref` is required when the bonus is on instead of defaulting to 56, and the bonus follows the same `apply_to` and `mask_sample` gates and the same last-in-the-postprocess ordering as the deduction. Metrics for it: `calls/mean`, `bonus/mean`, `seconds_per_call`, `bonus_saturated_frac`, `floored_frac`.

Net effect for comparing against the completed internal runs: training rewards differ only through item 1, and validation metrics through item 4.

- Credit to Mengru Wang, who wrote the original implementation and ran the experiments on the internal branch.
- Experiment notes from those runs: `apply_to: all` charged failures for elapsed time and taught the policy to quit early, costing accuracy on long problems; `apply_to: correct` is the follow-up arm.

