### PR TITLE
fix(trtllm): honor stop_strings on both TRT-LLM generation paths

### DIFF
--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -52,6 +52,7 @@ def _build_sampling_params(
     *,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None,
+    stop_strings: list[str] | None,
     max_tokens: int,
 ) -> Any:
     """Build the TRT-LLM sampling params for one HTTP rollout request.
@@ -65,6 +66,8 @@ def _build_sampling_params(
             helper stays importable and testable without the TRT-LLM runtime.
         sampling_config: NeMo-RL generation config (temperature / top_p / top_k).
         stop_token_ids: Extra stop tokens from the generation config, if any.
+        stop_strings: Stop strings from the generation config, if any. TRT-LLM
+            spells these ``stop``, alongside the token-id list.
         max_tokens: Output cap for this request, already clamped to the context window.
 
     Returns:
@@ -73,12 +76,14 @@ def _build_sampling_params(
     # TRT-LLM spells "no top-k restriction" as 0, the generation config as null.
     top_k_cfg = sampling_config["top_k"]
     stop_ids = list(stop_token_ids or [])
+    stops = list(stop_strings or [])
     return sampling_params_cls(
         temperature=float(sampling_config["temperature"]),
         top_p=float(sampling_config["top_p"]),
         top_k=int(top_k_cfg) if top_k_cfg is not None else 0,
         max_tokens=int(max_tokens),
         stop_token_ids=stop_ids or None,
+        stop=stops or None,
         # Include generated stop tokens so the adapter can trim tokens and logprobs together.
         include_stop_str_in_output=True,
         logprobs=True,
@@ -93,6 +98,7 @@ def create_app(
     max_seq_len: int,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None = None,
+    stop_strings: list[str] | None = None,
     default_chat_template_kwargs: dict[str, Any] | None = None,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
@@ -241,6 +247,7 @@ def create_app(
             TrtSamplingParams,
             sampling_config=sampling_config,
             stop_token_ids=stop_token_ids,
+            stop_strings=stop_strings,
             max_tokens=max_tokens,
         )
 
@@ -513,6 +520,7 @@ def start_server(
     max_seq_len: int,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None = None,
+    stop_strings: list[str] | None = None,
     host: str = "0.0.0.0",
     port: int = 0,
     default_chat_template_kwargs: dict[str, Any] | None = None,
@@ -540,6 +548,7 @@ def start_server(
         max_seq_len=max_seq_len,
         sampling_config=sampling_config,
         stop_token_ids=stop_token_ids,
+        stop_strings=stop_strings,
         default_chat_template_kwargs=default_chat_template_kwargs,
         tool_parser=tool_parser,
         reasoning_parser=reasoning_parser,

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -298,6 +298,7 @@ class TrtllmAsyncGenerationWorkerImpl:
                 "top_k": self.cfg["top_k"],
             },
             stop_token_ids=list(self.cfg.get("stop_token_ids") or []),
+            stop_strings=list(self.cfg.get("stop_strings") or []),
             default_chat_template_kwargs=self.cfg["trtllm_cfg"].get(
                 "default_chat_template_kwargs"
             ),
@@ -500,7 +501,10 @@ class TrtllmAsyncGenerationWorkerImpl:
             token_ids = input_ids[i, :length].tolist()
             prompts.append({"prompt_token_ids": token_ids})
 
-        sampling_params = self._build_sampling_params(greedy=greedy)
+        sampling_params = self._build_sampling_params(
+            greedy=greedy,
+            stop_strings=self._merge_stop_strings(data.get("stop_strings")),
+        )
 
         # Fan all prompts out concurrently; AsyncLLM batches them in-flight.
         outputs = await asyncio.gather(
@@ -566,7 +570,28 @@ class TrtllmAsyncGenerationWorkerImpl:
     #  Helpers
     # ------------------------------------------------------------------ #
 
-    def _build_sampling_params(self, *, greedy: bool):
+    def _merge_stop_strings(self, batch_stop_strings: Any) -> list[str] | None:
+        """Union the configured stop strings with the per-sample ones.
+
+        Mirrors ``BaseVllmGenerationWorker._merge_stop_strings``. One
+        ``SamplingParams`` is built per batch here, so a sample's stop strings
+        apply to the whole batch -- the same shape the vLLM backend has.
+        """
+        stop_set: set[str] = set()
+
+        if self.cfg.get("stop_strings"):
+            stop_set.update(self.cfg["stop_strings"])
+
+        if batch_stop_strings is not None:
+            for sample_stop_strings in batch_stop_strings:
+                if sample_stop_strings:
+                    stop_set.update(sample_stop_strings)
+
+        return sorted(stop_set) if stop_set else None
+
+    def _build_sampling_params(
+        self, *, greedy: bool, stop_strings: list[str] | None = None
+    ):
         top_k_cfg = self.cfg["top_k"]
         top_k_val = 1 if greedy else (top_k_cfg if top_k_cfg is not None else 0)
         temperature = 0.0 if greedy else self.cfg["temperature"]
@@ -579,6 +604,7 @@ class TrtllmAsyncGenerationWorkerImpl:
             top_k=top_k_val,
             max_tokens=self.cfg["max_new_tokens"],
             stop_token_ids=stop_ids or None,
+            stop=stop_strings or None,
             # Keep the EOS / stop token in the returned token_ids so that the
             # response sequence matches HF / vLLM behavior. Required for
             # logprob alignment with training-side Megatron.

--- a/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
@@ -59,6 +59,7 @@ def test_http_sampling_params_match_the_direct_path():
         sampling_params_cls,
         sampling_config={"temperature": 0.8, "top_p": 0.9, "top_k": 20},
         stop_token_ids=[9],
+        stop_strings=None,
         max_tokens=4,
     )
 
@@ -68,10 +69,48 @@ def test_http_sampling_params_match_the_direct_path():
         top_k=20,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
     )
+
+
+def test_http_sampling_params_forward_stop_strings():
+    """Stop strings must reach TRT-LLM as ``stop``, next to the token-id list.
+
+    The two are separate controls: ``stop_token_ids`` cannot express a multi-token
+    string like ``</answer>``, so dropping ``stop`` left the HTTP rollout path
+    generating past a boundary the config had asked it to stop at.
+    """
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 0.8, "top_p": 0.9, "top_k": 20},
+        stop_token_ids=[9],
+        stop_strings=["</answer>", "<eot>"],
+        max_tokens=4,
+    )
+
+    kwargs = sampling_params_cls.call_args.kwargs
+    assert kwargs["stop"] == ["</answer>", "<eot>"]
+    assert kwargs["stop_token_ids"] == [9]
+
+
+def test_http_sampling_params_empty_stop_strings_stay_none():
+    """[] must not reach TRT-LLM as an empty list; None keeps its own default."""
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 1.0, "top_p": 1.0, "top_k": None},
+        stop_token_ids=None,
+        stop_strings=[],
+        max_tokens=8,
+    )
+
+    assert sampling_params_cls.call_args.kwargs["stop"] is None
 
 
 def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
@@ -82,6 +121,7 @@ def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
         sampling_params_cls,
         sampling_config={"temperature": 1.0, "top_p": 1.0, "top_k": None},
         stop_token_ids=None,
+        stop_strings=None,
         max_tokens=8,
     )
 
@@ -91,6 +131,7 @@ def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
         top_k=0,
         max_tokens=8,
         stop_token_ids=None,
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -117,7 +117,9 @@ async def test_generate_async_converts_padded_batch_and_logprobs():
 
     output = await worker.generate_async(data, greedy=True)
 
-    worker._build_sampling_params.assert_called_once_with(greedy=True)
+    worker._build_sampling_params.assert_called_once_with(
+        greedy=True, stop_strings=None
+    )
     assert worker.llm.generate_async.await_count == 2
     assert torch.equal(
         output["output_ids"], torch.tensor([[11, 12, 21, 22], [13, 23, 0, 0]])
@@ -162,6 +164,41 @@ async def test_generate_async_empty_batch_does_not_call_engine():
     worker.llm.generate_async.assert_not_awaited()
 
 
+def test_build_sampling_params_forwards_configured_stop_strings():
+    """Configured stop strings must reach TRT-LLM, which spells them ``stop``.
+
+    vLLM, SGLang and Dynamo all honor ``policy.generation.stop_strings``; TRT-LLM
+    passed only ``stop_token_ids``, so the same config stopped generation on the
+    other backends and ran to max_new_tokens here.
+    """
+    worker = _worker()
+    worker.cfg["stop_strings"] = ["</answer>"]
+
+    worker._build_sampling_params(
+        greedy=False, stop_strings=worker._merge_stop_strings(None)
+    )
+
+    assert worker.TrtSamplingParams.call_args.kwargs["stop"] == ["</answer>"]
+
+
+def test_merge_stop_strings_unions_config_and_per_sample():
+    """Same shape as BaseVllmGenerationWorker._merge_stop_strings."""
+    worker = _worker()
+    worker.cfg["stop_strings"] = ["</answer>"]
+
+    merged = worker._merge_stop_strings([["<eot>"], None, ["</answer>", "STOP"]])
+
+    assert merged == ["</answer>", "<eot>", "STOP"]
+
+
+def test_merge_stop_strings_returns_none_when_nothing_configured():
+    """None, not [], so TRT-LLM keeps its own default rather than an empty list."""
+    worker = _worker()
+
+    assert worker._merge_stop_strings(None) is None
+    assert worker._merge_stop_strings([[], None]) is None
+
+
 def test_build_sampling_params_null_top_k_maps_to_zero():
     """null top_k (default) must reach TRT-LLM as 0, its spelling of 'no restriction'."""
     worker = _worker()
@@ -175,6 +212,7 @@ def test_build_sampling_params_null_top_k_maps_to_zero():
         top_k=0,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
@@ -191,6 +229,7 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_k=1,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
@@ -204,6 +243,7 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_k=20,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,


### PR DESCRIPTION
# What does this PR do ?

**Makes the TRT-LLM backend honor `stop_strings`, which it silently dropped on both of its generation paths.**

`stop_strings` is part of the shared generation contract: it is declared on `GenerationConfig` ([`interfaces.py:227`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/interfaces.py#L227)) and again per sample on `GenerationDatumSpec` ([`:336`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/interfaces.py#L336)). vLLM, SGLang and Dynamo all read it. TRT-LLM builds its `SamplingParams` with `stop_token_ids` and never `stop`, so the same config stops generation on the other three backends and runs on to `max_new_tokens` here.

The two controls are not interchangeable. `stop_token_ids` cannot express a multi-token boundary like `</answer>`, which is exactly the shape a chat or agentic rollout stops on. Nothing raises, so a run shows this only as rollouts that overrun the boundary the config asked for.

Both TRT-LLM paths are affected:

| path | before | after |
|---|---|---|
| direct `generate_async()` | `stop_token_ids` only | `stop` from config ∪ per-sample |
| HTTP (NeMo-Gym rollouts) | `stop_token_ids` only | `stop` from config |

Measured on the direct path with `stop_strings: ["</answer>"]` configured:

```
[before]  configured stop_strings : ['</answer>']
          SamplingParams got stop : <key absent>
          stop_token_ids          : [9]

[after]   configured stop_strings : ['</answer>']
          SamplingParams got stop : ['</answer>']
          stop_token_ids          : [9]
```

# Issues

No issue filed; found while comparing which generation-config keys each backend reads. TRT-LLM was the only backend not reading `stop_strings`.

# Usage

No config or API change. `policy.generation.stop_strings` simply takes effect on TRT-LLM now, as it already did elsewhere.

```yaml
policy:
  generation:
    backend: trtllm
    stop_strings: ["</answer>"]   # previously ignored on this backend
```

# Design & Code Changes

`tensorrt_llm.SamplingParams` already accepts `stop` alongside `stop_token_ids` ([`sampling_params.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/sampling_params.py): `stop: Optional[Union[str, List[str]]] = None`), so this is a plumbing fix rather than a new capability.

* `trtllm_worker_async.py`: adds `_merge_stop_strings`, mirroring [`BaseVllmGenerationWorker._merge_stop_strings`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/vllm/vllm_worker.py#L745). One `SamplingParams` is built per batch here, so a sample's stop strings apply to the batch, the same shape vLLM has. I matched the reference backend rather than inventing a stricter per-sample rule.
* `trtllm_http_server.py`: `_build_sampling_params` gains `stop_strings` next to `stop_token_ids`, threaded through `create_app` and `start_server`, mirroring how #3537 threaded the sampling config after the same drift was found in `top_k`.
* An empty result stays `None` rather than `[]`, so TRT-LLM keeps its own default.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

## Tests

Five added, and the three existing assertions that pin the exact `SamplingParams` kwargs updated for the new `stop`.

`test_trtllm_worker_async.py` (run with `--trtllm-only`):
* `test_build_sampling_params_forwards_configured_stop_strings`
* `test_merge_stop_strings_unions_config_and_per_sample`
* `test_merge_stop_strings_returns_none_when_nothing_configured`

`test_trtllm_http_server.py` (these carry no `trtllm` marker, so they run without the flag):
* `test_http_sampling_params_forward_stop_strings`
* `test_http_sampling_params_empty_stop_strings_stay_none`

```
pytest tests/unit/models/generation/trtllm/test_trtllm_http_server.py
  main:     5 passed, 5 skipped
  this PR:  7 passed, 5 skipped

pytest tests/unit/models/generation/trtllm/test_trtllm_worker_async.py --trtllm-only
  main:    11 passed
  this PR: 14 passed
```

No failures on either version. The 5 skips are local: my stub `tensorrt_llm` has no `tensorrt_llm.serve` submodule.

CPU only. I don't have a GPU box, so the tests needing a real TRT-LLM runtime did not run here and I could not exercise a rollout end to end. The change is confined to how `SamplingParams` is constructed, which is what the tests above cover.

`ruff 0.9.9` check, import sort and format are clean on all four files.

No docs change: `docs/design-docs/sampling-params.md` documents `top_k` spelling across backends and does not enumerate stop-string behaviour. Happy to add a line there if you would rather have it recorded.

