### PR TITLE
fix(vllm): load Super-Omni RADIO final LayerNorm

### DIFF
--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -2873,7 +2873,8 @@ def _postprocess_single_nemo_gym_group(
         identity_values = [row.get(identity_key) for row in nemo_gym_rows]
         if identity_values and all(value is not None for value in identity_values):
             final_batch[identity_key] = torch.tensor(
-                [int(value) for value in identity_values], dtype=torch.long
+                [int(value) for value in identity_values if value is not None],
+                dtype=torch.long,
             )
     # Env/agent mask flag: flagged samples are dropped from the loss but still
     # count for advantages. env.should_mask_flagged_samples=false skips this.

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -615,8 +615,7 @@ def _patch_vllm_radio_final_layernorm(logger) -> None:
         file_to_patch = _get_vllm_file("model_executor/models/nano_nemotron_vl.py")
     except RuntimeError:
         logger.warning(
-            "Could not locate nano_nemotron_vl.py for the RADIO final "
-            "LayerNorm patch."
+            "Could not locate nano_nemotron_vl.py for the RADIO final LayerNorm patch."
         )
         return
 

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -602,6 +602,190 @@ def _patch_vllm_radio_layerscale_loader(logger) -> None:
     )
 
 
+def _patch_vllm_radio_final_layernorm(logger) -> None:
+    """Match HF/Megatron's final RADIO encoder LayerNorm in vLLM.
+
+    Nemotron Super-Omni checkpoints with MTP apply a learned final LayerNorm to
+    RADIO features before pixel shuffle and projection. vLLM 0.25.1 omits the
+    module, operation, and checkpoint mapping. Patch all image/video feature
+    paths and load the learned affine parameters. The norm is selected from the
+    model configuration; it does not require a runtime experiment flag.
+    """
+    try:
+        file_to_patch = _get_vllm_file("model_executor/models/nano_nemotron_vl.py")
+    except RuntimeError:
+        logger.warning(
+            "Could not locate nano_nemotron_vl.py for the RADIO final "
+            "LayerNorm patch."
+        )
+        return
+
+    marker = "self.vision_final_layernorm = nn.LayerNorm("
+    replacements = (
+        (
+            """            self.mlp1 = mlp1.to(llm_dtype)
+            self.sound_encoder: ProjectedParakeet | None = None
+""",
+            """            self.mlp1 = mlp1.to(llm_dtype)
+            self.vision_final_layernorm: nn.LayerNorm | None = None
+            if (
+                getattr(config.text_config, "num_nextn_predict_layers", 0) or 0
+            ) > 0:
+                # Keep the tiny affine in fp32 so normalization matches the
+                # Megatron scoring path; checkpoint BF16 values load into it.
+                self.vision_final_layernorm = nn.LayerNorm(
+                    vit_hidden_size,
+                    eps=getattr(vision_config, "layer_norm_eps", 1.0e-6),
+                ).float()
+                logger.info_once(
+                    "Enabled checkpoint-backed RADIO final LayerNorm",
+                    scope="global",
+                )
+            self.sound_encoder: ProjectedParakeet | None = None
+""",
+        ),
+        (
+            """        return x
+
+    def extract_feature_dynamic(
+""",
+            """        return x
+
+    def _apply_vision_final_layernorm(
+        self, vit_embeds: torch.Tensor
+    ) -> torch.Tensor:
+        if self.vision_final_layernorm is None:
+            return vit_embeds
+        output_dtype = vit_embeds.dtype
+        return self.vision_final_layernorm(vit_embeds.float()).to(output_dtype)
+
+    def extract_feature_dynamic(
+""",
+        ),
+        (
+            """        _, vit_embeds = self.vision_model(pixel_values, imgs_sizes=imgs_sizes)
+        vit_embeds = vit_embeds.to(dtype=torch.bfloat16)
+""",
+            """        _, vit_embeds = self.vision_model(pixel_values, imgs_sizes=imgs_sizes)
+        vit_embeds = self._apply_vision_final_layernorm(vit_embeds)
+        vit_embeds = vit_embeds.to(dtype=torch.bfloat16)
+""",
+        ),
+        (
+            """            else:
+                _, vit_embeds = self.vision_model(chunk)
+            vit_embeds = vit_embeds.to(dtype=torch.bfloat16)
+""",
+            """            else:
+                _, vit_embeds = self.vision_model(chunk)
+            vit_embeds = self._apply_vision_final_layernorm(vit_embeds)
+            vit_embeds = vit_embeds.to(dtype=torch.bfloat16)
+""",
+        ),
+        (
+            """            connector=["mlp1", "sound_encoder.projection"],
+""",
+            """            connector=[
+                "mlp1",
+                "vision_final_layernorm",
+                "sound_encoder.projection",
+            ],
+""",
+        ),
+        (
+            """        adapter_dict = dict(self.mlp1.named_parameters())
+""",
+            """        adapter_dict = dict(self.mlp1.named_parameters())
+        final_layernorm_dict = (
+            dict(self.vision_final_layernorm.named_parameters())
+            if self.vision_final_layernorm is not None
+            else {}
+        )
+""",
+        ),
+        (
+            """            return None
+
+        def is_vision_weights(name: str) -> bool:
+""",
+            """            return None
+
+        def get_final_layernorm_name(name: str) -> str | None:
+            for prefix in (
+                "vision_final_layernorm.",
+                "vision_projector.vision_final_layernorm.",
+            ):
+                if name.startswith(prefix):
+                    return name.removeprefix(prefix)
+            return None
+
+        def is_vision_weights(name: str) -> bool:
+""",
+        ),
+        (
+            """        adapter_weights: list[tuple[str, torch.Tensor]] = []
+        vision_weights: list[tuple[str, torch.Tensor]] = []
+""",
+            """        adapter_weights: list[tuple[str, torch.Tensor]] = []
+        final_layernorm_weights: list[tuple[str, torch.Tensor]] = []
+        vision_weights: list[tuple[str, torch.Tensor]] = []
+""",
+        ),
+        (
+            """                elif is_vision_weights(name):
+""",
+            """                elif (
+                    final_layernorm_name := get_final_layernorm_name(name)
+                ) is not None:
+                    if (
+                        not load_multimodal_weights
+                        or self.vision_final_layernorm is None
+                    ):
+                        continue
+                    final_layernorm_weights.append(
+                        (final_layernorm_name, w.detach().clone())
+                    )
+                elif is_vision_weights(name):
+""",
+        ),
+        (
+            """            self.vision_model.load_weights(vision_weights)
+            if self.sound_encoder is not None and len(sound_weights) > 0:
+""",
+            """            for trimmed_name, w in final_layernorm_weights:
+                param = final_layernorm_dict[trimmed_name]
+                with torch.no_grad():
+                    default_weight_loader(param, w)
+            if final_layernorm_weights:
+                logger.info_once(
+                    "Loaded RADIO final LayerNorm affine parameters",
+                    scope="global",
+                )
+            self.vision_model.load_weights(vision_weights)
+            if self.sound_encoder is not None and len(sound_weights) > 0:
+""",
+        ),
+    )
+
+    with _locked_file_patch(file_to_patch) as (content, write_back):
+        if marker in content:
+            logger.info("vLLM RADIO final LayerNorm patch already applied.")
+            return
+        for old_snippet, _new_snippet in replacements:
+            if content.count(old_snippet) != 1:
+                logger.warning(
+                    "Could not apply vLLM RADIO final LayerNorm patch: expected "
+                    "vLLM 0.25.1 source shape was not found in %s.",
+                    file_to_patch,
+                )
+                return
+        for old_snippet, new_snippet in replacements:
+            content = content.replace(old_snippet, new_snippet, 1)
+        write_back(content)
+
+    logger.info("Applied checkpoint-backed vLLM RADIO final LayerNorm patch.")
+
+
 def _patch_vllm_nemotron_h_fp32_lm_head(logger) -> None:
     """Compute NemotronH logits with an fp32 LM head (MiniMax-M1-style).
 
@@ -677,6 +861,8 @@ def _patch_vllm_nemotron_h_fp32_lm_head(logger) -> None:
         write_back(content.replace(old_snippet, new_snippet, 1))
 
     logger.info("Applied NemotronH fp32 LM head source patch.")
+
+
 def _apply_vllm_flashinfer_trtllm_refit_buffer_runtime_patch(
     logger: Any | None = None,
 ) -> None:
@@ -1224,5 +1410,6 @@ def _apply_vllm_patches(
     _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)
     _patch_vllm_shm_broadcast_bind_retry(patch_logger)
     _patch_vllm_radio_layerscale_loader(patch_logger)
+    _patch_vllm_radio_final_layernorm(patch_logger)
     _patch_vllm_nemotron_h_fp32_lm_head(patch_logger)
     _patch_vllm_flashinfer_trtllm_refit_buffers(patch_logger)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -77,7 +77,6 @@ from nemo_rl.models.megatron.pipeline_parallel import (
 from nemo_rl.models.megatron.router_replay import router_replay_enabled
 from nemo_rl.models.megatron.setup import (
     apply_fp32_lm_head,
-    validate_fp32_lm_head_config,
     build_inference_model,
     finalize_megatron_setup,
     handle_model_import,
@@ -85,6 +84,7 @@ from nemo_rl.models.megatron.setup import (
     setup_model_and_optimizer,
     setup_reference_model_state,
     validate_and_set_config,
+    validate_fp32_lm_head_config,
     validate_model_paths,
 )
 from nemo_rl.models.megatron.train import (

--- a/tests/unit/models/generation/test_vllm_context_length_overflow.py
+++ b/tests/unit/models/generation/test_vllm_context_length_overflow.py
@@ -46,7 +46,6 @@ from nemo_rl.models.generation.vllm.vllm_worker_async import (
     is_context_length_error,
 )
 
-
 GYM_PROXY_SOURCE = (
     Path(nemo_rl.__file__).resolve().parents[1]
     / "3rdparty/Gym-workspace/Gym/responses_api_models/vllm_model/app.py"
@@ -85,7 +84,11 @@ def gym_recovers(status_code: int, body: str) -> bool:
         "result_content_str": body,
     }
     return all(
-        bool(eval(compile(ast.Expression(predicate), "<gym-proxy>", "eval"), {}, namespace))
+        bool(
+            eval(
+                compile(ast.Expression(predicate), "<gym-proxy>", "eval"), {}, namespace
+            )
+        )
         for predicate in _gym_overflow_predicates()
     )
 

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Guards for the vLLM source patches that had no coverage.
+"""Guards for vLLM source patches that depend on pinned source anchors.
 
 The two port patches ship their own suites. These cover the remaining two:
 
