### PR TITLE
fix(trtllm): report response truncation so overlong filtering can see it

### DIFF
--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -52,6 +52,7 @@ def _build_sampling_params(
     *,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None,
+    stop_strings: list[str] | None,
     max_tokens: int,
 ) -> Any:
     """Build the TRT-LLM sampling params for one HTTP rollout request.
@@ -65,6 +66,8 @@ def _build_sampling_params(
             helper stays importable and testable without the TRT-LLM runtime.
         sampling_config: NeMo-RL generation config (temperature / top_p / top_k).
         stop_token_ids: Extra stop tokens from the generation config, if any.
+        stop_strings: Stop strings from the generation config, if any. TRT-LLM
+            spells these ``stop``, alongside the token-id list.
         max_tokens: Output cap for this request, already clamped to the context window.
 
     Returns:
@@ -73,12 +76,14 @@ def _build_sampling_params(
     # TRT-LLM spells "no top-k restriction" as 0, the generation config as null.
     top_k_cfg = sampling_config["top_k"]
     stop_ids = list(stop_token_ids or [])
+    stops = list(stop_strings or [])
     return sampling_params_cls(
         temperature=float(sampling_config["temperature"]),
         top_p=float(sampling_config["top_p"]),
         top_k=int(top_k_cfg) if top_k_cfg is not None else 0,
         max_tokens=int(max_tokens),
         stop_token_ids=stop_ids or None,
+        stop=stops or None,
         # Include generated stop tokens so the adapter can trim tokens and logprobs together.
         include_stop_str_in_output=True,
         logprobs=True,
@@ -93,6 +98,7 @@ def create_app(
     max_seq_len: int,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None = None,
+    stop_strings: list[str] | None = None,
     default_chat_template_kwargs: dict[str, Any] | None = None,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
@@ -241,6 +247,7 @@ def create_app(
             TrtSamplingParams,
             sampling_config=sampling_config,
             stop_token_ids=stop_token_ids,
+            stop_strings=stop_strings,
             max_tokens=max_tokens,
         )
 
@@ -513,6 +520,7 @@ def start_server(
     max_seq_len: int,
     sampling_config: dict[str, Any],
     stop_token_ids: list[int] | None = None,
+    stop_strings: list[str] | None = None,
     host: str = "0.0.0.0",
     port: int = 0,
     default_chat_template_kwargs: dict[str, Any] | None = None,
@@ -540,6 +548,7 @@ def start_server(
         max_seq_len=max_seq_len,
         sampling_config=sampling_config,
         stop_token_ids=stop_token_ids,
+        stop_strings=stop_strings,
         default_chat_template_kwargs=default_chat_template_kwargs,
         tool_parser=tool_parser,
         reasoning_parser=reasoning_parser,

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -298,6 +298,7 @@ class TrtllmAsyncGenerationWorkerImpl:
                 "top_k": self.cfg["top_k"],
             },
             stop_token_ids=list(self.cfg.get("stop_token_ids") or []),
+            stop_strings=list(self.cfg.get("stop_strings") or []),
             default_chat_template_kwargs=self.cfg["trtllm_cfg"].get(
                 "default_chat_template_kwargs"
             ),
@@ -500,7 +501,10 @@ class TrtllmAsyncGenerationWorkerImpl:
             token_ids = input_ids[i, :length].tolist()
             prompts.append({"prompt_token_ids": token_ids})
 
-        sampling_params = self._build_sampling_params(greedy=greedy)
+        sampling_params = self._build_sampling_params(
+            greedy=greedy,
+            stop_strings=self._merge_stop_strings(data.get("stop_strings")),
+        )
 
         # Fan all prompts out concurrently; AsyncLLM batches them in-flight.
         outputs = await asyncio.gather(
@@ -566,7 +570,28 @@ class TrtllmAsyncGenerationWorkerImpl:
     #  Helpers
     # ------------------------------------------------------------------ #
 
-    def _build_sampling_params(self, *, greedy: bool):
+    def _merge_stop_strings(self, batch_stop_strings: Any) -> list[str] | None:
+        """Union the configured stop strings with the per-sample ones.
+
+        Mirrors ``BaseVllmGenerationWorker._merge_stop_strings``. One
+        ``SamplingParams`` is built per batch here, so a sample's stop strings
+        apply to the whole batch -- the same shape the vLLM backend has.
+        """
+        stop_set: set[str] = set()
+
+        if self.cfg.get("stop_strings"):
+            stop_set.update(self.cfg["stop_strings"])
+
+        if batch_stop_strings is not None:
+            for sample_stop_strings in batch_stop_strings:
+                if sample_stop_strings:
+                    stop_set.update(sample_stop_strings)
+
+        return sorted(stop_set) if stop_set else None
+
+    def _build_sampling_params(
+        self, *, greedy: bool, stop_strings: list[str] | None = None
+    ):
         top_k_cfg = self.cfg["top_k"]
         top_k_val = 1 if greedy else (top_k_cfg if top_k_cfg is not None else 0)
         temperature = 0.0 if greedy else self.cfg["temperature"]
@@ -579,6 +604,7 @@ class TrtllmAsyncGenerationWorkerImpl:
             top_k=top_k_val,
             max_tokens=self.cfg["max_new_tokens"],
             stop_token_ids=stop_ids or None,
+            stop=stop_strings or None,
             # Keep the EOS / stop token in the returned token_ids so that the
             # response sequence matches HF / vLLM behavior. Required for
             # logprob alignment with training-side Megatron.

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -484,6 +484,7 @@ class TrtllmAsyncGenerationWorkerImpl:
                     "logprobs": torch.zeros((0, 0), dtype=torch.float),
                     "generation_lengths": torch.zeros(0, dtype=torch.long),
                     "unpadded_sequence_lengths": torch.zeros(0, dtype=torch.long),
+                    "truncated": torch.zeros(0, dtype=torch.bool),
                 }
             )
 
@@ -518,6 +519,7 @@ class TrtllmAsyncGenerationWorkerImpl:
         logprobs_list = []
         generation_lengths = []
         unpadded_sequence_lengths = []
+        truncated_list = []
 
         max_gen_len = max(len(o.outputs[0].token_ids) for o in outputs)
 
@@ -553,6 +555,13 @@ class TrtllmAsyncGenerationWorkerImpl:
             generation_lengths.append(len(gen_tokens))
             unpadded_sequence_lengths.append(resp_len)
 
+            # "length" is how TRT-LLM reports hitting max_tokens without a stop
+            # token, the same condition the vLLM worker reads off finish_reason.
+            # Rollouts fold this into the batch's ``truncated`` column, which
+            # ``grpo.overlong_filtering`` uses to zero the loss for samples that
+            # ran out of budget; without it those samples train as if complete.
+            truncated_list.append(gen.finish_reason == "length")
+
         return BatchedDataDict[GenerationOutputSpec](
             {
                 "output_ids": torch.stack(output_ids_list),
@@ -560,6 +569,7 @@ class TrtllmAsyncGenerationWorkerImpl:
                 "generation_lengths": torch.tensor(
                     generation_lengths, dtype=torch.long
                 ),
+                "truncated": torch.tensor(truncated_list, dtype=torch.bool),
                 "unpadded_sequence_lengths": torch.tensor(
                     unpadded_sequence_lengths, dtype=torch.long
                 ),

--- a/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
@@ -59,6 +59,7 @@ def test_http_sampling_params_match_the_direct_path():
         sampling_params_cls,
         sampling_config={"temperature": 0.8, "top_p": 0.9, "top_k": 20},
         stop_token_ids=[9],
+        stop_strings=None,
         max_tokens=4,
     )
 
@@ -68,10 +69,48 @@ def test_http_sampling_params_match_the_direct_path():
         top_k=20,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
     )
+
+
+def test_http_sampling_params_forward_stop_strings():
+    """Stop strings must reach TRT-LLM as ``stop``, next to the token-id list.
+
+    The two are separate controls: ``stop_token_ids`` cannot express a multi-token
+    string like ``</answer>``, so dropping ``stop`` left the HTTP rollout path
+    generating past a boundary the config had asked it to stop at.
+    """
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 0.8, "top_p": 0.9, "top_k": 20},
+        stop_token_ids=[9],
+        stop_strings=["</answer>", "<eot>"],
+        max_tokens=4,
+    )
+
+    kwargs = sampling_params_cls.call_args.kwargs
+    assert kwargs["stop"] == ["</answer>", "<eot>"]
+    assert kwargs["stop_token_ids"] == [9]
+
+
+def test_http_sampling_params_empty_stop_strings_stay_none():
+    """[] must not reach TRT-LLM as an empty list; None keeps its own default."""
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 1.0, "top_p": 1.0, "top_k": None},
+        stop_token_ids=None,
+        stop_strings=[],
+        max_tokens=8,
+    )
+
+    assert sampling_params_cls.call_args.kwargs["stop"] is None
 
 
 def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
@@ -82,6 +121,7 @@ def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
         sampling_params_cls,
         sampling_config={"temperature": 1.0, "top_p": 1.0, "top_k": None},
         stop_token_ids=None,
+        stop_strings=None,
         max_tokens=8,
     )
 
@@ -91,6 +131,7 @@ def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
         top_k=0,
         max_tokens=8,
         stop_token_ids=None,
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -117,7 +117,9 @@ async def test_generate_async_converts_padded_batch_and_logprobs():
 
     output = await worker.generate_async(data, greedy=True)
 
-    worker._build_sampling_params.assert_called_once_with(greedy=True)
+    worker._build_sampling_params.assert_called_once_with(
+        greedy=True, stop_strings=None
+    )
     assert worker.llm.generate_async.await_count == 2
     assert torch.equal(
         output["output_ids"], torch.tensor([[11, 12, 21, 22], [13, 23, 0, 0]])
@@ -162,6 +164,41 @@ async def test_generate_async_empty_batch_does_not_call_engine():
     worker.llm.generate_async.assert_not_awaited()
 
 
+def test_build_sampling_params_forwards_configured_stop_strings():
+    """Configured stop strings must reach TRT-LLM, which spells them ``stop``.
+
+    vLLM, SGLang and Dynamo all honor ``policy.generation.stop_strings``; TRT-LLM
+    passed only ``stop_token_ids``, so the same config stopped generation on the
+    other backends and ran to max_new_tokens here.
+    """
+    worker = _worker()
+    worker.cfg["stop_strings"] = ["</answer>"]
+
+    worker._build_sampling_params(
+        greedy=False, stop_strings=worker._merge_stop_strings(None)
+    )
+
+    assert worker.TrtSamplingParams.call_args.kwargs["stop"] == ["</answer>"]
+
+
+def test_merge_stop_strings_unions_config_and_per_sample():
+    """Same shape as BaseVllmGenerationWorker._merge_stop_strings."""
+    worker = _worker()
+    worker.cfg["stop_strings"] = ["</answer>"]
+
+    merged = worker._merge_stop_strings([["<eot>"], None, ["</answer>", "STOP"]])
+
+    assert merged == ["</answer>", "<eot>", "STOP"]
+
+
+def test_merge_stop_strings_returns_none_when_nothing_configured():
+    """None, not [], so TRT-LLM keeps its own default rather than an empty list."""
+    worker = _worker()
+
+    assert worker._merge_stop_strings(None) is None
+    assert worker._merge_stop_strings([[], None]) is None
+
+
 def test_build_sampling_params_null_top_k_maps_to_zero():
     """null top_k (default) must reach TRT-LLM as 0, its spelling of 'no restriction'."""
     worker = _worker()
@@ -175,6 +212,7 @@ def test_build_sampling_params_null_top_k_maps_to_zero():
         top_k=0,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
@@ -191,6 +229,7 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_k=1,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,
@@ -204,6 +243,7 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_k=20,
         max_tokens=4,
         stop_token_ids=[9],
+        stop=None,
         include_stop_str_in_output=True,
         logprobs=True,
         logprobs_simple_format=True,

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -91,13 +91,20 @@ async def test_generate_async_converts_padded_batch_and_logprobs():
 
     responses = {
         (11, 12): SimpleNamespace(
-            outputs=[SimpleNamespace(token_ids=[21, 22], logprobs=[-0.1, -0.2])]
+            outputs=[
+                SimpleNamespace(
+                    token_ids=[21, 22],
+                    logprobs=[-0.1, -0.2],
+                    finish_reason="stop",
+                )
+            ]
         ),
         (13,): SimpleNamespace(
             outputs=[
                 SimpleNamespace(
                     token_ids=[23],
                     logprobs=[{23: SimpleNamespace(logprob=-0.3)}],
+                    finish_reason="length",
                 )
             ]
         ),
@@ -125,6 +132,7 @@ async def test_generate_async_converts_padded_batch_and_logprobs():
         output["output_ids"], torch.tensor([[11, 12, 21, 22], [13, 23, 0, 0]])
     )
     assert torch.equal(output["generation_lengths"], torch.tensor([2, 1]))
+    assert torch.equal(output["truncated"], torch.tensor([False, True]))
     assert torch.equal(output["unpadded_sequence_lengths"], torch.tensor([4, 2]))
     assert torch.allclose(
         output["logprobs"],
@@ -197,6 +205,66 @@ def test_merge_stop_strings_returns_none_when_nothing_configured():
 
     assert worker._merge_stop_strings(None) is None
     assert worker._merge_stop_strings([[], None]) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_reports_truncation_from_finish_reason():
+    """``truncated`` must reach the batch, or overlong filtering silently no-ops.
+
+    TRT-LLM reports hitting max_tokens without a stop token as
+    ``finish_reason == "length"`` -- the same signal the vLLM worker reads. The
+    backend returned no ``truncated`` column at all, so the rollout default of
+    all-False stood, and ``grpo.overlong_filtering`` kept the loss for samples
+    that had run out of budget.
+    """
+    worker = _worker()
+    worker._build_sampling_params = MagicMock(return_value=object())
+
+    responses = {
+        (11,): SimpleNamespace(
+            outputs=[
+                SimpleNamespace(token_ids=[21], logprobs=[-0.1], finish_reason="stop")
+            ]
+        ),
+        (12,): SimpleNamespace(
+            outputs=[
+                SimpleNamespace(token_ids=[22], logprobs=[-0.2], finish_reason="length")
+            ]
+        ),
+    }
+
+    async def generate_async(*, inputs, sampling_params):
+        return responses[tuple(inputs["prompt_token_ids"])]
+
+    worker.llm.generate_async.side_effect = generate_async
+    data = BatchedDataDict(
+        {
+            "input_ids": torch.tensor([[11], [12]]),
+            "input_lengths": torch.tensor([1, 1]),
+        }
+    )
+
+    output = await worker.generate_async(data)
+
+    assert torch.equal(output["truncated"], torch.tensor([False, True]))
+
+
+@pytest.mark.asyncio
+async def test_generate_async_empty_batch_returns_empty_truncated():
+    """The empty-batch shortcut must carry the same columns as a real batch."""
+    worker = _worker()
+
+    output = await worker.generate_async(
+        BatchedDataDict(
+            {
+                "input_ids": torch.zeros((0, 0), dtype=torch.long),
+                "input_lengths": torch.zeros(0, dtype=torch.long),
+            }
+        )
+    )
+
+    assert output["truncated"].dtype == torch.bool
+    assert output["truncated"].numel() == 0
 
 
 def test_build_sampling_params_null_top_k_maps_to_zero():


### PR DESCRIPTION
> **Stacked on #4041.** Both touch `trtllm_worker_async.py` and the same test, so this branch is rebased on that one and its commit shows up here too. Only the second commit, `fix(trtllm): report response truncation ...`, belongs to this PR. Happy to rebase onto `main` once #4041 lands, or to fold the two together if you would rather review them as one.

# What does this PR do ?

**Makes TRT-LLM report response truncation, so `grpo.overlong_filtering` stops silently doing nothing on that backend.**

`truncated` marks a sample whose response hit `max_new_tokens` without a stop token. vLLM, SGLang and Dynamo all return it in `GenerationOutputSpec`; TRT-LLM returned no such column.

That is not simply a missing field. [`run_multi_turn_rollout`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/experience/rollouts.py#L997) starts from an all-False tensor and only overwrites it when the backend supplied one:

```python
sample_truncated = torch.zeros(batch_size, dtype=torch.bool)      # :997
...
response_truncated = gen_metrics.pop("_response_truncated", None)
if response_truncated is not None:                                # :1055, skipped on TRT-LLM
    ...
current_batch["truncated"] = sample_truncated                     # :1169, always written
```

So the column exists and reads all-False on TRT-LLM. [`grpo.py:3374`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/algorithms/grpo.py#L3374) then does:

```python
if use_overlong_filtering:
    loss_multiplier[truncated] = 0
```

which zeroes nothing. Samples that ran out of budget train as if they had finished on their own, the opposite of what the flag asks for, with no error and no warning. `truncation_rate` under-reports for the same reason.

Observation truncation (an env observation cut to fit the context, [`rollouts.py:1116`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/experience/rollouts.py#L1116)) was never affected, since it is computed rollout-side. Only the response side was missing.

# Issues

No issue filed for this. Distinct from #2163 / #2395, which are about `truncated` being *absent* and raising `KeyError`; here the column is present and simply always False.

# Usage

No config or API change. `overlong_filtering: true` now behaves on TRT-LLM the way it already does on the other backends.

# Design & Code Changes

TRT-LLM already reports this per output: `finish_reason == "length"` is its spelling for hitting the token cap without a stop token ([`executor/result.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/executor/result.py): `finish_reason: Optional[Literal['stop', 'length', 'timeout', ...]]`). That is the same signal [`BaseVllmGenerationWorker`](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/models/generation/vllm/vllm_worker.py#L1137) reads, so this is a plumbing fix rather than new inference.

* `generate_async` collects `gen.finish_reason == "length"` per output and returns it as `truncated`.
* The empty-batch shortcut gets the matching `torch.zeros(0, dtype=torch.bool)`, so both branches return the same columns.

Scoped to TRT-LLM. **Megatron has the same gap** but reports no finish reason, and its mcore path would need truncation inferred from `termination_id` against the token cap. That is a judgement call about mcore semantics rather than a port of an existing signal, so I left it out rather than guess; happy to follow up if you want it in the same shape.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

## Tests

Two added in `test_trtllm_worker_async.py`, plus the existing `test_generate_async_converts_padded_batch_and_logprobs` extended so its fake outputs now carry `finish_reason`, which the real TRT-LLM object always has, and it asserts the new column.

* `test_generate_async_reports_truncation_from_finish_reason`: `"stop"` and `"length"` in one batch produce `[False, True]`
* `test_generate_async_empty_batch_returns_empty_truncated`: the shortcut returns an empty bool tensor rather than omitting the column

Reverting only `trtllm_worker_async.py` to `main`, the first fails on the missing column rather than on a signature change:

```
E   KeyError: 'truncated'
FAILED test_generate_async_reports_truncation_from_finish_reason
```

With the change (both commits on this branch):

```
pytest tests/unit/models/generation/trtllm/test_trtllm_worker_async.py --trtllm-only
  main:        11 passed
  this branch: 16 passed          (3 from #4041, 2 from this PR)

pytest tests/unit/models/generation/trtllm/test_trtllm_http_server.py
  7 passed, 5 skipped
```

No failures on either version. The 5 skips are local: my stub `tensorrt_llm` has no `tensorrt_llm.serve` submodule.

CPU only. I have no GPU box, so the tests needing a real TRT-LLM runtime did not run and I could not watch a rollout actually get filtered. The change is confined to how the output batch is assembled, which the tests above cover.

`ruff 0.9.9` check, import sort and format are clean on all four files.

