### PR TITLE
fix(data-plane): log single-controller metrics before the step is committed

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -2183,6 +2183,11 @@ class SingleControllerActor:
             self._logger.log_metrics(
                 step_metrics, step=self._train_steps, prefix="train"
             )
+            # Must precede the step_finished=True log below. That log commits
+            # the wandb step, and wandb silently discards anything logged
+            # against a step it has already committed -- no exception, no
+            # failed return, just an empty chart. grpo_sync had the same bug.
+            self._log_data_plane_metrics(total_time)
             # step_finished=True here since this is the final log of our current step.
             self._logger.log_metrics(
                 timing_metrics,
@@ -2190,7 +2195,6 @@ class SingleControllerActor:
                 prefix="timing/train",
                 step_finished=True,
             )
-            self._log_data_plane_metrics(total_time)
             self._timer.reset()
 
             # min sample version refers to the version each consumed sample was

--- a/tests/unit/data_plane/test_observability.py
+++ b/tests/unit/data_plane/test_observability.py
@@ -1263,3 +1263,48 @@ def test_inspection_snapshot_does_not_steal_codec_time():
         0.010, rel=1e-3
     )
     client.close()
+
+
+def test_no_algorithm_logs_data_plane_after_committing_the_step():
+    """``log_metrics(..., step_finished=True)`` commits the wandb step, and
+    wandb discards anything logged against a step it has already committed --
+    without raising, and without a falsy return to check.
+
+    This has bitten twice. ``grpo_sync`` was caught only because a real run
+    showed 85 logged keys and zero ``data_plane/*``. ``single_controller``
+    carried the same code -- its docstring says it mirrors ``grpo_sync`` --
+    and so carried the same bug, unnoticed, because no run exercised it.
+
+    Asserting the invariant for every algorithm rather than for one call site
+    is the point: a third wiring would otherwise repeat it. Source order is
+    the only observable, because the drop happens inside wandb where a fake
+    logger sees a perfectly ordinary call.
+    """
+    import pathlib
+
+    import nemo_rl
+
+    algorithms = pathlib.Path(nemo_rl.__file__).parent / "algorithms"
+    checked = []
+    for path in sorted(algorithms.glob("*.py")):
+        # Comments mention the flag too, so they cannot be part of the search.
+        source = "\n".join(
+            line
+            for line in path.read_text().splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        if "_log_data_plane_metrics(" not in source:
+            continue
+        if "step_finished=True" not in source:
+            continue
+        checked.append(path.name)
+        # rindex, not index: the first occurrence is the *definition*, which
+        # naturally precedes everything. The call site is what has to come
+        # before the commit, and it is the last occurrence.
+        assert source.rindex("_log_data_plane_metrics(") < source.index(
+            "step_finished=True"
+        ), (
+            f"{path.name}: data-plane metrics are logged after the "
+            "step_finished=True commit, so wandb will discard them"
+        )
+    assert len(checked) >= 2, f"expected sync and single-controller, got {checked}"


### PR DESCRIPTION
Fixes a silent metric loss on the async single-controller path, on top of #3616.

## The bug

`log_metrics(..., step_finished=True)` calls `run.log(..., commit=True)`, which
closes that wandb step. wandb accepts a later log against a closed step,
returns normally, and **discards it** — no exception, no falsy return.

`single_controller.py` called the data-plane logger immediately *after* that
commit:

```python
self._logger.log_metrics(timing_metrics, ..., step_finished=True)  # closes step N
self._log_data_plane_metrics(total_time)                           # dropped
```

So every `data_plane/*` series on the async path was computed — snapshot
gathered, deltas taken, breakdown table built — and thrown away.

## Why it went unnoticed

- **Silent by construction.** No exception, nothing falsy to check. The only
  symptom is an empty chart.
- **stdout still looked healthy.** The `• data plane: …ms, … MB moved` print
  lives *inside* the discarded call.
- **Invisible to unit tests.** A fake logger records the call happily; the drop
  happens inside wandb.
- **The comment asserted the opposite.** `# step_finished=True here since this
  is the final log of our current step` stopped being true when a log was added
  after it.

`grpo_sync` had the identical bug. It was caught only because a real GRPO run
showed 85 logged keys and zero `data_plane/*`, and was fixed there. This path
was never exercised by a run — its docstring says it mirrors `grpo_sync`, and
it mirrored this too.

## The fix

Move one statement above the commit.

## The test

Asserts the invariant for **every** algorithm module that logs data-plane
metrics, rather than for one call site — a third wiring would otherwise repeat
it. Source order is the only observable, since the drop happens inside wandb.

Two details worth review:

- It compares the **call site** (`rindex`), not the first occurrence. The first
  occurrence is the method *definition*, which trivially precedes everything —
  my first draft of this test passed against the unfixed file.
- Comment lines are stripped before searching, because the comments name
  `step_finished=True` too.

Verified by running the test's logic against both versions:

| | invariant holds |
|---|---|
| `single_controller` before fix | ✗ (test fails, as intended) |
| `single_controller` after fix | ✓ |
| `grpo_sync` | ✓ |

## Base

Branched off `zhiyul/data_plane_observability_metrics` rather than `main`,
because `_log_data_plane_metrics` in `single_controller.py` only exists in
#3616. Against `main` this would show 51 commits / 66 files; against the
feature branch it is 2 files.