@@ -26,6 +26,8 @@ The two port patches ship their own suites. These cover the remaining two:
   ``RAY_ENABLE_UV_RUN_RUNTIME_ENV`` and every user ``extra_env_vars`` to the
   Ray workers. Being additive rather than clobbering is the whole point of the
   rewrite, and it is pure string handling, so it is cheap to pin.
+* Nemotron Super-Omni checkpoints apply a learned final RADIO LayerNorm, but
+  vLLM 0.25.1 omits its module, forward operation, and weight mapping.
 """
 
 import ast
@@ -48,6 +50,9 @@ _MARKER = "except ImportError:  # openai < 2.25.0 predates namespace tools"
 _RADIO_SOURCE = "model_executor/models/radio.py"
 _RADIO_PATCH_FN = "_patch_vllm_radio_layerscale_loader"
 _RADIO_MARKER = "initializer_factor = self.config.initializer_factor"
+_NANO_VL_SOURCE = "model_executor/models/nano_nemotron_vl.py"
+_NANO_VL_PATCH_FN = "_patch_vllm_radio_final_layernorm"
+_NANO_VL_MARKER = "self.vision_final_layernorm = nn.LayerNorm("
 
 
 def test_external_vllm_patch_allowlist(monkeypatch):
@@ -91,6 +96,17 @@ def patched_radio_source(tmp_path, monkeypatch):
     copied = write_unpatched_copy(_RADIO_SOURCE, _RADIO_PATCH_FN, tmp_path / "radio.py")
     monkeypatch.setattr(patches, "_get_vllm_file", lambda _relative: str(copied))
     patches._patch_vllm_radio_layerscale_loader(logging.getLogger(__name__))
+    return copied
+
+
+@pytest.fixture
+def patched_nano_vl_source(tmp_path, monkeypatch):
+    """The installed Nemotron Omni model, unpatched then patched in tmp."""
+    copied = write_unpatched_copy(
+        _NANO_VL_SOURCE, _NANO_VL_PATCH_FN, tmp_path / "nano_nemotron_vl.py"
+    )
+    monkeypatch.setattr(patches, "_get_vllm_file", lambda _relative: str(copied))
+    patches._patch_vllm_radio_final_layernorm(logging.getLogger(__name__))
     return copied
 
 
@@ -173,6 +189,36 @@ def test_radio_layerscale_patch_is_idempotent(patched_radio_source, monkeypatch)
     patches._patch_vllm_radio_layerscale_loader(logging.getLogger(__name__))
 
     assert patched_radio_source.read_text() == before
+
+
+@pytest.mark.vllm
+def test_radio_final_layernorm_patch_covers_model_forward_and_loader(
+    patched_nano_vl_source,
+):
+    content = patched_nano_vl_source.read_text()
+
+    assert content.count(_NANO_VL_MARKER) == 1
+    # Dynamic images and fixed-resolution images/videos share the same helper.
+    assert content.count("self._apply_vision_final_layernorm(vit_embeds)") == 2
+    assert '"vision_final_layernorm"' in content
+    assert '"vision_projector.vision_final_layernorm."' in content
+    assert "final_layernorm_weights" in content
+    assert "default_weight_loader(param, w)" in content
+    ast.parse(content)
+
+
+@pytest.mark.vllm
+def test_radio_final_layernorm_patch_is_idempotent(
+    patched_nano_vl_source, monkeypatch
+):
+    before = patched_nano_vl_source.read_text()
+    monkeypatch.setattr(
+        patches, "_get_vllm_file", lambda _relative: str(patched_nano_vl_source)
+    )
+
+    patches._patch_vllm_radio_final_layernorm(logging.getLogger(__name__))
+
+    assert patched_nano_vl_source.read_text() == before
 
 
 def test_radio_layerscale_patch_warns_on_unknown_source(monkeypatch, tmp_path, caplog):

--- a/tests/unit/models/generation/test_vllm_patches.py
+++ b/tests/unit/models/generation/test_vllm_patches.py
@@ -49,7 +49,7 @@ _PATCH_FN = "_patch_vllm_tool_parser_namespace_tool"
 _MARKER = "except ImportError:  # openai < 2.25.0 predates namespace tools"
 _RADIO_SOURCE = "model_executor/models/radio.py"
 _RADIO_PATCH_FN = "_patch_vllm_radio_layerscale_loader"
-_RADIO_MARKER = "initializer_factor = self.config.initializer_factor"
+_RADIO_MARKER = 'initializer_factor = getattr(self.config, "initializer_factor", 1.0)'
 _NANO_VL_SOURCE = "model_executor/models/nano_nemotron_vl.py"
 _NANO_VL_PATCH_FN = "_patch_vllm_radio_final_layernorm"
 _NANO_VL_MARKER = "self.vision_final_layernorm = nn.LayerNorm("
@@ -174,9 +174,9 @@ def test_radio_layerscale_patch_loads_explicit_and_initializes_folded_weights(
 ):
     content = patched_radio_source.read_text()
     assert 'vllm_key = f"model.encoder.layers.{layer_idx}.{suffix}"' in content
-    assert 'name.endswith((".ls1", ".ls2"))' in content
-    assert "param.data.fill_(initializer_factor)" in content
-    assert "loaded_params.add(name)" in content
+    assert 'ls_name.endswith((".ls1", ".ls2"))' in content
+    assert "ls_param.data.fill_(initializer_factor)" in content
+    assert "loaded_params.add(ls_name)" in content
 
 
 @pytest.mark.vllm
@@ -208,9 +208,7 @@ def test_radio_final_layernorm_patch_covers_model_forward_and_loader(
 
 
 @pytest.mark.vllm
-def test_radio_final_layernorm_patch_is_idempotent(
-    patched_nano_vl_source, monkeypatch
-):
+def test_radio_final_layernorm_patch_is_idempotent(patched_nano_vl_source, monkeypatch):
     before = patched_nano_vl_source.read_text()
     monkeypatch.setattr(
         patches, "_get_vllm_file", lambda _relative: str(patched_nano_vl_source)
@@ -230,7 +228,7 @@ def test_radio_layerscale_patch_warns_on_unknown_source(monkeypatch, tmp_path, c
         patches._patch_vllm_radio_layerscale_loader(logging.getLogger(__name__))
 
     assert radio_source.read_text() == "class RadioModel:\n    pass\n"
-    assert "vLLM 0.25.1 source shape was not found" in caplog.text
+    assert "load_weights tail anchor was not found" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/generation/vllm_patch_source_utils.py
+++ b/tests/unit/models/generation/vllm_patch_source_utils.py
@@ -28,8 +28,8 @@ from pathlib import Path
 from nemo_rl.models.generation.vllm import patches
 
 
-def patch_snippets(patch_fn_name: str) -> tuple[str, str]:
-    """Return ``(old_snippet, new_snippet)`` for a patch function in patches.py.
+def patch_replacements(patch_fn_name: str) -> tuple[tuple[str, str], ...]:
+    """Return all ``(old_snippet, new_snippet)`` pairs for a source patch.
 
     Read out of the source with ``ast`` rather than duplicated here, so the
     snippets cannot drift from the patch they are meant to reverse.
@@ -47,6 +47,7 @@ def patch_snippets(patch_fn_name: str) -> tuple[str, str]:
         ) from None
 
     snippets = {}
+    replacements = None
     for node in ast.walk(func):
         if (
             isinstance(node, ast.Assign)
@@ -56,13 +57,35 @@ def patch_snippets(patch_fn_name: str) -> tuple[str, str]:
         ):
             snippets[node.targets[0].id] = ast.literal_eval(node.value)
 
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "replacements"
+        ):
+            replacements = ast.literal_eval(node.value)
+
+    if replacements is not None:
+        return tuple(replacements)
+
     missing = {"old_snippet", "new_snippet"} - snippets.keys()
     if missing:
         raise AssertionError(
             f"{patch_fn_name} no longer defines {sorted(missing)}; the test "
             "helper can no longer reverse its patch"
         )
-    return snippets["old_snippet"], snippets["new_snippet"]
+    return ((snippets["old_snippet"], snippets["new_snippet"]),)
+
+
+def patch_snippets(patch_fn_name: str) -> tuple[str, str]:
+    """Return the single replacement pair used by a one-anchor patch."""
+    replacements = patch_replacements(patch_fn_name)
+    if len(replacements) != 1:
+        raise AssertionError(
+            f"{patch_fn_name} has {len(replacements)} replacement pairs; use "
+            "patch_replacements()"
+        )
+    return replacements[0]
 
 
 def write_unpatched_copy(
@@ -80,19 +103,20 @@ def write_unpatched_copy(
     Returns:
         ``destination``.
     """
-    old_snippet, new_snippet = patch_snippets(patch_fn_name)
+    replacements = patch_replacements(patch_fn_name)
     content = Path(patches._get_vllm_file(relative_source)).read_text()
 
-    if new_snippet in content:
-        content = content.replace(new_snippet, old_snippet, 1)
-    assert new_snippet not in content, (
-        f"reversing {patch_fn_name} left its replacement behind in "
-        f"{relative_source}; the patch may have been applied more than once"
-    )
-    assert old_snippet in content, (
-        f"{relative_source} contains neither the patched nor the original form "
-        f"of the {patch_fn_name} anchor; vLLM has probably changed upstream"
-    )
+    for old_snippet, new_snippet in reversed(replacements):
+        if new_snippet in content:
+            content = content.replace(new_snippet, old_snippet, 1)
+        assert new_snippet not in content, (
+            f"reversing {patch_fn_name} left its replacement behind in "
+            f"{relative_source}; the patch may have been applied more than once"
+        )
+        assert old_snippet in content, (
+            f"{relative_source} contains neither the patched nor the original "
+            f"form of a {patch_fn_name} anchor; vLLM has probably changed upstream"
+        )
 
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(content)

--- a/tests/unit/models/generation/vllm_patch_source_utils.py
+++ b/tests/unit/models/generation/vllm_patch_source_utils.py
@@ -47,26 +47,37 @@ def patch_replacements(patch_fn_name: str) -> tuple[tuple[str, str], ...]:
         ) from None
 
     snippets = {}
+    named_pairs: dict[str, dict[str, str]] = {}
     replacements = None
     for node in ast.walk(func):
-        if (
+        if not (
             isinstance(node, ast.Assign)
             and len(node.targets) == 1
             and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id in ("old_snippet", "new_snippet")
         ):
-            snippets[node.targets[0].id] = ast.literal_eval(node.value)
+            continue
 
-        if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id == "replacements"
-        ):
+        target_name = node.targets[0].id
+        if target_name in ("old_snippet", "new_snippet"):
+            snippets[target_name] = ast.literal_eval(node.value)
+        elif target_name == "replacements":
             replacements = ast.literal_eval(node.value)
+        elif target_name.endswith(("_old", "_new")):
+            pair_name, side = target_name.rsplit("_", 1)
+            named_pairs.setdefault(pair_name, {})[side] = ast.literal_eval(node.value)
 
     if replacements is not None:
         return tuple(replacements)
+
+    if named_pairs:
+        incomplete = [
+            name for name, pair in named_pairs.items() if pair.keys() != {"old", "new"}
+        ]
+        if incomplete:
+            raise AssertionError(
+                f"{patch_fn_name} defines incomplete replacement pairs: {incomplete}"
+            )
+        return tuple((pair["old"], pair["new"]) for pair in named_pairs.values())
 
     missing = {"old_snippet", "new_snippet"} - snippets.keys()
     if missing:
@@ -107,6 +118,11 @@ def write_unpatched_copy(
     content = Path(patches._get_vllm_file(relative_source)).read_text()
 
     for old_snippet, new_snippet in reversed(replacements):
+        # A deletion-only optional edit cannot be reconstructed from the
+        # patched source. Leaving it deleted is sufficient to restore and
+        # exercise every required anchor in the patch.
+        if not new_snippet:
+            continue
         if new_snippet in content:
             content = content.replace(new_snippet, old_snippet, 1)
         assert new_snippet not in content, (


### PR DESCRIPTION
# What does this PR do ?

Aligns vLLM's Nemotron Super-Omni RADIO feature path with Megatron/HF by adding the checkpoint-backed final LayerNorm that is missing from vLLM 0.25.1.

The pinned vLLM implementation omitted the LayerNorm module, its forward application, and checkpoint/refit name mapping. With NeMo-RL's dummy startup load followed by refit, the missing module and mapping prevent the learned affine parameters from reaching the rollout model, causing visual features—and therefore rollout token log probabilities—to diverge from the Megatron policy.

This change:

- Creates the final RADIO LayerNorm for Super-Omni MTP configurations.
- Applies it in FP32 to both dynamic and fixed/chunked image/video feature paths before projection.
- Accepts both `vision_final_layernorm.*` and `vision_projector.vision_final_layernorm.*` checkpoint names.
- Includes the parameters in the multimodal connector/refit path and loads them with `default_weight_loader`.
- Applies the vLLM source patch atomically and idempotently.

# Issues

None.

# Usage

No new recipe option is required. The patch is selected from the model configuration and applied automatically during vLLM worker initialization. Successful activation emits:

```text
Enabled checkpoint-backed RADIO final LayerNorm
Loaded RADIO final LayerNorm affine parameters
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused coverage for forward paths, checkpoint mapping, syntax, and idempotency.
- [x] Ran the focused vLLM-backed tests in the Super-Omni container: 2 passed.
- [x] No documentation update is required because this is an automatic model-parity fix with no user-facing configuration.

# Additional Information

Target branch: `super-v3.5-posttraining`.

Focused test command:

```bash
python -m pytest -q --vllm-only \
  tests/unit/models/generation/test_vllm_patches.py::test_radio_final_layernorm_patch_covers_model_forward_and_loader \
  tests/unit/models/generation/test_vllm_patches.py::test_radio_final_layernorm_patch_is_idempotent
```
