### PR TITLE
feat(spec-decode): pipeline parallelism for draft co-training via a one-sided tap channel (Megatron)

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -329,9 +329,9 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
-    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires sequence_parallel == false)
     ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
-    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the draft loss internals (memory vs a few extra TP collectives; never affects results)
     # Draft-only optimizer param group; all null = share the policy optimizer settings.
     lr: null
     min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -324,6 +324,7 @@ policy:
 
   draft:
     enabled: false
+    speculator_type: eagle3 # "eagle3", or the DFlash block drafter "dflash"
     model_name: null
     loss_weight: 0.1
     num_layers: null

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -328,6 +328,13 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    # Draft-only optimizer param group; all null = share the policy optimizer settings.
+    lr: null
+    min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)
+    weight_decay: null
 
   # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
   # for more details on dynamic batching and sequence packing.

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -168,9 +168,9 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
-    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires sequence_parallel == false)
     ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
-    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the draft loss internals (memory vs a few extra TP collectives; never affects results)
     # Draft-only optimizer param group; all null = share the policy optimizer settings.
     lr: null
     min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -167,6 +167,13 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    # Draft-only optimizer param group; all null = share the policy optimizer settings.
+    lr: null
+    min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)
+    weight_decay: null
 
   generation:
     # HTTP ports use the shared [3000, 4999) virtual-cluster defaults.

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -163,6 +163,7 @@ policy:
 
   draft:
     enabled: false
+    speculator_type: eagle3 # "eagle3", or the DFlash block drafter "dflash"
     model_name: null
     loss_weight: 0.1
     num_layers: null

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3713,6 +3713,8 @@ def grpo_train(
                     metrics["draft_grad_norm"] = train_results[
                         "draft_grad_norm"
                     ].numpy()
+                if "draft_tap_wait_s" in train_results:
+                    metrics["draft_tap_wait_s"] = train_results["draft_tap_wait_s"]
                 if master_config.grpo.use_dynamic_sampling:
                     metrics["filtered_reward"] = rewards.numpy()
                     metrics["reward"] = repeated_batch["total_reward"].numpy()

--- a/nemo_rl/algorithms/loss/__init__.py
+++ b/nemo_rl/algorithms/loss/__init__.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     DPOLossDataDict,
     DPOLossFn,
     DraftCrossEntropyLossFn,
+    DraftTTTCrossEntropyLossFn,
     MseValueLossConfig,
     MseValueLossFn,
     NLLLossFn,

--- a/nemo_rl/algorithms/loss/__init__.py
+++ b/nemo_rl/algorithms/loss/__init__.py
@@ -23,7 +23,6 @@ from nemo_rl.algorithms.loss.loss_functions import (
     DPOLossDataDict,
     DPOLossFn,
     DraftCrossEntropyLossFn,
-    DraftTTTCrossEntropyLossFn,
     MseValueLossConfig,
     MseValueLossFn,
     NLLLossFn,

--- a/nemo_rl/algorithms/loss/__init__.py
+++ b/nemo_rl/algorithms/loss/__init__.py
@@ -29,6 +29,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     NLLLossFn,
     PreferenceLossDataDict,
     PreferenceLossFn,
+    resolve_block_draft_slot_weights,
 )
 from nemo_rl.algorithms.loss.utils import (
     prepare_loss_input,
@@ -61,5 +62,6 @@ __all__ = [
     "SequencePackingFusionLossWrapper",
     "SequencePackingLossWrapper",
     "DraftLossWrapper",
+    "resolve_block_draft_slot_weights",
     "wrap_loss_fn_with_input_preparation",
 ]

--- a/nemo_rl/algorithms/loss/interfaces.py
+++ b/nemo_rl/algorithms/loss/interfaces.py
@@ -55,6 +55,7 @@ class LossInputType(enum.Enum):
     DISTILLATION = "distillation"
     DISTILLATION_CROSS_TOKENIZER = "distillation_cross_tokenizer"
     DRAFT = "draft"
+    DRAFT_TTT = "draft_ttt"
 
 
 class LossFunction(Protocol):

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.loss.interfaces import (
     LossType,
     MetricNormalizer,
 )
+from nemo_rl.algorithms.loss.utils import draft_pass_token_mask
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
     LocalizedAlignment,
@@ -39,6 +40,7 @@ from nemo_rl.algorithms.x_token.loss_utils import (
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedCrossEntropy,
     DistributedCrossEntropy,
     cp_shift_next,
     group_all_reduce_sum,
@@ -59,6 +61,14 @@ class DraftCrossEntropyLossConfig(TypedDict):
 class DraftCrossEntropyLossDataDict(TypedDict):
     teacher_logits: Tensor
     student_logits: Tensor
+    token_mask: Tensor
+    sample_mask: Tensor
+    student_vocab_indices: NotRequired[Tensor]
+
+
+class DraftTTTCrossEntropyLossDataDict(TypedDict):
+    teacher_logits: Tensor
+    student_logits_by_pass: list[Tensor]
     token_mask: Tensor
     sample_mask: Tensor
     student_vocab_indices: NotRequired[Tensor]
@@ -107,6 +117,154 @@ class DraftCrossEntropyLossFn(LossFunction):
             mask,
             global_normalization_factor=global_valid_toks,
         )
+
+
+class DraftTTTCrossEntropyLossFn(LossFunction):
+    """Soft-target cross-entropy over several TTT draft passes.
+
+    The multi-pass sibling of :class:`DraftCrossEntropyLossFn`, selected when
+    ``policy.draft.ttt_steps > 1``. The single-pass class stays the loss for
+    ``ttt_steps == 1`` (including the packed layout), which is why the two live
+    side by side instead of behind a flag.
+
+    Pass ``d`` (1-indexed) student logits at position ``i`` predict token
+    ``x_{i+d+1}``; the matching soft target is the (detached, unshifted)
+    policy logits at position ``i + d``, so both sides are pure slices of
+    their full-length tensors. The per-pass mask is
+    ``token_mask[i + d + 1] * sample_mask`` (see ``draft_pass_token_mask``).
+
+    The scalar loss is ``sum_d alpha_d * masked_sum_d / denominator`` where
+    the denominator is ``sum_d alpha_d * global_draft_pass_counts[d-1]`` (the
+    DP-all-reduced per-pass counts from ``compute_draft_pass_valid_counts``)
+    when provided, else the policy's ``global_valid_toks`` (single-pass
+    fallback for callers that do not thread the draft counts).
+
+    Every returned metric is normalized by a GLOBAL denominator so the
+    driver's sum-over-microbatches aggregation reconstructs a global mean
+    (mirroring how the policy losses report): ``draft_loss_pass_d`` sums to
+    the global per-token soft-CE of pass d.
+    """
+
+    loss_type = LossType.TOKEN_LEVEL
+    input_type = LossInputType.DRAFT_TTT
+
+    def __init__(
+        self,
+        vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        pass_weights: Optional[list[float]] = None,
+        seq_chunk_size: int = 4096,
+    ):
+        self.vocab_parallel_group = vocab_parallel_group
+        self.pass_weights = pass_weights
+        # Sequence-dim tile for the loss internals: the fp32 soft-CE buffers
+        # here and the d2t full-vocab TP gather in prepare_loss_input. Trades
+        # a few extra TP collectives for peak memory; never affects results.
+        # Set via policy.draft.loss_seq_chunk_size.
+        self.seq_chunk_size = seq_chunk_size
+
+    def _per_token_soft_ce(
+        self, student_logits: Tensor, teacher_logits: Tensor
+    ) -> Tensor:
+        # Soft cross entropy matches the forward-KL student gradient. The
+        # sequence-chunked variant keeps the fp32 softmax buffers chunk-sized
+        # and saves only the bf16 logits references for backward — essential
+        # when several TTT passes stack up before the shared backward.
+        return ChunkedDistributedCrossEntropy.apply(
+            student_logits,
+            teacher_logits,
+            self.seq_chunk_size,
+            self.vocab_parallel_group,
+            False,
+        )
+
+    def __call__(
+        self,
+        teacher_logits: Tensor,
+        student_logits_by_pass: list[Tensor],
+        data: BatchedDataDict[DraftTTTCrossEntropyLossDataDict],
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Reduce the masked per-pass draft losses to a scalar and metrics."""
+        num_passes = len(student_logits_by_pass)
+        if self.pass_weights is not None and len(self.pass_weights) != num_passes:
+            raise ValueError(
+                f"pass_weights has {len(self.pass_weights)} entries but the "
+                f"draft produced {num_passes} passes."
+            )
+        if (
+            global_draft_pass_counts is not None
+            and global_draft_pass_counts.shape[0] != num_passes
+        ):
+            raise ValueError(
+                f"global_draft_pass_counts has {global_draft_pass_counts.shape[0]} "
+                f"entries but the draft produced {num_passes} passes."
+            )
+
+        token_mask = data["token_mask"]
+        sample_mask = data["sample_mask"]
+        seq_len = teacher_logits.shape[1]
+
+        if global_draft_pass_counts is not None:
+            pass_counts = global_draft_pass_counts.float()
+            weights = (
+                torch.ones_like(pass_counts)
+                if self.pass_weights is None
+                else pass_counts.new_tensor(self.pass_weights)
+            )
+            denominator = (weights * pass_counts).sum()
+        else:
+            pass_counts = None
+            denominator = global_valid_toks
+
+        metrics: dict[str, Any] = {}
+        total = teacher_logits.new_zeros((), dtype=torch.float32)
+        for pass_index, student_logits in enumerate(student_logits_by_pass):
+            # Passes count from 1: the draft consumes emb(x_{i+1}) alongside
+            # h_i, so its first prediction at slot i is x_{i+2} — deliberately
+            # one step deeper than DraftCrossEntropyLossFn, which pairs slot i
+            # with x_{i+1}. Each loss is consistent with its own slices.
+            ttt_pass = pass_index + 1
+            weight = (
+                1.0
+                if self.pass_weights is None
+                else float(self.pass_weights[pass_index])
+            )
+            valid_len = seq_len - ttt_pass - 1
+            if valid_len <= 0:
+                metrics[f"draft_loss_pass_{ttt_pass}"] = 0.0
+                continue
+
+            # Views into the unshifted tensors — the chunked CE makes its own
+            # per-chunk contiguous fp32 copies, so no full-pass copy here.
+            student_slice = student_logits[:, :valid_len]
+            teacher_slice = teacher_logits[:, ttt_pass : ttt_pass + valid_len]
+            per_token_loss = self._per_token_soft_ce(student_slice, teacher_slice)
+
+            pass_mask = draft_pass_token_mask(
+                token_mask, ttt_pass
+            ) * sample_mask.unsqueeze(-1)
+            pass_sum = (per_token_loss.float() * pass_mask).sum()
+            total = total + weight * pass_sum
+
+            with torch.no_grad():
+                # GLOBAL per-pass denominator: the driver aggregates mb-metric
+                # lists with a plain sum, so a per-microbatch mean would be
+                # inflated by the number of microbatches (~512x at gbs 512).
+                metric_denominator = (
+                    pass_counts[pass_index]
+                    if pass_counts is not None
+                    else global_valid_toks.float()
+                )
+                metrics[f"draft_loss_pass_{ttt_pass}"] = float(
+                    (
+                        pass_sum.detach() / torch.clamp(metric_denominator, min=1.0)
+                    ).item()
+                )
+
+        loss = total / torch.clamp(denominator.float(), min=1.0)
+        return loss, metrics
 
 
 class ClippedPGLossConfig(BaseModel, extra="allow"):

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Any, NotRequired, Optional, TypedDict, TypeVar
 
 import torch
@@ -23,7 +24,10 @@ from nemo_rl.algorithms.loss.interfaces import (
     LossType,
     MetricNormalizer,
 )
-from nemo_rl.algorithms.loss.utils import draft_pass_token_mask
+from nemo_rl.algorithms.loss.utils import (
+    block_draft_slot_mask,
+    draft_pass_token_mask,
+)
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
     LocalizedAlignment,
@@ -264,6 +268,183 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
                 )
 
         loss = total / torch.clamp(denominator.float(), min=1.0)
+        return loss, metrics
+
+
+BLOCK_DRAFT_LOSS_WEIGHTING_SCHEMES = ("uniform", "exp")
+
+# DFlash paper (arXiv 2602.06036) gamma_d table for the "exp" scheme, keyed by
+# block size (anchor + gamma slots, NOT gamma). Non-tabulated sizes
+# interpolate/extrapolate linearly, clamped to >= 1.
+_DFLASH_GAMMA_D_BY_BLOCK_SIZE: tuple[tuple[int, float], ...] = (
+    (8, 4.0),
+    (10, 5.0),
+    (16, 7.0),
+)
+
+
+def _dflash_gamma_d(block_size: int) -> float:
+    points = _DFLASH_GAMMA_D_BY_BLOCK_SIZE
+    if block_size <= points[0][0]:
+        (b0, g0), (b1, g1) = points[0], points[1]
+    elif block_size >= points[-1][0]:
+        (b0, g0), (b1, g1) = points[-2], points[-1]
+    else:
+        for (b0, g0), (b1, g1) in zip(points, points[1:]):
+            if b0 <= block_size <= b1:
+                break
+    gamma_d = g0 + (g1 - g0) * (block_size - b0) / (b1 - b0)
+    return max(gamma_d, 1.0)
+
+
+def resolve_block_draft_slot_weights(scheme: Optional[str], gamma: int) -> list[float]:
+    """Resolve a named block-draft slot-weighting scheme to per-slot weights.
+
+    Args:
+        scheme: ``None``/``"uniform"`` for all-ones weights, or ``"exp"`` for
+            the DFlash paper's exponentially decaying weight
+            ``w_j = exp(-j / gamma_d)``, with ``gamma_d`` tabulated by block
+            size (b8 -> 4, b10 -> 5, b16 -> 7) and interpolated in between.
+        gamma: Number of draft slots (block size minus the anchor).
+
+    Returns:
+        Weights of length ``gamma``, suitable as ``BlockDraftLossFn``
+        ``slot_weights``.
+    """
+    if scheme is None or scheme == "uniform":
+        return [1.0] * gamma
+    if scheme != "exp":
+        raise ValueError(
+            f"Unknown draft loss_weighting scheme {scheme!r}; expected null or "
+            f"one of {BLOCK_DRAFT_LOSS_WEIGHTING_SCHEMES}."
+        )
+    gamma_d = _dflash_gamma_d(gamma + 1)
+    return [math.exp(-j / gamma_d) for j in range(gamma)]
+
+
+class BlockDraftLossDataDict(TypedDict):
+    draft_anchor_positions: Tensor
+    draft_anchor_valid: Tensor
+    token_mask: Tensor
+    sample_mask: Tensor
+
+
+class BlockDraftLossFn(LossFunction):
+    """Soft-target cross-entropy for DFlash block draft training.
+
+    Slot ``j`` of a block anchored at ``p`` predicts ``x_{p + 1 + j}``; its
+    soft target is the (detached) policy logits at position ``p + j``. Both
+    student ``[B, N, gamma, V_local]`` and the gathered teacher are flattened
+    to a ``[B, N * gamma, V_local]`` "sequence" for the same chunked,
+    vocab-parallel soft CE the TTT draft loss uses.
+
+    ``slot_weights[j]`` (e.g. DFlash's exponential position decay) weights
+    both the numerator and the ``global_draft_pass_counts``-based denominator
+    — the counts vector here is the per-slot analogue produced by
+    ``compute_block_draft_slot_valid_counts`` (shape ``[gamma]``). Metrics are
+    normalized by the GLOBAL per-slot counts so the driver's
+    sum-over-microbatches reconstructs global means (same contract as
+    ``DraftCrossEntropyLossFn``).
+    """
+
+    loss_type = LossType.TOKEN_LEVEL
+    input_type = LossInputType.DRAFT
+
+    def __init__(
+        self,
+        vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        slot_weights: Optional[list[float]] = None,
+        seq_chunk_size: int = 4096,
+    ):
+        self.vocab_parallel_group = vocab_parallel_group
+        self.slot_weights = slot_weights
+        self.seq_chunk_size = seq_chunk_size
+
+    def __call__(
+        self,
+        teacher_logits: Tensor,
+        student_block_logits: Tensor,
+        data: BatchedDataDict[BlockDraftLossDataDict],
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        batch_size, num_anchors, gamma, _ = student_block_logits.shape
+        seq_len = teacher_logits.shape[1]
+        device = student_block_logits.device
+
+        if self.slot_weights is not None and len(self.slot_weights) != gamma:
+            raise ValueError(
+                f"slot_weights has {len(self.slot_weights)} entries but the "
+                f"draft produced gamma={gamma} slots."
+            )
+        if (
+            global_draft_pass_counts is not None
+            and global_draft_pass_counts.shape[0] != gamma
+        ):
+            raise ValueError(
+                f"global_draft_pass_counts has {global_draft_pass_counts.shape[0]} "
+                f"entries but the draft produced gamma={gamma} slots."
+            )
+
+        anchors = data["draft_anchor_positions"]
+        anchor_valid = data["draft_anchor_valid"]
+        token_mask = data["token_mask"]
+        sample_mask = data["sample_mask"]
+
+        # Teacher for slot j sits at position p + j (it predicts x_{p+1+j}).
+        teacher_pos = (
+            anchors.unsqueeze(-1) + torch.arange(gamma, device=device).view(1, 1, -1)
+        ).clamp(max=seq_len - 1)
+        gather_index = teacher_pos.reshape(batch_size, num_anchors * gamma, 1).expand(
+            -1, -1, teacher_logits.shape[-1]
+        )
+        teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
+
+        student_flat = student_block_logits.reshape(batch_size, num_anchors * gamma, -1)
+        per_token_loss = ChunkedDistributedCrossEntropy.apply(
+            student_flat,
+            teacher_block,
+            self.seq_chunk_size,
+            self.vocab_parallel_group,
+            False,
+        ).reshape(batch_size, num_anchors, gamma)
+
+        slot_mask = block_draft_slot_mask(
+            token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+        ).float()
+        weights = (
+            torch.ones(gamma, device=device, dtype=torch.float32)
+            if self.slot_weights is None
+            else torch.tensor(self.slot_weights, device=device, dtype=torch.float32)
+        )
+
+        per_slot_sum = (per_token_loss.float() * slot_mask).sum(dim=(0, 1))
+        total = (per_slot_sum * weights).sum()
+
+        if global_draft_pass_counts is not None:
+            slot_counts = global_draft_pass_counts.float()
+            denominator = (weights * slot_counts).sum()
+        else:
+            slot_counts = None
+            denominator = global_valid_toks.float()
+
+        metrics: dict[str, Any] = {}
+        with torch.no_grad():
+            for slot in range(gamma):
+                metric_denominator = (
+                    slot_counts[slot]
+                    if slot_counts is not None
+                    else global_valid_toks.float()
+                )
+                metrics[f"draft_loss_slot_{slot}"] = float(
+                    (
+                        per_slot_sum[slot].detach()
+                        / torch.clamp(metric_denominator, min=1.0)
+                    ).item()
+                )
+
+        loss = total / torch.clamp(denominator, min=1.0)
         return loss, metrics
 
 

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -26,7 +26,9 @@ from nemo_rl.algorithms.loss.interfaces import (
 )
 from nemo_rl.algorithms.loss.utils import (
     block_draft_slot_mask,
+    block_draft_slot_mask_packed,
     draft_pass_token_mask,
+    roll_packed_left_cp,
 )
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
@@ -45,7 +47,6 @@ from nemo_rl.algorithms.x_token.loss_utils import (
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     ChunkedDistributedCrossEntropy,
-    DistributedCrossEntropy,
     cp_shift_next,
     group_all_reduce_sum,
     group_all_reduce_sum_with_grad,
@@ -64,14 +65,6 @@ class DraftCrossEntropyLossConfig(TypedDict):
 
 class DraftCrossEntropyLossDataDict(TypedDict):
     teacher_logits: Tensor
-    student_logits: Tensor
-    token_mask: Tensor
-    sample_mask: Tensor
-    student_vocab_indices: NotRequired[Tensor]
-
-
-class DraftTTTCrossEntropyLossDataDict(TypedDict):
-    teacher_logits: Tensor
     student_logits_by_pass: list[Tensor]
     token_mask: Tensor
     sample_mask: Tensor
@@ -79,57 +72,7 @@ class DraftTTTCrossEntropyLossDataDict(TypedDict):
 
 
 class DraftCrossEntropyLossFn(LossFunction):
-    """Compute the auxiliary soft-target cross-entropy used for draft-model training."""
-
-    loss_type = LossType.TOKEN_LEVEL
-    input_type = LossInputType.DRAFT
-
-    def __init__(
-        self,
-        vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
-    ):
-        self.vocab_parallel_group = vocab_parallel_group
-
-    def __call__(
-        self,
-        teacher_logits: Tensor,
-        student_logits: Tensor,
-        token_mask: Tensor,
-        data: BatchedDataDict[DraftCrossEntropyLossDataDict],
-        global_valid_seqs: torch.Tensor,
-        global_valid_toks: torch.Tensor,
-    ) -> torch.Tensor:
-        """Reduce the masked per-token draft loss to a scalar."""
-        if self.vocab_parallel_group is not None:
-            # Soft cross entropy matches the forward-KL student gradient.
-            per_token_loss = DistributedCrossEntropy.apply(
-                student_logits,
-                teacher_logits,
-                self.vocab_parallel_group,
-                False,
-            )
-        else:
-            # teacher_logits is already detached at the call site (utils.py);
-            # match DistributedCrossEntropy semantics.
-            teacher_probs = torch.nn.functional.softmax(teacher_logits, dim=-1)
-            student_log_probs = torch.nn.functional.log_softmax(student_logits, dim=-1)
-            per_token_loss = -(teacher_probs * student_log_probs).sum(dim=-1)
-
-        mask = token_mask * data["sample_mask"].unsqueeze(-1)
-        return masked_mean(
-            per_token_loss,
-            mask,
-            global_normalization_factor=global_valid_toks,
-        )
-
-
-class DraftTTTCrossEntropyLossFn(LossFunction):
-    """Soft-target cross-entropy over several TTT draft passes.
-
-    The multi-pass sibling of :class:`DraftCrossEntropyLossFn`, selected when
-    ``policy.draft.ttt_steps > 1``. The single-pass class stays the loss for
-    ``ttt_steps == 1`` (including the packed layout), which is why the two live
-    side by side instead of behind a flag.
+    """Soft-target cross-entropy over one or more TTT draft passes.
 
     Pass ``d`` (1-indexed) student logits at position ``i`` predict token
     ``x_{i+d+1}``; the matching soft target is the (detached, unshifted)
@@ -150,20 +93,18 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
     """
 
     loss_type = LossType.TOKEN_LEVEL
-    input_type = LossInputType.DRAFT_TTT
+    input_type = LossInputType.DRAFT
 
     def __init__(
         self,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         pass_weights: Optional[list[float]] = None,
+        context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         seq_chunk_size: int = 4096,
     ):
         self.vocab_parallel_group = vocab_parallel_group
         self.pass_weights = pass_weights
-        # Sequence-dim tile for the loss internals: the fp32 soft-CE buffers
-        # here and the d2t full-vocab TP gather in prepare_loss_input. Trades
-        # a few extra TP collectives for peak memory; never affects results.
-        # Set via policy.draft.loss_seq_chunk_size.
+        self.context_parallel_group = context_parallel_group
         self.seq_chunk_size = seq_chunk_size
 
     def _per_token_soft_ce(
@@ -185,7 +126,7 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
         self,
         teacher_logits: Tensor,
         student_logits_by_pass: list[Tensor],
-        data: BatchedDataDict[DraftTTTCrossEntropyLossDataDict],
+        data: BatchedDataDict[DraftCrossEntropyLossDataDict],
         global_valid_seqs: torch.Tensor,
         global_valid_toks: torch.Tensor,
         global_draft_pass_counts: Optional[torch.Tensor] = None,
@@ -209,6 +150,24 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
         token_mask = data["token_mask"]
         sample_mask = data["sample_mask"]
         seq_len = teacher_logits.shape[1]
+
+        # Packed (THD) mode: student/teacher are [1, T_local] over the packed
+        # (possibly CP-zigzag-sharded) row. The pass-d shift can no longer be
+        # a tensor-wide slice — it must stop at subsequence boundaries and, in
+        # the zigzag layout, cross chunk boundaries onto other CP ranks. The
+        # teacher (detached) is therefore ROLLED once per pass with the
+        # CP-aware per-subsequence roll, while the per-token mask is gathered
+        # locally from the unpacked [B, S] token_mask via the zigzag coords
+        # the train loop stashed (zero communication).
+        packed = "draft_packed_pos_in_seq" in data
+        if packed:
+            packed_seq_index = data["draft_packed_seq_index"]
+            packed_pos_in_seq = data["draft_packed_pos_in_seq"]
+            packed_cu_local = data["draft_packed_local_cu_seqlens"]
+            packed_input_lengths = data["input_lengths"].to(
+                device=packed_pos_in_seq.device, dtype=torch.long
+            )
+            teacher_rolled = teacher_logits
 
         if global_draft_pass_counts is not None:
             pass_counts = global_draft_pass_counts.float()
@@ -235,20 +194,46 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
                 if self.pass_weights is None
                 else float(self.pass_weights[pass_index])
             )
-            valid_len = seq_len - ttt_pass - 1
-            if valid_len <= 0:
-                metrics[f"draft_loss_pass_{ttt_pass}"] = 0.0
-                continue
+            if packed:
+                # Advance the (detached) teacher one more per-subsequence
+                # step: after d rolls, position t holds the policy logits at
+                # its subsequence position pos+d. Rolled-past-the-end rows are
+                # zero (uniform soft target) and always masked below.
+                teacher_rolled = roll_packed_left_cp(
+                    teacher_rolled.squeeze(0),
+                    packed_cu_local,
+                    self.context_parallel_group,
+                ).unsqueeze(0)
+                per_token_loss = self._per_token_soft_ce(student_logits, teacher_rolled)
+                # Pass-d target x_{pos+d+1} is valid iff it exists in its
+                # subsequence AND is a trained (assistant) token; both come
+                # from the unpacked [B, S] masks via the local coords.
+                label_pos = packed_pos_in_seq + ttt_pass + 1
+                in_bounds = (label_pos < packed_input_lengths[packed_seq_index]) & (
+                    label_pos < token_mask.shape[1]
+                )
+                label_pos_clamped = label_pos.clamp(max=token_mask.shape[1] - 1)
+                pass_mask = (
+                    token_mask[packed_seq_index, label_pos_clamped]
+                    * in_bounds.to(token_mask.dtype)
+                    * sample_mask[packed_seq_index]
+                ).unsqueeze(0)
+            else:
+                valid_len = seq_len - ttt_pass - 1
+                if valid_len <= 0:
+                    metrics[f"draft_loss_pass_{ttt_pass}"] = 0.0
+                    continue
 
-            # Views into the unshifted tensors — the chunked CE makes its own
-            # per-chunk contiguous fp32 copies, so no full-pass copy here.
-            student_slice = student_logits[:, :valid_len]
-            teacher_slice = teacher_logits[:, ttt_pass : ttt_pass + valid_len]
-            per_token_loss = self._per_token_soft_ce(student_slice, teacher_slice)
+                # Views into the unshifted tensors — the chunked CE makes its
+                # own per-chunk contiguous fp32 copies, so no full-pass copy
+                # here.
+                student_slice = student_logits[:, :valid_len]
+                teacher_slice = teacher_logits[:, ttt_pass : ttt_pass + valid_len]
+                per_token_loss = self._per_token_soft_ce(student_slice, teacher_slice)
 
-            pass_mask = draft_pass_token_mask(
-                token_mask, ttt_pass
-            ) * sample_mask.unsqueeze(-1)
+                pass_mask = draft_pass_token_mask(
+                    token_mask, ttt_pass
+                ) * sample_mask.unsqueeze(-1)
             pass_sum = (per_token_loss.float() * pass_mask).sum()
             total = total + weight * pass_sum
 
@@ -261,10 +246,23 @@ class DraftTTTCrossEntropyLossFn(LossFunction):
                     if pass_counts is not None
                     else global_valid_toks.float()
                 )
+                # Under CP the local sum covers only this rank's sequence
+                # shard while the denominator is global; the GRADIENT path
+                # sums across CP implicitly (grad all-reduce), but the metric
+                # must reduce explicitly or it under-reports by cp_size.
+                metric_sum = pass_sum.detach()
+                if (
+                    self.context_parallel_group is not None
+                    and torch.distributed.is_initialized()
+                    and torch.distributed.get_world_size(self.context_parallel_group)
+                    > 1
+                ):
+                    metric_sum = metric_sum.clone()
+                    torch.distributed.all_reduce(
+                        metric_sum, group=self.context_parallel_group
+                    )
                 metrics[f"draft_loss_pass_{ttt_pass}"] = float(
-                    (
-                        pass_sum.detach() / torch.clamp(metric_denominator, min=1.0)
-                    ).item()
+                    (metric_sum / torch.clamp(metric_denominator, min=1.0)).item()
                 )
 
         loss = total / torch.clamp(denominator.float(), min=1.0)
@@ -322,11 +320,80 @@ def resolve_block_draft_slot_weights(scheme: Optional[str], gamma: int) -> list[
     return [math.exp(-j / gamma_d) for j in range(gamma)]
 
 
+def _cp_reduced_metric(value: Tensor, cp_group: Any) -> Tensor:
+    """Sum a detached metric numerator across CP ranks (no-op at CP == 1).
+
+    Under CP each rank's draft numerator covers only its owned blocks over a
+    global denominator; the GRADIENT path sums across CP implicitly (grad
+    all-reduce), but metrics must reduce explicitly or under-report.
+    """
+    if (
+        cp_group is None
+        or not torch.distributed.is_initialized()
+        or torch.distributed.get_world_size(cp_group) <= 1
+    ):
+        return value
+    value = value.clone()
+    torch.distributed.all_reduce(value, group=cp_group)
+    return value
+
+
+def _packed_block_teacher_gather(
+    teacher: Tensor,
+    seq_idx: Tensor,
+    anchors: Tensor,
+    gamma: int,
+    cu_seqlens_local: Tensor,
+    cp_group: Any,
+) -> Tensor:
+    """Teacher rows at in-subsequence positions ``p + j`` per owned block.
+
+    ``teacher`` is the rank-local packed (zigzag) ``[T_local, V]`` policy
+    logits. Each block's anchor chunk is rank-local by ownership; slot
+    positions spill at most ``gamma - 1`` rows past its end, which a one-hop
+    successor-halo exchange covers (rows past the sequence end come back as
+    zeros and belong to invalid, masked slots). Returns ``[NB * gamma, V]``.
+    """
+    from nemo_rl.algorithms.loss.utils import packed_zigzag_successor_halo
+
+    total_local, vocab_local = teacher.shape
+    cp_size = 1 if cp_group is None else torch.distributed.get_world_size(cp_group)
+    cp_rank = 0 if cp_group is None else torch.distributed.get_rank(cp_group)
+    cu = cu_seqlens_local.to(torch.long)
+    half_all = (cu[1:] - cu[:-1]) // 2
+    device = teacher.device
+
+    halo = gamma - 1
+    if halo > 0:
+        halo_rows = packed_zigzag_successor_halo(
+            teacher, cu, halo, cp_group if cp_size > 1 else None
+        )
+        extended = torch.cat([teacher, halo_rows.reshape(-1, vocab_local)], dim=0)
+    else:
+        extended = teacher
+
+    pos = anchors.unsqueeze(-1) + torch.arange(gamma, device=device).view(1, -1)
+    half = half_all[seq_idx].unsqueeze(-1)
+    anchor_chunk = (anchors // half_all[seq_idx]).unsqueeze(-1)
+    off = pos - anchor_chunk * half
+    is_front = anchor_chunk == cp_rank
+    local_row = cu[:-1][seq_idx].unsqueeze(-1) + torch.where(is_front, off, half + off)
+    halo_row = (
+        total_local
+        + (seq_idx.unsqueeze(-1) * 2 + torch.where(is_front, 0, 1)) * halo
+        + (off - half)
+    )
+    index = torch.where(off < half, local_row, halo_row)
+    return extended[index.reshape(-1)]
+
+
 class BlockDraftLossDataDict(TypedDict):
     draft_anchor_positions: Tensor
     draft_anchor_valid: Tensor
     token_mask: Tensor
     sample_mask: Tensor
+    draft_block_seq_idx: NotRequired[Tensor]
+    draft_packed_local_cu_seqlens: NotRequired[Tensor]
 
 
 class BlockDraftLossFn(LossFunction):
@@ -354,10 +421,12 @@ class BlockDraftLossFn(LossFunction):
         self,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         slot_weights: Optional[list[float]] = None,
+        context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         seq_chunk_size: int = 4096,
     ):
         self.vocab_parallel_group = vocab_parallel_group
         self.slot_weights = slot_weights
+        self.context_parallel_group = context_parallel_group
         self.seq_chunk_size = seq_chunk_size
 
     def __call__(
@@ -369,8 +438,7 @@ class BlockDraftLossFn(LossFunction):
         global_valid_toks: torch.Tensor,
         global_draft_pass_counts: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
-        batch_size, num_anchors, gamma, _ = student_block_logits.shape
-        seq_len = teacher_logits.shape[1]
+        gamma = student_block_logits.shape[-2]
         device = student_block_logits.device
 
         if self.slot_weights is not None and len(self.slot_weights) != gamma:
@@ -392,34 +460,63 @@ class BlockDraftLossFn(LossFunction):
         token_mask = data["token_mask"]
         sample_mask = data["sample_mask"]
 
-        # Teacher for slot j sits at position p + j (it predicts x_{p+1+j}).
-        teacher_pos = (
-            anchors.unsqueeze(-1) + torch.arange(gamma, device=device).view(1, 1, -1)
-        ).clamp(max=seq_len - 1)
-        gather_index = teacher_pos.reshape(batch_size, num_anchors * gamma, 1).expand(
-            -1, -1, teacher_logits.shape[-1]
-        )
-        teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
+        # Packed mode: the student is this rank's flat owned blocks
+        # [NB, gamma, V_local] and the teacher the rank-local packed row
+        # [1, T_local, V_local]; slot teachers gather via the successor-halo
+        # exchange. Unpacked mode flattens [B, N, ...] to the same [X, gamma]
+        # block-list core (teacher slots are plain [B, S] gathers).
+        packed = "draft_block_seq_idx" in data
+        if packed:
+            seq_idx = data["draft_block_seq_idx"]
+            teacher_block = _packed_block_teacher_gather(
+                teacher_logits.detach().squeeze(0),
+                seq_idx,
+                anchors,
+                gamma,
+                data["draft_packed_local_cu_seqlens"],
+                self.context_parallel_group,
+            )
+            num_blocks = anchors.shape[0]
+            slot_mask = block_draft_slot_mask_packed(
+                token_mask, sample_mask, seq_idx, anchors, anchor_valid, gamma=gamma
+            ).float()
+        else:
+            batch_size, num_anchors = anchors.shape
+            seq_len = teacher_logits.shape[1]
+            # Teacher for slot j sits at position p + j (it predicts x_{p+1+j}).
+            teacher_pos = (
+                anchors.unsqueeze(-1)
+                + torch.arange(gamma, device=device).view(1, 1, -1)
+            ).clamp(max=seq_len - 1)
+            gather_index = teacher_pos.reshape(
+                batch_size, num_anchors * gamma, 1
+            ).expand(-1, -1, teacher_logits.shape[-1])
+            teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
+            num_blocks = batch_size * num_anchors
+            slot_mask = (
+                block_draft_slot_mask(
+                    token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+                )
+                .float()
+                .reshape(num_blocks, gamma)
+            )
 
-        student_flat = student_block_logits.reshape(batch_size, num_anchors * gamma, -1)
+        student_flat = student_block_logits.reshape(1, num_blocks * gamma, -1)
         per_token_loss = ChunkedDistributedCrossEntropy.apply(
             student_flat,
-            teacher_block,
+            teacher_block.reshape(1, num_blocks * gamma, -1),
             self.seq_chunk_size,
             self.vocab_parallel_group,
             False,
-        ).reshape(batch_size, num_anchors, gamma)
+        ).reshape(num_blocks, gamma)
 
-        slot_mask = block_draft_slot_mask(
-            token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
-        ).float()
         weights = (
             torch.ones(gamma, device=device, dtype=torch.float32)
             if self.slot_weights is None
             else torch.tensor(self.slot_weights, device=device, dtype=torch.float32)
         )
 
-        per_slot_sum = (per_token_loss.float() * slot_mask).sum(dim=(0, 1))
+        per_slot_sum = (per_token_loss.float() * slot_mask).sum(dim=0)
         total = (per_slot_sum * weights).sum()
 
         if global_draft_pass_counts is not None:
@@ -431,6 +528,9 @@ class BlockDraftLossFn(LossFunction):
 
         metrics: dict[str, Any] = {}
         with torch.no_grad():
+            per_slot_metric = _cp_reduced_metric(
+                per_slot_sum.detach(), self.context_parallel_group
+            )
             for slot in range(gamma):
                 metric_denominator = (
                     slot_counts[slot]
@@ -439,8 +539,7 @@ class BlockDraftLossFn(LossFunction):
                 )
                 metrics[f"draft_loss_slot_{slot}"] = float(
                     (
-                        per_slot_sum[slot].detach()
-                        / torch.clamp(metric_denominator, min=1.0)
+                        per_slot_metric[slot] / torch.clamp(metric_denominator, min=1.0)
                     ).item()
                 )
 
@@ -455,6 +554,8 @@ class DSparkBlockLossDataDict(TypedDict):
     token_mask: torch.Tensor
     sample_mask: torch.Tensor
     draft_confidence_pred: torch.Tensor
+    draft_block_seq_idx: NotRequired[torch.Tensor]
+    draft_packed_local_cu_seqlens: NotRequired[torch.Tensor]
 
 
 class DSparkBlockLossFn(LossFunction):
@@ -481,6 +582,7 @@ class DSparkBlockLossFn(LossFunction):
         ce_loss_alpha: float = 0.1,
         tv_loss_alpha: float = 0.9,
         confidence_head_alpha: float = 1.0,
+        context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         seq_chunk_size: int = 4096,
     ):
         self.vocab_parallel_group = vocab_parallel_group
@@ -489,6 +591,7 @@ class DSparkBlockLossFn(LossFunction):
         self.ce_loss_alpha = float(ce_loss_alpha)
         self.tv_loss_alpha = float(tv_loss_alpha)
         self.confidence_head_alpha = float(confidence_head_alpha)
+        self.context_parallel_group = context_parallel_group
         self.seq_chunk_size = seq_chunk_size
 
     def __call__(
@@ -500,8 +603,7 @@ class DSparkBlockLossFn(LossFunction):
         global_valid_toks: torch.Tensor,
         global_draft_pass_counts: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
-        batch_size, num_anchors, gamma, vocab_local = student_block_logits.shape
-        seq_len = teacher_logits.shape[1]
+        gamma, vocab_local = student_block_logits.shape[-2:]
         device = student_block_logits.device
 
         if self.slot_weights is not None and len(self.slot_weights) != gamma:
@@ -523,18 +625,64 @@ class DSparkBlockLossFn(LossFunction):
         token_mask = data["token_mask"]
         sample_mask = data["sample_mask"]
         input_ids = data["input_ids"]
+        seq_len = input_ids.shape[1]
 
-        slot_offsets = torch.arange(gamma, device=device).view(1, 1, -1)
-        # Teacher for slot j sits at position p + j; its label is x_{p+1+j}.
-        teacher_pos = (anchors.unsqueeze(-1) + slot_offsets).clamp(max=seq_len - 1)
-        label_pos = (anchors.unsqueeze(-1) + 1 + slot_offsets).clamp(max=seq_len - 1)
-        gather_index = teacher_pos.reshape(batch_size, num_anchors * gamma, 1).expand(
-            -1, -1, vocab_local
-        )
-        teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
-        labels = torch.gather(
-            input_ids, 1, label_pos.reshape(batch_size, num_anchors * gamma)
-        )
+        # Packed mode: flat owned blocks + halo teacher gather; unpacked
+        # flattens [B, N, ...] onto the same [X, gamma] block-list core (see
+        # BlockDraftLossFn). Labels always come from the unpacked input_ids.
+        packed = "draft_block_seq_idx" in data
+        if packed:
+            seq_idx = data["draft_block_seq_idx"]
+            num_blocks = anchors.shape[0]
+            anchors_flat = anchors
+            teacher_block = _packed_block_teacher_gather(
+                teacher_logits.detach().squeeze(0),
+                seq_idx,
+                anchors_flat,
+                gamma,
+                data["draft_packed_local_cu_seqlens"],
+                self.context_parallel_group,
+            )
+            slot_mask = block_draft_slot_mask_packed(
+                token_mask,
+                sample_mask,
+                seq_idx,
+                anchors_flat,
+                anchor_valid,
+                gamma=gamma,
+            ).float()
+        else:
+            batch_size, num_anchors = anchors.shape
+            num_blocks = batch_size * num_anchors
+            slot_offsets = torch.arange(gamma, device=device).view(1, 1, -1)
+            # Teacher for slot j sits at position p + j.
+            teacher_pos = (anchors.unsqueeze(-1) + slot_offsets).clamp(max=seq_len - 1)
+            gather_index = teacher_pos.reshape(
+                batch_size, num_anchors * gamma, 1
+            ).expand(-1, -1, vocab_local)
+            teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
+            seq_idx = (
+                torch.arange(batch_size, device=device)
+                .unsqueeze(1)
+                .expand(-1, num_anchors)
+                .reshape(-1)
+            )
+            anchors_flat = anchors.reshape(-1)
+            slot_mask = (
+                block_draft_slot_mask(
+                    token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+                )
+                .float()
+                .reshape(num_blocks, gamma)
+            )
+
+        # Slot j's label is x_{p+1+j}, gathered from the unpacked ids.
+        label_pos = (
+            anchors_flat.reshape(-1).unsqueeze(-1)
+            + 1
+            + torch.arange(gamma, device=device).view(1, -1)
+        ).clamp(max=seq_len - 1)
+        labels = input_ids[seq_idx.unsqueeze(-1).expand(-1, gamma), label_pos]
 
         # Deferred import: dspark-path-only dependency.
         from nemo_rl.distributed.model_utils import ChunkedDistributedLabelCEAndTV
@@ -542,7 +690,7 @@ class DSparkBlockLossFn(LossFunction):
         # Flatten the batch dim into the chunked dim so the fp32 chunk
         # transients are bounded by chunk_size ROWS regardless of the
         # dynamic-batching batch size (the a512 OOM lesson).
-        total_rows = batch_size * num_anchors * gamma
+        total_rows = num_blocks * gamma
         per_token_ce, per_token_tv = ChunkedDistributedLabelCEAndTV.apply(
             student_block_logits.reshape(1, total_rows, vocab_local),
             teacher_block.reshape(1, total_rows, vocab_local),
@@ -552,12 +700,9 @@ class DSparkBlockLossFn(LossFunction):
             self.seq_chunk_size,
             self.vocab_parallel_group,
         )
-        per_token_ce = per_token_ce.reshape(batch_size, num_anchors, gamma)
-        per_token_tv = per_token_tv.reshape(batch_size, num_anchors, gamma)
+        per_token_ce = per_token_ce.reshape(num_blocks, gamma)
+        per_token_tv = per_token_tv.reshape(num_blocks, gamma)
 
-        slot_mask = block_draft_slot_mask(
-            token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
-        ).float()
         weights = (
             torch.ones(gamma, device=device, dtype=torch.float32)
             if self.slot_weights is None
@@ -571,7 +716,7 @@ class DSparkBlockLossFn(LossFunction):
         # TV acceptance rate per slot; training target for the confidence head.
         accept_rate = (1.0 - 0.5 * per_token_tv.detach()).clamp_(0.0, 1.0)
 
-        confidence_pred = data["draft_confidence_pred"]
+        confidence_pred = data["draft_confidence_pred"].reshape(num_blocks, gamma)
         confidence_bce = torch.nn.functional.binary_cross_entropy_with_logits(
             confidence_pred.float(), accept_rate, reduction="none"
         )
@@ -593,24 +738,47 @@ class DSparkBlockLossFn(LossFunction):
 
         metrics: dict[str, Any] = {}
         with torch.no_grad():
-            metrics["dspark_ce_loss"] = float((ce_sum / denominator).item())
-            metrics["dspark_tv_loss"] = float((tv_sum / denominator).item())
-            metrics["dspark_confidence_loss"] = float(
-                (confidence_sum / denominator).item()
-            )
+            cp_group = self.context_parallel_group
             confidence_error = (
                 torch.sigmoid(confidence_pred.float()) - accept_rate
             ) * weighted_mask
-            metrics["dspark_confidence_abs_error"] = float(
-                (confidence_error.abs().sum() / denominator).item()
-            )
-            metrics["dspark_confidence_bias"] = float(
-                (confidence_error.sum() / denominator).item()
-            )
-
             valid_accept = accept_rate * slot_mask
-            per_slot_ce_sum = (per_token_ce.float() * slot_mask).sum(dim=(0, 1))
-            per_slot_accept_sum = valid_accept.sum(dim=(0, 1))
+            # Expected accepted tokens per block (+1 bonus token), the
+            # probabilistic tau of the DeepSpec logs. Invalid slots zero the
+            # cumprod tail, matching the official eval_mask semantics. Valid
+            # blocks == slot-0-valid blocks (anchor candidates require a
+            # trained first label).
+            tau_per_block = 1.0 + valid_accept.cumprod(dim=-1).sum(dim=-1)
+            sums = _cp_reduced_metric(
+                torch.stack(
+                    [
+                        ce_sum.detach(),
+                        tv_sum.detach(),
+                        confidence_sum.detach(),
+                        confidence_error.abs().sum(),
+                        confidence_error.sum(),
+                        (tau_per_block * slot_mask[:, 0]).sum(),
+                    ]
+                ),
+                cp_group,
+            )
+            metrics["dspark_ce_loss"] = float((sums[0] / denominator).item())
+            metrics["dspark_tv_loss"] = float((sums[1] / denominator).item())
+            metrics["dspark_confidence_loss"] = float((sums[2] / denominator).item())
+            metrics["dspark_confidence_abs_error"] = float(
+                (sums[3] / denominator).item()
+            )
+            metrics["dspark_confidence_bias"] = float((sums[4] / denominator).item())
+
+            per_slot = _cp_reduced_metric(
+                torch.stack(
+                    [
+                        (per_token_ce.float() * slot_mask).sum(dim=0),
+                        valid_accept.sum(dim=0),
+                    ]
+                ),
+                cp_group,
+            )
             for slot in range(gamma):
                 metric_denominator = torch.clamp(
                     slot_counts[slot]
@@ -619,26 +787,19 @@ class DSparkBlockLossFn(LossFunction):
                     min=1.0,
                 )
                 metrics[f"draft_loss_slot_{slot}"] = float(
-                    (per_slot_ce_sum[slot] / metric_denominator).item()
+                    (per_slot[0, slot] / metric_denominator).item()
                 )
                 metrics[f"accept_rate_slot_{slot}"] = float(
-                    (per_slot_accept_sum[slot] / metric_denominator).item()
+                    (per_slot[1, slot] / metric_denominator).item()
                 )
 
-            # Expected accepted tokens per block (+1 bonus token), the
-            # probabilistic tau of the DeepSpec logs. Invalid slots zero the
-            # cumprod tail, matching the official eval_mask semantics. Valid
-            # blocks == slot-0-valid blocks (anchor candidates require a
-            # trained first label).
-            tau_per_block = 1.0 + valid_accept.cumprod(dim=-1).sum(dim=-1)
-            tau_sum = (tau_per_block * slot_mask[:, :, 0]).sum()
             block_count = (
                 float(slot_counts[0].item())
                 if slot_counts is not None
                 else float(tau_per_block.numel())
             )
             metrics["dspark_tau_probabilistic"] = float(
-                (tau_sum / max(block_count, 1.0)).item()
+                (sums[5] / max(block_count, 1.0)).item()
             )
 
         return loss, metrics

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -330,7 +330,7 @@ class BlockDraftLossDataDict(TypedDict):
 
 
 class BlockDraftLossFn(LossFunction):
-    """Soft-target cross-entropy for DFlash block draft training.
+    """Soft-target cross-entropy for DFlash/DSpark block draft training.
 
     Slot ``j`` of a block anchored at ``p`` predicts ``x_{p + 1 + j}``; its
     soft target is the (detached) policy logits at position ``p + j``. Both
@@ -445,6 +445,202 @@ class BlockDraftLossFn(LossFunction):
                 )
 
         loss = total / torch.clamp(denominator, min=1.0)
+        return loss, metrics
+
+
+class DSparkBlockLossDataDict(TypedDict):
+    input_ids: torch.Tensor
+    draft_anchor_positions: torch.Tensor
+    draft_anchor_valid: torch.Tensor
+    token_mask: torch.Tensor
+    sample_mask: torch.Tensor
+    draft_confidence_pred: torch.Tensor
+
+
+class DSparkBlockLossFn(LossFunction):
+    """DeepSpec's official DSpark loss (deepspec/modeling/dspark/loss.py).
+
+    Per slot ``j`` of a block anchored at ``p``:
+    ``loss = ce_loss_alpha * CE(draft logits, x_{p+1+j})
+    + tv_loss_alpha * sum_v |softmax(draft) - softmax(teacher at p+j)|
+    + confidence_head_alpha * BCE(confidence pred, accept)`` where
+    ``accept = clamp(1 - tv/2, 0, 1)`` is the TV acceptance rate (detached).
+    All terms share the weighted mask (slot validity x ``slot_weights``) in
+    numerator and (DP-global, via ``global_draft_pass_counts``) denominator —
+    the same normalization contract as :class:`BlockDraftLossFn`.
+    """
+
+    loss_type = LossType.TOKEN_LEVEL
+    input_type = LossInputType.DRAFT
+
+    def __init__(
+        self,
+        vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        vocab_parallel_rank: Optional[int] = None,
+        slot_weights: Optional[list[float]] = None,
+        ce_loss_alpha: float = 0.1,
+        tv_loss_alpha: float = 0.9,
+        confidence_head_alpha: float = 1.0,
+        seq_chunk_size: int = 4096,
+    ):
+        self.vocab_parallel_group = vocab_parallel_group
+        self.vocab_parallel_rank = int(vocab_parallel_rank or 0)
+        self.slot_weights = slot_weights
+        self.ce_loss_alpha = float(ce_loss_alpha)
+        self.tv_loss_alpha = float(tv_loss_alpha)
+        self.confidence_head_alpha = float(confidence_head_alpha)
+        self.seq_chunk_size = seq_chunk_size
+
+    def __call__(
+        self,
+        teacher_logits: torch.Tensor,
+        student_block_logits: torch.Tensor,
+        data: BatchedDataDict[DSparkBlockLossDataDict],
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        batch_size, num_anchors, gamma, vocab_local = student_block_logits.shape
+        seq_len = teacher_logits.shape[1]
+        device = student_block_logits.device
+
+        if self.slot_weights is not None and len(self.slot_weights) != gamma:
+            raise ValueError(
+                f"slot_weights has {len(self.slot_weights)} entries but the "
+                f"draft produced gamma={gamma} slots."
+            )
+        if (
+            global_draft_pass_counts is not None
+            and global_draft_pass_counts.shape[0] != gamma
+        ):
+            raise ValueError(
+                f"global_draft_pass_counts has {global_draft_pass_counts.shape[0]} "
+                f"entries but the draft produced gamma={gamma} slots."
+            )
+
+        anchors = data["draft_anchor_positions"]
+        anchor_valid = data["draft_anchor_valid"]
+        token_mask = data["token_mask"]
+        sample_mask = data["sample_mask"]
+        input_ids = data["input_ids"]
+
+        slot_offsets = torch.arange(gamma, device=device).view(1, 1, -1)
+        # Teacher for slot j sits at position p + j; its label is x_{p+1+j}.
+        teacher_pos = (anchors.unsqueeze(-1) + slot_offsets).clamp(max=seq_len - 1)
+        label_pos = (anchors.unsqueeze(-1) + 1 + slot_offsets).clamp(max=seq_len - 1)
+        gather_index = teacher_pos.reshape(batch_size, num_anchors * gamma, 1).expand(
+            -1, -1, vocab_local
+        )
+        teacher_block = torch.gather(teacher_logits.detach(), 1, gather_index)
+        labels = torch.gather(
+            input_ids, 1, label_pos.reshape(batch_size, num_anchors * gamma)
+        )
+
+        # Deferred import: dspark-path-only dependency.
+        from nemo_rl.distributed.model_utils import ChunkedDistributedLabelCEAndTV
+
+        # Flatten the batch dim into the chunked dim so the fp32 chunk
+        # transients are bounded by chunk_size ROWS regardless of the
+        # dynamic-batching batch size (the a512 OOM lesson).
+        total_rows = batch_size * num_anchors * gamma
+        per_token_ce, per_token_tv = ChunkedDistributedLabelCEAndTV.apply(
+            student_block_logits.reshape(1, total_rows, vocab_local),
+            teacher_block.reshape(1, total_rows, vocab_local),
+            labels.reshape(1, total_rows),
+            self.vocab_parallel_rank * vocab_local,
+            (self.vocab_parallel_rank + 1) * vocab_local,
+            self.seq_chunk_size,
+            self.vocab_parallel_group,
+        )
+        per_token_ce = per_token_ce.reshape(batch_size, num_anchors, gamma)
+        per_token_tv = per_token_tv.reshape(batch_size, num_anchors, gamma)
+
+        slot_mask = block_draft_slot_mask(
+            token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+        ).float()
+        weights = (
+            torch.ones(gamma, device=device, dtype=torch.float32)
+            if self.slot_weights is None
+            else torch.tensor(self.slot_weights, device=device, dtype=torch.float32)
+        )
+        weighted_mask = slot_mask * weights
+
+        ce_sum = (per_token_ce.float() * weighted_mask).sum()
+        tv_sum = (per_token_tv.float() * weighted_mask).sum()
+
+        # TV acceptance rate per slot; training target for the confidence head.
+        accept_rate = (1.0 - 0.5 * per_token_tv.detach()).clamp_(0.0, 1.0)
+
+        confidence_pred = data["draft_confidence_pred"]
+        confidence_bce = torch.nn.functional.binary_cross_entropy_with_logits(
+            confidence_pred.float(), accept_rate, reduction="none"
+        )
+        confidence_sum = (confidence_bce * weighted_mask).sum()
+
+        if global_draft_pass_counts is not None:
+            slot_counts = global_draft_pass_counts.float()
+            denominator = (weights * slot_counts).sum()
+        else:
+            slot_counts = None
+            denominator = global_valid_toks.float()
+        denominator = torch.clamp(denominator, min=1.0)
+
+        loss = (
+            self.ce_loss_alpha * ce_sum
+            + self.tv_loss_alpha * tv_sum
+            + self.confidence_head_alpha * confidence_sum
+        ) / denominator
+
+        metrics: dict[str, Any] = {}
+        with torch.no_grad():
+            metrics["dspark_ce_loss"] = float((ce_sum / denominator).item())
+            metrics["dspark_tv_loss"] = float((tv_sum / denominator).item())
+            metrics["dspark_confidence_loss"] = float(
+                (confidence_sum / denominator).item()
+            )
+            confidence_error = (
+                torch.sigmoid(confidence_pred.float()) - accept_rate
+            ) * weighted_mask
+            metrics["dspark_confidence_abs_error"] = float(
+                (confidence_error.abs().sum() / denominator).item()
+            )
+            metrics["dspark_confidence_bias"] = float(
+                (confidence_error.sum() / denominator).item()
+            )
+
+            valid_accept = accept_rate * slot_mask
+            per_slot_ce_sum = (per_token_ce.float() * slot_mask).sum(dim=(0, 1))
+            per_slot_accept_sum = valid_accept.sum(dim=(0, 1))
+            for slot in range(gamma):
+                metric_denominator = torch.clamp(
+                    slot_counts[slot]
+                    if slot_counts is not None
+                    else global_valid_toks.float(),
+                    min=1.0,
+                )
+                metrics[f"draft_loss_slot_{slot}"] = float(
+                    (per_slot_ce_sum[slot] / metric_denominator).item()
+                )
+                metrics[f"accept_rate_slot_{slot}"] = float(
+                    (per_slot_accept_sum[slot] / metric_denominator).item()
+                )
+
+            # Expected accepted tokens per block (+1 bonus token), the
+            # probabilistic tau of the DeepSpec logs. Invalid slots zero the
+            # cumprod tail, matching the official eval_mask semantics. Valid
+            # blocks == slot-0-valid blocks (anchor candidates require a
+            # trained first label).
+            tau_per_block = 1.0 + valid_accept.cumprod(dim=-1).sum(dim=-1)
+            tau_sum = (tau_per_block * slot_mask[:, :, 0]).sum()
+            block_count = (
+                float(slot_counts[0].item())
+                if slot_counts is not None
+                else float(tau_per_block.numel())
+            )
+            metrics["dspark_tau_probabilistic"] = float(
+                (tau_sum / max(block_count, 1.0)).item()
+            )
+
         return loss, metrics
 
 

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -45,6 +45,7 @@ def map_teacher_logits_to_draft_vocab(
     d2t: Optional[torch.Tensor],
     vocab_parallel_rank: Optional[int] = None,
     vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+    seq_chunk_size: Optional[int] = None,
 ) -> torch.Tensor:
     """Restrict full-vocab teacher logits to the draft vocabulary via ``d2t``.
 
@@ -53,6 +54,10 @@ def map_teacher_logits_to_draft_vocab(
     are gathered to the full vocab and re-sliced to this rank's shard of the
     draft vocabulary (the draft output layer is sharded the same way). No-op
     when ``d2t`` is None (full-vocab drafts).
+
+    ``seq_chunk_size`` gathers and subsets in sequence chunks instead of all at
+    once: the full ``[B, S, V_full]`` gather peaks at several GiB at long
+    sequence lengths while only the ``[B, S, draft_vocab/tp]`` subset survives.
     """
     if d2t is None:
         return teacher_logits
@@ -64,15 +69,37 @@ def map_teacher_logits_to_draft_vocab(
             gather_from_tensor_model_parallel_region,
         )
 
-        teacher_logits = gather_from_tensor_model_parallel_region(
-            teacher_logits, vocab_parallel_group
-        )
         tp_size = torch.distributed.get_world_size(vocab_parallel_group)
         local_draft_size = len(d2t) // tp_size
         assert vocab_parallel_rank is not None
         start_index = vocab_parallel_rank * local_draft_size
         end_index = (vocab_parallel_rank + 1) * local_draft_size
         reverse_mapping = reverse_mapping[start_index:end_index]
+
+        if seq_chunk_size is None:
+            teacher_logits = gather_from_tensor_model_parallel_region(
+                teacher_logits, vocab_parallel_group
+            )
+        else:
+            batch_size, seq_size = teacher_logits.shape[:2]
+            subset_teacher = torch.empty(
+                batch_size,
+                seq_size,
+                reverse_mapping.shape[0],
+                dtype=teacher_logits.dtype,
+                device=teacher_logits.device,
+            )
+            for chunk_start in range(0, seq_size, seq_chunk_size):
+                chunk_end = min(seq_size, chunk_start + seq_chunk_size)
+                gathered_chunk = gather_from_tensor_model_parallel_region(
+                    teacher_logits[:, chunk_start:chunk_end].contiguous(),
+                    vocab_parallel_group,
+                )
+                subset_teacher[:, chunk_start:chunk_end] = gathered_chunk[
+                    :, :, reverse_mapping
+                ]
+                del gathered_chunk
+            return subset_teacher
     return teacher_logits[:, :, reverse_mapping]
 
 
@@ -337,10 +364,77 @@ def prepare_loss_input(
             "token_mask": token_mask,
         }
 
+    elif loss_fn.input_type == LossInputType.DRAFT_TTT:
+        # Multi-pass convention: pass-d student logits z^d_i predict x_{i+d+1},
+        # so the matching teacher is the policy's logits at position i+d. The
+        # teacher stays UNSHIFTED here — DraftTTTCrossEntropyLossFn slices it
+        # per pass (pure views) and builds the shifted masks with
+        # draft_pass_token_mask. Slicing replaces the CP-aware roll, so this
+        # path requires CP == 1.
+        if (
+            context_parallel_group is not None
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size(context_parallel_group) > 1
+        ):
+            raise NotImplementedError(
+                "Multi-pass draft distillation requires context_parallel_size == 1."
+            )
+        teacher_logits = map_teacher_logits_to_draft_vocab(
+            logits.detach(),
+            d2t,
+            vocab_parallel_rank=vocab_parallel_rank,
+            vocab_parallel_group=vocab_parallel_group,
+            seq_chunk_size=loss_fn.seq_chunk_size,
+        )
+        loss_input = {
+            "teacher_logits": teacher_logits,
+            "student_logits_by_pass": list(data["student_logits_by_pass"]),
+        }
+
     else:
         raise ValueError(f"Unknown loss function input type: {loss_fn.input_type}")
 
     return loss_input, data
+
+
+def draft_pass_token_mask(token_mask: torch.Tensor, ttt_pass: int) -> torch.Tensor:
+    """Per-pass draft loss mask (before the sample_mask factor).
+
+    Pass ``d`` position ``i`` predicts token ``x_{i+d+1}``, so its validity is
+    ``token_mask[i + d + 1]``: a left shift by ``d + 1`` that also drops the
+    out-of-bounds tail. Returned shape is ``[B, S - d - 1]``, aligned with the
+    ``student[:, :S-d-1]`` / ``teacher[:, d:S-1]`` slices used by
+    ``DraftCrossEntropyLossFn``.
+    """
+    return token_mask[:, ttt_pass + 1 :]
+
+
+def compute_draft_pass_valid_counts(
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    *,
+    ttt_steps: int,
+) -> torch.Tensor:
+    """Local per-pass valid-token counts for the draft TTT loss.
+
+    Returns a fp32 tensor of shape ``[ttt_steps]`` where entry ``d-1`` is this
+    rank's ``#valid pass-d targets``. The caller must all-reduce it over the
+    data-parallel group (and only DP: every CP/TP rank computes the loss over
+    the full sequence/vocab, so reducing over those groups would double-count).
+
+    The loss consumes the vector twice: the gradient denominator is
+    ``sum_d alpha_d * counts[d-1]``, and the per-pass diagnostic metrics divide
+    by ``counts[d-1]`` so that the driver's sum-over-microbatches aggregation
+    (grpo.py logs mb-metric lists with ``np.sum``) reconstructs the global
+    per-token mean instead of summing per-microbatch means.
+    """
+    counts = token_mask.new_zeros((ttt_steps,), dtype=torch.float32)
+    for ttt_pass in range(1, ttt_steps + 1):
+        pass_mask = draft_pass_token_mask(token_mask, ttt_pass) * sample_mask.unsqueeze(
+            -1
+        )
+        counts[ttt_pass - 1] = pass_mask.sum().float()
+    return counts
 
 
 def _pack_input_ids(

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -445,7 +445,7 @@ def block_draft_slot_mask(
     *,
     gamma: int,
 ) -> torch.Tensor:
-    """Validity mask ``[B, N, gamma]`` for DFlash block draft slots.
+    """Validity mask ``[B, N, gamma]`` for DFlash/DSpark block draft slots.
 
     Slot ``j`` of a block anchored at ``p`` predicts ``x_{p + 1 + j}``; it is
     valid when the block is real (``anchor_valid``), the label position is in

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+import torch.distributed
 
 from nemo_rl.algorithms.logits_sampling_utils import (
     TrainingSamplingParams,
@@ -38,116 +39,6 @@ if TYPE_CHECKING:
     from nemo_automodel.components.distributed.context_parallel import (
         ContextParallelSharder,
     )
-
-
-def map_teacher_logits_to_draft_vocab(
-    teacher_logits: torch.Tensor,
-    d2t: Optional[torch.Tensor],
-    vocab_parallel_rank: Optional[int] = None,
-    vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
-    seq_chunk_size: Optional[int] = None,
-) -> torch.Tensor:
-    """Restrict full-vocab teacher logits to the draft vocabulary via ``d2t``.
-
-    ``d2t`` maps draft-vocab index ``i`` to target-vocab index ``i + d2t[i]``.
-    Under tensor parallelism the teacher logits arrive vocab-sharded, so they
-    are gathered to the full vocab and re-sliced to this rank's shard of the
-    draft vocabulary (the draft output layer is sharded the same way). No-op
-    when ``d2t`` is None (full-vocab drafts).
-
-    ``seq_chunk_size`` gathers and subsets in sequence chunks instead of all at
-    once: the full ``[B, S, V_full]`` gather peaks at several GiB at long
-    sequence lengths while only the ``[B, S, draft_vocab/tp]`` subset survives.
-    """
-    if d2t is None:
-        return teacher_logits
-    reverse_mapping = (
-        torch.arange(len(d2t), device=teacher_logits.device, dtype=d2t.dtype) + d2t
-    )
-    if vocab_parallel_group is not None:
-        from megatron.core.tensor_parallel import (
-            gather_from_tensor_model_parallel_region,
-        )
-
-        tp_size = torch.distributed.get_world_size(vocab_parallel_group)
-        local_draft_size = len(d2t) // tp_size
-        assert vocab_parallel_rank is not None
-        start_index = vocab_parallel_rank * local_draft_size
-        end_index = (vocab_parallel_rank + 1) * local_draft_size
-        reverse_mapping = reverse_mapping[start_index:end_index]
-
-        if seq_chunk_size is None:
-            teacher_logits = gather_from_tensor_model_parallel_region(
-                teacher_logits, vocab_parallel_group
-            )
-        else:
-            batch_size, seq_size = teacher_logits.shape[:2]
-            subset_teacher = torch.empty(
-                batch_size,
-                seq_size,
-                reverse_mapping.shape[0],
-                dtype=teacher_logits.dtype,
-                device=teacher_logits.device,
-            )
-            for chunk_start in range(0, seq_size, seq_chunk_size):
-                chunk_end = min(seq_size, chunk_start + seq_chunk_size)
-                gathered_chunk = gather_from_tensor_model_parallel_region(
-                    teacher_logits[:, chunk_start:chunk_end].contiguous(),
-                    vocab_parallel_group,
-                )
-                subset_teacher[:, chunk_start:chunk_end] = gathered_chunk[
-                    :, :, reverse_mapping
-                ]
-                del gathered_chunk
-            return subset_teacher
-    return teacher_logits[:, :, reverse_mapping]
-
-
-def roll_packed_seq_dim(
-    tensor: torch.Tensor,
-    cu_seqlens_padded: torch.Tensor,
-    seq_dim: int,
-) -> torch.Tensor:
-    """Left-shift a packed tensor by one along ``seq_dim`` within each segment.
-
-    Equivalent to a per-sequence ``torch.roll(shifts=-1)`` over the packed
-    layout: one global roll followed by zeroing each segment's final slot (the
-    only positions where the global roll would leak the next segment's first
-    row). Segment boundaries come from ``cu_seqlens_padded``, the physical
-    offsets of the packed layout.
-    """
-    rolled = torch.roll(tensor, shifts=-1, dims=seq_dim)
-    boundary_index = (cu_seqlens_padded[1:] - 1).to(
-        dtype=torch.long, device=rolled.device
-    )
-    index: list[Any] = [slice(None)] * rolled.dim()
-    index[seq_dim] = boundary_index
-    rolled[tuple(index)] = 0
-    return rolled
-
-
-def pack_rolled_draft_token_mask(
-    token_mask: torch.Tensor,
-    sample_mask: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    cu_seqlens_padded: torch.Tensor,
-) -> torch.Tensor:
-    """Build the packed draft-loss mask ``[1, T_packed]`` from unpacked masks.
-
-    Mirrors the non-packed DRAFT prepare (``token_mask`` left-shifted by one,
-    scaled by ``sample_mask``), laid out at each sequence's padded offset.
-    Each sequence's last real slot (whose shifted target would cross the
-    boundary) and all padding slots stay zero.
-
-    Reuses ``_pack_input_ids`` for the padded-offset layout (including its
-    clamp for bin-alignment padding absorbed into the last sequence's
-    effective length) and ``roll_packed_seq_dim`` for the boundary-safe
-    per-segment left shift.
-    """
-    packed = _pack_input_ids(
-        token_mask * sample_mask.unsqueeze(-1), cu_seqlens, cu_seqlens_padded
-    )
-    return roll_packed_seq_dim(packed, cu_seqlens_padded, seq_dim=1)
 
 
 def prepare_loss_input(
@@ -341,60 +232,303 @@ def prepare_loss_input(
                 ).contiguous(),
             )
     elif loss_fn.input_type == LossInputType.DRAFT:
-        from megatron.core.transformer.multi_token_prediction import roll_tensor
-
-        teacher_logits = roll_tensor(
-            logits.detach(),
-            shifts=-1,
-            dims=1,
-            cp_group=context_parallel_group,
-        )[0]
-        token_mask = roll_tensor(
-            data["token_mask"], shifts=-1, dims=1, cp_group=context_parallel_group
-        )[0]
-        teacher_logits = map_teacher_logits_to_draft_vocab(
-            teacher_logits,
-            d2t,
-            vocab_parallel_rank=vocab_parallel_rank,
-            vocab_parallel_group=vocab_parallel_group,
-        )
-        loss_input = {
-            "teacher_logits": teacher_logits,
-            "student_logits": data["student_logits"],
-            "token_mask": token_mask,
-        }
-
-    elif loss_fn.input_type == LossInputType.DRAFT_TTT:
-        # Multi-pass convention: pass-d student logits z^d_i predict x_{i+d+1},
-        # so the matching teacher is the policy's logits at position i+d. The
-        # teacher stays UNSHIFTED here — DraftTTTCrossEntropyLossFn slices it
-        # per pass (pure views) and builds the shifted masks with
-        # draft_pass_token_mask. Slicing replaces the CP-aware roll, so this
-        # path requires CP == 1.
+        # TTT convention: pass-d student logits z^d_i predict x_{i+d+1}; the
+        # matching teacher is the policy's logits at position i+d. The teacher
+        # stays UNSHIFTED here. In the unpacked path the loss fn slices per
+        # pass (pure views), which requires every rank to see the full
+        # sequence (CP == 1). In the packed path the loss fn instead rolls
+        # the teacher per subsequence with the CP-aware boundary exchange, so
+        # CP > 1 is allowed there (the train loop stashes the packed zigzag
+        # coords the loss needs).
         if (
             context_parallel_group is not None
             and torch.distributed.is_initialized()
             and torch.distributed.get_world_size(context_parallel_group) > 1
+            and "draft_packed_pos_in_seq" not in data
         ):
             raise NotImplementedError(
-                "Multi-pass draft distillation requires context_parallel_size == 1."
+                "Draft distillation loss requires context_parallel_size == 1 "
+                "unless sequence packing is enabled."
             )
-        teacher_logits = map_teacher_logits_to_draft_vocab(
-            logits.detach(),
-            d2t,
-            vocab_parallel_rank=vocab_parallel_rank,
-            vocab_parallel_group=vocab_parallel_group,
-            seq_chunk_size=loss_fn.seq_chunk_size,
-        )
+        teacher_logits = logits.detach()
+        if d2t is not None:
+            reverse_mapping = (
+                torch.arange(len(d2t), device=teacher_logits.device, dtype=d2t.dtype)
+                + d2t
+            )
+            if vocab_parallel_group is not None:
+                from megatron.core.tensor_parallel import (
+                    gather_from_tensor_model_parallel_region,
+                )
+
+                tp_size = torch.distributed.get_world_size(vocab_parallel_group)
+                local_draft_size = len(d2t) // tp_size
+                assert vocab_parallel_rank is not None
+                start_index = vocab_parallel_rank * local_draft_size
+                end_index = (vocab_parallel_rank + 1) * local_draft_size
+                reverse_mapping = reverse_mapping[start_index:end_index]
+
+                # Gather + d2t-subset in sequence chunks: gathering the whole
+                # [B, S, V_full] teacher at once peaks at several GiB at long
+                # sequence lengths, while only the [B, S, draft_vocab/tp]
+                # subset survives.
+                batch_size, seq_size = teacher_logits.shape[:2]
+                subset_teacher = torch.empty(
+                    batch_size,
+                    seq_size,
+                    reverse_mapping.shape[0],
+                    dtype=teacher_logits.dtype,
+                    device=teacher_logits.device,
+                )
+                for chunk_start in range(0, seq_size, loss_fn.seq_chunk_size):
+                    chunk_end = min(seq_size, chunk_start + loss_fn.seq_chunk_size)
+                    gathered_chunk = gather_from_tensor_model_parallel_region(
+                        teacher_logits[:, chunk_start:chunk_end].contiguous(),
+                        vocab_parallel_group,
+                    )
+                    subset_teacher[:, chunk_start:chunk_end] = gathered_chunk[
+                        :, :, reverse_mapping
+                    ]
+                    del gathered_chunk
+                teacher_logits = subset_teacher
+            else:
+                teacher_logits = teacher_logits[:, :, reverse_mapping]
+        if "student_logits_by_pass" in data:
+            student_logits_by_pass = list(data["student_logits_by_pass"])
+        else:
+            student_logits_by_pass = [data["student_logits"]]
         loss_input = {
             "teacher_logits": teacher_logits,
-            "student_logits_by_pass": list(data["student_logits_by_pass"]),
+            "student_logits_by_pass": student_logits_by_pass,
         }
 
     else:
         raise ValueError(f"Unknown loss function input type: {loss_fn.input_type}")
 
     return loss_input, data
+
+
+def roll_packed_left_cp(
+    tensor: torch.Tensor,
+    cu_seqlens_local: torch.Tensor,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Left-shift by one WITHIN each packed subsequence, zigzag-CP-aware.
+
+    ``tensor``'s dim 0 is the rank-local packed (THD) dimension and
+    ``cu_seqlens_local`` its subsequence boundaries. Without CP each
+    subsequence rolls independently with its tail zero-filled. Under CP the
+    local row of every subsequence is the zigzag pair ``[chunk_r,
+    chunk_{2cp-1-r}]`` (the ``_get_tokens_on_this_cp_rank`` layout), so each
+    chunk rolls locally and its tail element is the head of the globally NEXT
+    chunk: chunk ``r``'s successor lives on rank ``r+1`` (or is this rank's
+    own back chunk when ``r == cp-1``), chunk ``2cp-1-r``'s successor on rank
+    ``r-1`` (or is the global sequence tail, zero, when ``r == 0``). All
+    subsequences' boundary elements travel in ONE batched isend/irecv.
+    """
+    cp_size = 1 if cp_group is None else cp_group.size()
+    cu = cu_seqlens_local.to(dtype=torch.long)
+    seq_lens = cu[1:] - cu[:-1]
+
+    # Global roll first, then patch every chunk-tail row (which the global
+    # roll filled with the next chunk's head IN LOCAL LAYOUT — wrong across
+    # subsequence/zigzag boundaries).
+    rolled = torch.roll(tensor, shifts=-1, dims=0)
+
+    if cp_size == 1:
+        rolled[cu[1:] - 1] = 0
+        return rolled
+
+    cp_rank = cp_group.rank()
+    global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+    next_rank = global_ranks[(cp_rank + 1) % cp_size]
+    prev_rank = global_ranks[(cp_rank - 1) % cp_size]
+
+    half = seq_lens // 2
+    front_head = cu[:-1]
+    back_head = cu[:-1] + half
+    front_tail = back_head - 1
+    back_tail = cu[1:] - 1
+
+    send_to_prev = tensor[front_head]  # prev's front-chunk tails need these
+    send_to_next = tensor[back_head]  # next's back-chunk tails need these
+    recv_from_next = torch.empty_like(send_to_prev)
+    recv_from_prev = torch.empty_like(send_to_next)
+
+    ops = []
+    if cp_rank > 0:
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.isend, send_to_prev, prev_rank, cp_group
+            )
+        )
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.irecv, recv_from_prev, prev_rank, cp_group
+            )
+        )
+    if cp_rank < cp_size - 1:
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.isend, send_to_next, next_rank, cp_group
+            )
+        )
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.irecv, recv_from_next, next_rank, cp_group
+            )
+        )
+    if ops:
+        for req in torch.distributed.batch_isend_irecv(ops):
+            req.wait()
+    if cp_rank == cp_size - 1:
+        # Chunk cp-1's global successor is chunk cp — this rank's own back chunk.
+        recv_from_next = tensor[back_head]
+    if cp_rank == 0:
+        # Chunk 2cp-1 is the global sequence tail.
+        recv_from_prev = torch.zeros_like(recv_from_prev)
+
+    rolled[front_tail] = recv_from_next
+    rolled[back_tail] = recv_from_prev
+    return rolled
+
+
+def packed_zigzag_token_coords(
+    cu_seqlens_global: torch.Tensor,
+    cp_rank: int,
+    cp_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map each rank-local packed token to ``(subseq index, global position)``.
+
+    ``cu_seqlens_global`` holds the PRE-CP padded boundaries. The local
+    layout is the per-subsequence zigzag (`_get_tokens_on_this_cp_rank`):
+    rank ``r`` holds chunks ``r`` and ``2*cp - 1 - r`` of every subsequence.
+    Returns two ``[T_local]`` int64 tensors: the packed subsequence index
+    (== the pre-packing batch row) and the token's position WITHIN its
+    subsequence in the original (un-sharded) order. Pure local arithmetic,
+    no communication — the basis for gathering per-token masks/labels from
+    unpacked ``[B, S]`` tensors.
+    """
+    cu = cu_seqlens_global.to(dtype=torch.long)
+    lens_local = (cu[1:] - cu[:-1]) // cp_size
+    num_seqs = lens_local.numel()
+    device = cu.device
+    cu_local = torch.zeros(num_seqs + 1, dtype=torch.long, device=device)
+    cu_local[1:] = torch.cumsum(lens_local, dim=0)
+    seq_index = torch.repeat_interleave(
+        torch.arange(num_seqs, device=device), lens_local
+    )
+    pos_local = (
+        torch.arange(int(cu_local[-1].item()), device=device) - cu_local[:-1][seq_index]
+    )
+    if cp_size == 1:
+        return seq_index, pos_local
+    half = (lens_local // 2)[seq_index]
+    is_front = pos_local < half
+    pos_global = torch.where(
+        is_front,
+        cp_rank * half + pos_local,
+        (2 * cp_size - 1 - cp_rank) * half + (pos_local - half),
+    )
+    return seq_index, pos_global
+
+
+def packed_zigzag_local_index(
+    seq_idx: torch.Tensor,
+    pos: torch.Tensor,
+    cu_seqlens_local: torch.Tensor,
+    cp_rank: int,
+    cp_size: int,
+) -> torch.Tensor:
+    """Rank-local THD row of ``(subseq, global in-seq position)``.
+
+    The caller guarantees this rank owns each position's zigzag chunk
+    (``pos // half in {cp_rank, 2*cp - 1 - cp_rank}``).
+    """
+    cu = cu_seqlens_local.to(dtype=torch.long)
+    half = ((cu[1:] - cu[:-1]) // 2)[seq_idx]
+    front_off = pos - cp_rank * half
+    is_front = (front_off >= 0) & (front_off < half)
+    back_off = pos - (2 * cp_size - 1 - cp_rank) * half
+    return cu[:-1][seq_idx] + torch.where(is_front, front_off, half + back_off)
+
+
+def packed_zigzag_successor_halo(
+    tensor: torch.Tensor,
+    cu_seqlens_local: torch.Tensor,
+    halo: int,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """First ``halo`` rows of each local chunk's globally NEXT chunk.
+
+    ``tensor``'s dim 0 is the rank-local zigzag THD row. Returns
+    ``[num_seqs, 2, halo, ...]`` (index 0 = front chunk's successor, 1 = back
+    chunk's). Same neighbor pattern as :func:`roll_packed_left_cp`: front
+    chunk ``r``'s successor is rank ``r+1``'s front chunk head (``r == cp-1``:
+    this rank's own back chunk), back chunk ``2cp-1-r``'s successor is rank
+    ``r-1``'s back chunk head (``r == 0``: past the sequence end, zeros).
+    Requires ``halo <= min(half)`` — a successor chunk must cover the halo.
+    """
+    cp_size = 1 if cp_group is None else cp_group.size()
+    cu = cu_seqlens_local.to(dtype=torch.long)
+    half = (cu[1:] - cu[:-1]) // 2
+    if halo > int(half.min().item()):
+        raise ValueError(
+            f"successor halo {halo} exceeds the smallest local chunk "
+            f"{int(half.min().item())}; shorten gamma or lower CP for this "
+            "sequence length."
+        )
+    num_seqs = half.numel()
+    row_shape = tensor.shape[1:]
+    head_index = torch.arange(halo, device=tensor.device).view(1, -1) + cu[:-1].view(
+        -1, 1
+    )
+    front_head = tensor[head_index.reshape(-1)].reshape(num_seqs, halo, *row_shape)
+    back_head = tensor[(head_index + half.view(-1, 1)).reshape(-1)].reshape(
+        num_seqs, halo, *row_shape
+    )
+
+    if cp_size == 1:
+        return torch.stack([back_head, torch.zeros_like(back_head)], dim=1)
+
+    cp_rank = cp_group.rank()
+    global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+    next_rank = global_ranks[(cp_rank + 1) % cp_size]
+    prev_rank = global_ranks[(cp_rank - 1) % cp_size]
+
+    recv_front_halo = torch.empty_like(front_head)
+    recv_back_halo = torch.empty_like(back_head)
+    ops = []
+    if cp_rank > 0:
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.isend, front_head.contiguous(), prev_rank, cp_group
+            )
+        )
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.irecv, recv_back_halo, prev_rank, cp_group
+            )
+        )
+    if cp_rank < cp_size - 1:
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.isend, back_head.contiguous(), next_rank, cp_group
+            )
+        )
+        ops.append(
+            torch.distributed.P2POp(
+                torch.distributed.irecv, recv_front_halo, next_rank, cp_group
+            )
+        )
+    if ops:
+        for req in torch.distributed.batch_isend_irecv(ops):
+            req.wait()
+    if cp_rank == cp_size - 1:
+        recv_front_halo = back_head
+    if cp_rank == 0:
+        recv_back_halo = torch.zeros_like(back_head)
+    return torch.stack([recv_front_halo, recv_back_halo], dim=1)
 
 
 def draft_pass_token_mask(token_mask: torch.Tensor, ttt_pass: int) -> torch.Tensor:
@@ -459,23 +593,53 @@ def block_draft_slot_mask(
     not train the slots beyond it (multi-turn data would otherwise resurrect
     slots on the far side of the hole).
     """
-    batch_size, seq_len = token_mask.shape
-    num_anchors = anchors.shape[1]
+    batch_size, num_anchors = anchors.shape
+    seq_idx = (
+        torch.arange(batch_size, device=anchors.device)
+        .unsqueeze(1)
+        .expand(-1, num_anchors)
+        .reshape(-1)
+    )
+    return block_draft_slot_mask_packed(
+        token_mask,
+        sample_mask,
+        seq_idx,
+        anchors.reshape(-1),
+        anchor_valid.reshape(-1),
+        gamma=gamma,
+    ).reshape(batch_size, num_anchors, gamma)
+
+
+def block_draft_slot_mask_packed(
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    seq_idx: torch.Tensor,
+    anchors: torch.Tensor,
+    anchor_valid: torch.Tensor,
+    *,
+    gamma: int,
+) -> torch.Tensor:
+    """Flat-block variant of :func:`block_draft_slot_mask`.
+
+    ``seq_idx``/``anchors``/``anchor_valid`` are ``[NB]`` (one row per block,
+    e.g. this CP rank's owned subset of a packed microbatch); the masks stay
+    unpacked ``[B, S]``/``[B]``. Returns ``[NB, gamma]``.
+    """
+    seq_len = token_mask.shape[1]
     label_pos = (
         anchors.unsqueeze(-1)
         + 1
-        + torch.arange(gamma, device=anchors.device).view(1, 1, -1)
+        + torch.arange(gamma, device=anchors.device).view(1, -1)
     )
     in_bounds = label_pos < seq_len
-    label_pos_clamped = label_pos.clamp(max=seq_len - 1)
-    label_token_mask = torch.gather(
-        token_mask, 1, label_pos_clamped.reshape(batch_size, -1)
-    ).reshape(batch_size, num_anchors, gamma)
+    label_token_mask = token_mask[
+        seq_idx.unsqueeze(-1).expand(-1, gamma), label_pos.clamp(max=seq_len - 1)
+    ]
     slot_mask = (
         anchor_valid.unsqueeze(-1)
         & in_bounds
         & (label_token_mask > 0.5)
-        & (sample_mask.view(-1, 1, 1) > 0.5)
+        & (sample_mask[seq_idx].unsqueeze(-1) > 0.5)
     )
     return torch.cumprod(slot_mask.to(torch.int32), dim=-1).bool()
 

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -437,6 +437,69 @@ def compute_draft_pass_valid_counts(
     return counts
 
 
+def block_draft_slot_mask(
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    anchors: torch.Tensor,
+    anchor_valid: torch.Tensor,
+    *,
+    gamma: int,
+) -> torch.Tensor:
+    """Validity mask ``[B, N, gamma]`` for DFlash block draft slots.
+
+    Slot ``j`` of a block anchored at ``p`` predicts ``x_{p + 1 + j}``; it is
+    valid when the block is real (``anchor_valid``), the label position is in
+    bounds, the label token is trained (``token_mask``), and the sample is
+    valid. Anchors near the sequence end keep their in-bounds slots instead of
+    being rejected outright (see the CP design note's packing issue ③).
+
+    Validity is PREFIX-CONTIGUOUS along the slot axis: once a slot is invalid
+    every later slot is too. A speculative block at serving time never spans a
+    user/tool/prefill hole, so an anchor whose labels cross such a hole must
+    not train the slots beyond it (multi-turn data would otherwise resurrect
+    slots on the far side of the hole).
+    """
+    batch_size, seq_len = token_mask.shape
+    num_anchors = anchors.shape[1]
+    label_pos = (
+        anchors.unsqueeze(-1)
+        + 1
+        + torch.arange(gamma, device=anchors.device).view(1, 1, -1)
+    )
+    in_bounds = label_pos < seq_len
+    label_pos_clamped = label_pos.clamp(max=seq_len - 1)
+    label_token_mask = torch.gather(
+        token_mask, 1, label_pos_clamped.reshape(batch_size, -1)
+    ).reshape(batch_size, num_anchors, gamma)
+    slot_mask = (
+        anchor_valid.unsqueeze(-1)
+        & in_bounds
+        & (label_token_mask > 0.5)
+        & (sample_mask.view(-1, 1, 1) > 0.5)
+    )
+    return torch.cumprod(slot_mask.to(torch.int32), dim=-1).bool()
+
+
+def compute_block_draft_slot_valid_counts(
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    anchors: torch.Tensor,
+    anchor_valid: torch.Tensor,
+    *,
+    gamma: int,
+) -> torch.Tensor:
+    """Local per-slot valid counts ``[gamma]`` for the block draft loss.
+
+    The block analogue of :func:`compute_draft_pass_valid_counts` (same
+    DP-only all-reduce contract and the same denominator/metric consumption
+    in the loss): entry ``j`` counts this rank's valid slot-``j`` CE targets.
+    """
+    slot_mask = block_draft_slot_mask(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+    return slot_mask.float().sum(dim=(0, 1))
+
+
 def _pack_input_ids(
     input_ids: torch.Tensor,
     cu_seqlens_q: torch.Tensor,

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     BlockDraftLossFn,
     DraftCrossEntropyLossFn,
     DraftTTTCrossEntropyLossFn,
+    DSparkBlockLossFn,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
@@ -251,10 +252,13 @@ class DraftLossWrapper:
     ``ttt_steps > 1`` selects the multi-pass loss
     (:class:`DraftTTTCrossEntropyLossFn`), which returns per-pass metrics
     alongside the loss and needs ``global_draft_pass_counts``. Block drafts
-    are detected from ``data_dict["draft_block_logits"]`` (stashed by the
-    train loop) and use :class:`BlockDraftLossFn`. ``draft_loss_kwargs`` are
-    the selected LossFn's remaining ctor kwargs — ``slot_weights`` for block
-    drafts, ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
+    are detected from the tensors the train loop stashed:
+    ``data_dict["draft_block_logits"]`` selects :class:`BlockDraftLossFn`
+    (soft CE), plus ``data_dict["draft_confidence_pred"]`` selects
+    :class:`DSparkBlockLossFn` (the official hard-CE + TV + confidence
+    loss). ``draft_loss_kwargs`` are the selected LossFn's remaining ctor
+    kwargs — ``slot_weights`` (+ dspark alphas) for block drafts,
+    ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
     """
 
     def __init__(
@@ -301,8 +305,14 @@ class DraftLossWrapper:
                 "the unpacked [B, S] layout."
             )
         draft_loss_kwargs = draft_loss_kwargs or {}
-        if self.block_draft:
-            self.draft_loss_fn: Any = BlockDraftLossFn(
+        if self.block_draft and "draft_confidence_pred" in data_dict:
+            self.draft_loss_fn: Any = DSparkBlockLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                vocab_parallel_rank=vocab_parallel_rank,
+                **draft_loss_kwargs,
+            )
+        elif self.block_draft:
+            self.draft_loss_fn = BlockDraftLossFn(
                 vocab_parallel_group=vocab_parallel_group,
                 **draft_loss_kwargs,
             )

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -19,7 +19,10 @@ import torch
 import torch.distributed
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction
-from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import (
+    DraftCrossEntropyLossFn,
+    DraftTTTCrossEntropyLossFn,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
@@ -243,6 +246,12 @@ class DraftLossWrapper:
       vocabulary, and the token mask is packed with the same per-sequence
       shift; ``student_logits`` must be passed explicitly (it is kept out of
       the data dict so the packing loss wrappers never slice it).
+
+    ``ttt_steps > 1`` selects the multi-pass loss
+    (:class:`DraftTTTCrossEntropyLossFn`), which returns per-pass metrics
+    alongside the loss and needs ``global_draft_pass_counts``.
+    ``draft_loss_kwargs`` are the selected LossFn's remaining ctor kwargs —
+    ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
     """
 
     def __init__(
@@ -251,6 +260,8 @@ class DraftLossWrapper:
         prepare_fn: Optional[Callable[Any, Any]],
         data_dict: BatchedDataDict[Any],
         loss_weight: float = 1.0,
+        draft_loss_kwargs: Optional[dict[str, Any]] = None,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
@@ -258,11 +269,13 @@ class DraftLossWrapper:
         cu_seqlens_q_padded: Optional[torch.Tensor] = None,
         d2t: Optional[torch.Tensor] = None,
         student_logits: Optional[torch.Tensor] = None,
+        ttt_steps: int = 1,
     ):
         self.loss_fn = loss_fn
         self.prepare_fn = prepare_fn
         self.data_dict = data_dict
         self.loss_weight = loss_weight
+        self.global_draft_pass_counts = global_draft_pass_counts
         self.vocab_parallel_rank = vocab_parallel_rank
         self.vocab_parallel_group = vocab_parallel_group
         self.context_parallel_group = context_parallel_group
@@ -276,9 +289,24 @@ class DraftLossWrapper:
             raise ValueError("student_logits must be passed explicitly in packed mode.")
         if cu_seqlens_q is None and prepare_fn is None:
             raise ValueError("prepare_fn is required in unpacked mode.")
-        self.draft_loss_fn = DraftCrossEntropyLossFn(
-            vocab_parallel_group=vocab_parallel_group,
-        )
+        self.multi_pass = ttt_steps > 1
+        if cu_seqlens_q is not None and self.multi_pass:
+            raise ValueError(
+                "Multi-pass draft training (policy.draft.ttt_steps > 1) does not "
+                "support sequence packing; the per-pass slicing convention needs "
+                "the unpacked [B, S] layout."
+            )
+        draft_loss_kwargs = draft_loss_kwargs or {}
+        if self.multi_pass:
+            self.draft_loss_fn: Any = DraftTTTCrossEntropyLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                **draft_loss_kwargs,
+            )
+        else:
+            self.draft_loss_fn = DraftCrossEntropyLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                **draft_loss_kwargs,
+            )
 
     def _packed_draft_loss(
         self,
@@ -339,6 +367,7 @@ class DraftLossWrapper:
             **kwargs,
         )
 
+        draft_metrics: dict[str, Any] = {}
         if self.cu_seqlens_q is not None:
             draft_loss = self._packed_draft_loss(
                 next_token_logits, data, global_valid_seqs, global_valid_toks
@@ -352,14 +381,24 @@ class DraftLossWrapper:
                 vocab_parallel_group=self.vocab_parallel_group,
                 context_parallel_group=self.context_parallel_group,
             )
-            draft_loss = self.draft_loss_fn(
-                data=data,
-                global_valid_seqs=global_valid_seqs,
-                global_valid_toks=global_valid_toks,
-                **loss_input,
-            )
+            if self.multi_pass:
+                draft_loss, draft_metrics = self.draft_loss_fn(
+                    data=data,
+                    global_valid_seqs=global_valid_seqs,
+                    global_valid_toks=global_valid_toks,
+                    global_draft_pass_counts=self.global_draft_pass_counts,
+                    **loss_input,
+                )
+            else:
+                draft_loss = self.draft_loss_fn(
+                    data=data,
+                    global_valid_seqs=global_valid_seqs,
+                    global_valid_toks=global_valid_toks,
+                    **loss_input,
+                )
         combined_loss = policy_loss + self.loss_weight * draft_loss
         metrics["draft_loss"] = float(draft_loss.detach().item())
+        metrics.update(draft_metrics)
         return combined_loss, metrics
 
 

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -22,7 +22,6 @@ from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.loss.loss_functions import (
     BlockDraftLossFn,
     DraftCrossEntropyLossFn,
-    DraftTTTCrossEntropyLossFn,
     DSparkBlockLossFn,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -234,37 +233,23 @@ class SequencePackingFusionLossWrapper:
 
 
 class DraftLossWrapper:
-    """Combine policy loss with draft soft cross-entropy loss.
+    """Combine policy loss with the draft soft cross-entropy loss.
 
-    Two layouts are supported:
-
-    - Unpacked (default): ``prepare_fn`` (``prepare_loss_input`` with
-      ``LossInputType.DRAFT``) builds the shifted teacher logits and token mask
-      from the ``[B, S]`` batch, and the student logits come from
-      ``data["student_logits"]``.
-    - Packed (``cu_seqlens_q`` given): the draft cross-entropy is computed once
-      over the packed ``[1, T_packed]`` layout. The teacher logits are
-      left-shifted within each packed segment and restricted to the draft
-      vocabulary, and the token mask is packed with the same per-sequence
-      shift; ``student_logits`` must be passed explicitly (it is kept out of
-      the data dict so the packing loss wrappers never slice it).
-
-    ``ttt_steps > 1`` selects the multi-pass loss
-    (:class:`DraftTTTCrossEntropyLossFn`), which returns per-pass metrics
-    alongside the loss and needs ``global_draft_pass_counts``. Block drafts
-    are detected from the tensors the train loop stashed:
+    Block drafts are detected from the tensors the train loop stashed:
     ``data_dict["draft_block_logits"]`` selects :class:`BlockDraftLossFn`
     (soft CE), plus ``data_dict["draft_confidence_pred"]`` selects
-    :class:`DSparkBlockLossFn` (the official hard-CE + TV + confidence
-    loss). ``draft_loss_kwargs`` are the selected LossFn's remaining ctor
-    kwargs — ``slot_weights`` (+ dspark alphas) for block drafts,
-    ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
+    :class:`DSparkBlockLossFn` (the official hard-CE + TV + confidence loss);
+    otherwise the unified :class:`DraftCrossEntropyLossFn` covers single- and
+    multi-pass eagle3, packed or unpacked. ``draft_loss_kwargs`` are the
+    selected LossFn's remaining ctor kwargs — ``slot_weights`` (+ dspark
+    alphas) for block drafts, ``pass_weights`` / ``seq_chunk_size`` for
+    eagle3.
     """
 
     def __init__(
         self,
         loss_fn: Callable[..., tuple[torch.Tensor, dict[str, Any]]],
-        prepare_fn: Optional[Callable[Any, Any]],
+        prepare_fn: Callable[Any, Any],
         data_dict: BatchedDataDict[Any],
         loss_weight: float = 1.0,
         draft_loss_kwargs: Optional[dict[str, Any]] = None,
@@ -272,11 +257,6 @@ class DraftLossWrapper:
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
-        cu_seqlens_q: Optional[torch.Tensor] = None,
-        cu_seqlens_q_padded: Optional[torch.Tensor] = None,
-        d2t: Optional[torch.Tensor] = None,
-        student_logits: Optional[torch.Tensor] = None,
-        ttt_steps: int = 1,
     ):
         self.loss_fn = loss_fn
         self.prepare_fn = prepare_fn
@@ -286,87 +266,27 @@ class DraftLossWrapper:
         self.vocab_parallel_rank = vocab_parallel_rank
         self.vocab_parallel_group = vocab_parallel_group
         self.context_parallel_group = context_parallel_group
-        self.cu_seqlens_q = cu_seqlens_q
-        self.cu_seqlens_q_padded = (
-            cu_seqlens_q_padded if cu_seqlens_q_padded is not None else cu_seqlens_q
-        )
-        self.d2t = d2t
-        self.student_logits = student_logits
-        if cu_seqlens_q is not None and student_logits is None:
-            raise ValueError("student_logits must be passed explicitly in packed mode.")
-        if cu_seqlens_q is None and prepare_fn is None:
-            raise ValueError("prepare_fn is required in unpacked mode.")
-        self.multi_pass = ttt_steps > 1
         self.block_draft = "draft_block_logits" in data_dict
-        if cu_seqlens_q is not None and (self.multi_pass or self.block_draft):
-            raise ValueError(
-                "Only single-pass eagle3 draft training supports sequence "
-                "packing; the per-pass and per-slot slicing conventions need "
-                "the unpacked [B, S] layout."
-            )
         draft_loss_kwargs = draft_loss_kwargs or {}
         if self.block_draft and "draft_confidence_pred" in data_dict:
             self.draft_loss_fn: Any = DSparkBlockLossFn(
                 vocab_parallel_group=vocab_parallel_group,
                 vocab_parallel_rank=vocab_parallel_rank,
+                context_parallel_group=context_parallel_group,
                 **draft_loss_kwargs,
             )
         elif self.block_draft:
             self.draft_loss_fn = BlockDraftLossFn(
                 vocab_parallel_group=vocab_parallel_group,
-                **draft_loss_kwargs,
-            )
-        elif self.multi_pass:
-            self.draft_loss_fn = DraftTTTCrossEntropyLossFn(
-                vocab_parallel_group=vocab_parallel_group,
+                context_parallel_group=context_parallel_group,
                 **draft_loss_kwargs,
             )
         else:
             self.draft_loss_fn = DraftCrossEntropyLossFn(
                 vocab_parallel_group=vocab_parallel_group,
+                context_parallel_group=context_parallel_group,
                 **draft_loss_kwargs,
             )
-
-    def _packed_draft_loss(
-        self,
-        next_token_logits: torch.Tensor,
-        data: BatchedDataDict[Any],
-        global_valid_seqs: torch.Tensor | None,
-        global_valid_toks: torch.Tensor,
-    ) -> torch.Tensor:
-        from nemo_rl.algorithms.loss.utils import (
-            map_teacher_logits_to_draft_vocab,
-            pack_rolled_draft_token_mask,
-            roll_packed_seq_dim,
-        )
-
-        teacher_logits = roll_packed_seq_dim(
-            next_token_logits.detach(), self.cu_seqlens_q_padded, seq_dim=1
-        )
-        teacher_logits = map_teacher_logits_to_draft_vocab(
-            teacher_logits,
-            self.d2t,
-            vocab_parallel_rank=self.vocab_parallel_rank,
-            vocab_parallel_group=self.vocab_parallel_group,
-        )
-        token_mask = pack_rolled_draft_token_mask(
-            data["token_mask"],
-            data["sample_mask"],
-            self.cu_seqlens_q,
-            self.cu_seqlens_q_padded,
-        )
-        # sample_mask is already folded into the packed token mask.
-        ones_sample_mask = torch.ones(
-            1, dtype=token_mask.dtype, device=token_mask.device
-        )
-        return self.draft_loss_fn(
-            teacher_logits=teacher_logits,
-            student_logits=self.student_logits,
-            token_mask=token_mask,
-            data=BatchedDataDict({"sample_mask": ones_sample_mask}),
-            global_valid_seqs=global_valid_seqs,
-            global_valid_toks=global_valid_toks,
-        )
 
     def __call__(
         self,
@@ -378,31 +298,45 @@ class DraftLossWrapper:
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         if global_valid_toks is None:
             raise ValueError("global_valid_toks is required for DraftLossWrapper.")
+        # Every key the train loop stashes for the DRAFT loss. Their leading
+        # dim is blocks / local tokens / 1 — never the sequence count — so the
+        # inner packing wrapper, which slices data per sequence, must not see
+        # them; the draft loss below still gets the unfiltered `data`. Keep in
+        # lockstep with the data_dict writes in
+        # megatron/train.py::forward_with_post_processing_fn.
+        draft_only_keys = (
+            "draft_anchor_positions",
+            "draft_anchor_valid",
+            "draft_block_seq_idx",
+            "draft_packed_local_cu_seqlens",
+            "draft_block_logits",
+            "draft_confidence_pred",
+            "draft_packed_seq_index",
+            "draft_packed_pos_in_seq",
+            "student_logits",
+            "student_logits_by_pass",
+        )
+        policy_data = data
+        if any(k in data for k in draft_only_keys):
+            policy_data = BatchedDataDict(
+                {k: v for k, v in data.items() if k not in draft_only_keys}
+            )
         policy_loss, metrics = self.loss_fn(
             next_token_logits,
-            data,
+            policy_data,
             global_valid_seqs,
             global_valid_toks,
             **kwargs,
         )
 
-        draft_metrics: dict[str, Any] = {}
         if self.block_draft:
             # The block loss needs no prepare step: the teacher is the raw
             # (vocab-parallel) policy logits and the student block logits were
             # stashed by the train loop.
-            draft_loss, draft_metrics = self.draft_loss_fn(
-                data=data,
-                global_valid_seqs=global_valid_seqs,
-                global_valid_toks=global_valid_toks,
-                global_draft_pass_counts=self.global_draft_pass_counts,
-                teacher_logits=next_token_logits.detach(),
-                student_block_logits=data["draft_block_logits"],
-            )
-        elif self.cu_seqlens_q is not None:
-            draft_loss = self._packed_draft_loss(
-                next_token_logits, data, global_valid_seqs, global_valid_toks
-            )
+            loss_input = {
+                "teacher_logits": next_token_logits.detach(),
+                "student_block_logits": data["draft_block_logits"],
+            }
         else:
             loss_input, data = self.prepare_fn(
                 logits=next_token_logits,
@@ -412,23 +346,28 @@ class DraftLossWrapper:
                 vocab_parallel_group=self.vocab_parallel_group,
                 context_parallel_group=self.context_parallel_group,
             )
-            if self.multi_pass:
-                draft_loss, draft_metrics = self.draft_loss_fn(
-                    data=data,
-                    global_valid_seqs=global_valid_seqs,
-                    global_valid_toks=global_valid_toks,
-                    global_draft_pass_counts=self.global_draft_pass_counts,
-                    **loss_input,
-                )
-            else:
-                draft_loss = self.draft_loss_fn(
-                    data=data,
-                    global_valid_seqs=global_valid_seqs,
-                    global_valid_toks=global_valid_toks,
-                    **loss_input,
-                )
+        draft_loss, draft_metrics = self.draft_loss_fn(
+            data=data,
+            global_valid_seqs=global_valid_seqs,
+            global_valid_toks=global_valid_toks,
+            global_draft_pass_counts=self.global_draft_pass_counts,
+            **loss_input,
+        )
         combined_loss = policy_loss + self.loss_weight * draft_loss
-        metrics["draft_loss"] = float(draft_loss.detach().item())
+        # Under CP each rank's draft_loss covers only its sequence shard over
+        # a global denominator; the metric must sum across CP explicitly (the
+        # gradient path does so implicitly via the grad all-reduce).
+        draft_loss_metric = draft_loss.detach()
+        if (
+            self.context_parallel_group is not None
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size(self.context_parallel_group) > 1
+        ):
+            draft_loss_metric = draft_loss_metric.clone()
+            torch.distributed.all_reduce(
+                draft_loss_metric, group=self.context_parallel_group
+            )
+        metrics["draft_loss"] = float(draft_loss_metric.item())
         metrics.update(draft_metrics)
         return combined_loss, metrics
 

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -20,6 +20,7 @@ import torch.distributed
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.loss.loss_functions import (
+    BlockDraftLossFn,
     DraftCrossEntropyLossFn,
     DraftTTTCrossEntropyLossFn,
 )
@@ -249,9 +250,11 @@ class DraftLossWrapper:
 
     ``ttt_steps > 1`` selects the multi-pass loss
     (:class:`DraftTTTCrossEntropyLossFn`), which returns per-pass metrics
-    alongside the loss and needs ``global_draft_pass_counts``.
-    ``draft_loss_kwargs`` are the selected LossFn's remaining ctor kwargs —
-    ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
+    alongside the loss and needs ``global_draft_pass_counts``. Block drafts
+    are detected from ``data_dict["draft_block_logits"]`` (stashed by the
+    train loop) and use :class:`BlockDraftLossFn`. ``draft_loss_kwargs`` are
+    the selected LossFn's remaining ctor kwargs — ``slot_weights`` for block
+    drafts, ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
     """
 
     def __init__(
@@ -290,15 +293,21 @@ class DraftLossWrapper:
         if cu_seqlens_q is None and prepare_fn is None:
             raise ValueError("prepare_fn is required in unpacked mode.")
         self.multi_pass = ttt_steps > 1
-        if cu_seqlens_q is not None and self.multi_pass:
+        self.block_draft = "draft_block_logits" in data_dict
+        if cu_seqlens_q is not None and (self.multi_pass or self.block_draft):
             raise ValueError(
-                "Multi-pass draft training (policy.draft.ttt_steps > 1) does not "
-                "support sequence packing; the per-pass slicing convention needs "
+                "Only single-pass eagle3 draft training supports sequence "
+                "packing; the per-pass and per-slot slicing conventions need "
                 "the unpacked [B, S] layout."
             )
         draft_loss_kwargs = draft_loss_kwargs or {}
-        if self.multi_pass:
-            self.draft_loss_fn: Any = DraftTTTCrossEntropyLossFn(
+        if self.block_draft:
+            self.draft_loss_fn: Any = BlockDraftLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                **draft_loss_kwargs,
+            )
+        elif self.multi_pass:
+            self.draft_loss_fn = DraftTTTCrossEntropyLossFn(
                 vocab_parallel_group=vocab_parallel_group,
                 **draft_loss_kwargs,
             )
@@ -368,7 +377,19 @@ class DraftLossWrapper:
         )
 
         draft_metrics: dict[str, Any] = {}
-        if self.cu_seqlens_q is not None:
+        if self.block_draft:
+            # The block loss needs no prepare step: the teacher is the raw
+            # (vocab-parallel) policy logits and the student block logits were
+            # stashed by the train loop.
+            draft_loss, draft_metrics = self.draft_loss_fn(
+                data=data,
+                global_valid_seqs=global_valid_seqs,
+                global_valid_toks=global_valid_toks,
+                global_draft_pass_counts=self.global_draft_pass_counts,
+                teacher_logits=next_token_logits.detach(),
+                student_block_logits=data["draft_block_logits"],
+            )
+        elif self.cu_seqlens_q is not None:
             draft_loss = self._packed_draft_loss(
                 next_token_logits, data, global_valid_seqs, global_valid_toks
             )

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -267,6 +267,138 @@ class DistributedCrossEntropy(torch.autograd.Function):
         return grad_student, None, None, None
 
 
+class ChunkedDistributedCrossEntropy(torch.autograd.Function):
+    """Soft-target cross entropy across TP-sharded vocab, chunked along sequence.
+
+    Same math as :class:`DistributedCrossEntropy`, but the fp32 softmax /
+    log-softmax buffers only ever exist for one sequence chunk:
+
+    - forward computes the per-token CE chunk-by-chunk and saves only the
+      (typically bf16) logits references — DistributedCrossEntropy instead
+      saves two full-size fp32 probability tensors for backward, which is the
+      dominant memory cost when several draft TTT passes stack up before the
+      shared backward;
+    - backward recomputes the chunk softmaxes and writes the gradient into a
+      single input-dtype buffer (mirrors :class:`ChunkedDistributedLogprob`).
+
+    ``group=None`` runs the same chunked math without collectives (single
+    process / no vocab parallelism).
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        student_logits: torch.Tensor,
+        target_logits: torch.Tensor,
+        chunk_size: int,
+        group: Optional[torch.distributed.ProcessGroup],
+        inference_only: bool = False,
+    ) -> torch.Tensor:
+        if student_logits.shape != target_logits.shape:
+            raise ValueError(
+                "student_logits and target_logits must have the same shape, "
+                f"got {student_logits.shape} and {target_logits.shape}."
+            )
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        ce_chunks = []
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+            target_fp32 = target_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+
+            if group is None:
+                target_probs = torch.softmax(target_fp32, dim=-1)
+                student_log_probs = torch.log_softmax(student_fp32, dim=-1)
+                ce_chunk = (
+                    torch.einsum("...v,...v->...", target_probs, student_log_probs)
+                    .neg_()
+                    .contiguous()
+                )
+            else:
+                target_probs = _compute_distributed_softmax(target_fp32, group=group)
+                student_log_probs = _compute_distributed_log_softmax(
+                    student_fp32, group=group
+                )
+                ce_chunk = torch.einsum(
+                    "...v,...v->...", target_probs, student_log_probs
+                ).neg_()
+                torch.distributed.all_reduce(
+                    ce_chunk,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+
+            ce_chunks.append(ce_chunk)
+            del student_fp32, target_fp32, target_probs, student_log_probs
+
+        cross_entropy = torch.cat(ce_chunks, dim=1)
+
+        if not inference_only:
+            # Only references are saved; no fp32 full-size buffers survive.
+            ctx.save_for_backward(student_logits, target_logits)
+            ctx.chunk_size = chunk_size
+            ctx.group = group
+
+        return cross_entropy
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        *grad_outputs: torch.Tensor,
+    ) -> tuple[torch.Tensor, None, None, None, None]:
+        grad_output = grad_outputs[0]
+        student_logits, target_logits = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        group = ctx.group
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+
+        # Every chunk row is written below, so no zero-init is needed.
+        grad_student = torch.empty_like(student_logits)
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+            target_fp32 = target_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+
+            if group is None:
+                target_probs = torch.softmax(target_fp32, dim=-1)
+                student_probs = torch.softmax(student_fp32, dim=-1)
+            else:
+                target_probs = _compute_distributed_softmax(target_fp32, group=group)
+                student_probs = _compute_distributed_log_softmax(
+                    student_fp32, group=group
+                ).exp_()
+
+            # d(H(p, q))/d(z_v) = q_v - p_v
+            chunk_grad_fp32 = student_probs.sub_(target_probs)
+            chunk_grad_fp32.mul_(
+                grad_output[:, chunk_start:chunk_end].unsqueeze(dim=-1)
+            )
+            grad_student[:, chunk_start:chunk_end, :].copy_(chunk_grad_fp32)
+
+            del student_fp32, target_fp32, target_probs, student_probs
+            del chunk_grad_fp32
+
+        return grad_student, None, None, None, None
+
+
 class ChunkedDistributedLogprob(torch.autograd.Function):
     """Custom autograd function for computing log probabilities in a distributed setting.
 

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -399,6 +399,220 @@ class ChunkedDistributedCrossEntropy(torch.autograd.Function):
         return grad_student, None, None, None, None
 
 
+class ChunkedDistributedLabelCEAndTV(torch.autograd.Function):
+    """Hard-label CE + TV distillation across TP-sharded vocab, chunked along dim 1.
+
+    The two DSpark loss terms: ``ce = -log softmax(student)[label]`` and
+    ``tv = sum_v |softmax(student)_v - softmax(teacher)_v|`` (2x the
+    total-variation distance). Same memory contract as
+    :class:`ChunkedDistributedCrossEntropy`: fp32 buffers exist per chunk
+    only, backward recomputes from the saved (bf16) logits references.
+    Labels are GLOBAL vocab ids (each rank contributes its
+    ``[vocab_start_index, vocab_end_index)`` shard); only ``student_logits``
+    gets a gradient. Returns fp32 ``(ce, tv)`` of shape ``[B, T]``.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        student_logits: torch.Tensor,
+        teacher_logits: torch.Tensor,
+        labels: torch.Tensor,
+        vocab_start_index: int,
+        vocab_end_index: int,
+        chunk_size: int,
+        group: Optional[torch.distributed.ProcessGroup],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if student_logits.shape != teacher_logits.shape:
+            raise ValueError(
+                "student_logits and teacher_logits must have the same shape, "
+                f"got {student_logits.shape} and {teacher_logits.shape}."
+            )
+        if labels.shape != student_logits.shape[:-1]:
+            raise ValueError(
+                f"labels shape {labels.shape} does not match logits "
+                f"{student_logits.shape[:-1]}."
+            )
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        ce_chunks = []
+        tv_chunks = []
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            chunk_labels = labels[:, chunk_start:chunk_end]
+            label_mask = (chunk_labels < vocab_start_index) | (
+                chunk_labels >= vocab_end_index
+            )
+            local_labels = (chunk_labels - vocab_start_index).masked_fill(label_mask, 0)
+
+            # copy=True: the chunk is mutated in place below; without it an
+            # already-fp32 input would alias (and corrupt) the saved logits.
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32, copy=True
+            )
+            student_max = torch.amax(student_fp32, dim=-1, keepdim=True)
+            if group is not None:
+                torch.distributed.all_reduce(
+                    student_max,
+                    op=torch.distributed.ReduceOp.MAX,
+                    group=group,
+                )
+            shifted = student_fp32.sub_(student_max)
+            # Gather shifted[label] BEFORE the in-place exp (an exp->log
+            # round-trip would underflow for very unlikely labels).
+            picked_shifted = (
+                shifted.gather(-1, local_labels.unsqueeze(-1))
+                .squeeze(-1)
+                .masked_fill(label_mask, 0.0)
+            )
+            if group is not None:
+                torch.distributed.all_reduce(
+                    picked_shifted,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+            exp_student = shifted.exp_()
+            sum_exp = exp_student.sum(dim=-1, keepdim=True)
+            if group is not None:
+                torch.distributed.all_reduce(
+                    sum_exp,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+            ce_chunks.append(sum_exp.log().squeeze(-1) - picked_shifted)
+            student_probs = exp_student.div_(sum_exp)
+
+            teacher_fp32 = teacher_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32, copy=True
+            )
+            teacher_probs, _ = _shifted_softmax_with_log_norm(
+                teacher_fp32, group=group, in_place=True
+            )
+
+            tv_chunk = (student_probs - teacher_probs).abs().sum(dim=-1)
+            if group is not None:
+                torch.distributed.all_reduce(
+                    tv_chunk,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+            tv_chunks.append(tv_chunk)
+
+            del student_fp32, teacher_fp32, student_probs, teacher_probs
+
+        cross_entropy = torch.cat(ce_chunks, dim=1)
+        tv_distance = torch.cat(tv_chunks, dim=1)
+
+        # Only references are saved; no fp32 full-size buffers survive.
+        ctx.save_for_backward(student_logits, teacher_logits, labels)
+        ctx.chunk_size = chunk_size
+        ctx.group = group
+        ctx.vocab_start_index = vocab_start_index
+        ctx.vocab_end_index = vocab_end_index
+
+        return cross_entropy, tv_distance
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        *grad_outputs: torch.Tensor,
+    ) -> tuple[Optional[torch.Tensor], ...]:
+        grad_ce, grad_tv = grad_outputs
+        student_logits, teacher_logits, labels = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        group = ctx.group
+        vocab_start_index = ctx.vocab_start_index
+        vocab_end_index = ctx.vocab_end_index
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        grad_student = torch.empty_like(student_logits)
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32, copy=True
+            )
+            student_probs, _ = _shifted_softmax_with_log_norm(
+                student_fp32, group=group, in_place=True
+            )
+            teacher_fp32 = teacher_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32, copy=True
+            )
+            teacher_probs, _ = _shifted_softmax_with_log_norm(
+                teacher_fp32, group=group, in_place=True
+            )
+
+            # d(tv)/dz_u = p_u * (sign_u - sum_v sign_v p_v); the row sum needs
+            # the full vocab, hence the all-reduce.
+            sign = (student_probs - teacher_probs).sign_()
+            sign_prob_row = (sign * student_probs).sum(dim=-1, keepdim=True)
+            if group is not None:
+                torch.distributed.all_reduce(
+                    sign_prob_row,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+            d_tv = grad_tv[:, chunk_start:chunk_end].unsqueeze(-1)
+            chunk_grad = sign.sub_(sign_prob_row).mul_(student_probs).mul_(d_tv)
+
+            # d(ce)/dz = p - onehot(label), local-shard one-hot.
+            d_ce = grad_ce[:, chunk_start:chunk_end]
+            chunk_grad.add_(student_probs.mul_(d_ce.unsqueeze(-1)))
+            chunk_labels = labels[:, chunk_start:chunk_end]
+            label_mask = (chunk_labels < vocab_start_index) | (
+                chunk_labels >= vocab_end_index
+            )
+            local_labels = (chunk_labels - vocab_start_index).masked_fill(label_mask, 0)
+            onehot_grad = (d_ce * (~label_mask).float()).neg_()
+            chunk_grad.scatter_add_(
+                -1, local_labels.unsqueeze(-1), onehot_grad.unsqueeze(-1)
+            )
+
+            grad_student[:, chunk_start:chunk_end, :].copy_(chunk_grad)
+            del student_fp32, teacher_fp32, student_probs, teacher_probs
+            del sign, chunk_grad
+
+        return grad_student, None, None, None, None, None, None
+
+
+def _shifted_softmax_with_log_norm(
+    logits_fp32: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup],
+    in_place: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Full-vocab-stable softmax over a (possibly TP-sharded) fp32 chunk.
+
+    Returns ``(probs, log_norm)`` where ``log_norm = logsumexp - global_max``
+    is rank-identical. ``in_place=True`` reuses the input buffer for the
+    probs (the chunk copies in the callers above are throwaways).
+    """
+    logits_max = torch.amax(logits_fp32, dim=-1, keepdim=True)
+    if group is not None:
+        torch.distributed.all_reduce(
+            logits_max,
+            op=torch.distributed.ReduceOp.MAX,
+            group=group,
+        )
+    shifted = logits_fp32.sub_(logits_max) if in_place else logits_fp32 - logits_max
+    exp_logits = shifted.exp_() if in_place else shifted.exp()
+    sum_exp = exp_logits.sum(dim=-1, keepdim=True)
+    if group is not None:
+        torch.distributed.all_reduce(
+            sum_exp,
+            op=torch.distributed.ReduceOp.SUM,
+            group=group,
+        )
+    probs = exp_logits.div_(sum_exp)
+    return probs, sum_exp.log()
+
+
 class ChunkedDistributedLogprob(torch.autograd.Function):
     """Custom autograd function for computing log probabilities in a distributed setting.
 

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import gc
 import logging
 import re
@@ -596,8 +597,66 @@ class VllmInternalWorkerExtension:
         because these are dynamic vLLM model classes whose ``load_weights`` /
         ``mtp_start_layer_idx`` members are not visible through ``nn.Module``.
         """
-        draft_owner = getattr(self.model_runner, "drafter", None)
+        # The V1 model runner names the owner `drafter`; the V2 runner
+        # `speculator`. On both, non-last PP ranks carry the attribute as None.
+        draft_owner = getattr(self.model_runner, "drafter", None) or getattr(
+            self.model_runner, "speculator", None
+        )
         return getattr(draft_owner, "model", None) if draft_owner else None
+
+    def _unshare_draft_lm_head(self, draft_model: torch.nn.Module) -> None:
+        """Give the drafter a private lm_head before loading a trained head.
+
+        vLLM's spec-decode proposer aliases the drafter's ``lm_head`` MODULE to
+        the target's when their weights are identical at engine init — and
+        unconditionally for drafters without a ``has_own_lm_head`` flag
+        (``SpecDecodeBaseProposer._maybe_share_lm_head``, vLLM 0.26). For a
+        draft that TRAINS its own head (Eagle), the refit stream would then
+        write the diverged draft head through the alias, silently overwriting
+        the serving target's head (generation no longer matches the trained
+        policy — broken importance ratios / KL). Deep-copy the head into
+        drafter-private storage before such a load; later refits see distinct
+        storage and no-op.
+
+        Only called when the incoming draft weights actually contain an
+        lm_head update: head-less drafts WANT the sharing to persist — their
+        draft logits must track the target's live head. Embedding sharing is
+        likewise left intact.
+        """
+        target_model = getattr(self.model_runner, "model", None)
+        if target_model is not None and hasattr(target_model, "get_language_model"):
+            target_model = target_model.get_language_model()
+        draft_lm_head = getattr(draft_model, "lm_head", None)
+        target_lm_head = getattr(target_model, "lm_head", None)
+        if not isinstance(target_lm_head, torch.nn.Module):
+            return
+        draft_weight = getattr(draft_lm_head, "weight", None)
+        target_weight = getattr(target_lm_head, "weight", None)
+        if not isinstance(draft_weight, torch.Tensor) or not isinstance(
+            target_weight, torch.Tensor
+        ):
+            return
+        if (
+            draft_weight.untyped_storage().data_ptr()
+            != target_weight.untyped_storage().data_ptr()
+        ):
+            return
+        private_lm_head = copy.deepcopy(target_lm_head)
+        # Parameter.__deepcopy__ rebuilds bare Parameters, dropping the attrs
+        # vLLM attaches via set_weight_attrs (weight_loader, output_dim, ...);
+        # without them a later load_weights falls back to
+        # default_weight_loader, which cannot shard under TP. The loaders take
+        # the param explicitly, so rebinding the originals is safe.
+        for private_param, source_param in zip(
+            private_lm_head.parameters(), target_lm_head.parameters()
+        ):
+            private_param.__dict__.update(source_param.__dict__)
+        draft_model.lm_head = private_lm_head
+        print(
+            "[draft] Drafter lm_head was aliased to the target's (vLLM "
+            "share-on-identical-weights); un-shared it into private storage "
+            "before applying draft refit weights."
+        )
 
     def _load_draft_weights(
         self, draft_weights: list[tuple[str, torch.Tensor]]
@@ -607,10 +666,23 @@ class VllmInternalWorkerExtension:
 
         draft_model = self._get_drafter_model()
         if draft_model is None:
-            logger.warning(
-                "[draft] Received draft weights but vLLM drafter is unavailable; skipping draft update."
+            # vLLM places the drafter on the last PP stage only; its absence
+            # on earlier stages is expected (cf. load_mtp_weights_from_disk).
+            if not get_pp_group().is_last_rank:
+                return
+            # The trainer only streams draft.* weights when a draft model is
+            # co-training, so an unreachable drafter here means the weights
+            # would be silently dropped and serving would keep stale draft
+            # weights forever (observed: acceptance rate pinned at exactly 0
+            # while draft_loss fell). Fail loudly instead.
+            raise RuntimeError(
+                "[draft] Received draft weights but no vLLM drafter was found "
+                "on the model runner; the draft refit would be silently "
+                "dropped. Check the speculative_config and the vLLM "
+                "model-runner version compatibility."
             )
-            return
+        if any("lm_head" in name for name, _ in draft_weights):
+            self._unshare_draft_lm_head(draft_model)
         draft_weights = self._trim_vocab_padding(draft_model, draft_weights)
         draft_model.load_weights(weights=draft_weights)
 

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -596,6 +596,11 @@ class VllmInternalWorkerExtension:
         which vLLM keeps as a module separate from the main model. Typed ``Any``
         because these are dynamic vLLM model classes whose ``load_weights`` /
         ``mtp_start_layer_idx`` members are not visible through ``nn.Module``.
+
+        vLLM <= 0.20 (and 0.26's legacy ``gpu_model_runner``) exposes the
+        proposer as ``model_runner.drafter``; 0.26's V2 gpu model runner
+        renamed it to ``model_runner.speculator``. Both hold the draft model
+        at ``.model``.
         """
         # The V1 model runner names the owner `drafter`; the V2 runner
         # `speculator`. On both, non-last PP ranks carry the attribute as None.
@@ -619,10 +624,10 @@ class VllmInternalWorkerExtension:
         storage and no-op.
 
         Only called when the incoming draft weights actually contain an
-        lm_head update: head-less drafts (DFlash, official contract) WANT the
-        sharing to persist — their draft logits must track the target's live
-        head. Embedding sharing is likewise left intact (the mask row rides
-        the target's ``embed_tokens``).
+        lm_head update: head-less drafts (DFlash/DSpark, official contract)
+        WANT the sharing to persist — their draft logits must track the
+        target's live head. Embedding sharing is likewise left intact (the
+        trained mask row rides the target's ``embed_tokens``).
         """
         target_model = getattr(self.model_runner, "model", None)
         if target_model is not None and hasattr(target_model, "get_language_model"):
@@ -677,9 +682,9 @@ class VllmInternalWorkerExtension:
             # weights forever (observed: acceptance rate pinned at exactly 0
             # while draft_loss fell). Fail loudly instead.
             raise RuntimeError(
-                "[draft] Received draft weights but no vLLM drafter was found "
-                "on the model runner; the draft refit would be silently "
-                "dropped. Check the speculative_config and the vLLM "
+                "[draft] Received draft weights but no vLLM drafter/speculator "
+                "was found on the model runner; the draft refit would be "
+                "silently dropped. Check the speculative_config and the vLLM "
                 "model-runner version compatibility."
             )
         if any("lm_head" in name for name, _ in draft_weights):

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -619,9 +619,10 @@ class VllmInternalWorkerExtension:
         storage and no-op.
 
         Only called when the incoming draft weights actually contain an
-        lm_head update: head-less drafts WANT the sharing to persist — their
-        draft logits must track the target's live head. Embedding sharing is
-        likewise left intact.
+        lm_head update: head-less drafts (DFlash, official contract) WANT the
+        sharing to persist — their draft logits must track the target's live
+        head. Embedding sharing is likewise left intact (the mask row rides
+        the target's ``embed_tokens``).
         """
         target_model = getattr(self.model_runner, "model", None)
         if target_model is not None and hasattr(target_model, "get_language_model"):

--- a/nemo_rl/models/megatron/draft/__init__.py
+++ b/nemo_rl/models/megatron/draft/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nemo_rl.models.megatron.draft.dflash import (
+    DFlashDraftModel,
+    sample_block_anchors,
+)
 from nemo_rl.models.megatron.draft.eagle import EagleModel
 from nemo_rl.models.megatron.draft.hidden_capture import (
     CapturedStates,
@@ -21,17 +25,25 @@ from nemo_rl.models.megatron.draft.hidden_capture import (
 )
 from nemo_rl.models.megatron.draft.utils import (
     draft_model_detached,
+    export_block_draft_weights_to_hf,
+    export_draft_weights_to_hf,
     export_eagle_weights_to_hf,
+    load_hf_weights_to_block_draft,
     load_hf_weights_to_eagle,
 )
 
 __all__ = [
     "CapturedStates",
+    "DFlashDraftModel",
     "HiddenStateCapture",
     "get_capture_context",
     "EagleModel",
     "draft_model_detached",
     "load_hf_weights_to_eagle",
     "export_eagle_weights_to_hf",
+    "export_block_draft_weights_to_hf",
+    "export_draft_weights_to_hf",
+    "load_hf_weights_to_block_draft",
     "get_eagle3_aux_hidden_state_layers",
+    "sample_block_anchors",
 ]

--- a/nemo_rl/models/megatron/draft/__init__.py
+++ b/nemo_rl/models/megatron/draft/__init__.py
@@ -16,6 +16,7 @@ from nemo_rl.models.megatron.draft.dflash import (
     DFlashDraftModel,
     sample_block_anchors,
 )
+from nemo_rl.models.megatron.draft.dspark import DSparkDraftModel
 from nemo_rl.models.megatron.draft.eagle import EagleModel
 from nemo_rl.models.megatron.draft.hidden_capture import (
     CapturedStates,
@@ -35,6 +36,7 @@ from nemo_rl.models.megatron.draft.utils import (
 __all__ = [
     "CapturedStates",
     "DFlashDraftModel",
+    "DSparkDraftModel",
     "HiddenStateCapture",
     "get_capture_context",
     "EagleModel",

--- a/nemo_rl/models/megatron/draft/dflash.py
+++ b/nemo_rl/models/megatron/draft/dflash.py
@@ -31,7 +31,8 @@ This file matches the behavior of vLLM 0.26's
   current LM head, matching how serving shares those target-model weights.
 
 The decoder is a standard MCore ``TransformerBlock`` whose ``core_attention``
-modules are replaced by :class:`BlockDraftCoreAttention`.
+modules are replaced by :class:`BlockDraftCoreAttention`. The DSpark model in
+``draft/dspark.py`` subclasses :class:`DFlashDraftModel` and reuses this code.
 """
 
 from __future__ import annotations
@@ -71,7 +72,7 @@ if not (_fa_major == 2 and _fa_minor >= 7):
     )
 
 
-SUPPORTED_BLOCK_SPECULATOR_TYPES = ("dflash",)
+SUPPORTED_BLOCK_SPECULATOR_TYPES = ("dflash", "dspark")
 
 
 def sample_block_anchors(
@@ -840,11 +841,12 @@ class BlockDraftCoreAttention(torch.nn.Module):
 
 
 class DFlashDraftModel(MegatronModule):
-    """Block drafter with a context-only anchor slot.
+    """Training model shared by the DFlash and DSpark block drafters.
 
     A DFlash block has ``W = gamma + 1`` slots. Slot 0 contains the anchor and
     supplies context, but its logits are not trained. The remaining ``gamma``
-    slots predict new tokens.
+    slots predict new tokens. DSpark subclasses this model and changes
+    ``method`` and ``block_width`` for its serving and loss behavior.
     """
 
     speculator_type = "dflash"
@@ -874,7 +876,8 @@ class DFlashDraftModel(MegatronModule):
             )
         self.config = config
         self.gamma = int(gamma)
-        # DFlash adds one context-only anchor slot.
+        # DFlash adds one context-only anchor slot. DSpark overrides the width
+        # because its anchor slot also makes a prediction.
         self.block_width = int(block_width) if block_width is not None else gamma + 1
         self.mask_token_id = int(mask_token_id)
         self.num_aux_hidden_states = int(num_aux_hidden_states)

--- a/nemo_rl/models/megatron/draft/dflash.py
+++ b/nemo_rl/models/megatron/draft/dflash.py
@@ -1,0 +1,1069 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Megatron training implementation of the DFlash draft model.
+
+This file matches the behavior of vLLM 0.26's
+``vllm/model_executor/models/qwen3_dflash.py``. The main ideas are:
+
+- The draft model does not run a causal decoder over the target sequence.
+  It combines the target model's auxiliary hidden states once, then uses each
+  draft layer's K/V weights to build that layer's trunk keys and values.
+- An anchor at position ``p`` creates a block of ``W = gamma + 1`` tokens.
+  Slot 0 contains the embedding of token ``x_p`` and provides context only.
+  The other ``gamma`` slots predict ``x_{p+1} .. x_{p+gamma}``.
+- A block can attend to target tokens before ``p`` and to every token in its
+  own block. It cannot attend to other blocks. See
+  :class:`BlockDraftAttention` for an example mask.
+- The draft model has no separate mask embedding or LM head. ``forward``
+  receives detached references to the target model's mask-token embedding and
+  current LM head, matching how serving shares those target-model weights.
+
+The decoder is a standard MCore ``TransformerBlock`` whose ``core_attention``
+modules are replaced by :class:`BlockDraftCoreAttention`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import flash_attn
+import torch
+import torch.nn.functional as F
+from flash_attn.flash_attn_interface import (
+    _flash_attn_backward,
+    _flash_attn_forward,
+    _flash_attn_varlen_backward,
+    _flash_attn_varlen_forward,
+)
+from megatron.core.extensions.transformer_engine import TENorm
+from megatron.core.models.common.embeddings import RotaryEmbedding
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_spec,
+)
+from megatron.core.tensor_parallel import copy_to_tensor_model_parallel_region
+from megatron.core.transformer import MegatronModule, TransformerConfig
+from megatron.core.transformer.transformer_block import TransformerBlock
+from torch import Tensor
+
+# These are private FlashAttention functions, so their Python signatures
+# cannot be inspected reliably. This file uses the interface from version
+# 2.8.1, which is compatible with FlashAttention 2.7 and later 2.x releases.
+# Reject other versions early instead of failing with an unclear argument error.
+_fa_major, _fa_minor = (int(x) for x in flash_attn.__version__.split(".")[:2])
+if not (_fa_major == 2 and _fa_minor >= 7):
+    raise RuntimeError(
+        f"flash-attn {flash_attn.__version__} does not match the private "
+        "interface vendored for flash-attn 2.8.1; update "
+        "nemo_rl/models/megatron/draft/dflash.py."
+    )
+
+
+SUPPORTED_BLOCK_SPECULATOR_TYPES = ("dflash",)
+
+
+def sample_block_anchors(
+    *,
+    token_mask: Tensor,
+    sample_mask: Tensor,
+    input_ids: Tensor,
+    num_anchors: int,
+    generation_only: bool = True,
+) -> tuple[Tensor, Tensor]:
+    """Choose a fixed number of draft anchors for each sequence.
+
+    An anchor at position ``p`` uses ``x_p`` as context and starts predicting
+    at ``x_{p+1}``. By default, ``p`` is eligible only when ``x_{p+1}`` is a
+    trained generation token. This excludes prompt, user, and tool spans that
+    are handled as prefill during serving.
+
+    If a sequence has too few eligible positions, positions are sampled with
+    replacement. If it has none, position 0 is returned as a dummy anchor and
+    marked invalid. The batch's token IDs seed a local CPU generator so all TP
+    ranks choose the same anchors without changing the global random state.
+
+    Args:
+        token_mask: ``[B, S]`` mask. A value of 1 marks a trained target token.
+        sample_mask: ``[B]`` mask. A value of 1 marks a valid sequence.
+        input_ids: ``[B, S]`` token IDs used to create the sampling seed.
+        num_anchors: Number of anchors ``N`` to return per sequence.
+        generation_only: If true, choose anchors only before trained targets.
+
+    Returns:
+        A pair containing ``anchors`` with shape ``[B, N]`` and a Boolean
+        ``anchor_valid`` mask with the same shape.
+    """
+    if num_anchors < 1:
+        raise ValueError(f"num_anchors must be >= 1, got {num_anchors}.")
+    batch_size = token_mask.shape[0]
+    device = token_mask.device
+
+    if generation_only:
+        candidate_mask = token_mask[:, 1:] > 0.5  # p such that token_mask[p+1]==1
+    else:
+        candidate_mask = torch.ones_like(token_mask[:, 1:], dtype=torch.bool)
+    candidate_mask = candidate_mask & (sample_mask.view(-1, 1) > 0.5)
+
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(int(input_ids.sum().item()) % (2**63 - 1))
+
+    anchors = torch.zeros((batch_size, num_anchors), dtype=torch.int64)
+    anchor_valid = torch.zeros((batch_size, num_anchors), dtype=torch.bool)
+    candidate_mask_cpu = candidate_mask.cpu()
+    for row in range(batch_size):
+        candidates = torch.nonzero(candidate_mask_cpu[row], as_tuple=True)[0]
+        if candidates.numel() == 0:
+            continue
+        if candidates.numel() >= num_anchors:
+            pick = torch.randperm(candidates.numel(), generator=gen)[:num_anchors]
+        else:
+            pick = torch.randint(candidates.numel(), (num_anchors,), generator=gen)
+        anchors[row] = candidates[pick]
+        anchor_valid[row] = True
+    return anchors.to(device), anchor_valid.to(device)
+
+
+def anchors_to_count_map(anchors: Tensor, anchor_valid: Tensor, seq_len: int) -> Tensor:
+    """Convert anchor lists into a sequence-shaped count map.
+
+    Dynamic batching knows how to truncate and reorder tensors shaped like
+    ``[B, S]``, but it cannot safely transform the anchor layout ``[B, N]``.
+    The count map solves that problem: each value tells how many blocks use
+    that sequence position. Counts greater than one preserve anchors that were
+    sampled more than once.
+
+    Args:
+        anchors: Anchor positions with shape ``[B, N]``.
+        anchor_valid: Boolean validity mask with shape ``[B, N]``.
+        seq_len: Sequence length ``S`` of the returned map.
+
+    Returns:
+        Per-position anchor counts with shape ``[B, S]``.
+    """
+    count_map = anchors.new_zeros((anchors.shape[0], seq_len), dtype=torch.int32)
+    count_map.scatter_add_(1, anchors, anchor_valid.to(torch.int32))
+    return count_map
+
+
+def count_map_to_anchors(count_map: Tensor) -> tuple[Tensor, Tensor]:
+    """Rebuild padded anchor lists from a count map.
+
+    A position is repeated according to its count. Rows are padded to the
+    largest number of anchors in the microbatch; padding uses position 0 and
+    is marked invalid. If the entire microbatch is empty, one invalid column
+    is still returned so downstream tensors never have a zero-width dimension.
+    The order within a row is not preserved because blocks are independent.
+
+    Args:
+        count_map: Per-position anchor counts with shape ``[B, S]``.
+
+    Returns:
+        A pair containing padded ``anchors`` and its Boolean ``anchor_valid``
+        mask, both with shape ``[B, N_max]``.
+    """
+    batch_size = count_map.shape[0]
+    device = count_map.device
+    max_blocks = max(int(count_map.sum(dim=1).max().item()), 1)
+
+    anchors = torch.zeros((batch_size, max_blocks), dtype=torch.int64, device=device)
+    anchor_valid = torch.zeros_like(anchors, dtype=torch.bool)
+    for row in range(batch_size):
+        positions = torch.nonzero(count_map[row], as_tuple=True)[0]
+        if positions.numel() == 0:
+            continue
+        repeated = torch.repeat_interleave(positions, count_map[row, positions].long())
+        anchors[row, : repeated.numel()] = repeated
+        anchor_valid[row, : repeated.numel()] = True
+    return anchors, anchor_valid
+
+
+# ---------------------------------------------------------------------------
+# Exact two-part block attention (mask diagram on BlockDraftAttention).
+# ---------------------------------------------------------------------------
+
+
+def _fa_dense_forward(
+    q: Tensor, k: Tensor, v: Tensor, softmax_scale: float
+) -> tuple[Tensor, Tensor]:
+    """Dense non-causal FA forward; returns (out [1,Sq,Hq,D], lse [1,Hq,Sq] fp32)."""
+    out, softmax_lse, _, _ = _flash_attn_forward(
+        q,
+        k,
+        v,
+        0.0,  # dropout_p
+        softmax_scale,
+        False,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # return_softmax
+    )
+    return out, softmax_lse
+
+
+def _fa_dense_backward(
+    *,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+    softmax_scale: float,
+) -> None:
+    """Dense FA backward into preallocated dq/dk/dv (fed the joint (out, lse))."""
+    _flash_attn_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        lse,
+        dq,
+        dk,
+        dv,
+        0.0,  # dropout_p
+        softmax_scale,
+        False,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # deterministic
+        None,  # rng_state
+    )
+
+
+def _fa_varlen_forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_k: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+) -> tuple[Tensor, Tensor]:
+    """Varlen non-causal FA forward; returns (out [Tq,Hq,D], lse [Hq,Tq] fp32)."""
+    out, softmax_lse, _, _ = _flash_attn_varlen_forward(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        0.0,  # dropout_p
+        softmax_scale,
+        False,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # return_softmax
+        None,  # block_table
+    )
+    return out, softmax_lse
+
+
+def _fa_varlen_backward(
+    *,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_k: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+) -> None:
+    """Varlen FA backward into preallocated dq/dk/dv (fed the joint (out, lse))."""
+    _flash_attn_varlen_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        lse,
+        dq,
+        dk,
+        dv,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        0.0,  # dropout_p
+        softmax_scale,
+        False,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # deterministic
+        None,  # rng_state
+    )
+
+
+def _ragged_arange(lengths: Tensor) -> Tensor:
+    """``concat(arange(l) for l in lengths)`` without a python loop."""
+    total = int(lengths.sum().item())
+    if total == 0:
+        return lengths.new_zeros((0,))
+    starts = torch.cumsum(lengths, dim=0) - lengths
+    return torch.arange(total, device=lengths.device) - starts.repeat_interleave(
+        lengths
+    )
+
+
+class _PartBGather:
+    """Index bookkeeping for the part-B (varlen) gathered key/value buffer.
+
+    Block ``b`` owns the buffer slice ``[cu_k[b], cu_k[b+1])`` laid out as its
+    trunk remainder ``[part_a_len_b, vis_len_b)`` followed by its own ``W``
+    keys. Recomputed in backward (cheap integer math) instead of saving the
+    index tensors.
+    """
+
+    def __init__(
+        self,
+        block_row: Tensor,
+        vis_len: Tensor,
+        part_a_len: Tensor,
+        block_width: int,
+        trunk_seqlen: int,
+    ):
+        rem_len = vis_len - part_a_len
+        kv_len = rem_len + block_width
+        num_blocks = block_row.shape[0]
+        device = block_row.device
+
+        self.kv_len = kv_len
+        self.cu_k = torch.zeros(num_blocks + 1, device=device, dtype=torch.int32)
+        self.cu_k[1:] = torch.cumsum(kv_len, dim=0).to(torch.int32)
+        self.total_k = int(self.cu_k[-1].item())
+        self.max_seqlen_k = int(kv_len.max().item()) if num_blocks else 0
+
+        starts = (self.cu_k[:-1]).to(torch.long)
+        rem_offsets = _ragged_arange(rem_len)
+        rem_block = torch.repeat_interleave(
+            torch.arange(num_blocks, device=device), rem_len
+        )
+        # Destination rows in the gathered buffer / source rows in the
+        # flattened [B * S] trunk for each remainder key.
+        self.rem_dest = starts[rem_block] + rem_offsets
+        self.rem_src = (
+            block_row[rem_block] * trunk_seqlen + part_a_len[rem_block] + rem_offsets
+        )
+        own_offsets = torch.arange(block_width, device=device)
+        self.own_dest = (
+            (starts + rem_len).unsqueeze(1) + own_offsets.unsqueeze(0)
+        ).reshape(-1)
+
+    def gather(self, trunk_flat: Tensor, own: Tensor) -> Tensor:
+        """Build the gathered buffer from ``trunk_flat`` [B*S, Hkv, D] and ``own`` [NB, W, Hkv, D]."""
+        num_blocks, block_width = own.shape[0], own.shape[1]
+        gathered = trunk_flat.new_empty((self.total_k, own.shape[2], own.shape[3]))
+        gathered[self.rem_dest] = trunk_flat[self.rem_src]
+        gathered[self.own_dest] = own.reshape(num_blocks * block_width, *own.shape[2:])
+        return gathered
+
+    def scatter_grads(
+        self, d_gathered: Tensor, d_trunk_flat: Tensor, own_shape: tuple[int, ...]
+    ) -> Tensor:
+        """Accumulate remainder grads into ``d_trunk_flat`` and return the own-block grads."""
+        d_trunk_flat.index_add_(0, self.rem_src, d_gathered[self.rem_dest])
+        return d_gathered[self.own_dest].reshape(own_shape)
+
+
+def _part_a_buckets(
+    block_row: Tensor, part_a_len: Tensor
+) -> list[tuple[int, int, Tensor]]:
+    """Group blocks by ``(batch_row, part_a_len)``; skip empty prefixes."""
+    buckets: list[tuple[int, int, Tensor]] = []
+    pairs = torch.stack([block_row, part_a_len], dim=1)
+    unique_pairs, inverse = torch.unique(pairs, dim=0, return_inverse=True)
+    for pair_index in range(unique_pairs.shape[0]):
+        row = int(unique_pairs[pair_index, 0].item())
+        prefix_len = int(unique_pairs[pair_index, 1].item())
+        if prefix_len == 0:
+            continue
+        buckets.append(
+            (row, prefix_len, torch.nonzero(inverse == pair_index, as_tuple=True)[0])
+        )
+    return buckets
+
+
+class BlockDraftAttention(torch.autograd.Function):
+    """Attend each draft block to the earlier trunk and to its own tokens.
+
+    A block anchored at position ``p`` can attend to exactly two sets of keys:
+
+    - Trunk positions ``[0, p)``. The anchor itself is not included.
+    - All ``W`` positions in the same block, with bidirectional attention.
+
+    It cannot attend to any other draft block. Only block positions are
+    queries; trunk positions provide keys and values only.
+
+    The example below uses prompt tokens ``p1..p4``, response tokens
+    ``r1..r3``, one four-token block (``gamma = 3``, ``W = 4``) at each
+    response token, and ``chunk = 4``. ``A`` marks a shared, full-chunk trunk
+    prefix. ``x`` marks the remaining visible trunk keys or the block's own
+    keys. A blank cell is masked::
+
+                   |      trunk keys      | r1's block  | r2's block  | r3's block  |
+                   | p1 p2 p3 p4 r1 r2 r3 | r1  m  m  m | r2  m  m  m | r3  m  m  m |
+        =============================================================================
+        r1 (pos 4) |  A  A  A  A          |  x  x  x  x |             |             |
+        m  (pos 5) |  A  A  A  A          |  x  x  x  x |             |             |
+        m  (pos 6) |  A  A  A  A          |  x  x  x  x |             |             |
+        m  (pos 7) |  A  A  A  A          |  x  x  x  x |             |             |
+        -----------------------------------------------------------------------------
+        r2 (pos 5) |  A  A  A  A  x       |             |  x  x  x  x |             |
+        m  (pos 6) |  A  A  A  A  x       |             |  x  x  x  x |             |
+        m  (pos 7) |  A  A  A  A  x       |             |  x  x  x  x |             |
+        m  (pos 8) |  A  A  A  A  x       |             |  x  x  x  x |             |
+        -----------------------------------------------------------------------------
+        r3 (pos 6) |  A  A  A  A  x  x    |             |             |  x  x  x  x |
+        m  (pos 7) |  A  A  A  A  x  x    |             |             |  x  x  x  x |
+        m  (pos 8) |  A  A  A  A  x  x    |             |             |  x  x  x  x |
+        m  (pos 9) |  A  A  A  A  x  x    |             |             |  x  x  x  x |
+        =============================================================================
+
+    The anchor is represented by its embedding in block slot 0. This matters
+    during serving: the anchor is the newest accepted token, so its target
+    hidden state is not available yet. Earlier response tokens can later
+    appear in the trunk, but a block never reads its own anchor from the trunk.
+
+    The computation is split without changing the result:
+
+    1. A block's visible trunk keys form a prefix, split at
+       ``part_a_len = (vis_len // chunk) * chunk``.
+    2. Blocks in the same row that share ``part_a_len`` share one dense
+       FlashAttention call for the full-chunk prefix (the ``A`` cells). One
+       variable-length call handles the remainder plus each block's own keys
+       (the ``x`` cells).
+    3. These calls cover disjoint key sets. Their outputs and log-sum-exp
+       values are merged to recover the exact softmax over all visible keys.
+
+    Backward repeats the same kernel split. It uses the final output and
+    log-sum-exp so each call computes its part of the joint-softmax gradient,
+    the same mechanism as :class:`~nemo_rl.models.megatron.draft.eagle.TwoPartTTTAttention`;
+    trunk-key gradients are scattered back with ``index_add``.
+
+    Floating-point inputs use contiguous bf16/fp16 FlashAttention layouts.
+    Tensor shapes passed to ``apply`` are:
+
+    - ``q``: ``[NB, W, Hq, D]`` block queries after RoPE.
+    - ``k_own`` and ``v_own``: ``[NB, W, Hkv, D]`` block-local K/V.
+    - ``trunk_k`` and ``trunk_v``: ``[B, S, Hkv, D]`` per-layer projected taps.
+    - ``block_row``: ``[NB]`` batch row of each block.
+    - ``vis_len``: ``[NB]`` anchor position, which is also the visible trunk
+      length.
+    - ``chunk``: Size of the shared dense-attention prefix buckets.
+    - ``softmax_scale``: Scale applied to attention scores.
+
+    The result has shape ``[NB, W, Hq, D]`` and equals attention over
+    ``trunk[row, :p]`` together with the block's own keys.
+    """
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any,
+        q: Tensor,
+        k_own: Tensor,
+        v_own: Tensor,
+        trunk_k: Tensor,
+        trunk_v: Tensor,
+        block_row: Tensor,
+        vis_len: Tensor,
+        chunk: int,
+        softmax_scale: float,
+    ) -> Tensor:
+        num_blocks, block_width, num_q_heads, head_dim = q.shape
+        trunk_seqlen = trunk_k.shape[1]
+        device = q.device
+
+        if int(vis_len.max().item()) > trunk_seqlen:
+            raise ValueError(
+                f"vis_len max {int(vis_len.max().item())} exceeds trunk length "
+                f"{trunk_seqlen}."
+            )
+
+        part_a_len = torch.div(vis_len, chunk, rounding_mode="floor") * chunk
+
+        # ---- Part B: trunk remainder + own block, one varlen call ----
+        gather = _PartBGather(block_row, vis_len, part_a_len, block_width, trunk_seqlen)
+        trunk_k_flat = trunk_k.reshape(-1, *trunk_k.shape[2:])
+        trunk_v_flat = trunk_v.reshape(-1, *trunk_v.shape[2:])
+        kb = gather.gather(trunk_k_flat, k_own)
+        vb = gather.gather(trunk_v_flat, v_own)
+        q_flat = q.reshape(num_blocks * block_width, num_q_heads, head_dim)
+        cu_q = torch.arange(
+            0,
+            (num_blocks + 1) * block_width,
+            block_width,
+            device=device,
+            dtype=torch.int32,
+        )
+        out_b_flat, lse_b_flat = _fa_varlen_forward(
+            q_flat,
+            kb,
+            vb,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=gather.cu_k,
+            max_seqlen_q=block_width,
+            max_seqlen_k=gather.max_seqlen_k,
+            softmax_scale=softmax_scale,
+        )
+        # [Hq, NB*W] -> [NB, Hq, W] (uniform q length per block).
+        lse_b = (
+            lse_b_flat.view(num_q_heads, num_blocks, block_width)
+            .permute(1, 0, 2)
+            .float()
+        )
+        out_b = out_b_flat.view(num_blocks, block_width, num_q_heads, head_dim)
+
+        # ---- Part A: shared full-chunk prefixes, one dense call per bucket ----
+        lse_a = torch.full(
+            (num_blocks, num_q_heads, block_width),
+            float("-inf"),
+            device=device,
+            dtype=torch.float32,
+        )
+        out_a = torch.zeros_like(out_b, dtype=torch.float32)
+        buckets = _part_a_buckets(block_row, part_a_len)
+        for row, prefix_len, idx in buckets:
+            q_bucket = q[idx].reshape(1, -1, num_q_heads, head_dim)
+            out_bucket, lse_bucket = _fa_dense_forward(
+                q_bucket,
+                trunk_k[row : row + 1, :prefix_len],
+                trunk_v[row : row + 1, :prefix_len],
+                softmax_scale,
+            )
+            lse_a[idx] = (
+                lse_bucket.view(num_q_heads, idx.shape[0], block_width)
+                .permute(1, 0, 2)
+                .float()
+            )
+            out_a[idx] = out_bucket.view(
+                idx.shape[0], block_width, num_q_heads, head_dim
+            ).float()
+
+        # ---- Exact LSE merge of the two disjoint key sets ----
+        lse_joint = torch.logaddexp(lse_a, lse_b)  # [NB, Hq, W]
+        # [NB, Hq, W] -> [NB, W, Hq, 1] weights.
+        w_a = torch.exp(lse_a - lse_joint).permute(0, 2, 1).unsqueeze(-1)
+        w_b = torch.exp(lse_b - lse_joint).permute(0, 2, 1).unsqueeze(-1)
+        out = (w_a * out_a + w_b * out_b.float()).to(q.dtype)
+
+        ctx.save_for_backward(
+            q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, out, lse_joint
+        )
+        ctx.chunk = chunk
+        ctx.softmax_scale = softmax_scale
+        return out
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, dout: Tensor
+    ) -> tuple[Optional[Tensor], ...]:
+        (
+            q,
+            k_own,
+            v_own,
+            trunk_k,
+            trunk_v,
+            block_row,
+            vis_len,
+            out,
+            lse_joint,
+        ) = ctx.saved_tensors
+        chunk = ctx.chunk
+        softmax_scale = ctx.softmax_scale
+
+        num_blocks, block_width, num_q_heads, head_dim = q.shape
+        trunk_seqlen = trunk_k.shape[1]
+        device = q.device
+        dout = dout.contiguous()
+
+        part_a_len = torch.div(vis_len, chunk, rounding_mode="floor") * chunk
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        d_trunk_k = torch.zeros_like(trunk_k, dtype=torch.float32)
+        d_trunk_v = torch.zeros_like(trunk_v, dtype=torch.float32)
+
+        # ---- Part B backward (joint lse -> exact joint gradient on B keys) ----
+        gather = _PartBGather(block_row, vis_len, part_a_len, block_width, trunk_seqlen)
+        trunk_k_flat = trunk_k.reshape(-1, *trunk_k.shape[2:])
+        trunk_v_flat = trunk_v.reshape(-1, *trunk_v.shape[2:])
+        kb = gather.gather(trunk_k_flat, k_own)
+        vb = gather.gather(trunk_v_flat, v_own)
+        q_flat = q.reshape(num_blocks * block_width, num_q_heads, head_dim)
+        cu_q = torch.arange(
+            0,
+            (num_blocks + 1) * block_width,
+            block_width,
+            device=device,
+            dtype=torch.int32,
+        )
+        lse_joint_flat = (
+            lse_joint.permute(1, 0, 2)
+            .reshape(num_q_heads, num_blocks * block_width)
+            .contiguous()
+        )
+        dq_b = torch.empty_like(q_flat)
+        dkb = torch.empty_like(kb)
+        dvb = torch.empty_like(vb)
+        _fa_varlen_backward(
+            dout=dout.reshape(num_blocks * block_width, num_q_heads, head_dim),
+            q=q_flat,
+            k=kb,
+            v=vb,
+            out=out.reshape(num_blocks * block_width, num_q_heads, head_dim),
+            lse=lse_joint_flat,
+            dq=dq_b,
+            dk=dkb,
+            dv=dvb,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=gather.cu_k,
+            max_seqlen_q=block_width,
+            max_seqlen_k=gather.max_seqlen_k,
+            softmax_scale=softmax_scale,
+        )
+        dq += dq_b.view_as(q).float()
+        dk_own = gather.scatter_grads(
+            dkb.float(), d_trunk_k.view(-1, *trunk_k.shape[2:]), k_own.shape
+        )
+        dv_own = gather.scatter_grads(
+            dvb.float(), d_trunk_v.view(-1, *trunk_v.shape[2:]), v_own.shape
+        )
+
+        # ---- Part A backward, one dense call per bucket ----
+        for row, prefix_len, idx in _part_a_buckets(block_row, part_a_len):
+            nb = idx.shape[0]
+            q_bucket = q[idx].reshape(1, nb * block_width, num_q_heads, head_dim)
+            out_bucket = out[idx].reshape(1, nb * block_width, num_q_heads, head_dim)
+            dout_bucket = (
+                dout[idx]
+                .reshape(1, nb * block_width, num_q_heads, head_dim)
+                .contiguous()
+            )
+            lse_bucket = (
+                lse_joint[idx]
+                .permute(1, 0, 2)
+                .reshape(1, num_q_heads, nb * block_width)
+                .contiguous()
+            )
+            k_bucket = trunk_k[row : row + 1, :prefix_len].contiguous()
+            v_bucket = trunk_v[row : row + 1, :prefix_len].contiguous()
+            dq_a = torch.empty_like(q_bucket)
+            dk_a = torch.empty_like(k_bucket)
+            dv_a = torch.empty_like(v_bucket)
+            _fa_dense_backward(
+                dout=dout_bucket,
+                q=q_bucket,
+                k=k_bucket,
+                v=v_bucket,
+                out=out_bucket,
+                lse=lse_bucket,
+                dq=dq_a,
+                dk=dk_a,
+                dv=dv_a,
+                softmax_scale=softmax_scale,
+            )
+            dq[idx] += dq_a.view(nb, block_width, num_q_heads, head_dim).float()
+            d_trunk_k[row, :prefix_len] += dk_a[0].float()
+            d_trunk_v[row, :prefix_len] += dv_a[0].float()
+
+        return (
+            dq.to(q.dtype),
+            dk_own.to(k_own.dtype),
+            dv_own.to(v_own.dtype),
+            d_trunk_k.to(trunk_k.dtype),
+            d_trunk_v.to(trunk_v.dtype),
+            None,  # block_row
+            None,  # vis_len
+            None,  # chunk
+            None,  # softmax_scale
+        )
+
+
+def block_draft_attention(
+    q: Tensor,
+    k_own: Tensor,
+    v_own: Tensor,
+    trunk_k: Tensor,
+    trunk_v: Tensor,
+    block_row: Tensor,
+    vis_len: Tensor,
+    *,
+    chunk: int = 1024,
+    softmax_scale: Optional[float] = None,
+) -> Tensor:
+    """Functional wrapper for :class:`BlockDraftAttention` (see class docstring)."""
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    if chunk < 1:
+        raise ValueError(f"chunk must be >= 1, got {chunk}.")
+    return BlockDraftAttention.apply(
+        q,
+        k_own,
+        v_own,
+        trunk_k.contiguous(),
+        trunk_v.contiguous(),
+        block_row,
+        vis_len,
+        chunk,
+        softmax_scale,
+    )
+
+
+class BlockDraftCoreAttention(torch.nn.Module):
+    """Drop-in ``core_attention`` for the block-draft decoder layers.
+
+    Receives the post-RoPE q/k/v of the flattened block stream (sbhd with
+    batch 1, seq = ``NB * W`` in block-major order) and attends against the
+    per-layer trunk K/V staged by the model via :meth:`stage_trunk` before the
+    decoder call. Statefulness contract mirrors ``TTTDraftCoreAttention``:
+    the model stages fresh trunk tensors every forward and :meth:`reset`
+    clears them (never leaks across microbatches).
+    """
+
+    def __init__(self, config: TransformerConfig, chunk: int):
+        super().__init__()
+        attention_dropout = float(getattr(config, "attention_dropout", 0.0) or 0.0)
+        if attention_dropout != 0.0:
+            raise ValueError(
+                "BlockDraftCoreAttention does not support attention dropout "
+                f"(got attention_dropout={attention_dropout})."
+            )
+        if int(getattr(config, "context_parallel_size", 1) or 1) != 1:
+            raise ValueError(
+                "BlockDraftCoreAttention requires context_parallel_size == 1."
+            )
+        self.chunk = int(chunk)
+        self.softmax_scale: Optional[float] = getattr(config, "softmax_scale", None)
+        self._trunk_k: Optional[Tensor] = None
+        self._trunk_v: Optional[Tensor] = None
+        self._block_row: Optional[Tensor] = None
+        self._vis_len: Optional[Tensor] = None
+        self._block_width: int = 0
+
+    def stage_trunk(
+        self,
+        trunk_k: Tensor,
+        trunk_v: Tensor,
+        block_row: Tensor,
+        vis_len: Tensor,
+        block_width: int,
+    ) -> None:
+        """Stage this layer's trunk K/V ``[B, S, Hkv, D]`` and block metadata."""
+        self._trunk_k = trunk_k
+        self._trunk_v = trunk_v
+        self._block_row = block_row
+        self._vis_len = vis_len
+        self._block_width = int(block_width)
+
+    def reset(self) -> None:
+        """Drop staged trunk references (frees the autograd graph)."""
+        self._trunk_k = None
+        self._trunk_v = None
+        self._block_row = None
+        self._vis_len = None
+        self._block_width = 0
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Optional[Tensor],
+        attn_mask_type: Optional[Any] = None,
+        attention_bias: Optional[Tensor] = None,
+        packed_seq_params: Optional[Any] = None,
+    ) -> Tensor:
+        if packed_seq_params is not None:
+            raise NotImplementedError(
+                "Block draft training does not support sequence packing; "
+                "disable policy.sequence_packing."
+            )
+        if self._trunk_k is None:
+            raise RuntimeError(
+                "BlockDraftCoreAttention.forward called without staged trunk "
+                "K/V; the draft model must call stage_trunk() first."
+            )
+
+        seqlen, block_width = query.shape[0], self._block_width
+        softmax_scale = self.softmax_scale or query.shape[-1] ** -0.5
+
+        # sbhd (b=1) -> [NB, W, H, D]; the reshapes themselves reject any
+        # stream that is not batch-1 block-major.
+        num_blocks = seqlen // block_width
+        q = query.reshape(num_blocks, block_width, *query.shape[2:])
+        k_own = key.reshape(num_blocks, block_width, *key.shape[2:])
+        v_own = value.reshape(num_blocks, block_width, *value.shape[2:])
+
+        out = block_draft_attention(
+            q,
+            k_own,
+            v_own,
+            self._trunk_k,
+            self._trunk_v,
+            self._block_row,
+            self._vis_len,
+            chunk=self.chunk,
+            softmax_scale=softmax_scale,
+        )
+        # [NB, W, Hq, D] -> [S, 1, Hq * D] (core_attention output contract).
+        return out.reshape(seqlen, 1, -1)
+
+
+class DFlashDraftModel(MegatronModule):
+    """Block drafter with a context-only anchor slot.
+
+    A DFlash block has ``W = gamma + 1`` slots. Slot 0 contains the anchor and
+    supplies context, but its logits are not trained. The remaining ``gamma``
+    slots predict new tokens.
+    """
+
+    speculator_type = "dflash"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        *,
+        gamma: int,
+        mask_token_id: int,
+        num_aux_hidden_states: int,
+        target_hidden_size: Optional[int] = None,
+        trunk_chunk: int = 1024,
+        block_width: Optional[int] = None,
+    ):
+        super().__init__(config=config)
+        if gamma < 1:
+            raise ValueError(f"gamma must be >= 1, got {gamma}.")
+        if bool(getattr(config, "add_bias_linear", False)):
+            raise NotImplementedError(
+                "Block draft trunk projection assumes bias-free qkv (Qwen3 style)."
+            )
+        tp_size = int(config.tensor_model_parallel_size or 1)
+        if int(config.num_query_groups or config.num_attention_heads) % tp_size != 0:
+            raise NotImplementedError(
+                "Block draft trunk projection requires num_query_groups % TP == 0."
+            )
+        self.config = config
+        self.gamma = int(gamma)
+        # DFlash adds one context-only anchor slot.
+        self.block_width = int(block_width) if block_width is not None else gamma + 1
+        self.mask_token_id = int(mask_token_id)
+        self.num_aux_hidden_states = int(num_aux_hidden_states)
+        self.trunk_chunk = int(trunk_chunk)
+
+        target_hidden = int(target_hidden_size or config.hidden_size)
+        # Keep this Linear replicated across TP ranks. The input is already
+        # replicated, and every rank needs the complete output to build its
+        # local K/V heads. Sharding it would add a collective and would not
+        # match the dense ``fc.weight`` stored in existing checkpoints.
+        self.fc = torch.nn.Linear(
+            target_hidden * self.num_aux_hidden_states,
+            config.hidden_size,
+            bias=False,
+            dtype=config.params_dtype,
+        )
+        # There is no trainable mask embedding here. Mask slots reuse the
+        # detached mask-token embedding supplied by the target model.
+        self.hidden_norm = TENorm(config, config.hidden_size, config.layernorm_epsilon)
+
+        layer_spec = get_gpt_layer_with_transformer_engine_spec(
+            qk_layernorm=bool(getattr(config, "qk_layernorm", False))
+        )
+        self.decoder = TransformerBlock(
+            config=config,
+            spec=layer_spec,
+            post_layer_norm=True,
+            pre_process=True,
+            post_process=True,
+        )
+
+        self.rotary_pos_emb = RotaryEmbedding(
+            kv_channels=config.kv_channels,
+            rotary_percent=1.0,
+            rotary_interleaved=False,
+            seq_len_interpolation_factor=None,
+            rotary_base=getattr(config, "rotary_base", 10000),
+            rope_scaling=getattr(config, "rope_scaling", False),
+            rope_scaling_factor=getattr(config, "rope_scaling_factor", 8.0),
+            use_cpu_initialization=getattr(
+                config, "use_cpu_initialization", not torch.cuda.is_available()
+            ),
+        )
+
+        self._block_attn_modules: list[BlockDraftCoreAttention] = []
+        for layer in self.decoder.layers:
+            core = BlockDraftCoreAttention(config, self.trunk_chunk)
+            layer.self_attention.core_attention = core
+            self._block_attn_modules.append(core)
+
+        # NO lm_head (official contract; z-lab ckpts ship only
+        # layers/fc/hidden_norm/norm): logits project through the target's
+        # live head, passed detached into forward(). A head-less ckpt makes
+        # vLLM share the target's lm_head with the drafter unconditionally.
+
+    def _project_trunk_kv(
+        self, self_attention: torch.nn.Module, trunk_hidden: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        """Project trunk hidden states through one layer's K/V rows.
+
+        Slices the K/V rows out of the layer's fused, TP-local
+        ``linear_qkv.weight`` (Megatron interleaves per query group as
+        ``[q.. k v | q.. k v | ...]``) and applies them to the shared
+        ``hidden_norm``-ed trunk — bypassing the fused input layernorm, which
+        inference does *not* apply on the context path.
+        """
+        num_groups = self_attention.num_query_groups_per_partition
+        heads_per_group = self_attention.num_attention_heads_per_partition // num_groups
+        head_dim = self_attention.hidden_size_per_attention_head
+        weight = self_attention.linear_qkv.weight
+        grouped = weight.view(num_groups, (heads_per_group + 2) * head_dim, -1)
+        k_weight = grouped[
+            :, heads_per_group * head_dim : (heads_per_group + 1) * head_dim
+        ].reshape(num_groups * head_dim, -1)
+        v_weight = grouped[:, (heads_per_group + 1) * head_dim :].reshape(
+            num_groups * head_dim, -1
+        )
+
+        seq_len, batch = trunk_hidden.shape[0], trunk_hidden.shape[1]
+        key = F.linear(trunk_hidden, k_weight).view(
+            seq_len, batch, num_groups, head_dim
+        )
+        value = F.linear(trunk_hidden, v_weight).view(
+            seq_len, batch, num_groups, head_dim
+        )
+        k_layernorm = getattr(self_attention, "k_layernorm", None)
+        if k_layernorm is not None:
+            key = k_layernorm(key)
+        return key, value
+
+    def forward(
+        self,
+        *,
+        taps: Tensor,
+        input_embeds: Tensor,
+        anchors: Tensor,
+        anchor_valid: Tensor,
+        lm_head_weight: Tensor,
+        mask_embedding: Tensor,
+    ) -> Tensor:
+        """Run the block drafter for one batch.
+
+        The method builds per-layer trunk K/V, creates each block from one
+        anchor embedding plus mask embeddings, runs the decoder, and projects
+        its outputs with the target model's LM head.
+
+        Args:
+            taps: Target auxiliary hidden states with shape
+                ``[S, B, k * target_h]``.
+            input_embeds: Unshifted target embeddings with shape ``[S, B, h]``.
+            anchors: Anchor positions with shape ``[B, N]``.
+            anchor_valid: Validity mask with shape ``[B, N]``. Invalid blocks
+                keep tensor shapes static and are masked by the loss.
+            lm_head_weight: Detached target LM-head shard with shape
+                ``[V_local, h]``. It produces logits but is not trained here.
+            mask_embedding: Detached target mask-token embedding with shape
+                ``[h]``. Every mask slot starts from this same vector.
+
+        Returns:
+            Vocab-parallel logits with shape ``[B, N, W, V_local]``. Slot 0 is
+            the anchor slot.
+        """
+        seq_len, batch = taps.shape[0], taps.shape[1]
+        num_anchors = anchors.shape[1]
+        num_blocks = batch * num_anchors
+        block_width = self.block_width
+        device = taps.device
+
+        if anchors.shape[0] != batch:
+            raise ValueError(f"anchors batch {anchors.shape[0]} != taps batch {batch}.")
+        if int(anchors.max().item()) >= seq_len:
+            raise ValueError("anchor position exceeds sequence length.")
+
+        # Build the target-derived trunk K/V used by every draft block.
+        trunk_hidden = self.hidden_norm(self.fc(taps))
+        # ``F.linear`` bypasses the input-gradient reduction normally provided
+        # by ``ColumnParallelLinear``. This wrapper is an identity in forward
+        # and sums gradients across TP ranks in backward, keeping the
+        # replicated ``fc`` and ``hidden_norm`` parameters in sync.
+        trunk_hidden = copy_to_tensor_model_parallel_region(trunk_hidden)
+        rotary_table = self.rotary_pos_emb(seq_len + block_width)
+        trunk_freqs = rotary_table[:seq_len]
+
+        block_row = torch.arange(batch, device=device).repeat_interleave(num_anchors)
+        anchors_flat = anchors.reshape(-1)
+        # An anchor at p can see trunk positions [0, p). Its own token is
+        # supplied separately as block slot 0.
+        vis_len = anchors_flat
+
+        for layer, core in zip(self.decoder.layers, self._block_attn_modules):
+            key, value = self._project_trunk_kv(layer.self_attention, trunk_hidden)
+            key = apply_rotary_pos_emb(key, trunk_freqs, config=self.config)
+            # [S, B, Hkv, D] -> [B, S, Hkv, D]
+            core.stage_trunk(
+                key.permute(1, 0, 2, 3).contiguous(),
+                value.permute(1, 0, 2, 3).contiguous(),
+                block_row,
+                vis_len,
+                block_width,
+            )
+
+        # Create each block from its anchor embedding followed by mask vectors.
+        embeds_flat = input_embeds.permute(1, 0, 2).reshape(batch * seq_len, -1)
+        anchor_embeds = embeds_flat[block_row * seq_len + anchors_flat]
+        hidden = (
+            mask_embedding.to(anchor_embeds.dtype)
+            .expand(num_blocks, block_width, -1)
+            .clone()
+        )
+        hidden[:, 0] = anchor_embeds
+        hidden = hidden.reshape(num_blocks * block_width, 1, -1)
+
+        offsets = torch.arange(block_width, device=device)
+        positions = (anchors_flat.unsqueeze(1) + offsets).reshape(-1)
+        block_freqs = rotary_table[positions]
+
+        try:
+            decoder_hidden = self.decoder(
+                hidden_states=hidden,
+                attention_mask=None,
+                rotary_pos_emb=block_freqs,
+            )
+        finally:
+            for core in self._block_attn_modules:
+                core.reset()
+
+        # The manual projection through the sharded LM head has the same TP
+        # gradient issue as the trunk projection above. Sum its input gradient.
+        decoder_hidden = copy_to_tensor_model_parallel_region(decoder_hidden)
+        logits = F.linear(decoder_hidden, lm_head_weight)
+        # [NB * W, 1, V_local] -> [B, N, W, V_local]
+        return logits.reshape(batch, num_anchors, block_width, -1)

--- a/nemo_rl/models/megatron/draft/dflash.py
+++ b/nemo_rl/models/megatron/draft/dflash.py
@@ -26,6 +26,14 @@ This file matches the behavior of vLLM 0.26's
 - A block can attend to target tokens before ``p`` and to every token in its
   own block. It cannot attend to other blocks. See
   :class:`BlockDraftAttention` for an example mask.
+- Layers marked ``sliding_attention`` in the checkpoint's ``layer_types``
+  are causal with a per-query ``sliding_window`` (vLLM's resolution for
+  mixed-type checkpoints) and run as one windowed varlen call.
+- Packed and unpacked inputs both use a flat THD trunk internally. With
+  context parallelism (CP), full-attention layers move trunk K/V shards
+  around a zigzag ring while each block stays on the rank that owns its
+  anchor; sliding layers instead all-gather the layer's trunk K/V back to
+  global order and keep their single windowed call.
 - The draft model has no separate mask embedding or LM head. ``forward``
   receives detached references to the target model's mask-token embedding and
   current LM head, matching how serving shares those target-model weights.
@@ -41,6 +49,7 @@ from typing import Any, Optional
 
 import flash_attn
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 from flash_attn.flash_attn_interface import (
     _flash_attn_backward,
@@ -48,6 +57,7 @@ from flash_attn.flash_attn_interface import (
     _flash_attn_varlen_backward,
     _flash_attn_varlen_forward,
 )
+from megatron.core import parallel_state
 from megatron.core.extensions.transformer_engine import TENorm
 from megatron.core.models.common.embeddings import RotaryEmbedding
 from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
@@ -260,6 +270,8 @@ def _fa_varlen_forward(
     max_seqlen_q: int,
     max_seqlen_k: int,
     softmax_scale: float,
+    window_left: int,
+    window_right: int,
 ) -> tuple[Tensor, Tensor]:
     """Varlen non-causal FA forward; returns (out [Tq,Hq,D], lse [Hq,Tq] fp32)."""
     out, softmax_lse, _, _ = _flash_attn_varlen_forward(
@@ -273,8 +285,8 @@ def _fa_varlen_forward(
         0.0,  # dropout_p
         softmax_scale,
         False,  # causal
-        -1,  # window_size_left
-        -1,  # window_size_right
+        window_left,
+        window_right,
         0.0,  # softcap
         None,  # alibi_slopes
         False,  # return_softmax
@@ -299,6 +311,8 @@ def _fa_varlen_backward(
     max_seqlen_q: int,
     max_seqlen_k: int,
     softmax_scale: float,
+    window_left: int,
+    window_right: int,
 ) -> None:
     """Varlen FA backward into preallocated dq/dk/dv (fed the joint (out, lse))."""
     _flash_attn_varlen_backward(
@@ -318,8 +332,8 @@ def _fa_varlen_backward(
         0.0,  # dropout_p
         softmax_scale,
         False,  # causal
-        -1,  # window_size_left
-        -1,  # window_size_right
+        window_left,
+        window_right,
         0.0,  # softcap
         None,  # alibi_slopes
         False,  # deterministic
@@ -338,82 +352,253 @@ def _ragged_arange(lengths: Tensor) -> Tensor:
     )
 
 
-class _PartBGather:
-    """Index bookkeeping for the part-B (varlen) gathered key/value buffer.
+def _global_cp_group() -> Optional[dist.ProcessGroup]:
+    """The global CP group, or None before model-parallel init (unit tests)."""
+    if not parallel_state.model_parallel_is_initialized():
+        return None
+    return parallel_state.get_context_parallel_group()
 
-    Block ``b`` owns the buffer slice ``[cu_k[b], cu_k[b+1])`` laid out as its
-    trunk remainder ``[part_a_len_b, vis_len_b)`` followed by its own ``W``
-    keys. Recomputed in backward (cheap integer math) instead of saving the
-    index tensors.
+
+def _ring_send_recv(
+    tensors: list[Tensor],
+    send_rank: int,
+    recv_rank: int,
+    cp_group: dist.ProcessGroup,
+) -> tuple[list[Tensor], list[Any]]:
+    """Batched P2P hop: send each tensor to next, receive a like one from prev.
+
+    The caller must keep the sent tensors alive until it waits on the requests.
+    """
+    recvs = [torch.empty_like(t) for t in tensors]
+    ops = []
+    for send_t, recv_t in zip(tensors, recvs):
+        ops.append(dist.P2POp(dist.isend, send_t.contiguous(), send_rank, cp_group))
+        ops.append(dist.P2POp(dist.irecv, recv_t, recv_rank, cp_group))
+    return recvs, dist.batch_isend_irecv(ops)
+
+
+def _merge_rows(
+    out_acc: Tensor,
+    lse_acc: Tensor,
+    rows: Tensor,
+    out_step: Tensor,
+    lse_step: Tensor,
+) -> None:
+    """Merge attention over another set of keys into selected output rows.
+
+    ``out_step`` is normalized only over the keys handled by this step. Its
+    log-sum-exp value, ``lse_step``, provides the exact weight needed to merge
+    it with earlier steps. The fp32 accumulators start at 0 and ``-inf``, so
+    the first merge acts like a copy.
+
+    Shapes are ``[NB, W, Hq, D]`` for ``out_acc``, ``[NB, Hq, W]`` for
+    ``lse_acc``, ``[nb, W, Hq, D]`` for ``out_step``, and ``[nb, Hq, W]`` for
+    ``lse_step``.
+    """
+    lse_old = lse_acc[rows]
+    lse_new = torch.logaddexp(lse_old, lse_step)
+    w_old = torch.exp(lse_old - lse_new).permute(0, 2, 1).unsqueeze(-1)
+    w_new = torch.exp(lse_step - lse_new).permute(0, 2, 1).unsqueeze(-1)
+    out_acc[rows] = out_acc[rows] * w_old + out_step.float() * w_new
+    lse_acc[rows] = lse_new
+
+
+class _RingStepGeometry:
+    """Describe the visible keys for one context-parallel ring step.
+
+    Forward and backward need the same gather and scatter indices. They are
+    cheap to compute, so backward creates this object again instead of saving
+    all index tensors from forward. :meth:`gather` builds the temporary K/V
+    buffer, and :meth:`scatter_grads` maps its gradients back.
+
+    At a ring step, the local trunk buffer contains two zigzag chunks from
+    source rank ``src``: a front chunk ``c_f = src`` and a back chunk
+    ``c_b = 2 * cp_size - 1 - src``. For an anchor at position ``p``, the
+    number of visible tokens in this buffer is shown below. ``half`` is the
+    number of tokens in either half of a rank's local zigzag shard.
+
+    ``clamp(p - c_f * half, 0, half) + clamp(p - c_b * half, 0, half)``.
+
+    These tokens form a local prefix. The largest whole multiple of ``chunk``
+    becomes the shared dense-attention part. The remaining trunk tokens use
+    variable-length attention. On the first ring step, that variable-length
+    part also includes the block's own ``W`` keys.
     """
 
     def __init__(
         self,
-        block_row: Tensor,
+        block_seq: Tensor,
         vis_len: Tensor,
-        part_a_len: Tensor,
+        cu_local: Tensor,
+        chunk: int,
+        src: int,
+        cp_size: int,
         block_width: int,
-        trunk_seqlen: int,
+        include_own: bool,
     ):
-        rem_len = vis_len - part_a_len
-        kv_len = rem_len + block_width
-        num_blocks = block_row.shape[0]
-        device = block_row.device
+        device = block_seq.device
+        cu = cu_local.to(torch.long)
+        half = ((cu[1:] - cu[:-1]) // 2)[block_seq]
+        c_front, c_back = src, 2 * cp_size - 1 - src
+        vis_front = torch.minimum((vis_len - c_front * half).clamp(min=0), half)
+        vis_back = torch.minimum((vis_len - c_back * half).clamp(min=0), half)
+        vis = vis_front + vis_back
+        self.part_a_len = torch.div(vis, chunk, rounding_mode="floor") * chunk
+        rem_len = vis - self.part_a_len
+        seg_start = cu[:-1][block_seq]
 
-        self.kv_len = kv_len
-        self.cu_k = torch.zeros(num_blocks + 1, device=device, dtype=torch.int32)
-        self.cu_k[1:] = torch.cumsum(kv_len, dim=0).to(torch.int32)
-        self.total_k = int(self.cu_k[-1].item())
-        self.max_seqlen_k = int(kv_len.max().item()) if num_blocks else 0
+        own_w = block_width if include_own else 0
+        kv_len = rem_len + own_w
+        self.active = torch.nonzero(kv_len > 0, as_tuple=True)[0]
+        self.own_w = own_w
+        num_active = self.active.numel()
+        rem_active = rem_len[self.active]
+        self.cu_k = torch.zeros(num_active + 1, device=device, dtype=torch.int32)
+        self.cu_k[1:] = torch.cumsum(kv_len[self.active], dim=0).to(torch.int32)
+        self.total_k = int(self.cu_k[-1].item()) if num_active else 0
+        self.max_seqlen_k = int(kv_len[self.active].max().item()) if num_active else 0
 
-        starts = (self.cu_k[:-1]).to(torch.long)
-        rem_offsets = _ragged_arange(rem_len)
-        rem_block = torch.repeat_interleave(
-            torch.arange(num_blocks, device=device), rem_len
+        starts = self.cu_k[:-1].to(torch.long)
+        rem_offsets = _ragged_arange(rem_active)
+        rem_block = torch.arange(num_active, device=device).repeat_interleave(
+            rem_active
         )
-        # Destination rows in the gathered buffer / source rows in the
-        # flattened [B * S] trunk for each remainder key.
+        # Map the visible remainder from the current trunk shard into the
+        # temporary variable-length K/V buffer.
+        act = self.active
         self.rem_dest = starts[rem_block] + rem_offsets
-        self.rem_src = (
-            block_row[rem_block] * trunk_seqlen + part_a_len[rem_block] + rem_offsets
-        )
-        own_offsets = torch.arange(block_width, device=device)
-        self.own_dest = (
-            (starts + rem_len).unsqueeze(1) + own_offsets.unsqueeze(0)
-        ).reshape(-1)
+        self.rem_src = (seg_start[act] + self.part_a_len[act])[rem_block] + rem_offsets
+        if own_w:
+            own_start = (starts + rem_active).unsqueeze(1)
+            self.own_dest = (own_start + torch.arange(own_w, device=device)).reshape(-1)
+        else:
+            self.own_dest = None
 
-    def gather(self, trunk_flat: Tensor, own: Tensor) -> Tensor:
-        """Build the gathered buffer from ``trunk_flat`` [B*S, Hkv, D] and ``own`` [NB, W, Hkv, D]."""
-        num_blocks, block_width = own.shape[0], own.shape[1]
-        gathered = trunk_flat.new_empty((self.total_k, own.shape[2], own.shape[3]))
-        gathered[self.rem_dest] = trunk_flat[self.rem_src]
-        gathered[self.own_dest] = own.reshape(num_blocks * block_width, *own.shape[2:])
+    def gather(self, trunk_step: Tensor, own: Tensor) -> Tensor:
+        """Gather visible trunk rows and, on step 0, the block's own keys."""
+        gathered = trunk_step.new_empty((self.total_k, *trunk_step.shape[1:]))
+        gathered[self.rem_dest] = trunk_step[self.rem_src]
+        if self.own_w:
+            gathered[self.own_dest] = own[self.active].reshape(-1, *own.shape[2:])
         return gathered
 
     def scatter_grads(
-        self, d_gathered: Tensor, d_trunk_flat: Tensor, own_shape: tuple[int, ...]
-    ) -> Tensor:
-        """Accumulate remainder grads into ``d_trunk_flat`` and return the own-block grads."""
-        d_trunk_flat.index_add_(0, self.rem_src, d_gathered[self.rem_dest])
-        return d_gathered[self.own_dest].reshape(own_shape)
+        self, d_gathered: Tensor, d_trunk_step: Tensor, d_own: Optional[Tensor]
+    ) -> None:
+        """Scatter gathered-buffer gradients back to trunk and block tensors."""
+        d_trunk_step.index_add_(0, self.rem_src, d_gathered[self.rem_dest])
+        if self.own_w:
+            d_own[self.active] += d_gathered[self.own_dest].reshape(
+                self.active.numel(), self.own_w, *d_gathered.shape[1:]
+            )
 
 
 def _part_a_buckets(
-    block_row: Tensor, part_a_len: Tensor
+    block_seq: Tensor, part_a_len: Tensor
 ) -> list[tuple[int, int, Tensor]]:
-    """Group blocks by ``(batch_row, part_a_len)``; skip empty prefixes."""
+    """Group blocks by ``(subsequence, part_a_len)``; skip empty prefixes."""
     buckets: list[tuple[int, int, Tensor]] = []
-    pairs = torch.stack([block_row, part_a_len], dim=1)
+    pairs = torch.stack([block_seq, part_a_len], dim=1)
     unique_pairs, inverse = torch.unique(pairs, dim=0, return_inverse=True)
     for pair_index in range(unique_pairs.shape[0]):
-        row = int(unique_pairs[pair_index, 0].item())
+        seq = int(unique_pairs[pair_index, 0].item())
         prefix_len = int(unique_pairs[pair_index, 1].item())
         if prefix_len == 0:
             continue
-        buckets.append(
-            (row, prefix_len, torch.nonzero(inverse == pair_index, as_tuple=True)[0])
-        )
+        idx = torch.nonzero(inverse == pair_index, as_tuple=True)[0]
+        buckets.append((seq, prefix_len, idx))
     return buckets
+
+
+def _sliding_gather(
+    trunk_k: Tensor,
+    trunk_v: Tensor,
+    k_own: Tensor,
+    v_own: Tensor,
+    block_seq: Tensor,
+    vis_len: Tensor,
+    cu_local: Tensor,
+    window: int,
+) -> tuple[Tensor, Tensor, Tensor, int, Tensor, Tensor, Tensor]:
+    """Key buffers + maps for the sliding path's single windowed varlen call.
+
+    Per block the visible keys are trunk ``[max(0, p - window + 1), p)`` plus
+    the own ``W`` keys — contiguous positions, so FA's native window applies
+    the per-slot mask exactly. Returns ``(kb, vb, cu_k, max_seqlen_k, rem_src,
+    rem_dest, own_dest)``; backward recalls this instead of saving the maps
+    (cheap integer math, same policy as :class:`_RingStepGeometry`).
+    """
+    num_blocks, block_width = k_own.shape[0], k_own.shape[1]
+    device = block_seq.device
+    cu = cu_local.to(torch.long)
+    lo = (vis_len - (window - 1)).clamp(min=0)
+    rem_len = vis_len - lo
+    kv_len = rem_len + block_width
+    cu_k = torch.zeros(num_blocks + 1, device=device, dtype=torch.int32)
+    cu_k[1:] = torch.cumsum(kv_len, dim=0).to(torch.int32)
+    starts = cu_k[:-1].to(torch.long)
+    rem_offsets = _ragged_arange(rem_len)
+    rem_block = torch.arange(num_blocks, device=device).repeat_interleave(rem_len)
+    rem_dest = starts[rem_block] + rem_offsets
+    rem_src = (cu[block_seq] + lo)[rem_block] + rem_offsets
+    own_start = (starts + rem_len).unsqueeze(1)
+    own_dest = (own_start + torch.arange(block_width, device=device)).reshape(-1)
+
+    kb = trunk_k.new_empty((int(cu_k[-1].item()), *trunk_k.shape[1:]))
+    vb = torch.empty_like(kb)
+    kb[rem_dest] = trunk_k[rem_src]
+    vb[rem_dest] = trunk_v[rem_src]
+    kb[own_dest] = k_own.reshape(-1, *k_own.shape[2:])
+    vb[own_dest] = v_own.reshape(-1, *v_own.shape[2:])
+    return kb, vb, cu_k, int(kv_len.max().item()), rem_src, rem_dest, own_dest
+
+
+def _unzigzag_rows(cu_local: Tensor, cp_size: int, t_local: int) -> Tensor:
+    """Row map from global THD order into the rank-major all-gathered buffer.
+
+    Rank ``r``'s shard holds, per sequence, zigzag chunks ``r`` and
+    ``2 * cp_size - 1 - r`` back to back, so global token ``g`` of a sequence
+    lives at buffer row ``src_rank * t_local + local_offset``. Indexing the
+    all-gathered ``[cp_size * t_local, ...]`` buffer with the result yields
+    the sequence-packed trunk in global order; backward reuses the same map
+    (a bijection) to lay gradient rows out for ``reduce_scatter_tensor``.
+    """
+    cu = cu_local.to(torch.long)
+    device = cu_local.device
+    rows = []
+    for seq in range(int(cu.numel()) - 1):
+        half = (int(cu[seq + 1]) - int(cu[seq])) // 2
+        if half == 0:
+            continue
+        g = torch.arange(2 * cp_size * half, device=device)
+        chunk_idx = torch.div(g, half, rounding_mode="floor")
+        back = chunk_idx >= cp_size
+        src_rank = torch.where(back, 2 * cp_size - 1 - chunk_idx, chunk_idx)
+        local = int(cu[seq]) + back.long() * half + g % half
+        rows.append(src_rank * t_local + local)
+    return torch.cat(rows)
+
+
+def _allgather_trunk(
+    trunk_k: Tensor,
+    trunk_v: Tensor,
+    cu_local: Tensor,
+    cp_size: int,
+    cp_group: dist.ProcessGroup,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """All-gather zigzag trunk K/V shards into global THD order.
+
+    Transient by design: forward and backward each call this instead of
+    saving the gathered buffers, the same recompute policy as
+    :class:`_RingStepGeometry`.
+    """
+    t_local = trunk_k.shape[0]
+    k_all = trunk_k.new_empty((cp_size * t_local, *trunk_k.shape[1:]))
+    v_all = torch.empty_like(k_all)
+    dist.all_gather_into_tensor(k_all, trunk_k.contiguous(), group=cp_group)
+    dist.all_gather_into_tensor(v_all, trunk_v.contiguous(), group=cp_group)
+    unzig = _unzigzag_rows(cu_local, cp_size, t_local)
+    return k_all[unzig], v_all[unzig], unzig
 
 
 class BlockDraftAttention(torch.autograd.Function):
@@ -459,34 +644,58 @@ class BlockDraftAttention(torch.autograd.Function):
 
     The computation is split without changing the result:
 
-    1. A block's visible trunk keys form a prefix, split at
-       ``part_a_len = (vis_len // chunk) * chunk``.
-    2. Blocks in the same row that share ``part_a_len`` share one dense
-       FlashAttention call for the full-chunk prefix (the ``A`` cells). One
-       variable-length call handles the remainder plus each block's own keys
-       (the ``x`` cells).
-    3. These calls cover disjoint key sets. Their outputs and log-sum-exp
+    1. With CP, blocks stay on their owner rank while trunk K/V shards move
+       from rank to rank for ``cp_size`` steps. With one rank, this is one step.
+    2. At each step, a block's visible local trunk keys form a prefix. The
+       prefix is split at ``part_a_len = (vis // chunk) * chunk``.
+    3. Blocks with the same sequence and ``part_a_len`` share one dense
+       FlashAttention call for the full-chunk prefix (the ``A`` cells).
+       One variable-length call handles the remainder and, on step 0, each
+       block's own keys (the ``x`` cells).
+    4. These calls cover disjoint key sets. Their outputs and log-sum-exp
        values are merged to recover the exact softmax over all visible keys.
 
-    Backward repeats the same kernel split. It uses the final output and
-    log-sum-exp so each call computes its part of the joint-softmax gradient,
-    the same mechanism as :class:`~nemo_rl.models.megatron.draft.eagle.TwoPartTTTAttention`;
-    trunk-key gradients are scattered back with ``index_add``.
+    Backward repeats the same ring steps and kernel split. It uses the final
+    output and log-sum-exp so each call computes its part of the joint-softmax
+    gradient. Trunk K/V gradients travel with their shard and finish with one
+    last hop back to the rank that owns them.
+
+    ``window > 0`` selects sliding-window attention for the layer instead
+    (official 35B-style checkpoints: ``layer_types`` + ``sliding_window``).
+    vLLM resolves such layers as CAUSAL sliding windows
+    (``qwen3_dflash._resolve_layer_attention``: mixed-type checkpoints are
+    causal on sliding layers, non-causal on full layers), so key ``k`` is
+    visible to query ``q`` iff ``0 <= q - k <= window - 1`` — block-internal
+    attention becomes lower-triangular too. The visible keys
+    ``[max(0, p - window + 1), p)`` plus the own block form one contiguous
+    position run, so the whole layer becomes a single varlen call with FA's
+    native ``(window - 1, 0)`` window: the per-slot mask is exact, with no
+    kernel split, no LSE merge, and no ring. Under CP the sliding layer
+    all-gathers its trunk K/V shard back to global order first and keeps
+    that single call; backward re-gathers and returns trunk gradients home
+    with one reduce-scatter. Windowing the ring instead would break FA's
+    bottom-right causal alignment on mid-ring key segments (per-slot lower
+    bounds need a staircase split the full path never has), and a block only
+    ever reads ``window + W`` keys, so the transient gather is the cheaper
+    exact form.
 
     Floating-point inputs use contiguous bf16/fp16 FlashAttention layouts.
     Tensor shapes passed to ``apply`` are:
 
     - ``q``: ``[NB, W, Hq, D]`` block queries after RoPE.
     - ``k_own`` and ``v_own``: ``[NB, W, Hkv, D]`` block-local K/V.
-    - ``trunk_k`` and ``trunk_v``: ``[B, S, Hkv, D]`` per-layer projected taps.
-    - ``block_row``: ``[NB]`` batch row of each block.
+    - ``trunk_k`` and ``trunk_v``: ``[T, Hkv, D]`` local trunk K/V shard.
+    - ``block_seq``: ``[NB]`` subsequence index for each block.
     - ``vis_len``: ``[NB]`` anchor position, which is also the visible trunk
-      length.
+      length in global subsequence coordinates.
+    - ``cu_seqlens_local``: ``[B + 1]`` local subsequence boundaries.
     - ``chunk``: Size of the shared dense-attention prefix buckets.
+    - ``window``: Sliding window size for this layer; 0 means full attention.
     - ``softmax_scale``: Scale applied to attention scores.
+    - ``cp_group``: CP process group, or ``None`` on a single rank.
 
     The result has shape ``[NB, W, Hq, D]`` and equals attention over
-    ``trunk[row, :p]`` together with the block's own keys.
+    ``trunk[seq, :p]`` together with the block's own keys.
     """
 
     @staticmethod
@@ -497,93 +706,161 @@ class BlockDraftAttention(torch.autograd.Function):
         v_own: Tensor,
         trunk_k: Tensor,
         trunk_v: Tensor,
-        block_row: Tensor,
+        block_seq: Tensor,
         vis_len: Tensor,
+        cu_seqlens_local: Tensor,
         chunk: int,
+        window: int,
         softmax_scale: float,
+        cp_group: Optional[dist.ProcessGroup],
     ) -> Tensor:
         num_blocks, block_width, num_q_heads, head_dim = q.shape
-        trunk_seqlen = trunk_k.shape[1]
         device = q.device
+        cp_size = 1 if cp_group is None else cp_group.size()
+        cp_rank = 0 if cp_group is None else cp_group.rank()
+        if cp_size > 1:
+            global_ranks = dist.get_process_group_ranks(cp_group)
+            send_rank = global_ranks[(cp_rank + 1) % cp_size]
+            recv_rank = global_ranks[(cp_rank - 1) % cp_size]
 
-        if int(vis_len.max().item()) > trunk_seqlen:
-            raise ValueError(
-                f"vis_len max {int(vis_len.max().item())} exceeds trunk length "
-                f"{trunk_seqlen}."
+        cu = cu_seqlens_local.to(torch.long)
+        seq_lens = (cu[1:] - cu[:-1]) * cp_size
+        if bool((vis_len > seq_lens[block_seq]).any().item()):
+            raise ValueError("vis_len exceeds its subsequence's trunk length.")
+
+        cu_q = block_width * torch.arange(
+            num_blocks + 1, device=device, dtype=torch.int32
+        )
+
+        if window > 0:
+            if cp_size > 1:
+                k_attn, v_attn, _ = _allgather_trunk(
+                    trunk_k, trunk_v, cu, cp_size, cp_group
+                )
+                cu_attn = cu * cp_size
+            else:
+                k_attn, v_attn, cu_attn = trunk_k, trunk_v, cu
+            kb, vb, cu_k, max_k, _, _, _ = _sliding_gather(
+                k_attn, v_attn, k_own, v_own, block_seq, vis_len, cu_attn, window
             )
-
-        part_a_len = torch.div(vis_len, chunk, rounding_mode="floor") * chunk
-
-        # ---- Part B: trunk remainder + own block, one varlen call ----
-        gather = _PartBGather(block_row, vis_len, part_a_len, block_width, trunk_seqlen)
-        trunk_k_flat = trunk_k.reshape(-1, *trunk_k.shape[2:])
-        trunk_v_flat = trunk_v.reshape(-1, *trunk_v.shape[2:])
-        kb = gather.gather(trunk_k_flat, k_own)
-        vb = gather.gather(trunk_v_flat, v_own)
-        q_flat = q.reshape(num_blocks * block_width, num_q_heads, head_dim)
-        cu_q = torch.arange(
-            0,
-            (num_blocks + 1) * block_width,
-            block_width,
-            device=device,
-            dtype=torch.int32,
-        )
-        out_b_flat, lse_b_flat = _fa_varlen_forward(
-            q_flat,
-            kb,
-            vb,
-            cu_seqlens_q=cu_q,
-            cu_seqlens_k=gather.cu_k,
-            max_seqlen_q=block_width,
-            max_seqlen_k=gather.max_seqlen_k,
-            softmax_scale=softmax_scale,
-        )
-        # [Hq, NB*W] -> [NB, Hq, W] (uniform q length per block).
-        lse_b = (
-            lse_b_flat.view(num_q_heads, num_blocks, block_width)
-            .permute(1, 0, 2)
-            .float()
-        )
-        out_b = out_b_flat.view(num_blocks, block_width, num_q_heads, head_dim)
-
-        # ---- Part A: shared full-chunk prefixes, one dense call per bucket ----
-        lse_a = torch.full(
-            (num_blocks, num_q_heads, block_width),
-            float("-inf"),
-            device=device,
-            dtype=torch.float32,
-        )
-        out_a = torch.zeros_like(out_b, dtype=torch.float32)
-        buckets = _part_a_buckets(block_row, part_a_len)
-        for row, prefix_len, idx in buckets:
-            q_bucket = q[idx].reshape(1, -1, num_q_heads, head_dim)
-            out_bucket, lse_bucket = _fa_dense_forward(
-                q_bucket,
-                trunk_k[row : row + 1, :prefix_len],
-                trunk_v[row : row + 1, :prefix_len],
-                softmax_scale,
+            out_b, lse = _fa_varlen_forward(
+                q.reshape(-1, num_q_heads, head_dim),
+                kb,
+                vb,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=block_width,
+                max_seqlen_k=max_k,
+                softmax_scale=softmax_scale,
+                window_left=window - 1,
+                window_right=0,
             )
-            lse_a[idx] = (
-                lse_bucket.view(num_q_heads, idx.shape[0], block_width)
-                .permute(1, 0, 2)
-                .float()
+            out = out_b.view(num_blocks, block_width, num_q_heads, head_dim)
+            ctx.save_for_backward(
+                q,
+                k_own,
+                v_own,
+                trunk_k,
+                trunk_v,
+                block_seq,
+                vis_len,
+                cu_seqlens_local,
+                out,
+                lse,
             )
-            out_a[idx] = out_bucket.view(
-                idx.shape[0], block_width, num_q_heads, head_dim
-            ).float()
+            ctx.chunk = chunk
+            ctx.window = window
+            ctx.softmax_scale = softmax_scale
+            ctx.cp_group = cp_group
+            ctx.cp_size = cp_size
+            return out
 
-        # ---- Exact LSE merge of the two disjoint key sets ----
-        lse_joint = torch.logaddexp(lse_a, lse_b)  # [NB, Hq, W]
-        # [NB, Hq, W] -> [NB, W, Hq, 1] weights.
-        w_a = torch.exp(lse_a - lse_joint).permute(0, 2, 1).unsqueeze(-1)
-        w_b = torch.exp(lse_b - lse_joint).permute(0, 2, 1).unsqueeze(-1)
-        out = (w_a * out_a + w_b * out_b.float()).to(q.dtype)
+        out_acc = torch.zeros_like(q, dtype=torch.float32)
+        lse_acc = q.new_full(
+            (num_blocks, num_q_heads, block_width), float("-inf"), dtype=torch.float32
+        )
 
+        k_cur, v_cur = trunk_k, trunk_v
+        reqs: list[Any] = []
+        for step in range(cp_size):
+            if step + 1 < cp_size:
+                (k_next, v_next), reqs = _ring_send_recv(
+                    [k_cur, v_cur], send_rank, recv_rank, cp_group
+                )
+            geo = _RingStepGeometry(
+                block_seq,
+                vis_len,
+                cu,
+                chunk,
+                (cp_rank - step) % cp_size,
+                cp_size,
+                block_width,
+                include_own=step == 0,
+            )
+            if geo.active.numel():
+                kb = geo.gather(k_cur, k_own)
+                vb = geo.gather(v_cur, v_own)
+                nb = geo.active.numel()
+                q_act = q[geo.active].reshape(-1, num_q_heads, head_dim)
+                out_b, lse_b = _fa_varlen_forward(
+                    q_act,
+                    kb,
+                    vb,
+                    cu_seqlens_q=cu_q[: nb + 1],
+                    cu_seqlens_k=geo.cu_k,
+                    max_seqlen_q=block_width,
+                    max_seqlen_k=geo.max_seqlen_k,
+                    softmax_scale=softmax_scale,
+                    window_left=-1,
+                    window_right=-1,
+                )
+                _merge_rows(
+                    out_acc,
+                    lse_acc,
+                    geo.active,
+                    out_b.view(nb, block_width, num_q_heads, head_dim),
+                    lse_b.view(num_q_heads, nb, block_width).permute(1, 0, 2).float(),
+                )
+            for seq, prefix_len, idx in _part_a_buckets(block_seq, geo.part_a_len):
+                seg_start = int(cu[seq].item())
+                nbk = idx.shape[0]
+                q_bucket = q[idx].reshape(1, -1, num_q_heads, head_dim)
+                out_a, lse_a = _fa_dense_forward(
+                    q_bucket,
+                    k_cur[seg_start : seg_start + prefix_len].unsqueeze(0),
+                    v_cur[seg_start : seg_start + prefix_len].unsqueeze(0),
+                    softmax_scale,
+                )
+                _merge_rows(
+                    out_acc,
+                    lse_acc,
+                    idx,
+                    out_a.view(nbk, block_width, num_q_heads, head_dim),
+                    lse_a.view(num_q_heads, nbk, block_width).permute(1, 0, 2).float(),
+                )
+            if step + 1 < cp_size:
+                for req in reqs:
+                    req.wait()
+                k_cur, v_cur = k_next, v_next
+
+        out = out_acc.to(q.dtype)
         ctx.save_for_backward(
-            q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, out, lse_joint
+            q,
+            k_own,
+            v_own,
+            trunk_k,
+            trunk_v,
+            block_seq,
+            vis_len,
+            cu_seqlens_local,
+            out,
+            lse_acc,
         )
         ctx.chunk = chunk
+        ctx.window = window
         ctx.softmax_scale = softmax_scale
+        ctx.cp_group = cp_group
+        ctx.cp_size = cp_size
         return out
 
     @staticmethod
@@ -596,202 +873,290 @@ class BlockDraftAttention(torch.autograd.Function):
             v_own,
             trunk_k,
             trunk_v,
-            block_row,
+            block_seq,
             vis_len,
+            cu_seqlens_local,
             out,
             lse_joint,
         ) = ctx.saved_tensors
         chunk = ctx.chunk
+        window = ctx.window
         softmax_scale = ctx.softmax_scale
+        cp_group = ctx.cp_group
+        cp_size = ctx.cp_size
 
         num_blocks, block_width, num_q_heads, head_dim = q.shape
-        trunk_seqlen = trunk_k.shape[1]
         device = q.device
         dout = dout.contiguous()
+        cp_rank = 0 if cp_group is None else cp_group.rank()
+        if cp_size > 1:
+            global_ranks = dist.get_process_group_ranks(cp_group)
+            send_rank = global_ranks[(cp_rank + 1) % cp_size]
+            recv_rank = global_ranks[(cp_rank - 1) % cp_size]
 
-        part_a_len = torch.div(vis_len, chunk, rounding_mode="floor") * chunk
-        dq = torch.zeros_like(q, dtype=torch.float32)
-        d_trunk_k = torch.zeros_like(trunk_k, dtype=torch.float32)
-        d_trunk_v = torch.zeros_like(trunk_v, dtype=torch.float32)
-
-        # ---- Part B backward (joint lse -> exact joint gradient on B keys) ----
-        gather = _PartBGather(block_row, vis_len, part_a_len, block_width, trunk_seqlen)
-        trunk_k_flat = trunk_k.reshape(-1, *trunk_k.shape[2:])
-        trunk_v_flat = trunk_v.reshape(-1, *trunk_v.shape[2:])
-        kb = gather.gather(trunk_k_flat, k_own)
-        vb = gather.gather(trunk_v_flat, v_own)
-        q_flat = q.reshape(num_blocks * block_width, num_q_heads, head_dim)
-        cu_q = torch.arange(
-            0,
-            (num_blocks + 1) * block_width,
-            block_width,
-            device=device,
-            dtype=torch.int32,
-        )
-        lse_joint_flat = (
-            lse_joint.permute(1, 0, 2)
-            .reshape(num_q_heads, num_blocks * block_width)
-            .contiguous()
-        )
-        dq_b = torch.empty_like(q_flat)
-        dkb = torch.empty_like(kb)
-        dvb = torch.empty_like(vb)
-        _fa_varlen_backward(
-            dout=dout.reshape(num_blocks * block_width, num_q_heads, head_dim),
-            q=q_flat,
-            k=kb,
-            v=vb,
-            out=out.reshape(num_blocks * block_width, num_q_heads, head_dim),
-            lse=lse_joint_flat,
-            dq=dq_b,
-            dk=dkb,
-            dv=dvb,
-            cu_seqlens_q=cu_q,
-            cu_seqlens_k=gather.cu_k,
-            max_seqlen_q=block_width,
-            max_seqlen_k=gather.max_seqlen_k,
-            softmax_scale=softmax_scale,
-        )
-        dq += dq_b.view_as(q).float()
-        dk_own = gather.scatter_grads(
-            dkb.float(), d_trunk_k.view(-1, *trunk_k.shape[2:]), k_own.shape
-        )
-        dv_own = gather.scatter_grads(
-            dvb.float(), d_trunk_v.view(-1, *trunk_v.shape[2:]), v_own.shape
+        cu = cu_seqlens_local.to(torch.long)
+        cu_q = block_width * torch.arange(
+            num_blocks + 1, device=device, dtype=torch.int32
         )
 
-        # ---- Part A backward, one dense call per bucket ----
-        for row, prefix_len, idx in _part_a_buckets(block_row, part_a_len):
-            nb = idx.shape[0]
-            q_bucket = q[idx].reshape(1, nb * block_width, num_q_heads, head_dim)
-            out_bucket = out[idx].reshape(1, nb * block_width, num_q_heads, head_dim)
-            dout_bucket = (
-                dout[idx]
-                .reshape(1, nb * block_width, num_q_heads, head_dim)
-                .contiguous()
+        if window > 0:
+            # Replay the single windowed varlen call (saved lse is [Hq, NB*W]).
+            if cp_size > 1:
+                k_attn, v_attn, unzig = _allgather_trunk(
+                    trunk_k, trunk_v, cu, cp_size, cp_group
+                )
+                cu_attn = cu * cp_size
+            else:
+                k_attn, v_attn, cu_attn = trunk_k, trunk_v, cu
+            kb, vb, cu_k, max_k, rem_src, rem_dest, own_dest = _sliding_gather(
+                k_attn, v_attn, k_own, v_own, block_seq, vis_len, cu_attn, window
             )
-            lse_bucket = (
-                lse_joint[idx]
-                .permute(1, 0, 2)
-                .reshape(1, num_q_heads, nb * block_width)
-                .contiguous()
+            q_flat, out_flat, dout_flat = (
+                t.reshape(-1, num_q_heads, head_dim) for t in (q, out, dout)
             )
-            k_bucket = trunk_k[row : row + 1, :prefix_len].contiguous()
-            v_bucket = trunk_v[row : row + 1, :prefix_len].contiguous()
-            dq_a = torch.empty_like(q_bucket)
-            dk_a = torch.empty_like(k_bucket)
-            dv_a = torch.empty_like(v_bucket)
-            _fa_dense_backward(
-                dout=dout_bucket,
-                q=q_bucket,
-                k=k_bucket,
-                v=v_bucket,
-                out=out_bucket,
-                lse=lse_bucket,
-                dq=dq_a,
-                dk=dk_a,
-                dv=dv_a,
+            dq_flat = torch.empty_like(q_flat)
+            dkb = torch.empty_like(kb)
+            dvb = torch.empty_like(vb)
+            _fa_varlen_backward(
+                dout=dout_flat,
+                q=q_flat,
+                k=kb,
+                v=vb,
+                out=out_flat,
+                lse=lse_joint,
+                dq=dq_flat,
+                dk=dkb,
+                dv=dvb,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=block_width,
+                max_seqlen_k=max_k,
                 softmax_scale=softmax_scale,
+                window_left=window - 1,
+                window_right=0,
             )
-            dq[idx] += dq_a.view(nb, block_width, num_q_heads, head_dim).float()
-            d_trunk_k[row, :prefix_len] += dk_a[0].float()
-            d_trunk_v[row, :prefix_len] += dv_a[0].float()
+            # Blocks can share trunk rows, so trunk grads accumulate in fp32.
+            dk_trunk = torch.zeros_like(k_attn, dtype=torch.float32)
+            dv_trunk = torch.zeros_like(dk_trunk)
+            dk_trunk.index_add_(0, rem_src, dkb[rem_dest].float())
+            dv_trunk.index_add_(0, rem_src, dvb[rem_dest].float())
+            if cp_size > 1:
+                # unzig is a bijection, so scattering through it lays the
+                # global-order grads out rank-major; reduce-scatter then sums
+                # every rank's contribution into the owner's local shard.
+                t_local = trunk_k.shape[0]
+                dk_buf = dk_trunk.new_zeros((cp_size * t_local, *dk_trunk.shape[1:]))
+                dv_buf = torch.zeros_like(dk_buf)
+                dk_buf[unzig] = dk_trunk
+                dv_buf[unzig] = dv_trunk
+                dk_trunk = dk_trunk.new_empty((t_local, *dk_trunk.shape[1:]))
+                dv_trunk = torch.empty_like(dk_trunk)
+                dist.reduce_scatter_tensor(dk_trunk, dk_buf, group=cp_group)
+                dist.reduce_scatter_tensor(dv_trunk, dv_buf, group=cp_group)
+            return (
+                dq_flat.view_as(q),
+                dkb[own_dest].view_as(k_own),
+                dvb[own_dest].view_as(v_own),
+                dk_trunk.to(trunk_k.dtype),
+                dv_trunk.to(trunk_v.dtype),
+                None,  # block_seq
+                None,  # vis_len
+                None,  # cu_seqlens_local
+                None,  # chunk
+                None,  # window
+                None,  # softmax_scale
+                None,  # cp_group
+            )
+
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        dk_own = torch.zeros_like(k_own, dtype=torch.float32)
+        dv_own = torch.zeros_like(v_own, dtype=torch.float32)
+        # dK/dV accumulate (and travel the ring) in fp32, paired with the KV
+        # in hand; after the loop one final hop delivers them home.
+        dk_cur = torch.zeros_like(trunk_k, dtype=torch.float32)
+        dv_cur = torch.zeros_like(dk_cur)
+
+        k_cur, v_cur = trunk_k, trunk_v
+        for step in range(cp_size):
+            kv_reqs: list[Any] = []
+            if step + 1 < cp_size:
+                (k_next, v_next), kv_reqs = _ring_send_recv(
+                    [k_cur, v_cur], send_rank, recv_rank, cp_group
+                )
+            geo = _RingStepGeometry(
+                block_seq,
+                vis_len,
+                cu,
+                chunk,
+                (cp_rank - step) % cp_size,
+                cp_size,
+                block_width,
+                include_own=step == 0,
+            )
+            if geo.active.numel():
+                kb = geo.gather(k_cur, k_own)
+                vb = geo.gather(v_cur, v_own)
+                nb = geo.active.numel()
+                q_act, out_act, dout_act = (
+                    t[geo.active].reshape(-1, num_q_heads, head_dim)
+                    for t in (q, out, dout)
+                )
+                lse_act = lse_joint[geo.active].permute(1, 0, 2)
+                lse_act = lse_act.reshape(num_q_heads, -1).contiguous()
+                dq_b = torch.empty_like(q_act)
+                dkb = torch.empty_like(kb)
+                dvb = torch.empty_like(vb)
+                _fa_varlen_backward(
+                    dout=dout_act,
+                    q=q_act,
+                    k=kb,
+                    v=vb,
+                    out=out_act,
+                    lse=lse_act,
+                    dq=dq_b,
+                    dk=dkb,
+                    dv=dvb,
+                    cu_seqlens_q=cu_q[: nb + 1],
+                    cu_seqlens_k=geo.cu_k,
+                    max_seqlen_q=block_width,
+                    max_seqlen_k=geo.max_seqlen_k,
+                    softmax_scale=softmax_scale,
+                    window_left=-1,
+                    window_right=-1,
+                )
+                dq[geo.active] += dq_b.float().view(nb, -1, num_q_heads, head_dim)
+                geo.scatter_grads(dkb.float(), dk_cur, dk_own)
+                geo.scatter_grads(dvb.float(), dv_cur, dv_own)
+            for seq, prefix_len, idx in _part_a_buckets(block_seq, geo.part_a_len):
+                seg_start = int(cu[seq].item())
+                nbk = idx.shape[0]
+                q_bucket, out_bucket, dout_bucket = (
+                    t[idx].reshape(1, -1, num_q_heads, head_dim) for t in (q, out, dout)
+                )
+                lse_bucket = lse_joint[idx].permute(1, 0, 2)
+                lse_bucket = lse_bucket.reshape(1, num_q_heads, -1).contiguous()
+                k_bucket = k_cur[seg_start : seg_start + prefix_len].unsqueeze(0)
+                v_bucket = v_cur[seg_start : seg_start + prefix_len].unsqueeze(0)
+                dq_a = torch.empty_like(q_bucket)
+                dk_a = torch.empty_like(k_bucket)
+                dv_a = torch.empty_like(v_bucket)
+                _fa_dense_backward(
+                    dout=dout_bucket,
+                    q=q_bucket,
+                    k=k_bucket,
+                    v=v_bucket,
+                    out=out_bucket,
+                    lse=lse_bucket,
+                    dq=dq_a,
+                    dk=dk_a,
+                    dv=dv_a,
+                    softmax_scale=softmax_scale,
+                )
+                dq[idx] += dq_a.view(nbk, block_width, num_q_heads, head_dim).float()
+                dk_cur[seg_start : seg_start + prefix_len] += dk_a[0].float()
+                dv_cur[seg_start : seg_start + prefix_len] += dv_a[0].float()
+            if step + 1 < cp_size:
+                for req in kv_reqs:
+                    req.wait()
+                # dK/dV hop only AFTER this step's contribution is folded in.
+                (dk_next, dv_next), dkv_reqs = _ring_send_recv(
+                    [dk_cur, dv_cur], send_rank, recv_rank, cp_group
+                )
+                for req in dkv_reqs:
+                    req.wait()
+                k_cur, v_cur = k_next, v_next
+                dk_cur, dv_cur = dk_next, dv_next
+        if cp_size > 1:
+            (dk_home, dv_home), dkv_reqs = _ring_send_recv(
+                [dk_cur, dv_cur], send_rank, recv_rank, cp_group
+            )
+            for req in dkv_reqs:
+                req.wait()
+            dk_cur, dv_cur = dk_home, dv_home
 
         return (
             dq.to(q.dtype),
             dk_own.to(k_own.dtype),
             dv_own.to(v_own.dtype),
-            d_trunk_k.to(trunk_k.dtype),
-            d_trunk_v.to(trunk_v.dtype),
-            None,  # block_row
+            dk_cur.to(trunk_k.dtype),
+            dv_cur.to(trunk_v.dtype),
+            None,  # block_seq
             None,  # vis_len
+            None,  # cu_seqlens_local
             None,  # chunk
+            None,  # window
             None,  # softmax_scale
+            None,  # cp_group
         )
 
 
-def block_draft_attention(
-    q: Tensor,
-    k_own: Tensor,
-    v_own: Tensor,
-    trunk_k: Tensor,
-    trunk_v: Tensor,
-    block_row: Tensor,
-    vis_len: Tensor,
-    *,
-    chunk: int = 1024,
-    softmax_scale: Optional[float] = None,
-) -> Tensor:
-    """Functional wrapper for :class:`BlockDraftAttention` (see class docstring)."""
-    if softmax_scale is None:
-        softmax_scale = q.shape[-1] ** -0.5
-    if chunk < 1:
-        raise ValueError(f"chunk must be >= 1, got {chunk}.")
-    return BlockDraftAttention.apply(
-        q,
-        k_own,
-        v_own,
-        trunk_k.contiguous(),
-        trunk_v.contiguous(),
-        block_row,
-        vis_len,
-        chunk,
-        softmax_scale,
-    )
-
-
 class BlockDraftCoreAttention(torch.nn.Module):
-    """Drop-in ``core_attention`` for the block-draft decoder layers.
+    """Adapt an MCore decoder layer to block-draft attention.
 
-    Receives the post-RoPE q/k/v of the flattened block stream (sbhd with
-    batch 1, seq = ``NB * W`` in block-major order) and attends against the
-    per-layer trunk K/V staged by the model via :meth:`stage_trunk` before the
-    decoder call. Statefulness contract mirrors ``TTTDraftCoreAttention``:
-    the model stages fresh trunk tensors every forward and :meth:`reset`
-    clears them (never leaks across microbatches).
+    MCore supplies the block Q/K/V as one flattened stream with shape
+    ``[NB * W, 1, H, D]``. Before running the decoder, the model calls
+    :meth:`stage_trunk` to store this layer's trunk K/V and block metadata.
+    :meth:`forward` reshapes the stream and calls :class:`BlockDraftAttention`.
+
+    The standard MCore mask, bias, and packing arguments are accepted only to
+    match its interface. They are ignored because block attention creates its
+    own mask. ``window > 0`` runs this layer with sliding-window attention.
+    The model must call :meth:`reset` after every decoder run so tensors and
+    autograd graphs do not leak into the next microbatch.
     """
 
-    def __init__(self, config: TransformerConfig, chunk: int):
+    def __init__(self, config: TransformerConfig, chunk: int, window: int):
         super().__init__()
-        attention_dropout = float(getattr(config, "attention_dropout", 0.0) or 0.0)
-        if attention_dropout != 0.0:
+        if getattr(config, "attention_dropout", 0.0):
             raise ValueError(
-                "BlockDraftCoreAttention does not support attention dropout "
-                f"(got attention_dropout={attention_dropout})."
+                "BlockDraftCoreAttention does not support attention dropout."
             )
         if int(getattr(config, "context_parallel_size", 1) or 1) != 1:
             raise ValueError(
                 "BlockDraftCoreAttention requires context_parallel_size == 1."
             )
+        if chunk < 1:
+            raise ValueError(f"chunk must be >= 1, got {chunk}.")
+        if window < 0:
+            raise ValueError(f"window must be >= 0 (0 = full attention), got {window}.")
         self.chunk = int(chunk)
+        self.window = int(window)
         self.softmax_scale: Optional[float] = getattr(config, "softmax_scale", None)
         self._trunk_k: Optional[Tensor] = None
         self._trunk_v: Optional[Tensor] = None
-        self._block_row: Optional[Tensor] = None
+        self._block_seq: Optional[Tensor] = None
         self._vis_len: Optional[Tensor] = None
+        self._cu_seqlens_local: Optional[Tensor] = None
+        self._cp_group: Optional[dist.ProcessGroup] = None
         self._block_width: int = 0
 
     def stage_trunk(
         self,
         trunk_k: Tensor,
         trunk_v: Tensor,
-        block_row: Tensor,
+        block_seq: Tensor,
         vis_len: Tensor,
+        cu_seqlens_local: Tensor,
         block_width: int,
+        cp_group: Optional[dist.ProcessGroup],
     ) -> None:
-        """Stage this layer's trunk K/V ``[B, S, Hkv, D]`` and block metadata."""
+        """Stage this layer's THD trunk K/V ``[T, Hkv, D]`` and block metadata."""
         self._trunk_k = trunk_k
         self._trunk_v = trunk_v
-        self._block_row = block_row
+        self._block_seq = block_seq
         self._vis_len = vis_len
+        self._cu_seqlens_local = cu_seqlens_local
+        self._cp_group = cp_group
         self._block_width = int(block_width)
 
     def reset(self) -> None:
         """Drop staged trunk references (frees the autograd graph)."""
         self._trunk_k = None
         self._trunk_v = None
-        self._block_row = None
+        self._block_seq = None
         self._vis_len = None
+        self._cu_seqlens_local = None
+        self._cp_group = None
         self._block_width = 0
 
     def forward(
@@ -804,17 +1169,11 @@ class BlockDraftCoreAttention(torch.nn.Module):
         attention_bias: Optional[Tensor] = None,
         packed_seq_params: Optional[Any] = None,
     ) -> Tensor:
-        if packed_seq_params is not None:
-            raise NotImplementedError(
-                "Block draft training does not support sequence packing; "
-                "disable policy.sequence_packing."
-            )
         if self._trunk_k is None:
             raise RuntimeError(
                 "BlockDraftCoreAttention.forward called without staged trunk "
                 "K/V; the draft model must call stage_trunk() first."
             )
-
         seqlen, block_width = query.shape[0], self._block_width
         softmax_scale = self.softmax_scale or query.shape[-1] ** -0.5
 
@@ -825,16 +1184,19 @@ class BlockDraftCoreAttention(torch.nn.Module):
         k_own = key.reshape(num_blocks, block_width, *key.shape[2:])
         v_own = value.reshape(num_blocks, block_width, *value.shape[2:])
 
-        out = block_draft_attention(
+        out = BlockDraftAttention.apply(
             q,
             k_own,
             v_own,
             self._trunk_k,
             self._trunk_v,
-            self._block_row,
+            self._block_seq,
             self._vis_len,
-            chunk=self.chunk,
-            softmax_scale=softmax_scale,
+            self._cu_seqlens_local,
+            self.chunk,
+            self.window,
+            softmax_scale,
+            self._cp_group,
         )
         # [NB, W, Hq, D] -> [S, 1, Hq * D] (core_attention output contract).
         return out.reshape(seqlen, 1, -1)
@@ -847,6 +1209,10 @@ class DFlashDraftModel(MegatronModule):
     supplies context, but its logits are not trained. The remaining ``gamma``
     slots predict new tokens. DSpark subclasses this model and changes
     ``method`` and ``block_width`` for its serving and loss behavior.
+
+    ``layer_windows`` gives each decoder layer its sliding window (0 = full
+    attention), mirroring the checkpoint's ``layer_types``/``sliding_window``;
+    ``None`` means all layers use full attention.
     """
 
     speculator_type = "dflash"
@@ -860,6 +1226,7 @@ class DFlashDraftModel(MegatronModule):
         num_aux_hidden_states: int,
         target_hidden_size: Optional[int] = None,
         trunk_chunk: int = 1024,
+        layer_windows: Optional[list[int]] = None,
         block_width: Optional[int] = None,
     ):
         super().__init__(config=config)
@@ -882,6 +1249,14 @@ class DFlashDraftModel(MegatronModule):
         self.mask_token_id = int(mask_token_id)
         self.num_aux_hidden_states = int(num_aux_hidden_states)
         self.trunk_chunk = int(trunk_chunk)
+        if layer_windows is None:
+            layer_windows = [0] * int(config.num_layers)
+        if len(layer_windows) != int(config.num_layers):
+            raise ValueError(
+                f"layer_windows has {len(layer_windows)} entries for "
+                f"{config.num_layers} decoder layers."
+            )
+        self.layer_windows = [int(w) for w in layer_windows]
 
         target_hidden = int(target_hidden_size or config.hidden_size)
         # Keep this Linear replicated across TP ranks. The input is already
@@ -923,50 +1298,133 @@ class DFlashDraftModel(MegatronModule):
         )
 
         self._block_attn_modules: list[BlockDraftCoreAttention] = []
-        for layer in self.decoder.layers:
-            core = BlockDraftCoreAttention(config, self.trunk_chunk)
+        for layer, layer_window in zip(self.decoder.layers, self.layer_windows):
+            core = BlockDraftCoreAttention(config, self.trunk_chunk, layer_window)
             layer.self_attention.core_attention = core
             self._block_attn_modules.append(core)
 
-        # NO lm_head (official contract; z-lab ckpts ship only
-        # layers/fc/hidden_norm/norm): logits project through the target's
-        # live head, passed detached into forward(). A head-less ckpt makes
-        # vLLM share the target's lm_head with the drafter unconditionally.
+        # There is no draft LM head. ``forward`` uses the detached target LM
+        # head, which matches both existing checkpoints and vLLM serving.
 
     def _project_trunk_kv(
         self, self_attention: torch.nn.Module, trunk_hidden: Tensor
     ) -> tuple[Tensor, Tensor]:
-        """Project trunk hidden states through one layer's K/V rows.
+        """Build one decoder layer's trunk keys and values.
 
-        Slices the K/V rows out of the layer's fused, TP-local
-        ``linear_qkv.weight`` (Megatron interleaves per query group as
-        ``[q.. k v | q.. k v | ...]``) and applies them to the shared
-        ``hidden_norm``-ed trunk — bypassing the fused input layernorm, which
-        inference does *not* apply on the context path.
+        Megatron stores each TP rank's Q/K/V weights in one fused tensor. For
+        every query group, its rows are ordered as ``[Q rows, K row, V row]``.
+        This method selects only the K and V rows and applies them to the
+        already-normalized trunk. It intentionally skips the decoder layer's
+        input normalization because the serving context path skips it too.
+
+        Args:
+            self_attention: Decoder self-attention module that owns the fused
+                Q/K/V weight and optional K normalization.
+            trunk_hidden: Normalized trunk states with shape ``[T, B, H]``.
+
+        Returns:
+            The layer's key and value tensors, each with shape
+            ``[T, B, Hkv_local, D]``.
         """
         num_groups = self_attention.num_query_groups_per_partition
         heads_per_group = self_attention.num_attention_heads_per_partition // num_groups
         head_dim = self_attention.hidden_size_per_attention_head
         weight = self_attention.linear_qkv.weight
         grouped = weight.view(num_groups, (heads_per_group + 2) * head_dim, -1)
-        k_weight = grouped[
-            :, heads_per_group * head_dim : (heads_per_group + 1) * head_dim
-        ].reshape(num_groups * head_dim, -1)
-        v_weight = grouped[:, (heads_per_group + 1) * head_dim :].reshape(
-            num_groups * head_dim, -1
-        )
+        q_rows = heads_per_group * head_dim
+        k_weight = grouped[:, q_rows : q_rows + head_dim].reshape(-1, weight.shape[1])
+        v_weight = grouped[:, q_rows + head_dim :].reshape(-1, weight.shape[1])
 
         seq_len, batch = trunk_hidden.shape[0], trunk_hidden.shape[1]
-        key = F.linear(trunk_hidden, k_weight).view(
-            seq_len, batch, num_groups, head_dim
-        )
-        value = F.linear(trunk_hidden, v_weight).view(
-            seq_len, batch, num_groups, head_dim
-        )
+        key = F.linear(trunk_hidden, k_weight).view(seq_len, batch, num_groups, -1)
+        value = F.linear(trunk_hidden, v_weight).view(seq_len, batch, num_groups, -1)
         k_layernorm = getattr(self_attention, "k_layernorm", None)
         if k_layernorm is not None:
             key = k_layernorm(key)
         return key, value
+
+    def _flatten_to_thd(
+        self,
+        taps: Tensor,
+        input_embeds: Tensor,
+        anchors: Tensor,
+        packed_seq_params: Optional[Any],
+        block_seq_idx: Optional[Tensor],
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, int, Any, tuple]:
+        """Convert packed or padded inputs to the same flat THD layout.
+
+        Packed inputs are already a rank-local zigzag shard. Their anchors are
+        a flat list of blocks owned by this rank. For padded inputs, the batch
+        dimension is flattened into ``B`` equal-length subsequences. After
+        this conversion, the rest of the model can use one code path.
+
+        Args:
+            taps: Concatenated target hidden states in packed or padded layout.
+            input_embeds: Target token embeddings in the same layout as
+                ``taps``.
+            anchors: Anchor positions for all local blocks.
+            packed_seq_params: Packing metadata, or ``None`` for padded input.
+            block_seq_idx: For packed input, the subsequence index of each
+                local block.
+
+        Returns:
+            ``(taps_flat, embeds_flat, block_seq, anchors_flat, cu_local,
+            pos_in_seq, max_len, cp_group, out_shape)``. These values contain
+            the flat trunk tensors, block-to-sequence mapping, local sequence
+            boundaries, global token positions, CP group, and final logit
+            shape.
+        """
+        device = taps.device
+        if packed_seq_params is not None:
+            from nemo_rl.algorithms.loss.utils import packed_zigzag_token_coords
+
+            cp_group = _global_cp_group()
+            cp_size = 1 if cp_group is None else cp_group.size()
+            cp_rank = 0 if cp_group is None else cp_group.rank()
+            cu_global = packed_seq_params.cu_seqlens_q_padded
+            if cu_global is None:
+                cu_global = packed_seq_params.cu_seqlens_q
+            cu_local = (cu_global // cp_size).to(torch.long)
+            _, pos_in_seq = packed_zigzag_token_coords(cu_global, cp_rank, cp_size)
+            block_seq = block_seq_idx.to(torch.long)
+            anchors_flat = anchors.reshape(-1).to(torch.long)
+            max_len = int((cu_local[1:] - cu_local[:-1]).max().item()) * cp_size
+            embeds_flat = input_embeds.reshape(-1, input_embeds.shape[-1])
+            out_shape = (anchors_flat.shape[0], self.block_width, -1)
+            return (
+                taps,
+                embeds_flat,
+                block_seq,
+                anchors_flat,
+                cu_local,
+                pos_in_seq.to(device),
+                max_len,
+                cp_group,
+                out_shape,
+            )
+
+        seq_len, batch = taps.shape[0], taps.shape[1]
+        num_anchors = anchors.shape[1]
+        if anchors.shape[0] != batch:
+            raise ValueError(f"anchors batch {anchors.shape[0]} != taps batch {batch}.")
+        taps_flat = taps.permute(1, 0, 2).reshape(batch * seq_len, 1, -1)
+        embeds_flat = input_embeds.permute(1, 0, 2).reshape(batch * seq_len, -1)
+        block_seq = torch.arange(batch, device=device).repeat_interleave(num_anchors)
+        anchors_flat = anchors.reshape(-1)
+        cu_local = torch.arange(0, batch + 1, device=device, dtype=torch.long) * seq_len
+        pos_in_seq = torch.arange(seq_len, device=device).repeat(batch)
+        out_shape = (batch, num_anchors, self.block_width, -1)
+        return (
+            taps_flat,
+            embeds_flat,
+            block_seq,
+            anchors_flat,
+            cu_local,
+            pos_in_seq,
+            seq_len,
+            None,
+            out_shape,
+        )
 
     def forward(
         self,
@@ -977,6 +1435,8 @@ class DFlashDraftModel(MegatronModule):
         anchor_valid: Tensor,
         lm_head_weight: Tensor,
         mask_embedding: Tensor,
+        packed_seq_params: Optional[Any] = None,
+        block_seq_idx: Optional[Tensor] = None,
     ) -> Tensor:
         """Run the block drafter for one batch.
 
@@ -985,44 +1445,60 @@ class DFlashDraftModel(MegatronModule):
         its outputs with the target model's LM head.
 
         Args:
-            taps: Target auxiliary hidden states with shape
-                ``[S, B, k * target_h]``.
-            input_embeds: Unshifted target embeddings with shape ``[S, B, h]``.
-            anchors: Anchor positions with shape ``[B, N]``.
-            anchor_valid: Validity mask with shape ``[B, N]``. Invalid blocks
-                keep tensor shapes static and are masked by the loss.
+            taps: Target auxiliary hidden states. Padded shape is
+                ``[S, B, k * target_h]``; packed shape is the local zigzag
+                shard ``[T_local, 1, k * target_h]``.
+            input_embeds: Unshifted target embeddings. Padded shape is
+                ``[S, B, h]``; packed shape is ``[T_local, 1, h]``.
+            anchors: Anchor positions. Padded shape is ``[B, N]``; packed
+                shape is ``[NB]`` for the blocks owned by this rank.
+            anchor_valid: Validity mask with the same layout as ``anchors``.
+                Invalid blocks keep tensor shapes static and are masked by the
+                loss.
             lm_head_weight: Detached target LM-head shard with shape
                 ``[V_local, h]``. It produces logits but is not trained here.
             mask_embedding: Detached target mask-token embedding with shape
                 ``[h]``. Every mask slot starts from this same vector.
+            packed_seq_params: Global THD packing metadata, or ``None`` for
+                padded input.
+            block_seq_idx: For packed input, the subsequence index of each
+                local block, with shape ``[NB]``.
 
         Returns:
-            Vocab-parallel logits with shape ``[B, N, W, V_local]``. Slot 0 is
-            the anchor slot.
+            Vocab-parallel logits. Padded shape is ``[B, N, W, V_local]``;
+            packed shape is ``[NB, W, V_local]``. Slot 0 is the anchor slot.
         """
-        seq_len, batch = taps.shape[0], taps.shape[1]
-        num_anchors = anchors.shape[1]
-        num_blocks = batch * num_anchors
-        block_width = self.block_width
         device = taps.device
-
-        if anchors.shape[0] != batch:
-            raise ValueError(f"anchors batch {anchors.shape[0]} != taps batch {batch}.")
-        if int(anchors.max().item()) >= seq_len:
+        block_width = self.block_width
+        (
+            taps_flat,
+            embeds_flat,
+            block_seq,
+            anchors_flat,
+            cu_local,
+            pos_in_seq,
+            max_len,
+            cp_group,
+            out_shape,
+        ) = self._flatten_to_thd(
+            taps, input_embeds, anchors, packed_seq_params, block_seq_idx
+        )
+        num_blocks = block_seq.shape[0]
+        if int(anchors_flat.max().item()) >= max_len:
             raise ValueError("anchor position exceeds sequence length.")
 
         # Build the target-derived trunk K/V used by every draft block.
-        trunk_hidden = self.hidden_norm(self.fc(taps))
+        trunk_hidden = self.hidden_norm(self.fc(taps_flat))
         # ``F.linear`` bypasses the input-gradient reduction normally provided
         # by ``ColumnParallelLinear``. This wrapper is an identity in forward
         # and sums gradients across TP ranks in backward, keeping the
         # replicated ``fc`` and ``hidden_norm`` parameters in sync.
         trunk_hidden = copy_to_tensor_model_parallel_region(trunk_hidden)
-        rotary_table = self.rotary_pos_emb(seq_len + block_width)
-        trunk_freqs = rotary_table[:seq_len]
+        # Build one full RoPE table and index it with explicit global positions;
+        # this avoids RotaryEmbedding slicing it a second time for CP.
+        rotary_table = self.rotary_pos_emb(max_len + block_width, packed_seq=True)
+        trunk_freqs = rotary_table[pos_in_seq]
 
-        block_row = torch.arange(batch, device=device).repeat_interleave(num_anchors)
-        anchors_flat = anchors.reshape(-1)
         # An anchor at p can see trunk positions [0, p). Its own token is
         # supplied separately as block slot 0.
         vis_len = anchors_flat
@@ -1030,24 +1506,22 @@ class DFlashDraftModel(MegatronModule):
         for layer, core in zip(self.decoder.layers, self._block_attn_modules):
             key, value = self._project_trunk_kv(layer.self_attention, trunk_hidden)
             key = apply_rotary_pos_emb(key, trunk_freqs, config=self.config)
-            # [S, B, Hkv, D] -> [B, S, Hkv, D]
+            # [T, 1, Hkv, D] -> [T, Hkv, D]
             core.stage_trunk(
-                key.permute(1, 0, 2, 3).contiguous(),
-                value.permute(1, 0, 2, 3).contiguous(),
-                block_row,
+                key.squeeze(1).contiguous(),
+                value.squeeze(1).contiguous(),
+                block_seq,
                 vis_len,
+                cu_local,
                 block_width,
+                cp_group,
             )
 
         # Create each block from its anchor embedding followed by mask vectors.
-        embeds_flat = input_embeds.permute(1, 0, 2).reshape(batch * seq_len, -1)
-        anchor_embeds = embeds_flat[block_row * seq_len + anchors_flat]
-        hidden = (
-            mask_embedding.to(anchor_embeds.dtype)
-            .expand(num_blocks, block_width, -1)
-            .clone()
-        )
-        hidden[:, 0] = anchor_embeds
+        rows = self._anchor_embed_index(block_seq, anchors_flat, cu_local, cp_group)
+        mask_row = mask_embedding.to(embeds_flat.dtype)
+        hidden = mask_row.expand(num_blocks, block_width, -1).clone()
+        hidden[:, 0] = embeds_flat[rows]
         hidden = hidden.reshape(num_blocks * block_width, 1, -1)
 
         offsets = torch.arange(block_width, device=device)
@@ -1068,5 +1542,20 @@ class DFlashDraftModel(MegatronModule):
         # gradient issue as the trunk projection above. Sum its input gradient.
         decoder_hidden = copy_to_tensor_model_parallel_region(decoder_hidden)
         logits = F.linear(decoder_hidden, lm_head_weight)
-        # [NB * W, 1, V_local] -> [B, N, W, V_local]
-        return logits.reshape(batch, num_anchors, block_width, -1)
+        return logits.reshape(out_shape)
+
+    @staticmethod
+    def _anchor_embed_index(
+        block_seq: Tensor,
+        anchors_flat: Tensor,
+        cu_local: Tensor,
+        cp_group: Optional[dist.ProcessGroup],
+    ) -> Tensor:
+        """Row of each block's anchor embedding in the flat local embeds."""
+        if cp_group is None or cp_group.size() == 1:
+            return cu_local[block_seq] + anchors_flat
+        from nemo_rl.algorithms.loss.utils import packed_zigzag_local_index
+
+        return packed_zigzag_local_index(
+            block_seq, anchors_flat, cu_local, cp_group.rank(), cp_group.size()
+        )

--- a/nemo_rl/models/megatron/draft/dspark.py
+++ b/nemo_rl/models/megatron/draft/dspark.py
@@ -32,7 +32,7 @@ come from :class:`~nemo_rl.models.megatron.draft.dflash.DFlashDraftModel`.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn.functional as F
@@ -66,6 +66,7 @@ class DSparkDraftModel(DFlashDraftModel):
         target_hidden_size: Optional[int] = None,
         markov_rank: int = 64,
         trunk_chunk: int = 1024,
+        layer_windows: Optional[list[int]] = None,
     ):
         super().__init__(
             config,
@@ -74,6 +75,7 @@ class DSparkDraftModel(DFlashDraftModel):
             num_aux_hidden_states=num_aux_hidden_states,
             target_hidden_size=target_hidden_size,
             trunk_chunk=trunk_chunk,
+            layer_windows=layer_windows,
             block_width=gamma,  # no bonus anchor slot
         )
         if markov_rank < 1:
@@ -107,11 +109,11 @@ class DSparkDraftModel(DFlashDraftModel):
 
         Args:
             prev_tokens: Token preceding each prediction, with shape
-                ``[B, N, gamma]``. For slot 0, this is the anchor token.
+                ``[..., gamma]``. For slot 0, this is the anchor token.
 
         Returns:
             Vocab-parallel logit bias with shape
-            ``[B, N, gamma, draft_vocab_local]``.
+            ``[..., gamma, draft_vocab_local]``.
         """
         embedded = self.markov_w1(prev_tokens)
         # ColumnParallelLinear expects sequence, batch, hidden dimensions.
@@ -122,11 +124,11 @@ class DSparkDraftModel(DFlashDraftModel):
         """Predict an acceptance logit for every draft slot.
 
         Args:
-            hidden: Decoder states with shape ``[B, N, gamma, h]``.
-            prev_tokens: Previous-token IDs with shape ``[B, N, gamma]``.
+            hidden: Decoder states with shape ``[..., gamma, h]``.
+            prev_tokens: Previous-token IDs with shape ``[..., gamma]``.
 
         Returns:
-            Pre-sigmoid fp32 logits with shape ``[B, N, gamma]``.
+            Pre-sigmoid fp32 logits with shape ``[..., gamma]``.
         """
         prev_embeddings = self.markov_w1(prev_tokens).to(dtype=hidden.dtype)
         features = torch.cat([hidden, prev_embeddings], dim=-1)
@@ -142,80 +144,95 @@ class DSparkDraftModel(DFlashDraftModel):
         lm_head_weight: Tensor,
         mask_embedding: Tensor,
         input_ids: Tensor,
+        packed_seq_params: Optional[Any] = None,
+        block_seq_idx: Optional[Tensor] = None,
     ) -> tuple[Tensor, Tensor]:
         """Run the DSpark drafter and its two additional heads.
 
         For an anchor at ``p``, slot ``j`` predicts ``x_{p+j+1}``. Its Markov
-        and confidence inputs therefore use the ground-truth token ``x_{p+j}``,
-        which for slot 0 is the anchor token itself.
+        and confidence inputs therefore use the ground-truth token
+        ``x_{p+j}``. ``input_ids`` remains an unpacked, replicated ``[B, S]``
+        tensor even when the model trunk is packed, so these tokens can be
+        gathered locally without extra CP communication.
 
         The confidence head reads ``decoder_hidden`` before the LM-head TP
         gradient wrapper. Its loss is already computed in full on every TP
         rank; applying the wrapper would sum that complete gradient again.
 
         Args:
-            taps: Target auxiliary hidden states with shape ``[S, B, h_aux]``.
-            input_embeds: Unshifted target embeddings with shape ``[S, B, h]``.
-            anchors: Anchor positions with shape ``[B, N]``.
-            anchor_valid: Validity mask with shape ``[B, N]``. Invalid blocks
-                are ignored by the loss.
+            taps: Target auxiliary hidden states in padded or packed layout.
+            input_embeds: Unshifted target embeddings in the same layout as
+                ``taps``.
+            anchors: Anchor positions. Shape is ``[B, N]`` for padded input or
+                ``[NB]`` for packed blocks owned by this rank.
+            anchor_valid: Validity mask with the same layout as ``anchors``.
+                Invalid blocks are ignored by the loss.
             lm_head_weight: Detached target LM-head shard with shape
                 ``[V_local, h]``.
             mask_embedding: Detached target mask-token embedding with shape
                 ``[h]``.
-            input_ids: Ground-truth token IDs with shape ``[B, S]``.
+            input_ids: Replicated ground-truth token IDs with shape ``[B, S]``.
+            packed_seq_params: Global THD packing metadata, or ``None`` for
+                padded input.
+            block_seq_idx: For packed input, the subsequence index of each
+                local block, with shape ``[NB]``.
 
         Returns:
-            Markov-biased vocabulary logits with shape ``[B, N, W, V_local]``
-            and pre-sigmoid confidence logits with shape ``[B, N, W]``.
+            Markov-biased vocabulary logits and pre-sigmoid confidence logits.
+            Their padded shapes are ``[B, N, W, V_local]`` and ``[B, N, W]``;
+            packed shapes are ``[NB, W, V_local]`` and ``[NB, W]``.
         """
-        seq_len, batch = taps.shape[0], taps.shape[1]
-        num_anchors = anchors.shape[1]
-        num_blocks = batch * num_anchors
-        block_width = self.block_width
         device = taps.device
-
-        if anchors.shape[0] != batch:
-            raise ValueError(f"anchors batch {anchors.shape[0]} != taps batch {batch}.")
-        if int(anchors.max().item()) >= seq_len:
+        block_width = self.block_width
+        (
+            taps_flat,
+            embeds_flat,
+            block_seq,
+            anchors_flat,
+            cu_local,
+            pos_in_seq,
+            max_len,
+            cp_group,
+            out_shape,
+        ) = self._flatten_to_thd(
+            taps, input_embeds, anchors, packed_seq_params, block_seq_idx
+        )
+        num_blocks = block_seq.shape[0]
+        if int(anchors_flat.max().item()) >= max_len:
             raise ValueError("anchor position exceeds sequence length.")
 
         # Build the target-derived trunk K/V used by every draft block.
-        trunk_hidden = self.hidden_norm(self.fc(taps))
+        trunk_hidden = self.hidden_norm(self.fc(taps_flat))
         trunk_hidden = copy_to_tensor_model_parallel_region(trunk_hidden)
-        rotary_table = self.rotary_pos_emb(seq_len + block_width)
-        trunk_freqs = rotary_table[:seq_len]
+        # Build one full RoPE table and index it with explicit global positions;
+        # this avoids RotaryEmbedding slicing it a second time for CP.
+        rotary_table = self.rotary_pos_emb(max_len + block_width, packed_seq=True)
+        trunk_freqs = rotary_table[pos_in_seq]
 
-        block_row = torch.arange(batch, device=device).repeat_interleave(num_anchors)
-        anchors_flat = anchors.reshape(-1)
         vis_len = anchors_flat
 
         for layer, core in zip(self.decoder.layers, self._block_attn_modules):
             key, value = self._project_trunk_kv(layer.self_attention, trunk_hidden)
             key = apply_rotary_pos_emb(key, trunk_freqs, config=self.config)
             core.stage_trunk(
-                key.permute(1, 0, 2, 3).contiguous(),
-                value.permute(1, 0, 2, 3).contiguous(),
-                block_row,
+                key.squeeze(1).contiguous(),
+                value.squeeze(1).contiguous(),
+                block_seq,
                 vis_len,
+                cu_local,
                 block_width,
+                cp_group,
             )
 
         # Create each block from its anchor embedding followed by mask vectors.
-        embeds_flat = input_embeds.permute(1, 0, 2).reshape(batch * seq_len, -1)
-        anchor_embeds = embeds_flat[block_row * seq_len + anchors_flat]
-        hidden = (
-            mask_embedding.to(anchor_embeds.dtype)
-            .expand(num_blocks, block_width, -1)
-            .clone()
-        )
-        hidden[:, 0] = anchor_embeds
+        rows = self._anchor_embed_index(block_seq, anchors_flat, cu_local, cp_group)
+        mask_row = mask_embedding.to(embeds_flat.dtype)
+        hidden = mask_row.expand(num_blocks, block_width, -1).clone()
+        hidden[:, 0] = embeds_flat[rows]
         hidden = hidden.reshape(num_blocks * block_width, 1, -1)
 
-        positions = (
-            anchors_flat.unsqueeze(1)
-            + torch.arange(block_width, device=device).unsqueeze(0)
-        ).reshape(-1)
+        offsets = torch.arange(block_width, device=device)
+        positions = (anchors_flat.unsqueeze(1) + offsets).reshape(-1)
         block_freqs = rotary_table[positions]
 
         try:
@@ -230,17 +247,15 @@ class DSparkDraftModel(DFlashDraftModel):
 
         head_input = copy_to_tensor_model_parallel_region(decoder_hidden)
         logits = F.linear(head_input, lm_head_weight)
-        logits = logits.reshape(batch, num_anchors, block_width, -1)
-        hidden = decoder_hidden.reshape(batch, num_anchors, block_width, -1)
+        logits = logits.reshape(*out_shape)
+        hidden = decoder_hidden.reshape(*out_shape[:-1], -1)
 
         # Slot j uses the ground-truth token at p + j as its previous token.
-        prev_pos = (
-            anchors.unsqueeze(-1)
-            + torch.arange(block_width, device=device).view(1, 1, -1)
-        ).clamp(max=seq_len - 1)
-        prev_ids = torch.gather(input_ids, 1, prev_pos.reshape(batch, -1)).reshape(
-            batch, num_anchors, block_width
-        )
+        seq_len = input_ids.shape[1]
+        prev_pos = positions.reshape(num_blocks, block_width).clamp(max=seq_len - 1)
+        prev_ids = input_ids[
+            block_seq.unsqueeze(1).expand(-1, block_width), prev_pos
+        ].reshape(*out_shape[:-1])
         return (
             logits + self.markov_bias(prev_ids),
             self.confidence_logits(hidden, prev_ids),

--- a/nemo_rl/models/megatron/draft/dspark.py
+++ b/nemo_rl/models/megatron/draft/dspark.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Megatron training implementation of the DSpark draft model.
+
+DSpark reuses the DFlash trunk and block-attention code, but changes the block
+output and adds two prediction heads:
+
+- A block has exactly ``W = gamma`` slots. For an anchor at position ``p``,
+  slot ``j`` reads token ``x_{p+j}`` and predicts ``x_{p+j+1}``. Therefore,
+  every slot makes a prediction, including slot 0 that contains the anchor.
+- The Markov head converts the previous ground-truth token into a vocabulary
+  bias and adds it to the decoder logits. Training uses teacher forcing.
+- The confidence head combines the decoder hidden state with the Markov
+  embedding and predicts whether each drafted token will be accepted. This
+  score is trained with BCE and can be used to choose a dynamic draft length.
+
+Trunk K/V construction, block attention, mask embeddings, and LM-head sharing
+come from :class:`~nemo_rl.models.megatron.draft.dflash.DFlashDraftModel`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+from megatron.core.tensor_parallel import (
+    ColumnParallelLinear,
+    copy_to_tensor_model_parallel_region,
+)
+from megatron.core.transformer import TransformerConfig
+from torch import Tensor
+
+from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+
+
+class DSparkDraftModel(DFlashDraftModel):
+    """DFlash-style block drafter with Markov and confidence heads.
+
+    DSpark uses ``W = gamma`` because its anchor slot predicts a token instead
+    of serving only as context.
+    """
+
+    speculator_type = "dspark"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        *,
+        gamma: int,
+        mask_token_id: int,
+        num_aux_hidden_states: int,
+        target_hidden_size: Optional[int] = None,
+        markov_rank: int = 64,
+        trunk_chunk: int = 1024,
+    ):
+        super().__init__(
+            config,
+            gamma=gamma,
+            mask_token_id=mask_token_id,
+            num_aux_hidden_states=num_aux_hidden_states,
+            target_hidden_size=target_hidden_size,
+            trunk_chunk=trunk_chunk,
+            block_width=gamma,  # no bonus anchor slot
+        )
+        if markov_rank < 1:
+            raise ValueError(f"markov_rank must be >= 1, got {markov_rank}.")
+        self.markov_rank = int(markov_rank)
+        self.markov_w1 = torch.nn.Embedding(
+            config.vocab_size, self.markov_rank, dtype=config.params_dtype
+        )
+        self.markov_w2 = ColumnParallelLinear(
+            self.markov_rank,
+            config.draft_vocab_size,
+            config=config,
+            init_method=torch.nn.init.zeros_,
+            bias=False,
+            gather_output=False,
+        )
+        # Keep this head replicated. Every TP rank computes the same complete
+        # confidence loss, so its gradients need no cross-rank reduction.
+        self.confidence_head = torch.nn.Linear(
+            config.hidden_size + self.markov_rank,
+            1,
+            bias=True,
+            dtype=config.params_dtype,
+        )
+
+    def markov_bias(self, prev_tokens: Tensor) -> Tensor:
+        """Compute the vocabulary bias from each slot's previous token.
+
+        Training passes the ground-truth previous tokens here, so this is the
+        teacher-forced Markov contribution to the final logits.
+
+        Args:
+            prev_tokens: Token preceding each prediction, with shape
+                ``[B, N, gamma]``. For slot 0, this is the anchor token.
+
+        Returns:
+            Vocab-parallel logit bias with shape
+            ``[B, N, gamma, draft_vocab_local]``.
+        """
+        embedded = self.markov_w1(prev_tokens)
+        # ColumnParallelLinear expects sequence, batch, hidden dimensions.
+        bias, _ = self.markov_w2(embedded.reshape(-1, 1, self.markov_rank))
+        return bias.reshape(*prev_tokens.shape, -1)
+
+    def confidence_logits(self, hidden: Tensor, prev_tokens: Tensor) -> Tensor:
+        """Predict an acceptance logit for every draft slot.
+
+        Args:
+            hidden: Decoder states with shape ``[B, N, gamma, h]``.
+            prev_tokens: Previous-token IDs with shape ``[B, N, gamma]``.
+
+        Returns:
+            Pre-sigmoid fp32 logits with shape ``[B, N, gamma]``.
+        """
+        prev_embeddings = self.markov_w1(prev_tokens).to(dtype=hidden.dtype)
+        features = torch.cat([hidden, prev_embeddings], dim=-1)
+        return self.confidence_head(features).squeeze(-1).float()
+
+    def forward(
+        self,
+        *,
+        taps: Tensor,
+        input_embeds: Tensor,
+        anchors: Tensor,
+        anchor_valid: Tensor,
+        lm_head_weight: Tensor,
+        mask_embedding: Tensor,
+        input_ids: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Run the DSpark drafter and its two additional heads.
+
+        For an anchor at ``p``, slot ``j`` predicts ``x_{p+j+1}``. Its Markov
+        and confidence inputs therefore use the ground-truth token ``x_{p+j}``,
+        which for slot 0 is the anchor token itself.
+
+        The confidence head reads ``decoder_hidden`` before the LM-head TP
+        gradient wrapper. Its loss is already computed in full on every TP
+        rank; applying the wrapper would sum that complete gradient again.
+
+        Args:
+            taps: Target auxiliary hidden states with shape ``[S, B, h_aux]``.
+            input_embeds: Unshifted target embeddings with shape ``[S, B, h]``.
+            anchors: Anchor positions with shape ``[B, N]``.
+            anchor_valid: Validity mask with shape ``[B, N]``. Invalid blocks
+                are ignored by the loss.
+            lm_head_weight: Detached target LM-head shard with shape
+                ``[V_local, h]``.
+            mask_embedding: Detached target mask-token embedding with shape
+                ``[h]``.
+            input_ids: Ground-truth token IDs with shape ``[B, S]``.
+
+        Returns:
+            Markov-biased vocabulary logits with shape ``[B, N, W, V_local]``
+            and pre-sigmoid confidence logits with shape ``[B, N, W]``.
+        """
+        seq_len, batch = taps.shape[0], taps.shape[1]
+        num_anchors = anchors.shape[1]
+        num_blocks = batch * num_anchors
+        block_width = self.block_width
+        device = taps.device
+
+        if anchors.shape[0] != batch:
+            raise ValueError(f"anchors batch {anchors.shape[0]} != taps batch {batch}.")
+        if int(anchors.max().item()) >= seq_len:
+            raise ValueError("anchor position exceeds sequence length.")
+
+        # Build the target-derived trunk K/V used by every draft block.
+        trunk_hidden = self.hidden_norm(self.fc(taps))
+        trunk_hidden = copy_to_tensor_model_parallel_region(trunk_hidden)
+        rotary_table = self.rotary_pos_emb(seq_len + block_width)
+        trunk_freqs = rotary_table[:seq_len]
+
+        block_row = torch.arange(batch, device=device).repeat_interleave(num_anchors)
+        anchors_flat = anchors.reshape(-1)
+        vis_len = anchors_flat
+
+        for layer, core in zip(self.decoder.layers, self._block_attn_modules):
+            key, value = self._project_trunk_kv(layer.self_attention, trunk_hidden)
+            key = apply_rotary_pos_emb(key, trunk_freqs, config=self.config)
+            core.stage_trunk(
+                key.permute(1, 0, 2, 3).contiguous(),
+                value.permute(1, 0, 2, 3).contiguous(),
+                block_row,
+                vis_len,
+                block_width,
+            )
+
+        # Create each block from its anchor embedding followed by mask vectors.
+        embeds_flat = input_embeds.permute(1, 0, 2).reshape(batch * seq_len, -1)
+        anchor_embeds = embeds_flat[block_row * seq_len + anchors_flat]
+        hidden = (
+            mask_embedding.to(anchor_embeds.dtype)
+            .expand(num_blocks, block_width, -1)
+            .clone()
+        )
+        hidden[:, 0] = anchor_embeds
+        hidden = hidden.reshape(num_blocks * block_width, 1, -1)
+
+        positions = (
+            anchors_flat.unsqueeze(1)
+            + torch.arange(block_width, device=device).unsqueeze(0)
+        ).reshape(-1)
+        block_freqs = rotary_table[positions]
+
+        try:
+            decoder_hidden = self.decoder(
+                hidden_states=hidden,
+                attention_mask=None,
+                rotary_pos_emb=block_freqs,
+            )
+        finally:
+            for core in self._block_attn_modules:
+                core.reset()
+
+        head_input = copy_to_tensor_model_parallel_region(decoder_hidden)
+        logits = F.linear(head_input, lm_head_weight)
+        logits = logits.reshape(batch, num_anchors, block_width, -1)
+        hidden = decoder_hidden.reshape(batch, num_anchors, block_width, -1)
+
+        # Slot j uses the ground-truth token at p + j as its previous token.
+        prev_pos = (
+            anchors.unsqueeze(-1)
+            + torch.arange(block_width, device=device).view(1, 1, -1)
+        ).clamp(max=seq_len - 1)
+        prev_ids = torch.gather(input_ids, 1, prev_pos.reshape(batch, -1)).reshape(
+            batch, num_anchors, block_width
+        )
+        return (
+            logits + self.markov_bias(prev_ids),
+            self.confidence_logits(hidden, prev_ids),
+        )

--- a/nemo_rl/models/megatron/draft/eagle.py
+++ b/nemo_rl/models/megatron/draft/eagle.py
@@ -12,12 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Megatron training implementation of the EAGLE-3 draft model.
+
+This file wraps ModelOpt's ``EagleModule`` and adds two training paths:
+
+- :meth:`EagleModel.forward` runs one causal draft pass when ``ttt_steps == 1``.
+- :meth:`EagleModel.forward_ttt` runs several sequential TTT passes.
+  Each pass feeds its hidden state and shifted token embeddings into the next
+  pass, matching the draft model's self-conditioning during serving.
+
+For a query at anchor ``i`` in TTT pass ``d``, attention can read:
+
+- the pass-1 trunk at positions ``0..i``; and
+- the entry at anchor ``i`` from every pass ``2..d``.
+
+It cannot read a later trunk position or another anchor's branch. This matches
+the serving cache: causal prefill entries followed by one draft-generated entry
+for each speculation depth. :class:`TwoPartTTTAttention` shows the full mask.
+
+The causal trunk uses FlashAttention. The short per-anchor branch uses an
+einsum. Their output and log-sum-exp values are merged to produce the exact
+softmax over both sets of keys; backward uses the same joint values to produce
+the exact gradients.
+
+The implementation uses private FlashAttention functions because the merge
+needs their log-sum-exp values. Their interface is pinned to the compatible
+FlashAttention 2.x versions checked below.
+"""
+
 from __future__ import annotations
 
 from contextlib import contextmanager, nullcontext
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
+import flash_attn
 import torch
+from flash_attn.flash_attn_interface import (
+    _flash_attn_backward,
+    _flash_attn_forward,
+    flash_attn_func,
+)
+from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.models.common.embeddings import RotaryEmbedding
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -30,10 +65,388 @@ from megatron.core.transformer.utils import (
 from torch import Tensor
 
 
+def _check_flash_attn_version() -> None:
+    """Reject flash-attn versions whose private interface may not match.
+
+    ``_flash_attn_forward``/``_flash_attn_backward`` are private FlashAttention
+    functions, so their signatures cannot be inspected reliably; this file uses
+    the interface from version 2.8.1, compatible with FlashAttention 2.7 and
+    later 2.x releases. Checked when the multi-pass attention is built — not at
+    import — so a future flash-attn bump surfaces here as a clear error for TTT
+    users instead of an import failure for every Megatron run (this module is
+    imported on the refit path even with the draft disabled).
+    """
+    major, minor = (int(x) for x in flash_attn.__version__.split(".")[:2])
+    if not (major == 2 and minor >= 7):
+        raise RuntimeError(
+            f"flash-attn {flash_attn.__version__} does not match the private "
+            "interface vendored for flash-attn 2.8.1; update "
+            "nemo_rl/models/megatron/draft/eagle.py."
+        )
+
+
+def _fa_forward_causal(
+    q: Tensor, k: Tensor, v: Tensor, softmax_scale: float
+) -> tuple[Tensor, Tensor]:
+    """Run causal FlashAttention on batch-first tensors.
+
+    Returns the output with shape ``[B, S, Hq, D]`` and fp32 log-sum-exp values
+    with shape ``[B, Hq, S]``.
+    """
+    out, softmax_lse, _, _ = _flash_attn_forward(
+        q,
+        k,
+        v,
+        0.0,  # dropout_p
+        softmax_scale,
+        True,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # return_softmax
+    )
+    return out, softmax_lse
+
+
+def _fa_backward_causal(
+    *,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+    softmax_scale: float,
+) -> None:
+    """Run causal FlashAttention backward into existing buffers.
+
+    ``out`` and ``lse`` describe attention over all merged key sets. Passing
+    them to this call produces the exact part of that joint-softmax gradient
+    that belongs to this call's keys.
+    """
+    _flash_attn_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        lse,
+        dq,
+        dk,
+        dv,
+        0.0,  # dropout_p
+        softmax_scale,
+        True,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # deterministic
+        None,  # rng_state
+    )
+
+
+class TwoPartTTTAttention(torch.autograd.Function):
+    """Combine a causal pass-1 trunk with each anchor's own branch keys.
+
+    In TTT pass ``d``, the query at anchor ``i`` can attend to:
+
+    - pass-1 trunk keys at positions ``0..i``; and
+    - the key at anchor ``i`` from every pass ``2..d``.
+
+    It cannot attend to later trunk positions or branch keys from another
+    anchor. Teacher forcing treats every sequence position as an independent
+    anchor, so all anchors from one pass can be processed together.
+
+    The example below has four anchors and three passes. ``q2@1`` means the
+    query for anchor 1 during pass 2. ``A`` marks trunk attention computed by
+    FlashAttention, ``x`` marks the small same-anchor branch computed by an
+    fp32 einsum, and blank cells are masked. Each group of query rows is one
+    :class:`TwoPartTTTAttention` call; pass 1 has no branch::
+
+                 | pass-1 KV(trunk) |    pass-2 KV    |    pass-3 KV    |
+       anchor j: |  0   1   2   3   |  0   1   2   3  |  0   1   2   3  |
+       ==================================================================
+       q1@0      |  A               |                 |                 |
+       q1@1      |  A   A           |                 |                 |
+       q1@2      |  A   A   A       |                 |                 |
+       q1@3      |  A   A   A   A   |                 |                 |
+       ------------------------------------------------------------------
+       q2@0      |  A               |  x              |                 |
+       q2@1      |  A   A           |      x          |                 |
+       q2@2      |  A   A   A       |          x      |                 |
+       q2@3      |  A   A   A   A   |              x  |                 |
+       ------------------------------------------------------------------
+       q3@0      |  A               |  x              |  x              |
+       q3@1      |  A   A           |      x          |      x          |
+       q3@2      |  A   A   A       |          x      |          x      |
+       q3@3      |  A   A   A   A   |              x  |              x  |
+       ==================================================================
+
+    The RoPE positions follow the serving cache. For ``q_d@i``, the trunk uses
+    positions ``0..i`` and branch keys use ``i+1..i+d-1``. The query and its
+    current-pass key both use ``i+d-1``. Thus the cache contains the causal
+    prefill plus the ``d - 1`` entries generated by this speculation chain.
+
+    For pass ``d`` and anchor ``i``:
+
+    - Input: ``concat(e(x_{i+d}), h^{d-1}_i)``. Here ``h^0`` is the projected
+      target auxiliary state, and later ``h`` values are pre-norm draft states.
+    - RoPE position: ``i + d - 1``.
+    - Training target: ``x_{i+d+1}``.
+    - Saved state: ``(k^d_i, v^d_i)``, which becomes a branch entry for the
+      next pass.
+
+    The trunk and branch are evaluated separately, then merged with their
+    log-sum-exp values. This gives the exact softmax over the union of keys
+    without creating an ``S x S`` score matrix. Backward passes the merged
+    output and log-sum-exp to FlashAttention for the trunk and computes the
+    branch gradient directly.
+
+    Inputs to ``apply`` use the batch-first FlashAttention layout:
+
+    - ``q``: Current-pass queries with shape ``[B, S, Hq, D]``.
+    - ``k1`` and ``v1``: Pass-1 trunk K/V with shape ``[B, S, Hkv, D]``.
+    - ``kb`` and ``vb``: Branch K/V with shape ``[B, S, Hkv, P, D]``. The branch
+      axis stores passes ``2..d`` for the same anchor, so ``P = d - 1``.
+    - ``softmax_scale``: Scale applied to attention scores.
+
+    The returned tensor has shape ``[B, S, Hq, D]``.
+    """
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any,
+        q: Tensor,
+        k1: Tensor,
+        v1: Tensor,
+        kb: Tensor,
+        vb: Tensor,
+        softmax_scale: float,
+    ) -> Tensor:
+        batch, seqlen, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[2]
+        group = num_q_heads // num_kv_heads
+
+        out_t, lse_t = _fa_forward_causal(q, k1, v1, softmax_scale)
+
+        # Branch part in fp32: scores/probs over at most P keys per query.
+        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+        # [B, S, Hkv, G, P]
+        scores_b = (
+            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
+        )
+        lse_b = torch.logsumexp(scores_b, dim=-1)  # [B, S, Hkv, G]
+        probs_b = torch.exp(scores_b - lse_b.unsqueeze(-1))
+        out_b = torch.einsum("bskgp,bskpd->bskgd", probs_b, vb.float())
+
+        # Exact LSE merge of the two disjoint key sets.
+        lse_t_grouped = (
+            lse_t.permute(0, 2, 1).view(batch, seqlen, num_kv_heads, group).float()
+        )
+        lse_joint = torch.logaddexp(lse_t_grouped, lse_b)  # [B, S, Hkv, G]
+        w_t = torch.exp(lse_t_grouped - lse_joint).unsqueeze(-1)
+        w_b = torch.exp(lse_b - lse_joint).unsqueeze(-1)
+        out_f32 = (
+            w_t * out_t.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+            + w_b * out_b
+        )
+        out = out_f32.view(batch, seqlen, num_q_heads, head_dim).to(q.dtype)
+
+        # FlashAttention backward expects lse as [B, Hq, S] fp32.
+        lse_joint_hbs = (
+            lse_joint.view(batch, seqlen, num_q_heads).permute(0, 2, 1).contiguous()
+        )
+
+        ctx.save_for_backward(q, k1, v1, kb, vb, out, lse_joint_hbs)
+        ctx.softmax_scale = softmax_scale
+        return out
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, dout: Tensor
+    ) -> tuple[Optional[Tensor], ...]:
+        q, k1, v1, kb, vb, out, lse_joint_hbs = ctx.saved_tensors
+        softmax_scale = ctx.softmax_scale
+        batch, seqlen, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[2]
+        group = num_q_heads // num_kv_heads
+
+        dout = dout.contiguous()
+
+        # Trunk gradient: FA backward with the joint (out, lse) returns the
+        # exact joint-softmax gradient restricted to the trunk key set.
+        dq_t = torch.empty_like(q)
+        dk1 = torch.empty_like(k1)
+        dv1 = torch.empty_like(v1)
+        _fa_backward_causal(
+            dout=dout,
+            q=q,
+            k=k1,
+            v=v1,
+            out=out,
+            lse=lse_joint_hbs,
+            dq=dq_t,
+            dk=dk1,
+            dv=dv1,
+            softmax_scale=softmax_scale,
+        )
+
+        # Branch gradient in closed form (fp32): probs are joint-normalized,
+        # and the D_i = rowsum(dout * out_joint) term carries the cross-part
+        # softmax correction (same identity the FA kernel applies internally).
+        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+        scores_b = (
+            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
+        )
+        lse_joint_grouped = (
+            lse_joint_hbs.permute(0, 2, 1)
+            .reshape(batch, seqlen, num_kv_heads, group)
+            .float()
+        )
+        probs_bj = torch.exp(scores_b - lse_joint_grouped.unsqueeze(-1))
+
+        dout_f32 = dout.float()
+        d_row = (
+            (dout_f32 * out.float())
+            .sum(dim=-1)
+            .view(batch, seqlen, num_kv_heads, group)
+        )
+        dout_grouped = dout_f32.view(batch, seqlen, num_kv_heads, group, head_dim)
+
+        dvb = torch.einsum("bskgp,bskgd->bskpd", probs_bj, dout_grouped)
+        d_probs = torch.einsum("bskgd,bskpd->bskgp", dout_grouped, vb.float())
+        d_scores = probs_bj * (d_probs - d_row.unsqueeze(-1)) * softmax_scale
+        dq_b = torch.einsum("bskgp,bskpd->bskgd", d_scores, kb.float()).view(
+            batch, seqlen, num_q_heads, head_dim
+        )
+        dkb = torch.einsum("bskgp,bskgd->bskpd", d_scores, q_grouped)
+
+        dq = (dq_t.float() + dq_b).to(q.dtype)
+        return dq, dk1, dv1, dkb.to(kb.dtype), dvb.to(vb.dtype), None
+
+
+class TTTDraftCoreAttention(torch.nn.Module):
+    """Drop-in ``core_attention`` for the draft decoder's multi-pass training.
+
+    Replaces the layer's TE core attention (see ``EagleModel``); receives the
+    post-RoPE q/k/v that MCore's ``SelfAttention.forward`` hands to
+    ``core_attention`` in sbhd layout and returns ``[S, B, Hq * D]``.
+
+    Statefulness contract: the TTT driver calls :meth:`begin_pass` before each
+    draft decoder pass and :meth:`reset` when the multi-pass loop finishes (or
+    aborts). Pass 1 runs plain causal FlashAttention and stashes its KV
+    (non-detached — cross-pass reuse must carry gradients back to the pass-1
+    projections); later passes stash their own KV as branch entries and run
+    :class:`TwoPartTTTAttention` against the trunk. Because the stash holds
+    the exact tensors fed to the kernels, a single backward over the combined
+    loss accumulates every pass's contribution automatically.
+    """
+
+    def __init__(self, config: Any):
+        super().__init__()
+        _check_flash_attn_version()
+        attention_dropout = float(getattr(config, "attention_dropout", 0.0) or 0.0)
+        if attention_dropout != 0.0:
+            raise ValueError(
+                "TTTDraftCoreAttention does not support attention dropout "
+                f"(got attention_dropout={attention_dropout})."
+            )
+        if int(getattr(config, "context_parallel_size", 1) or 1) != 1:
+            raise ValueError(
+                "TTTDraftCoreAttention requires context_parallel_size == 1."
+            )
+        # Match MCore's DotProductAttention convention: explicit config
+        # softmax_scale, else 1/sqrt(head_dim).
+        self.softmax_scale: Optional[float] = getattr(config, "softmax_scale", None)
+        self._pass_idx = 0
+        self._kv_by_pass: list[tuple[Tensor, Tensor]] = []
+
+    def begin_pass(self, pass_idx: int) -> None:
+        """Arm the module for TTT pass ``pass_idx`` (1-indexed)."""
+        if pass_idx == 1:
+            self._kv_by_pass = []
+        elif pass_idx != self._pass_idx + 1:
+            raise RuntimeError(
+                f"TTT passes must run in order; got begin_pass({pass_idx}) "
+                f"after pass {self._pass_idx}."
+            )
+        self._pass_idx = pass_idx
+
+    def reset(self) -> None:
+        """Clear saved K/V and release the cross-pass autograd graph."""
+        self._pass_idx = 0
+        self._kv_by_pass = []
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Optional[Tensor],
+        attn_mask_type: Optional[Any] = None,
+        attention_bias: Optional[Tensor] = None,
+        packed_seq_params: Optional[Any] = None,
+    ) -> Tensor:
+        if packed_seq_params is not None:
+            raise NotImplementedError(
+                "TTT draft training does not support sequence packing; "
+                "disable policy.sequence_packing."
+            )
+        if attention_mask is not None:
+            # The layer spec is AttnMaskType.arbitrary, so MCore may hand in a
+            # mask; this module builds its own trunk/branch structure and
+            # silently dropping a padding mask would be wrong.
+            raise ValueError(
+                "TTTDraftCoreAttention builds its own trunk/branch attention_mask "
+                "structure and cannot honour an external attention_mask."
+            )
+        if attention_bias is not None:
+            raise ValueError("TTTDraftCoreAttention does not support attention_bias.")
+        if self._pass_idx < 1:
+            raise RuntimeError(
+                "TTTDraftCoreAttention.forward called without begin_pass(); "
+                "the TTT driver must arm the pass index before each pass."
+            )
+
+        seqlen, batch = query.shape[0], query.shape[1]
+        softmax_scale = self.softmax_scale or query.shape[-1] ** -0.5
+
+        # sbhd -> bshd (FlashAttention layout).
+        q = query.transpose(0, 1).contiguous()
+        k = key.transpose(0, 1).contiguous()
+        v = value.transpose(0, 1).contiguous()
+
+        self._kv_by_pass.append((k, v))
+
+        if self._pass_idx == 1:
+            out = flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=True)
+        else:
+            k1, v1 = self._kv_by_pass[0]
+            kb = torch.stack([kv[0] for kv in self._kv_by_pass[1:]], dim=3)
+            vb = torch.stack([kv[1] for kv in self._kv_by_pass[1:]], dim=3)
+            out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+
+        # bshd -> [S, B, Hq * D] (core_attention output contract).
+        return out.transpose(0, 1).reshape(seqlen, batch, -1)
+
+
 class EagleModel(MegatronModule):
-    def __init__(self, config: TransformerConfig):
+    def __init__(
+        self,
+        config: TransformerConfig,
+        *,
+        ttt_steps: int = 1,
+    ):
         super().__init__(config=config)
         self.config = config
+        self.ttt_steps = int(ttt_steps)
+        if self.ttt_steps < 1:
+            raise ValueError(f"ttt_steps must be >= 1, got {self.ttt_steps}.")
 
         rotary_pos_emb = RotaryEmbedding(
             kv_channels=config.kv_channels,
@@ -59,6 +472,32 @@ class EagleModel(MegatronModule):
         self.eagle_module = EagleModule(
             config=config, rotary_pos_emb=rotary_pos_emb, bias=False
         )
+
+        self._ttt_attn_modules: list[TTTDraftCoreAttention] = []
+        self._ttt_prenorm_hidden: Optional[Tensor] = None
+        if self.ttt_steps > 1:
+            if getattr(config, "recompute_granularity", None) is not None:
+                # Activation recomputation would call this stateful attention
+                # again during backward and corrupt its per-pass K/V list.
+                raise ValueError(
+                    "TTT draft training (ttt_steps > 1) is incompatible with "
+                    "activation recomputation on the draft config."
+                )
+            for layer in self.eagle_module.decoder.layers:
+                ttt_attention = TTTDraftCoreAttention(config)
+                layer.self_attention.core_attention = ttt_attention
+                self._ttt_attn_modules.append(ttt_attention)
+            # ModelOpt's hook saves a detached value. TTT instead needs the
+            # pre-final-norm hidden state with gradients for the next pass.
+            self.eagle_module.decoder.layers[-1].register_forward_hook(
+                self._capture_prenorm_hidden_hook
+            )
+
+    def _capture_prenorm_hidden_hook(
+        self, _module: torch.nn.Module, _args: Tuple, output: Tensor | Tuple
+    ) -> None:
+        hidden_states = output[0] if isinstance(output, tuple) else output
+        self._ttt_prenorm_hidden = hidden_states
 
     def sharded_state_dict(
         self,
@@ -163,3 +602,91 @@ class EagleModel(MegatronModule):
         logits, _ = self.eagle_module.eagle_output_layer(hidden_states)
         logits = logits.transpose(0, 1).contiguous()
         return logits
+
+    def _ttt_rotary_pos_emb(self, ttt_pass: int, seq_len: int) -> Optional[Tensor]:
+        """Build RoPE frequencies for one TTT pass.
+
+        Pass ``d`` shifts every position by ``d - 1``. A query at anchor ``i``
+        therefore uses position ``i + d - 1``, matching the extra cache entry
+        created at each speculation depth during serving. Pass 1 returns
+        ``None`` because EagleModule's default table is already correct.
+
+        Args:
+            ttt_pass: One-indexed TTT pass ``d``.
+            seq_len: Length of the input sequence.
+
+        Returns:
+            Shifted RoPE frequencies for this pass, or ``None`` for pass 1.
+        """
+        if ttt_pass == 1:
+            return None
+        rotary = self.eagle_module.rotary_pos_emb(seq_len + ttt_pass - 1)
+        return rotary[ttt_pass - 1 :]
+
+    def forward_ttt(
+        self,
+        hidden_states: Tensor,
+        input_embeds: Tensor,
+    ) -> list[Tensor]:
+        """Run the configured TTT passes in sequence.
+
+        Pass 1 projects the target auxiliary hidden states. Every later pass
+        receives the previous pass's pre-final-norm hidden state without
+        detaching it, so gradients flow through the entire pass chain. Token
+        embeddings shift left by one position before each new pass.
+
+        Args:
+            hidden_states: Target auxiliary hidden states with shape
+                ``[S, B, 3h]``.
+            input_embeds: Pass-1 token embeddings ``e(x_{i+1})`` with shape
+                ``[S, B, h]``. They have already been shifted left once.
+
+        Returns:
+            One ``[B, S, draft_vocab]`` logits tensor per pass. At pass ``d``,
+            position ``i`` predicts token ``x_{i+d+1}``.
+        """
+        if self.ttt_steps < 2:
+            raise RuntimeError(
+                "forward_ttt requires ttt_steps >= 2; use forward() for the "
+                "single-pass draft."
+            )
+        # Needed only by the multi-pass training path.
+        from megatron.core.transformer.multi_token_prediction import roll_tensor
+
+        hidden = self.eagle_module.fc(hidden_states)[0]
+        embeds = input_embeds
+        logits_by_pass: list[Tensor] = []
+        try:
+            for ttt_pass in range(1, self.ttt_steps + 1):
+                for ttt_attention in self._ttt_attn_modules:
+                    ttt_attention.begin_pass(ttt_pass)
+                self._ttt_prenorm_hidden = None
+                decoder_hidden, _ = self.eagle_module(
+                    embeddings=embeds,
+                    hidden_states=hidden,
+                    # The custom attention modules create the trunk/branch mask.
+                    attention_mask=None,
+                    rotary_pos_emb=self._ttt_rotary_pos_emb(ttt_pass, embeds.shape[0]),
+                )
+                logits, _ = self.eagle_module.eagle_output_layer(decoder_hidden)
+                logits_by_pass.append(logits.transpose(0, 1).contiguous())
+
+                if ttt_pass < self.ttt_steps:
+                    if self._ttt_prenorm_hidden is None:
+                        raise RuntimeError(
+                            "TTT pre-norm hidden-state capture hook did not "
+                            "fire; cannot feed the next draft pass."
+                        )
+                    hidden = self._ttt_prenorm_hidden
+                    embeds = roll_tensor(
+                        embeds,
+                        shifts=-1,
+                        dims=0,
+                        cp_group=parallel_state.get_context_parallel_group(),
+                    )[0]
+        finally:
+            # Clear saved K/V and hidden states even if a pass raises an error.
+            for ttt_attention in self._ttt_attn_modules:
+                ttt_attention.reset()
+            self._ttt_prenorm_hidden = None
+        return logits_by_pass

--- a/nemo_rl/models/megatron/draft/eagle.py
+++ b/nemo_rl/models/megatron/draft/eagle.py
@@ -35,6 +35,11 @@ einsum. Their output and log-sum-exp values are merged to produce the exact
 softmax over both sets of keys; backward uses the same joint values to produce
 the exact gradients.
 
+Packed and padded inputs share one flat THD code path. With context
+parallelism (CP), queries and branch K/V stay local while pass-1 trunk K/V
+moves around the zigzag ring. Partial attention results are merged at each
+step, and trunk gradients finish by returning to the rank that owns them.
+
 The implementation uses private FlashAttention functions because the merge
 needs their log-sum-exp values. Their interface is pinned to the compatible
 FlashAttention 2.x versions checked below.
@@ -42,20 +47,18 @@ FlashAttention 2.x versions checked below.
 
 from __future__ import annotations
 
-from contextlib import contextmanager, nullcontext
 from typing import Any, Optional, Tuple
 
 import flash_attn
 import torch
+import torch.distributed as dist
 from flash_attn.flash_attn_interface import (
-    _flash_attn_backward,
-    _flash_attn_forward,
-    flash_attn_func,
+    _flash_attn_varlen_backward,
+    _flash_attn_varlen_forward,
 )
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.models.common.embeddings import RotaryEmbedding
-from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.utils import (
@@ -68,13 +71,14 @@ from torch import Tensor
 def _check_flash_attn_version() -> None:
     """Reject flash-attn versions whose private interface may not match.
 
-    ``_flash_attn_forward``/``_flash_attn_backward`` are private FlashAttention
-    functions, so their signatures cannot be inspected reliably; this file uses
-    the interface from version 2.8.1, compatible with FlashAttention 2.7 and
-    later 2.x releases. Checked when the multi-pass attention is built — not at
-    import — so a future flash-attn bump surfaces here as a clear error for TTT
-    users instead of an import failure for every Megatron run (this module is
-    imported on the refit path even with the draft disabled).
+    ``_flash_attn_varlen_forward``/``_flash_attn_varlen_backward`` are private
+    FlashAttention functions, so their signatures cannot be inspected reliably;
+    this file uses the interface from version 2.8.1, compatible with
+    FlashAttention 2.7 and later 2.x releases. Checked when the multi-pass
+    attention is built — not at import — so a future flash-attn bump surfaces
+    here as a clear error for TTT users instead of an import failure for every
+    Megatron run (this module is imported on the refit path even with the
+    draft disabled).
     """
     major, minor = (int(x) for x in flash_attn.__version__.split(".")[:2])
     if not (major == 2 and minor >= 7):
@@ -85,21 +89,33 @@ def _check_flash_attn_version() -> None:
         )
 
 
-def _fa_forward_causal(
-    q: Tensor, k: Tensor, v: Tensor, softmax_scale: float
+def _fa_varlen_forward(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_kv: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
+    softmax_scale: float,
+    causal: bool,
 ) -> tuple[Tensor, Tensor]:
-    """Run causal FlashAttention on batch-first tensors.
+    """Run variable-length FlashAttention on flat THD tensors.
 
-    Returns the output with shape ``[B, S, Hq, D]`` and fp32 log-sum-exp values
-    with shape ``[B, Hq, S]``.
+    Returns the output with shape ``[T, Hq, D]`` and fp32 log-sum-exp values
+    with shape ``[Hq, T]``.
     """
-    out, softmax_lse, _, _ = _flash_attn_forward(
+    out, softmax_lse, _, _ = _flash_attn_varlen_forward(
         q,
         k,
         v,
+        cu_seqlens_q,
+        cu_seqlens_kv,
+        max_seqlen_q,
+        max_seqlen_kv,
         0.0,  # dropout_p
         softmax_scale,
-        True,  # causal
+        causal,
         -1,  # window_size_left
         -1,  # window_size_right
         0.0,  # softcap
@@ -109,7 +125,7 @@ def _fa_forward_causal(
     return out, softmax_lse
 
 
-def _fa_backward_causal(
+def _fa_varlen_backward(
     *,
     dout: Tensor,
     q: Tensor,
@@ -120,15 +136,20 @@ def _fa_backward_causal(
     dq: Tensor,
     dk: Tensor,
     dv: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_kv: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
     softmax_scale: float,
+    causal: bool,
 ) -> None:
-    """Run causal FlashAttention backward into existing buffers.
+    """Run variable-length FlashAttention backward into existing buffers.
 
     ``out`` and ``lse`` describe attention over all merged key sets. Passing
     them to this call produces the exact part of that joint-softmax gradient
     that belongs to this call's keys.
     """
-    _flash_attn_backward(
+    _flash_attn_varlen_backward(
         dout,
         q,
         k,
@@ -138,9 +159,13 @@ def _fa_backward_causal(
         dq,
         dk,
         dv,
+        cu_seqlens_q,
+        cu_seqlens_kv,
+        max_seqlen_q,
+        max_seqlen_kv,
         0.0,  # dropout_p
         softmax_scale,
-        True,  # causal
+        causal,
         -1,  # window_size_left
         -1,  # window_size_right
         0.0,  # softcap
@@ -148,6 +173,92 @@ def _fa_backward_causal(
         False,  # deterministic
         None,  # rng_state
     )
+
+
+def _global_cp_group() -> Optional[dist.ProcessGroup]:
+    """The global CP group, or None before model-parallel init (unit tests)."""
+    if not parallel_state.model_parallel_is_initialized():
+        return None
+    return parallel_state.get_context_parallel_group()
+
+
+def _zigzag_half_split(cu_seqlens: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    """Split every local zigzag subsequence into its front and back halves.
+
+    A CP rank stores two equally sized chunks from each global subsequence.
+    Rank ``r`` owns front chunk ``r`` and back chunk ``2 * cp_size - 1 - r``.
+
+    Args:
+        cu_seqlens: Boundaries of the rank-local THD subsequences.
+
+    Returns:
+        Indices of all front rows, indices of all back rows, and THD
+        boundaries for a tensor containing one half of each subsequence.
+    """
+    device = cu_seqlens.device
+    lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.long)
+    half = lens // 2
+    total = int(cu_seqlens[-1].item())
+    seq_id = torch.repeat_interleave(torch.arange(lens.numel(), device=device), lens)
+    pos_local = (
+        torch.arange(total, device=device) - cu_seqlens[:-1].to(torch.long)[seq_id]
+    )
+    front_mask = pos_local < half[seq_id]
+    front_index = front_mask.nonzero(as_tuple=True)[0]
+    back_index = (~front_mask).nonzero(as_tuple=True)[0]
+    cu_half = torch.zeros_like(cu_seqlens)
+    cu_half[1:] = torch.cumsum(half, dim=0).to(cu_seqlens.dtype)
+    return front_index, back_index, cu_half
+
+
+def _ring_send_recv(
+    tensors: list[Tensor],
+    send_rank: int,
+    recv_rank: int,
+    cp_group: dist.ProcessGroup,
+) -> tuple[list[Tensor], list[Any]]:
+    """Move a list of tensors one step around the CP ring.
+
+    Each tensor is sent to the next rank while a same-shaped tensor is received
+    from the previous rank. The caller must keep the sent tensors alive until
+    all returned requests have completed.
+    """
+    recvs = [torch.empty_like(t) for t in tensors]
+    ops = []
+    for send_t, recv_t in zip(tensors, recvs):
+        ops.append(dist.P2POp(dist.isend, send_t.contiguous(), send_rank, cp_group))
+        ops.append(dist.P2POp(dist.irecv, recv_t, recv_rank, cp_group))
+    return recvs, dist.batch_isend_irecv(ops)
+
+
+def _lse_merge_update(
+    out_acc: Tensor,
+    lse_acc: Tensor,
+    out_step: Tensor,
+    lse_step: Tensor,
+    rows: Optional[Tensor] = None,
+) -> None:
+    """Merge attention over another set of keys into fp32 accumulators.
+
+    ``out_step`` is normalized only over the keys handled by this step. Its
+    log-sum-exp value supplies the exact weight needed to combine it with the
+    earlier results. The accumulators start at 0 and ``-inf``, so the first
+    merge acts like a copy. ``rows`` limits the merge when only the local back
+    half contains valid queries.
+    """
+    if rows is None:
+        lse_new = torch.logaddexp(lse_acc, lse_step)
+        w_old = torch.exp(lse_acc - lse_new).transpose(0, 1).unsqueeze(-1)
+        w_new = torch.exp(lse_step - lse_new).transpose(0, 1).unsqueeze(-1)
+        out_acc.mul_(w_old).add_(out_step.float() * w_new)
+        lse_acc.copy_(lse_new)
+    else:
+        lse_old = lse_acc[:, rows]
+        lse_new = torch.logaddexp(lse_old, lse_step)
+        w_old = torch.exp(lse_old - lse_new).transpose(0, 1).unsqueeze(-1)
+        w_new = torch.exp(lse_step - lse_new).transpose(0, 1).unsqueeze(-1)
+        out_acc[rows] = out_acc[rows] * w_old + out_step.float() * w_new
+        lse_acc[:, rows] = lse_new
 
 
 class TwoPartTTTAttention(torch.autograd.Function):
@@ -203,19 +314,42 @@ class TwoPartTTTAttention(torch.autograd.Function):
 
     The trunk and branch are evaluated separately, then merged with their
     log-sum-exp values. This gives the exact softmax over the union of keys
-    without creating an ``S x S`` score matrix. Backward passes the merged
+    without creating a ``T x T`` score matrix. Backward passes the merged
     output and log-sum-exp to FlashAttention for the trunk and computes the
     branch gradient directly.
 
-    Inputs to ``apply`` use the batch-first FlashAttention layout:
+    Inputs to ``apply`` use flat THD layout:
 
-    - ``q``: Current-pass queries with shape ``[B, S, Hq, D]``.
-    - ``k1`` and ``v1``: Pass-1 trunk K/V with shape ``[B, S, Hkv, D]``.
-    - ``kb`` and ``vb``: Branch K/V with shape ``[B, S, Hkv, P, D]``. The branch
-      axis stores passes ``2..d`` for the same anchor, so ``P = d - 1``.
+    - ``q``: Current-pass queries with shape ``[T, Hq, D]``.
+    - ``k1`` and ``v1``: Pass-1 trunk K/V with shape ``[T, Hkv, D]``.
+    - ``kb`` and ``vb``: Branch K/V with shape ``[T, Hkv, P, D]``. The branch
+      axis stores passes ``2..d`` for the same local anchor, so ``P = d - 1``.
+      Both tensors are ``None`` during pass 1.
+    - ``cu_seqlens``: Rank-local subsequence boundaries with shape ``[N + 1]``.
+    - ``max_seqlen``: Maximum rank-local subsequence length.
     - ``softmax_scale``: Scale applied to attention scores.
+    - ``cp_group``: CP process group, or ``None`` on a single rank.
 
-    The returned tensor has shape ``[B, S, Hq, D]``.
+    Packing boundaries are respected by variable-length FlashAttention. The
+    causal trunk restarts at every subsequence, while each branch stays at one
+    local row and therefore cannot cross into another subsequence. Padded input
+    is converted to ``B`` equal-length THD subsequences by the caller.
+
+    With CP, rank ``r`` owns a front chunk ``r`` and a back chunk
+    ``2 * cp_size - 1 - r`` from every subsequence. Queries remain local while
+    trunk K/V moves around the ring. Each ring step uses one of three masks:
+
+    - Step 0 uses causal attention over this rank's concatenated front and back
+      chunks.
+    - At steps ``s <= r``, all local queries see the arriving front chunk and
+      none see its back chunk.
+    - At steps ``s > r``, only local back-chunk queries see the entire arriving
+      K/V shard.
+
+    The local branch is merged as one additional step. Backward replays the
+    ring, and trunk K/V gradients make a final hop back to their owner rank.
+
+    The returned tensor has shape ``[T, Hq, D]``.
     """
 
     @staticmethod
@@ -224,127 +358,332 @@ class TwoPartTTTAttention(torch.autograd.Function):
         q: Tensor,
         k1: Tensor,
         v1: Tensor,
-        kb: Tensor,
-        vb: Tensor,
+        kb: Optional[Tensor],
+        vb: Optional[Tensor],
+        cu_seqlens: Tensor,
+        max_seqlen: int,
         softmax_scale: float,
+        cp_group: Optional[dist.ProcessGroup],
     ) -> Tensor:
-        batch, seqlen, num_q_heads, head_dim = q.shape
-        num_kv_heads = k1.shape[2]
+        total, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[1]
         group = num_q_heads // num_kv_heads
+        has_branch = kb is not None
 
-        out_t, lse_t = _fa_forward_causal(q, k1, v1, softmax_scale)
+        cp_size = 1 if cp_group is None else cp_group.size()
+        if cp_size > 1:
+            cp_rank = cp_group.rank()
+            global_ranks = dist.get_process_group_ranks(cp_group)
+            send_rank = global_ranks[(cp_rank + 1) % cp_size]
+            recv_rank = global_ranks[(cp_rank - 1) % cp_size]
+            front_index, back_index, cu_half = _zigzag_half_split(cu_seqlens)
+            max_half = max(max_seqlen // 2, 1)
+            q_back = q[back_index]
+        else:
+            cp_rank = 0
+            front_index = back_index = cu_half = None
 
-        # Branch part in fp32: scores/probs over at most P keys per query.
-        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
-        # [B, S, Hkv, G, P]
-        scores_b = (
-            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
-        )
-        lse_b = torch.logsumexp(scores_b, dim=-1)  # [B, S, Hkv, G]
-        probs_b = torch.exp(scores_b - lse_b.unsqueeze(-1))
-        out_b = torch.einsum("bskgp,bskpd->bskgd", probs_b, vb.float())
+        out_acc = q.new_zeros((total, num_q_heads, head_dim), dtype=torch.float32)
+        lse_acc = q.new_full((num_q_heads, total), float("-inf"), dtype=torch.float32)
 
-        # Exact LSE merge of the two disjoint key sets.
-        lse_t_grouped = (
-            lse_t.permute(0, 2, 1).view(batch, seqlen, num_kv_heads, group).float()
-        )
-        lse_joint = torch.logaddexp(lse_t_grouped, lse_b)  # [B, S, Hkv, G]
-        w_t = torch.exp(lse_t_grouped - lse_joint).unsqueeze(-1)
-        w_b = torch.exp(lse_b - lse_joint).unsqueeze(-1)
-        out_f32 = (
-            w_t * out_t.view(batch, seqlen, num_kv_heads, group, head_dim).float()
-            + w_b * out_b
-        )
-        out = out_f32.view(batch, seqlen, num_q_heads, head_dim).to(q.dtype)
+        k_cur, v_cur = k1, v1
+        reqs: list[Any] = []
+        for step in range(cp_size):
+            if step + 1 < cp_size:
+                (k_next, v_next), reqs = _ring_send_recv(
+                    [k_cur, v_cur], send_rank, recv_rank, cp_group
+                )
+            if step == 0:
+                out_s, lse_s = _fa_varlen_forward(
+                    q,
+                    k_cur,
+                    v_cur,
+                    cu_seqlens,
+                    cu_seqlens,
+                    max_seqlen,
+                    max_seqlen,
+                    softmax_scale,
+                    causal=True,
+                )
+                _lse_merge_update(out_acc, lse_acc, out_s, lse_s)
+            elif step <= cp_rank:
+                out_s, lse_s = _fa_varlen_forward(
+                    q,
+                    k_cur[front_index],
+                    v_cur[front_index],
+                    cu_seqlens,
+                    cu_half,
+                    max_seqlen,
+                    max_half,
+                    softmax_scale,
+                    causal=False,
+                )
+                _lse_merge_update(out_acc, lse_acc, out_s, lse_s)
+            else:
+                out_s, lse_s = _fa_varlen_forward(
+                    q_back,
+                    k_cur,
+                    v_cur,
+                    cu_half,
+                    cu_seqlens,
+                    max_half,
+                    max_seqlen,
+                    softmax_scale,
+                    causal=False,
+                )
+                _lse_merge_update(out_acc, lse_acc, out_s, lse_s, rows=back_index)
+            if step + 1 < cp_size:
+                for req in reqs:
+                    req.wait()
+                k_cur, v_cur = k_next, v_next
 
-        # FlashAttention backward expects lse as [B, Hq, S] fp32.
-        lse_joint_hbs = (
-            lse_joint.view(batch, seqlen, num_q_heads).permute(0, 2, 1).contiguous()
-        )
+        if has_branch:
+            # Each query has at most P branch keys, so compute this small part
+            # directly in fp32.
+            q_grouped = q.view(total, num_kv_heads, group, head_dim).float()
+            scores_b = (
+                torch.einsum("tkgd,tkpd->tkgp", q_grouped, kb.float()) * softmax_scale
+            )
+            lse_b = torch.logsumexp(scores_b, dim=-1)  # [T, Hkv, G]
+            probs_b = torch.exp(scores_b - lse_b.unsqueeze(-1))
+            out_b = torch.einsum("tkgp,tkpd->tkgd", probs_b, vb.float())
 
-        ctx.save_for_backward(q, k1, v1, kb, vb, out, lse_joint_hbs)
+            # Merge in place. An einsum result may have a permuted KV-major
+            # layout; replacing ``out_acc`` with a broadcast expression could
+            # inherit that layout and break the final view.
+            lse_t = lse_acc.transpose(0, 1).reshape(total, num_kv_heads, group)
+            lse_joint = torch.logaddexp(lse_t, lse_b)
+            w_t = torch.exp(lse_t - lse_joint).unsqueeze(-1)
+            w_b = torch.exp(lse_b - lse_joint).unsqueeze(-1)
+            out_acc_grouped = out_acc.view(total, num_kv_heads, group, head_dim)
+            out_acc_grouped.mul_(w_t).add_(w_b * out_b)
+            out = out_acc.view(total, num_q_heads, head_dim).to(q.dtype)
+            # FlashAttention backward expects fp32 LSE in [Hq, T] layout.
+            lse_final = lse_joint.view(total, num_q_heads).transpose(0, 1).contiguous()
+        else:
+            out = out_acc.to(q.dtype)
+            lse_final = lse_acc
+
+        saved = [q, k1, v1, out, lse_final, cu_seqlens]
+        if has_branch:
+            saved += [kb, vb]
+        if cp_size > 1:
+            saved += [front_index, back_index, cu_half]
+        ctx.save_for_backward(*saved)
+        ctx.has_branch = has_branch
         ctx.softmax_scale = softmax_scale
+        ctx.cp_group = cp_group
+        ctx.cp_size = cp_size
+        ctx.max_seqlen = max_seqlen
         return out
 
     @staticmethod
     def backward(  # type: ignore[override]
         ctx: Any, dout: Tensor
     ) -> tuple[Optional[Tensor], ...]:
-        q, k1, v1, kb, vb, out, lse_joint_hbs = ctx.saved_tensors
+        saved = list(ctx.saved_tensors)
+        q, k1, v1, out, lse_joint, cu_seqlens = saved[:6]
+        cursor = 6
+        if ctx.has_branch:
+            kb, vb = saved[cursor : cursor + 2]
+            cursor += 2
+        if ctx.cp_size > 1:
+            front_index, back_index, cu_half = saved[cursor : cursor + 3]
+        cp_group = ctx.cp_group
+        cp_size = ctx.cp_size
         softmax_scale = ctx.softmax_scale
-        batch, seqlen, num_q_heads, head_dim = q.shape
-        num_kv_heads = k1.shape[2]
+        max_seqlen = ctx.max_seqlen
+
+        total, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[1]
         group = num_q_heads // num_kv_heads
 
         dout = dout.contiguous()
+        # Accumulate K/V gradients in fp32 while they travel with their shard;
+        # each FlashAttention call returns lower-precision step gradients.
+        dq_acc = q.new_zeros((total, num_q_heads, head_dim), dtype=torch.float32)
+        dk_cur = q.new_zeros(k1.shape, dtype=torch.float32)
+        dv_cur = torch.zeros_like(dk_cur)
 
-        # Trunk gradient: FA backward with the joint (out, lse) returns the
-        # exact joint-softmax gradient restricted to the trunk key set.
-        dq_t = torch.empty_like(q)
-        dk1 = torch.empty_like(k1)
-        dv1 = torch.empty_like(v1)
-        _fa_backward_causal(
-            dout=dout,
-            q=q,
-            k=k1,
-            v=v1,
-            out=out,
-            lse=lse_joint_hbs,
-            dq=dq_t,
-            dk=dk1,
-            dv=dv1,
-            softmax_scale=softmax_scale,
-        )
+        if cp_size > 1:
+            cp_rank = cp_group.rank()
+            global_ranks = dist.get_process_group_ranks(cp_group)
+            send_rank = global_ranks[(cp_rank + 1) % cp_size]
+            recv_rank = global_ranks[(cp_rank - 1) % cp_size]
+            max_half = max(max_seqlen // 2, 1)
+            q_back = q[back_index]
+            dout_back = dout[back_index]
+            out_back = out[back_index]
+            lse_back = lse_joint[:, back_index].contiguous()
+        else:
+            cp_rank = 0
 
-        # Branch gradient in closed form (fp32): probs are joint-normalized,
-        # and the D_i = rowsum(dout * out_joint) term carries the cross-part
-        # softmax correction (same identity the FA kernel applies internally).
-        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
-        scores_b = (
-            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
-        )
-        lse_joint_grouped = (
-            lse_joint_hbs.permute(0, 2, 1)
-            .reshape(batch, seqlen, num_kv_heads, group)
-            .float()
-        )
-        probs_bj = torch.exp(scores_b - lse_joint_grouped.unsqueeze(-1))
+        # Replay the forward ring. Add each step's K/V gradient before moving
+        # the shard and its accumulator together. A final hop returns the full
+        # gradient to the rank that owns the shard.
+        k_cur, v_cur = k1, v1
+        for step in range(cp_size):
+            kv_reqs: list[Any] = []
+            if step + 1 < cp_size:
+                (k_next, v_next), kv_reqs = _ring_send_recv(
+                    [k_cur, v_cur], send_rank, recv_rank, cp_group
+                )
+            if step == 0:
+                dq_s = torch.empty_like(q)
+                dk_s = torch.empty_like(k_cur)
+                dv_s = torch.empty_like(v_cur)
+                _fa_varlen_backward(
+                    dout=dout,
+                    q=q,
+                    k=k_cur,
+                    v=v_cur,
+                    out=out,
+                    lse=lse_joint,
+                    dq=dq_s,
+                    dk=dk_s,
+                    dv=dv_s,
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_kv=cu_seqlens,
+                    max_seqlen_q=max_seqlen,
+                    max_seqlen_kv=max_seqlen,
+                    softmax_scale=softmax_scale,
+                    causal=True,
+                )
+                dq_acc += dq_s.float()
+                dk_cur += dk_s.float()
+                dv_cur += dv_s.float()
+            elif step <= cp_rank:
+                k_half = k_cur[front_index]
+                v_half = v_cur[front_index]
+                dq_s = torch.empty_like(q)
+                dk_s = torch.empty_like(k_half)
+                dv_s = torch.empty_like(v_half)
+                _fa_varlen_backward(
+                    dout=dout,
+                    q=q,
+                    k=k_half,
+                    v=v_half,
+                    out=out,
+                    lse=lse_joint,
+                    dq=dq_s,
+                    dk=dk_s,
+                    dv=dv_s,
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_kv=cu_half,
+                    max_seqlen_q=max_seqlen,
+                    max_seqlen_kv=max_half,
+                    softmax_scale=softmax_scale,
+                    causal=False,
+                )
+                dq_acc += dq_s.float()
+                dk_cur.index_add_(0, front_index, dk_s.float())
+                dv_cur.index_add_(0, front_index, dv_s.float())
+            else:
+                dq_s = torch.empty_like(q_back)
+                dk_s = torch.empty_like(k_cur)
+                dv_s = torch.empty_like(v_cur)
+                _fa_varlen_backward(
+                    dout=dout_back,
+                    q=q_back,
+                    k=k_cur,
+                    v=v_cur,
+                    out=out_back,
+                    lse=lse_back,
+                    dq=dq_s,
+                    dk=dk_s,
+                    dv=dv_s,
+                    cu_seqlens_q=cu_half,
+                    cu_seqlens_kv=cu_seqlens,
+                    max_seqlen_q=max_half,
+                    max_seqlen_kv=max_seqlen,
+                    softmax_scale=softmax_scale,
+                    causal=False,
+                )
+                dq_acc.index_add_(0, back_index, dq_s.float())
+                dk_cur += dk_s.float()
+                dv_cur += dv_s.float()
+            if step + 1 < cp_size:
+                for req in kv_reqs:
+                    req.wait()
+                # Move gradients only after adding this step's contribution.
+                (dk_next, dv_next), dkv_reqs = _ring_send_recv(
+                    [dk_cur, dv_cur], send_rank, recv_rank, cp_group
+                )
+                for req in dkv_reqs:
+                    req.wait()
+                k_cur, v_cur = k_next, v_next
+                dk_cur, dv_cur = dk_next, dv_next
+        if cp_size > 1:
+            (dk_own, dv_own), dkv_reqs = _ring_send_recv(
+                [dk_cur, dv_cur], send_rank, recv_rank, cp_group
+            )
+            for req in dkv_reqs:
+                req.wait()
+            dk_cur, dv_cur = dk_own, dv_own
 
-        dout_f32 = dout.float()
-        d_row = (
-            (dout_f32 * out.float())
-            .sum(dim=-1)
-            .view(batch, seqlen, num_kv_heads, group)
-        )
-        dout_grouped = dout_f32.view(batch, seqlen, num_kv_heads, group, head_dim)
+        if ctx.has_branch:
+            # Compute the branch gradient directly in fp32. ``probs_bj`` uses
+            # the joint normalization, and ``d_row`` supplies the correction
+            # caused by sharing one softmax with the trunk.
+            q_grouped = q.view(total, num_kv_heads, group, head_dim).float()
+            scores_b = (
+                torch.einsum("tkgd,tkpd->tkgp", q_grouped, kb.float()) * softmax_scale
+            )
+            lse_joint_grouped = (
+                lse_joint.transpose(0, 1).reshape(total, num_kv_heads, group).float()
+            )
+            probs_bj = torch.exp(scores_b - lse_joint_grouped.unsqueeze(-1))
 
-        dvb = torch.einsum("bskgp,bskgd->bskpd", probs_bj, dout_grouped)
-        d_probs = torch.einsum("bskgd,bskpd->bskgp", dout_grouped, vb.float())
-        d_scores = probs_bj * (d_probs - d_row.unsqueeze(-1)) * softmax_scale
-        dq_b = torch.einsum("bskgp,bskpd->bskgd", d_scores, kb.float()).view(
-            batch, seqlen, num_q_heads, head_dim
-        )
-        dkb = torch.einsum("bskgp,bskgd->bskpd", d_scores, q_grouped)
+            dout_f32 = dout.float()
+            d_row = (
+                (dout_f32 * out.float()).sum(dim=-1).view(total, num_kv_heads, group)
+            )
+            dout_grouped = dout_f32.view(total, num_kv_heads, group, head_dim)
 
-        dq = (dq_t.float() + dq_b).to(q.dtype)
-        return dq, dk1, dv1, dkb.to(kb.dtype), dvb.to(vb.dtype), None
+            dvb = torch.einsum("tkgp,tkgd->tkpd", probs_bj, dout_grouped)
+            d_probs = torch.einsum("tkgd,tkpd->tkgp", dout_grouped, vb.float())
+            d_scores = probs_bj * (d_probs - d_row.unsqueeze(-1)) * softmax_scale
+            # Use reshape because einsum may return a permuted layout.
+            dq_acc += torch.einsum("tkgp,tkpd->tkgd", d_scores, kb.float()).reshape(
+                total, num_q_heads, head_dim
+            )
+            dkb = torch.einsum("tkgp,tkgd->tkpd", d_scores, q_grouped).to(kb.dtype)
+            dvb = dvb.to(vb.dtype)
+        else:
+            dkb = dvb = None
+
+        return (
+            dq_acc.to(q.dtype),
+            dk_cur.to(k1.dtype),
+            dv_cur.to(v1.dtype),
+            dkb,
+            dvb,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 class TTTDraftCoreAttention(torch.nn.Module):
-    """Drop-in ``core_attention`` for the draft decoder's multi-pass training.
+    """Adapt MCore self-attention to the multi-pass TTT mask.
 
-    Replaces the layer's TE core attention (see ``EagleModel``); receives the
-    post-RoPE q/k/v that MCore's ``SelfAttention.forward`` hands to
-    ``core_attention`` in sbhd layout and returns ``[S, B, Hq * D]``.
+    This module replaces each draft decoder layer's TE core attention. MCore
+    passes Q/K/V after RoPE in one of two layouts:
 
-    Statefulness contract: the TTT driver calls :meth:`begin_pass` before each
-    draft decoder pass and :meth:`reset` when the multi-pass loop finishes (or
-    aborts). Pass 1 runs plain causal FlashAttention and stashes its KV
-    (non-detached — cross-pass reuse must carry gradients back to the pass-1
-    projections); later passes stash their own KV as branch entries and run
-    :class:`TwoPartTTTAttention` against the trunk. Because the stash holds
-    the exact tensors fed to the kernels, a single backward over the combined
-    loss accumulates every pass's contribution automatically.
+    - padded: ``[S, B, H, D]``;
+    - packed THD: ``[T, H, D]``, with the batch dimension removed.
+
+    The returned layouts are ``[S, B, Hq * D]`` and ``[T, Hq * D]``.
+
+    The module keeps K/V from earlier passes. :meth:`begin_pass` selects the
+    current pass. Pass 1 becomes the causal trunk; later passes are appended as
+    branch entries. These tensors are not detached because later-pass losses
+    must also update the projections that created earlier K/V. :meth:`reset`
+    clears all saved tensors after the TTT loop, including error paths.
+
+    ``pg_collection`` supplies the CP process group. Multiple CP ranks require
+    packed THD input because padded input has no zigzag position metadata.
     """
 
     def __init__(self, config: Any):
@@ -352,22 +691,22 @@ class TTTDraftCoreAttention(torch.nn.Module):
         _check_flash_attn_version()
         attention_dropout = float(getattr(config, "attention_dropout", 0.0) or 0.0)
         if attention_dropout != 0.0:
+            # The two-part flash calls hard-code dropout_p=0.0; ignoring the
+            # config value would silently train without the requested dropout.
             raise ValueError(
                 "TTTDraftCoreAttention does not support attention dropout "
                 f"(got attention_dropout={attention_dropout})."
             )
-        if int(getattr(config, "context_parallel_size", 1) or 1) != 1:
-            raise ValueError(
-                "TTTDraftCoreAttention requires context_parallel_size == 1."
-            )
-        # Match MCore's DotProductAttention convention: explicit config
-        # softmax_scale, else 1/sqrt(head_dim).
+        # Match MCore: use the configured scale, or default to 1 / sqrt(D).
         self.softmax_scale: Optional[float] = getattr(config, "softmax_scale", None)
+        # ``build_draft_model`` injects this collection. The draft module itself
+        # is replicated rather than sharded across CP ranks.
+        self.pg_collection: Optional[Any] = None
         self._pass_idx = 0
         self._kv_by_pass: list[tuple[Tensor, Tensor]] = []
 
     def begin_pass(self, pass_idx: int) -> None:
-        """Arm the module for TTT pass ``pass_idx`` (1-indexed)."""
+        """Start the one-indexed TTT pass ``pass_idx``."""
         if pass_idx == 1:
             self._kv_by_pass = []
         elif pass_idx != self._pass_idx + 1:
@@ -382,6 +721,12 @@ class TTTDraftCoreAttention(torch.nn.Module):
         self._pass_idx = 0
         self._kv_by_pass = []
 
+    def _cp_group(self) -> Optional[dist.ProcessGroup]:
+        group = getattr(self.pg_collection, "cp", None)
+        if group is None or group.size() == 1:
+            return None
+        return group
+
     def forward(
         self,
         query: Tensor,
@@ -392,11 +737,6 @@ class TTTDraftCoreAttention(torch.nn.Module):
         attention_bias: Optional[Tensor] = None,
         packed_seq_params: Optional[Any] = None,
     ) -> Tensor:
-        if packed_seq_params is not None:
-            raise NotImplementedError(
-                "TTT draft training does not support sequence packing; "
-                "disable policy.sequence_packing."
-            )
         if attention_mask is not None:
             # The layer spec is AttnMaskType.arbitrary, so MCore may hand in a
             # mask; this module builds its own trunk/branch structure and
@@ -413,26 +753,71 @@ class TTTDraftCoreAttention(torch.nn.Module):
                 "the TTT driver must arm the pass index before each pass."
             )
 
-        seqlen, batch = query.shape[0], query.shape[1]
+        cp_group = self._cp_group()
         softmax_scale = self.softmax_scale or query.shape[-1] ** -0.5
 
-        # sbhd -> bshd (FlashAttention layout).
-        q = query.transpose(0, 1).contiguous()
-        k = key.transpose(0, 1).contiguous()
-        v = value.transpose(0, 1).contiguous()
+        if packed_seq_params is not None:
+            if getattr(packed_seq_params, "qkv_format", None) != "thd":
+                raise NotImplementedError(
+                    "TTT draft training supports packed sequences only in "
+                    f"'thd' format, got {getattr(packed_seq_params, 'qkv_format', None)!r}."
+                )
+            # MCore removes the singleton batch dimension in THD mode.
+            q, k, v = query, key, value
+            cu_global = packed_seq_params.cu_seqlens_q_padded
+            if cu_global is None:
+                cu_global = packed_seq_params.cu_seqlens_q
+            cp_size = 1 if cp_group is None else cp_group.size()
+            cu_local = torch.div(cu_global, cp_size, rounding_mode="floor").to(
+                torch.int32
+            )
+            max_local = int(packed_seq_params.max_seqlen_q) // cp_size
+            packed = True
+        else:
+            if cp_group is not None:
+                raise NotImplementedError(
+                    "Context-parallel TTT draft training requires sequence "
+                    "packing (THD input); enable policy.sequence_packing."
+                )
+            # Treat a padded batch as B equal-length THD subsequences.
+            seqlen, batch = query.shape[0], query.shape[1]
+            q = (
+                query.transpose(0, 1)
+                .contiguous()
+                .view(batch * seqlen, *query.shape[2:])
+            )
+            k = key.transpose(0, 1).contiguous().view(batch * seqlen, *key.shape[2:])
+            v = (
+                value.transpose(0, 1)
+                .contiguous()
+                .view(batch * seqlen, *value.shape[2:])
+            )
+            cu_local = (
+                torch.arange(0, batch + 1, device=query.device, dtype=torch.int32)
+                * seqlen
+            )
+            max_local = seqlen
+            packed = False
 
         self._kv_by_pass.append((k, v))
 
         if self._pass_idx == 1:
-            out = flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=True)
+            out = TwoPartTTTAttention.apply(
+                q, k, v, None, None, cu_local, max_local, softmax_scale, cp_group
+            )
         else:
             k1, v1 = self._kv_by_pass[0]
-            kb = torch.stack([kv[0] for kv in self._kv_by_pass[1:]], dim=3)
-            vb = torch.stack([kv[1] for kv in self._kv_by_pass[1:]], dim=3)
-            out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+            kb = torch.stack([kv[0] for kv in self._kv_by_pass[1:]], dim=2)
+            vb = torch.stack([kv[1] for kv in self._kv_by_pass[1:]], dim=2)
+            out = TwoPartTTTAttention.apply(
+                q, k1, v1, kb, vb, cu_local, max_local, softmax_scale, cp_group
+            )
 
-        # bshd -> [S, B, Hq * D] (core_attention output contract).
-        return out.transpose(0, 1).reshape(seqlen, batch, -1)
+        if packed:
+            # MCore expects [T, Hq * D] here and restores batch size 1 itself.
+            return out.reshape(out.shape[0], -1)
+        # Restore the padded core-attention output layout [S, B, Hq * D].
+        return out.view(batch, seqlen, -1).transpose(0, 1)
 
 
 class EagleModel(MegatronModule):
@@ -457,36 +842,47 @@ class EagleModel(MegatronModule):
             rope_scaling=getattr(config, "rope_scaling", False),
             rope_scaling_factor=getattr(config, "rope_scaling_factor", 8.0),
             use_cpu_initialization=getattr(
-                config,
-                "use_cpu_initialization",
-                not torch.cuda.is_available(),
+                config, "use_cpu_initialization", not torch.cuda.is_available()
             ),
         )
-        # Prevent modelopt import from breaking unrelated functionality.
-        # TODO: Investigate the circular import chain inside `modelopt.torch.quantization`:
-        # backends/__init__.py -> from .nvfp4_gemm import * -> nvfp4_gemm.py ->
-        # from ...quant_linear import RealQuantLinear -> quant_linear.py -> from ... import backends
+        # Import here to avoid a circular dependency inside ModelOpt's
+        # quantization backends.
         from modelopt.torch.speculative.plugins.megatron_eagle import EagleModule
 
-        # Many specdec libraries use LlamaForCausalLMEagle3 class by default so rope is hardcoded
+        # Supply RoPE explicitly instead of relying on the Llama-style defaults
+        # used by many speculative-decoding wrappers.
         self.eagle_module = EagleModule(
             config=config, rotary_pos_emb=rotary_pos_emb, bias=False
         )
 
+        # ModelOpt defaults to an arbitrary mask, which selects TE's unfused
+        # quadratic fp32 path. This file builds the mask itself, so the decoder
+        # can use the fused causal path and receive ``attention_mask=None``.
+        for layer in self.eagle_module.decoder.layers:
+            layer.self_attention.attn_mask_type = AttnMaskType.causal
+
+        # Multi-pass TTT needs the branch mask. CP also needs this implementation
+        # because TE's CP path does not expose the LSE required for merging.
+        cp_group = _global_cp_group()
+        cp_size = 1 if cp_group is None else cp_group.size()
+        self._needs_ttt_attention = self.ttt_steps > 1 or cp_size > 1
+
         self._ttt_attn_modules: list[TTTDraftCoreAttention] = []
         self._ttt_prenorm_hidden: Optional[Tensor] = None
-        if self.ttt_steps > 1:
+        if self._needs_ttt_attention:
             if getattr(config, "recompute_granularity", None) is not None:
                 # Activation recomputation would call this stateful attention
                 # again during backward and corrupt its per-pass K/V list.
                 raise ValueError(
-                    "TTT draft training (ttt_steps > 1) is incompatible with "
-                    "activation recomputation on the draft config."
+                    "TTT draft training (ttt_steps > 1 or CP > 1) is "
+                    "incompatible with activation recomputation on the draft "
+                    "config."
                 )
             for layer in self.eagle_module.decoder.layers:
                 ttt_attention = TTTDraftCoreAttention(config)
                 layer.self_attention.core_attention = ttt_attention
                 self._ttt_attn_modules.append(ttt_attention)
+        if self.ttt_steps > 1:
             # ModelOpt's hook saves a detached value. TTT instead needs the
             # pre-final-norm hidden state with gradients for the next pass.
             self.eagle_module.decoder.layers[-1].register_forward_hook(
@@ -505,15 +901,24 @@ class EagleModel(MegatronModule):
         sharded_offsets: Tuple[Tuple[int, int, int], ...] = (),
         metadata: Optional[dict] = None,
     ) -> ShardedStateDict:
-        """Override to fix a bug in modelopt < 0.42.0.
+        """Build a sharded state dict with correct TP metadata.
 
-        In modelopt < 0.42.0, EagleTransformerBlock.sharded_state_dict omits
-        tp_group when calling sharded_state_dict_default for non-layer children
-        (e.g. final_layernorm). This causes make_sharded_tensors_for_checkpoint
-        to receive tp_group=None while dp_cp_group is set, so the
-        ``tp_group is None and dp_cp_group is None`` guard never fires, and
-        get_pg_rank(None)=0 is used for all TP ranks. With TP>1 and DP>1, two
-        ranks end up with replica_id=(0,0,0), triggering CheckpointingException.
+        ModelOpt versions before 0.42.0 omit ``tp_group`` for decoder children
+        outside the layer list, such as the final layer norm. With both TP and
+        DP enabled, this can assign the same checkpoint replica ID to multiple
+        ranks and raise ``CheckpointingException``.
+
+        This method first builds the normal state dict, then rebuilds only the
+        affected child entries with the decoder's TP group.
+
+        Args:
+            prefix: Prefix added to every state-dict key.
+            sharded_offsets: Parent-provided sharding offsets.
+            metadata: Distributed checkpoint metadata.
+
+        Returns:
+            Sharded state dict with corrected entries for non-layer decoder
+            children.
         """
         sd = super().sharded_state_dict(
             prefix=prefix, sharded_offsets=sharded_offsets, metadata=metadata
@@ -525,9 +930,8 @@ class EagleModel(MegatronModule):
 
         metadata = ensure_metadata_has_dp_cp_group(metadata)
 
-        # Regenerate all non-layer children of the decoder with the correct
-        # tp_group. EagleTransformerBlock asserts sharded_offsets=() so we
-        # always use () here too.
+        # Rebuild non-layer children with the correct TP group. ModelOpt's
+        # EagleTransformerBlock requires empty offsets for these entries.
         for name, module in decoder.named_children():
             if module is decoder.layers:
                 continue
@@ -537,36 +941,11 @@ class EagleModel(MegatronModule):
                     del sd[k]
             sd.update(
                 sharded_state_dict_default(
-                    module,
-                    child_prefix,
-                    (),
-                    metadata,
-                    tp_group=decoder.tp_group,
+                    module, child_prefix, (), metadata, tp_group=decoder.tp_group
                 )
             )
 
         return sd
-
-    @contextmanager
-    def _thd_attention_mask_type(self):
-        """Temporarily run the eagle layers with a padding_causal mask type.
-
-        modelopt builds the eagle decoder with ``AttnMaskType.arbitrary`` (its
-        own multi-step training manipulates masks explicitly), but TE's THD
-        kernels only accept ``padding``/``padding_causal``, and mcore's
-        auto-conversion covers only ``causal``/``no_mask``. The packed draft
-        forward wants plain block-diagonal causal attention, which is exactly
-        ``padding_causal`` + ``cu_seqlens``.
-        """
-        layers = self.eagle_module.decoder.layers
-        original_mask_types = [layer.self_attention.attn_mask_type for layer in layers]
-        for layer in layers:
-            layer.self_attention.attn_mask_type = AttnMaskType.padding_causal
-        try:
-            yield
-        finally:
-            for layer, mask_type in zip(layers, original_mask_types):
-                layer.self_attention.attn_mask_type = mask_type
 
     def forward(
         self,
@@ -574,7 +953,7 @@ class EagleModel(MegatronModule):
         input_embeds: Tensor,
         attention_mask: Optional[Tensor] = None,
         bootstrap_hidden_states: bool = True,
-        packed_seq_params: Optional[PackedSeqParams] = None,
+        packed_seq_params: Optional[Any] = None,
     ) -> Tensor:
         if bootstrap_hidden_states:
             hidden_states = self.eagle_module.fc(hidden_states)[0]
@@ -584,74 +963,138 @@ class EagleModel(MegatronModule):
                 f"`bootstrap_hidden_states=False`, got {hidden_states.shape[-1]}."
             )
 
-        # packed_seq_params drives the draft decoder's THD attention (segment
-        # boundaries + per-sequence RoPE restarts) when the trainer runs with
-        # sequence packing; None keeps the dense [s, b, h] path.
-        mask_type_ctx = (
-            self._thd_attention_mask_type()
-            if packed_seq_params is not None
-            else nullcontext()
-        )
-        with mask_type_ctx:
+        # Packed THD input needs explicit RoPE. EagleModule's fallback sizes the
+        # table from total packed tokens and slices it for CP too early.
+        rotary_pos_emb = None
+        if packed_seq_params is not None:
+            rotary_pos_emb = self._rotary_for_pass(
+                1, packed_seq_params, input_embeds.shape[0]
+            )
+
+        for ttt_attention in self._ttt_attn_modules:
+            ttt_attention.begin_pass(1)
+        try:
             hidden_states, _ = self.eagle_module(
                 embeddings=input_embeds,
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,
+                rotary_pos_emb=rotary_pos_emb,
                 packed_seq_params=packed_seq_params,
             )
+        finally:
+            for ttt_attention in self._ttt_attn_modules:
+                ttt_attention.reset()
         logits, _ = self.eagle_module.eagle_output_layer(hidden_states)
         logits = logits.transpose(0, 1).contiguous()
         return logits
 
-    def _ttt_rotary_pos_emb(self, ttt_pass: int, seq_len: int) -> Optional[Tensor]:
+    def _rotary_for_pass(
+        self,
+        ttt_pass: int,
+        packed_seq_params: Optional[Any],
+        local_seq_len: int,
+    ) -> Optional[Tensor]:
         """Build RoPE frequencies for one TTT pass.
 
         Pass ``d`` shifts every position by ``d - 1``. A query at anchor ``i``
         therefore uses position ``i + d - 1``, matching the extra cache entry
-        created at each speculation depth during serving. Pass 1 returns
-        ``None`` because EagleModule's default table is already correct.
+        created at each speculation depth during serving.
+
+        For packed THD input, the table is based on the maximum subsequence
+        length rather than the total number of packed tokens. Positions restart
+        in every subsequence, and MCore performs the rank-local zigzag slice.
+        Using ``packed_seq=True`` prevents this method from slicing the table
+        before MCore receives it.
+
+        For padded input, pass 1 returns ``None`` because EagleModule's default
+        table is already correct. Later passes build a shifted global table;
+        when CP is active, this method then selects the current rank's zigzag
+        rows because the padded path applies the returned frequencies directly.
 
         Args:
             ttt_pass: One-indexed TTT pass ``d``.
-            seq_len: Length of the input sequence.
+            packed_seq_params: THD packing metadata, or ``None`` for padded
+                input.
+            local_seq_len: Number of local rows in the padded input.
 
         Returns:
-            Shifted RoPE frequencies for this pass, or ``None`` for pass 1.
+            Shifted RoPE frequencies for this pass, or ``None`` when the
+            single-pass padded default can be used.
         """
+        if packed_seq_params is not None:
+            max_seqlen = int(packed_seq_params.max_seqlen_q)
+            rotary = self.eagle_module.rotary_pos_emb(
+                max_seqlen + ttt_pass - 1, packed_seq=True
+            )
+            return rotary[ttt_pass - 1 :]
+
         if ttt_pass == 1:
             return None
-        rotary = self.eagle_module.rotary_pos_emb(seq_len + ttt_pass - 1)
-        return rotary[ttt_pass - 1 :]
+        cp_group = _global_cp_group()
+        cp_size = 1 if cp_group is None else cp_group.size()
+        global_seq_len = local_seq_len * cp_size
+        rotary = self.eagle_module.rotary_pos_emb(
+            global_seq_len + ttt_pass - 1, packed_seq=True
+        )
+        rotary = rotary[ttt_pass - 1 :]
+        if cp_size > 1:
+            from megatron.core.models.common.embeddings.rope_utils import (
+                get_pos_emb_on_this_cp_rank,
+            )
+
+            rotary = get_pos_emb_on_this_cp_rank(rotary, 0, cp_group)
+        return rotary
 
     def forward_ttt(
         self,
         hidden_states: Tensor,
         input_embeds: Tensor,
+        packed_seq_params: Optional[Any] = None,
     ) -> list[Tensor]:
         """Run the configured TTT passes in sequence.
 
         Pass 1 projects the target auxiliary hidden states. Every later pass
         receives the previous pass's pre-final-norm hidden state without
         detaching it, so gradients flow through the entire pass chain. Token
-        embeddings shift left by one position before each new pass.
+        embeddings shift left by one position before each new pass. Packed
+        shifts stop at subsequence boundaries and exchange boundary values
+        between CP chunks when needed.
 
         Args:
-            hidden_states: Target auxiliary hidden states with shape
-                ``[S, B, 3h]``.
-            input_embeds: Pass-1 token embeddings ``e(x_{i+1})`` with shape
-                ``[S, B, h]``. They have already been shifted left once.
+            hidden_states: Target auxiliary hidden states with padded shape
+                ``[S, B, 3h]`` or packed local shape ``[T, 1, 3h]``.
+            input_embeds: Pass-1 token embeddings ``e(x_{i+1})`` with padded
+                shape ``[S, B, h]`` or packed shape ``[T, 1, h]``. They have
+                already been shifted left once within each subsequence.
+            packed_seq_params: Global THD packing metadata, or ``None`` for
+                padded input.
 
         Returns:
-            One ``[B, S, draft_vocab]`` logits tensor per pass. At pass ``d``,
-            position ``i`` predicts token ``x_{i+d+1}``.
+            One logits tensor per pass. Padded tensors have shape
+            ``[B, S, draft_vocab]`` and packed tensors have shape
+            ``[1, T, draft_vocab]``. At pass ``d``, position ``i`` predicts
+            token ``x_{i+d+1}`` in its subsequence.
         """
         if self.ttt_steps < 2:
             raise RuntimeError(
                 "forward_ttt requires ttt_steps >= 2; use forward() for the "
                 "single-pass draft."
             )
-        # Needed only by the multi-pass training path.
+        # These helpers are needed only by the multi-pass training path.
         from megatron.core.transformer.multi_token_prediction import roll_tensor
+
+        from nemo_rl.algorithms.loss.utils import roll_packed_left_cp
+
+        cp_group = _global_cp_group()
+        cu_local = None
+        if packed_seq_params is not None:
+            cu_global = packed_seq_params.cu_seqlens_q_padded
+            if cu_global is None:
+                cu_global = packed_seq_params.cu_seqlens_q
+            cp_size = 1 if cp_group is None else cp_group.size()
+            cu_local = torch.div(cu_global, cp_size, rounding_mode="floor").to(
+                torch.int32
+            )
 
         hidden = self.eagle_module.fc(hidden_states)[0]
         embeds = input_embeds
@@ -666,7 +1109,10 @@ class EagleModel(MegatronModule):
                     hidden_states=hidden,
                     # The custom attention modules create the trunk/branch mask.
                     attention_mask=None,
-                    rotary_pos_emb=self._ttt_rotary_pos_emb(ttt_pass, embeds.shape[0]),
+                    rotary_pos_emb=self._rotary_for_pass(
+                        ttt_pass, packed_seq_params, embeds.shape[0]
+                    ),
+                    packed_seq_params=packed_seq_params,
                 )
                 logits, _ = self.eagle_module.eagle_output_layer(decoder_hidden)
                 logits_by_pass.append(logits.transpose(0, 1).contiguous())
@@ -678,12 +1124,12 @@ class EagleModel(MegatronModule):
                             "fire; cannot feed the next draft pass."
                         )
                     hidden = self._ttt_prenorm_hidden
-                    embeds = roll_tensor(
-                        embeds,
-                        shifts=-1,
-                        dims=0,
-                        cp_group=parallel_state.get_context_parallel_group(),
-                    )[0]
+                    if packed_seq_params is not None:
+                        embeds = roll_packed_left_cp(embeds, cu_local, cp_group)
+                    else:
+                        embeds = roll_tensor(
+                            embeds, shifts=-1, dims=0, cp_group=cp_group
+                        )[0]
         finally:
             # Clear saved K/V and hidden states even if a pass raises an error.
             for ttt_attention in self._ttt_attn_modules:

--- a/nemo_rl/models/megatron/draft/hidden_capture.py
+++ b/nemo_rl/models/megatron/draft/hidden_capture.py
@@ -14,15 +14,18 @@
 
 from __future__ import annotations
 
+import os
+import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
-from typing import ContextManager, Dict, List, Optional, Tuple
+from typing import Any, ContextManager, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state
 from megatron.core.utils import unwrap_model
 from torch import Tensor, nn
+from torch.multiprocessing.reductions import reduce_tensor
 
 
 def get_eagle3_aux_hidden_state_layers(num_layers: int) -> tuple[int, ...]:
@@ -36,15 +39,6 @@ def get_eagle3_aux_hidden_state_layers(num_layers: int) -> tuple[int, ...]:
     return tuple(valid_indices)
 
 
-_DTYPE_TO_CODE = {
-    torch.float16: 0,
-    torch.bfloat16: 1,
-    torch.float32: 2,
-}
-
-_CODE_TO_DTYPE = {code: dtype for dtype, code in _DTYPE_TO_CODE.items()}
-
-
 @dataclass
 class CapturedStates:
     """Container for hidden states captured from the policy model."""
@@ -53,22 +47,545 @@ class CapturedStates:
     inputs_embeds: Optional[Tensor] = None
 
 
+def _handle_done(handle: torch.cuda.Event) -> bool:
+    """Non-blocking done check for a completion event (IPC and net paths)."""
+    return handle.query()
+
+
+class TapChannel:
+    """Tap transport for PP > 1 draft co-training (design §4.6, G v2).
+
+    Under PP > 1 the draft model lives on the last pipeline stage, but the
+    policy layers it taps (and the input embeddings) live on earlier stages.
+    The last stage pre-allocates one ring of landing slots per source stage;
+    the transport into a slot is chosen per source at setup:
+
+    - same host as the draft stage: the ring is exported over CUDA IPC and
+      the source writes one-sided on a side stream, then stamps a header the
+      consumer polls. No recv, no pairing, no message ordering — it cannot
+      interleave with (or deadlock against) Megatron's own pipeline P2P, the
+      failure mode of putting send/recv inside forward callbacks.
+    - different host (multi-node PP makes every stage pair cross-host under
+      Megatron's pp-outermost rank order): NCCL send/recv on a DEDICATED side
+      communicator per PP column (GPUDirect RDMA on the wire). Two-sided, but
+      it cannot deadlock the schedule either: it never shares a communicator
+      with Megatron's P2P, both ends post ops in the same monotone microbatch
+      order (NCCL matches per-pair FIFO), and an unmatched send merely parks
+      on the channel's own stream without blocking the host.
+
+    Rendezvous is by position, not by id: with a non-interleaved schedule
+    every stage forwards microbatches in the same order, so the writer's n-th
+    put and the consumer's n-th get are the same microbatch. A header stamp
+    carries the writer's sequence number, so an ordering violation surfaces
+    as a loud stamp mismatch instead of silent training on the wrong
+    microbatch's taps. Interleaved (virtual PP) schedules break this
+    invariant and are rejected at build time.
+
+    Reserved memory is exact and static: per source stage,
+    ``ring_slots × slot_rows × width × dtype`` where width covers the stage's
+    tap layers (plus the input embeddings on the first stage) and slot_rows
+    is the per-rank microbatch token budget.
+    """
+
+    def __init__(
+        self,
+        *,
+        aux_layer_ids: list[int],
+        local_layer_ids: list[int],
+        has_embedding: bool,
+        hidden_size: int,
+        slot_rows: int,
+        dtype: torch.dtype,
+        pp_group: dist.ProcessGroup,
+        net_group: Optional[dist.ProcessGroup] = None,
+        net_sources_override: Optional[list[int]] = None,
+        needs_mask_row: bool = False,
+        mask_token_id: Optional[int] = None,
+        ring_slots: Optional[int] = None,
+        put_timeout_s: float = 120.0,
+        # Strictly below torch's 600s NCCL watchdog: if a rank is starved of
+        # taps, OUR error (with microbatch + source stage) must fire before
+        # the watchdog aborts the job and masks it.
+        get_timeout_s: float = 240.0,
+    ):
+        self.aux_layer_ids = tuple(int(i) for i in aux_layer_ids)
+        self.hidden_size = int(hidden_size)
+        self.slot_rows = int(slot_rows)
+        self.dtype = dtype
+        self.pp_group = pp_group
+        self.needs_mask_row = needs_mask_row
+        self.mask_token_id = mask_token_id
+        self.mask_row: Optional[Tensor] = None
+        self.put_timeout_s = put_timeout_s
+        self.get_timeout_s = get_timeout_s
+
+        self.group_ranks = dist.get_process_group_ranks(pp_group)
+        self.pp_size = len(self.group_ranks)
+        self.pp_rank = dist.get_rank(pp_group)
+        assert self.pp_rank == parallel_state.get_pipeline_model_parallel_rank()
+        self.is_last_stage = self.pp_rank == self.pp_size - 1
+
+        width = (self.hidden_size if has_embedding else 0) + len(
+            local_layer_ids
+        ) * self.hidden_size
+        meta = [None] * self.pp_size
+        dist.all_gather_object(
+            meta,
+            {
+                "host": os.uname().nodename,
+                "width": width,
+                "has_embedding": has_embedding,
+            },
+            group=pp_group,
+        )
+        last_host = meta[-1]["host"]
+        # Sources = every earlier stage with something to send. The first stage
+        # always sends (it owns the input embeddings the draft consumes).
+        self.sources = [r for r in range(self.pp_size - 1) if meta[r]["width"] > 0]
+        if not self.sources or self.sources[0] != 0 or not meta[0]["has_embedding"]:
+            raise RuntimeError(
+                "[draft] Tap channel expects the first pipeline stage to own the "
+                f"policy embedding; got per-stage meta {meta}."
+            )
+        # Transport per source: same host as the draft stage -> one-sided CUDA
+        # IPC; different host -> NCCL send/recv on the dedicated side
+        # communicator. net_sources_override is a test knob.
+        if net_sources_override is not None:
+            self.net_sources = [
+                r for r in self.sources if r in set(net_sources_override)
+            ]
+        else:
+            self.net_sources = [r for r in self.sources if meta[r]["host"] != last_host]
+        self.ipc_sources = [r for r in self.sources if r not in self.net_sources]
+        self.net_group = net_group
+        if self.net_sources and net_group is None:
+            raise ValueError(
+                "[draft] Cross-host tap sources need the dedicated NCCL side "
+                "communicator; build the channel via build_tap_channel."
+            )
+        if self.net_sources:
+            # NCCL initializes lazily on first use, and BOTH steps are
+            # peer-synchronous: the communicator (all group members) and each
+            # point-to-point connection (its src/dst pair). Left lazy, a
+            # source's first in-schedule isend host-blocks until the
+            # consumer's first irecv — which waits on activations from that
+            # very forward. Warm both up here, outside the schedule.
+            dist.barrier(group=net_group)
+            probe = torch.zeros(1, dtype=torch.int32, device="cuda")
+            if self.pp_rank in self.net_sources:
+                self._net_ops(dist.isend, probe, self.pp_size - 1).synchronize()
+            elif self.is_last_stage:
+                for src in self.net_sources:
+                    self._net_ops(dist.irecv, probe, src).synchronize()
+        self._widths = {r: meta[r]["width"] for r in self.sources}
+        # In-flight bound: 1F1B keeps stage s at most (pp_size - s) microbatches
+        # ahead of the last stage; forward-only passes can run slightly further
+        # ahead (bounded by the activation P2P rendezvous), so double it.
+        self._slots = {
+            r: int(ring_slots) if ring_slots is not None else 2 * (self.pp_size - r)
+            for r in self.sources
+        }
+
+        # The consumer allocates the landing rings for every source. IPC
+        # sources additionally get an exported header ring (int32 [ring, 4] =
+        # (stamp, rows, batch, 0); stamp 0 marks a free slot); net sources
+        # ship the header as a message and keep their ring consumer-side only.
+        handles: list[Any] = [None]
+        if self.is_last_stage:
+            self._data = {
+                r: torch.zeros(
+                    self._slots[r],
+                    self.slot_rows,
+                    self._widths[r],
+                    dtype=dtype,
+                    device="cuda",
+                )
+                for r in self.sources
+            }
+            self._headers = {
+                r: torch.zeros(self._slots[r], 4, dtype=torch.int32, device="cuda")
+                for r in self.ipc_sources
+            }
+            # Persistent landing buffers for net headers. The hot loop must
+            # never allocate: per-microbatch torch.empty headers were observed
+            # (in full trainer runs) landing on allocator blocks double-booked
+            # with live int64 tensors — the received header kept mutating
+            # AFTER delivery. Ctor-time buffers never re-enter the pool.
+            self._net_headers = {
+                r: torch.zeros(4, dtype=torch.int32, device="cuda")
+                for r in self.net_sources
+            }
+            self._consume_event: Optional[torch.cuda.Event] = None
+            handles = [
+                {
+                    r: (reduce_tensor(self._data[r]), reduce_tensor(self._headers[r]))
+                    for r in self.ipc_sources
+                }
+            ]
+            reserved = sum(t.numel() * t.element_size() for t in self._data.values())
+            print(
+                f"[draft] Tap channel reserved {reserved / (1 << 20):.0f} MiB on the "
+                f"draft stage: rows/slot={self.slot_rows}, "
+                f"per-source (width, slots)="
+                f"{[(self._widths[r], self._slots[r]) for r in self.sources]}.",
+                flush=True,
+            )
+        dist.broadcast_object_list(handles, src=self.group_ranks[-1], group=pp_group)
+        self.is_source = self.pp_rank in self.sources
+        self.is_net_source = self.pp_rank in self.net_sources
+        if self.is_source:
+            if not self.is_net_source:
+                (data_fn, data_args), (hdr_fn, hdr_args) = handles[0][self.pp_rank]
+                self._remote_data = data_fn(*data_args)
+                self._remote_header = hdr_fn(*hdr_args)
+            # Persistent header staging ring (see _net_headers): staged rows
+            # are reused only after their send/copy retired via the ring bound.
+            self._header_ring = torch.zeros(
+                self._slots[self.pp_rank], 4, dtype=torch.int32, device="cuda"
+            )
+            self._io_stream = torch.cuda.Stream()
+            self._pending: list[tuple[Tensor, torch.cuda.Event]] = []
+        if self.is_last_stage:
+            self._poll_stream = torch.cuda.Stream()
+
+        self._put_seq = 0
+        self._get_seq = 0
+        self._wait_seconds = 0.0
+
+    def _net_ops(self, op: Any, tensor: Tensor, peer: int) -> torch.cuda.Event:
+        """One batched p2p op on the net communicator; returns a completion event.
+
+        Batched (not bare send/recv): unbatched p2p takes torch's lazy
+        per-rank-pair subcommunicator path (the ProcessGroupNCCL size-2
+        warning) — the same special path Megatron's PP=2 activation p2p is
+        forced onto for the SAME rank pair; batched ops stay on net_group's
+        own communicator, like Megatron's `_batched_p2p_ops` and the DFlash
+        ring.
+
+        Completion is signalled by a CUDA event recorded behind the NCCL end
+        event on the CALLER'S ACTIVE stream, never by Work.is_completed():
+        the latter was observed returning True while the recv'd buffer was
+        still mutating (read-before-delivery), and on the send side it would
+        release the pending chunk ref while NCCL is still reading it.
+        """
+        work = dist.batch_isend_irecv(
+            [dist.P2POp(op, tensor, self.group_ranks[peer], self.net_group)]
+        )[0]
+        work.wait()  # the active stream now depends on the NCCL end event
+        done = torch.cuda.Event()
+        done.record()
+        return done
+
+    def begin_pass(self, model: Any) -> None:
+        """Per-pass refresh outside the schedule: prune writer refs, fetch the mask row.
+
+        The DFlash/DSpark mask embedding is the policy's LIVE
+        ``embed_tokens[mask_token_id]`` row, which only the first stage owns —
+        broadcast it over the PP group so the draft stage matches the PP = 1
+        semantics each pass.
+        """
+        if self.is_source and self._pending and _handle_done(self._pending[-1][-1]):
+            self._pending.clear()  # io stream / NCCL pair are FIFO: last done => all done
+        if not self.needs_mask_row:
+            return
+        from nemo_rl.models.megatron.draft.utils import get_policy_embedding_row
+
+        chunks = model if isinstance(model, list) else [model]
+        if self.pp_rank == 0:
+            row = get_policy_embedding_row(
+                unwrap_model(chunks[0]), int(self.mask_token_id)
+            )
+            row = row.detach().to(self.dtype).contiguous()
+        else:
+            row = torch.empty(self.hidden_size, dtype=self.dtype, device="cuda")
+        dist.broadcast(row, src=self.group_ranks[0], group=self.pp_group)
+        self.mask_row = row
+
+    def put(self, chunk: Tensor) -> None:
+        """Ship this stage's (S, B, width) tap chunk for the next microbatch."""
+        assert self.is_source
+        seq_len, batch, width = chunk.shape
+        rows = seq_len * batch
+        if width != self._widths[self.pp_rank] or rows > self.slot_rows:
+            raise RuntimeError(
+                f"[draft] Tap chunk (rows={rows}, width={width}) does not fit its "
+                f"slot (rows={self.slot_rows}, width={self._widths[self.pp_rank]}); "
+                "the microbatch token budget changed after channel setup."
+            )
+        slots = self._slots[self.pp_rank]
+        slot = self._put_seq % slots
+        deadline = time.perf_counter() + self.put_timeout_s
+        if self.is_net_source:
+            # Unmatched sends park harmlessly on the io stream; bound the
+            # in-flight chunks we keep alive to the same ring depth as IPC.
+            while len(self._pending) >= slots:
+                if _handle_done(self._pending[0][-1]):
+                    self._pending.pop(0)
+                    continue
+                if time.perf_counter() > deadline:
+                    raise RuntimeError(
+                        f"[draft] Tap send for put #{self._put_seq - slots} still "
+                        f"unconsumed after {self.put_timeout_s}s at put "
+                        f"#{self._put_seq} — the draft stage is more than {slots} "
+                        "microbatches behind, which no supported schedule produces."
+                    )
+        else:
+            while int(self._remote_header[slot, 0].item()) != 0:
+                if time.perf_counter() > deadline:
+                    raise RuntimeError(
+                        f"[draft] Tap slot {slot} still unconsumed after "
+                        f"{self.put_timeout_s}s at put #{self._put_seq} — the draft "
+                        f"stage is more than {slots} microbatches behind, which no "
+                        "supported schedule produces."
+                    )
+        staged = self._header_ring[slot]
+        staged[0], staged[1], staged[2] = self._put_seq + 1, seq_len, batch
+        ready = torch.cuda.Event()
+        ready.record()
+        with torch.cuda.stream(self._io_stream):
+            self._io_stream.wait_event(ready)
+            if self.is_net_source:
+                self._net_ops(dist.isend, staged, self.pp_size - 1)
+                done = self._net_ops(
+                    dist.isend, chunk.reshape(rows, width), self.pp_size - 1
+                )
+            else:
+                self._remote_data[slot, :rows].copy_(
+                    chunk.reshape(rows, width), non_blocking=True
+                )
+                # Same stream: the data lands before the stamp becomes visible.
+                self._remote_header[slot].copy_(staged, non_blocking=True)
+                done = torch.cuda.Event()
+                done.record(self._io_stream)
+        self._pending.append((chunk, done))
+        while self._pending and _handle_done(self._pending[0][-1]):
+            self._pending.pop(0)
+        self._put_seq += 1
+
+    def get(self, local_hidden_chunks: list[Tensor]) -> tuple[Tensor, Tensor]:
+        """Assemble (inputs_embeds, hidden_states) for the next microbatch.
+
+        Polls every source's header, concatenates the remote chunks (ascending
+        stage order == ascending tap-layer order) with the last stage's own
+        chunks, then frees the slots. Returned tensors own their storage.
+        """
+        assert self.is_last_stage
+        stamp = self._get_seq + 1
+        views = {}
+        rows = batch = None
+        wait_t0 = time.perf_counter()
+        for src in self.sources:
+            slot = self._get_seq % self._slots[src]
+            deadline = time.perf_counter() + self.get_timeout_s
+            if src in self.net_sources:
+                head = self._recv_net(src, slot, stamp, deadline)
+            else:
+                while True:
+                    with torch.cuda.stream(self._poll_stream):
+                        head = [int(v) for v in self._headers[src][slot].tolist()]
+                    if head[0] == stamp:
+                        break
+                    if head[0] > stamp or time.perf_counter() > deadline:
+                        raise RuntimeError(
+                            f"[draft] Tap rendezvous failed for microbatch "
+                            f"#{self._get_seq} from stage {src}: expected stamp "
+                            f"{stamp}, header={head} (timeout {self.get_timeout_s}s). "
+                            "Source and draft stages disagree on the microbatch order."
+                        )
+            if rows is None:
+                rows, batch = head[1], head[2]
+            elif (rows, batch) != (head[1], head[2]):
+                raise RuntimeError(
+                    f"[draft] Tap shape mismatch across stages at microbatch "
+                    f"#{self._get_seq}: {(rows, batch)} vs {tuple(head[1:3])}."
+                )
+            views[src] = self._data[src][slot, : rows * batch].view(
+                rows, batch, self._widths[src]
+            )
+        self._wait_seconds += time.perf_counter() - wait_t0
+        inputs_embeds = views[0][..., : self.hidden_size].clone()
+        pieces = [views[0][..., self.hidden_size :]]
+        pieces += [views[src] for src in self.sources[1:]]
+        pieces += list(local_hidden_chunks)
+        pieces = [p for p in pieces if p.shape[-1] > 0]
+        hidden_states = torch.cat(pieces, dim=-1)
+        for src in self.ipc_sources:  # stream-ordered after the reads above
+            self._headers[src][self._get_seq % self._slots[src]].zero_()
+        if self.net_sources:
+            # Ring reuse fence: the next recv into these slots must not start
+            # before the cats above finished reading them.
+            self._consume_event = torch.cuda.Event()
+            self._consume_event.record()
+        self._get_seq += 1
+        return inputs_embeds, hidden_states
+
+    def pop_rendezvous_wait_s(self) -> float:
+        """Consumer-side rendezvous wait accumulated by get() since the last pop.
+
+        Covers stamp polling plus (net sources) header/payload recv — the time
+        the draft stage's forward is blocked on taps, excluding the assembly
+        compute that follows.
+        """
+        seconds, self._wait_seconds = self._wait_seconds, 0.0
+        return seconds
+
+    def _recv_net(self, src: int, slot: int, stamp: int, deadline: float) -> list[int]:
+        """Receive one microbatch's header + payload from a cross-host source."""
+        header = self._net_headers[src]
+        with torch.cuda.stream(self._poll_stream):
+            if self._consume_event is not None:
+                self._poll_stream.wait_event(self._consume_event)
+            done = self._net_ops(dist.irecv, header, src)
+        self._wait_net_event(done, src, stamp, deadline)
+        with torch.cuda.stream(self._poll_stream):
+            head = [int(v) for v in header.tolist()]
+        if head[0] != stamp:
+            time.sleep(0.2)  # forensic: a changed re-read = read-before-delivery
+            with torch.cuda.stream(self._poll_stream):
+                recheck = [int(v) for v in header.tolist()]
+            raise RuntimeError(
+                f"[draft] Tap rendezvous failed for microbatch #{self._get_seq} "
+                f"from stage {src}: expected stamp {stamp}, header={head}, "
+                f"recheck after 200ms={recheck}. "
+                "Source and draft stages disagree on the microbatch order."
+            )
+        with torch.cuda.stream(self._poll_stream):
+            done = self._net_ops(
+                dist.irecv, self._data[src][slot, : head[1] * head[2]], src
+            )
+        self._wait_net_event(done, src, stamp, deadline)
+        return head
+
+    def _wait_net_event(
+        self, event: torch.cuda.Event, src: int, stamp: int, deadline: float
+    ) -> None:
+        while not event.query():
+            if time.perf_counter() > deadline:
+                raise RuntimeError(
+                    f"[draft] Tap rendezvous failed for microbatch #{self._get_seq} "
+                    f"from stage {src}: NCCL recv (stamp {stamp}) did not complete "
+                    f"within {self.get_timeout_s}s."
+                )
+
+
+def tap_slot_rows(policy_cfg: dict[str, Any]) -> int:
+    """Per-rank landing-slot row budget from the config's microbatch token budget."""
+    for key in ("sequence_packing", "dynamic_batching"):
+        sub = policy_cfg.get(key) or {}
+        if sub.get("enabled"):
+            tokens = int(sub["train_mb_tokens"])
+            break
+    else:
+        tokens = int(policy_cfg["max_total_sequence_length"]) * int(
+            policy_cfg["train_micro_batch_size"]
+        )
+    cp = parallel_state.get_context_parallel_world_size()
+    # + slack for the pad-to-multiple (sequence_length_round × CP zigzag) the
+    # packers apply on top of the budget.
+    return tokens // cp + 1024
+
+
+def build_tap_channel(
+    model: Any, draft_config: dict[str, Any], policy_cfg: dict[str, Any]
+) -> TapChannel:
+    """Scan the local model chunk and build the PP tap channel (all PP ranks)."""
+    from nemo_rl.models.megatron.draft.utils import resolve_draft_aux_layer_ids
+
+    chunks = model if isinstance(model, list) else [model]
+    vpp = parallel_state.get_virtual_pipeline_model_parallel_world_size()
+    if len(chunks) > 1 or (vpp or 1) > 1:
+        raise NotImplementedError(
+            "[draft] PP draft co-training does not support interleaved (virtual) "
+            "pipeline schedules: the tap channel matches microbatches by "
+            "per-stage forward order, which interleaving breaks."
+        )
+    chunk = unwrap_model(chunks[0])
+    hidden_size = int(chunk.config.hidden_size)
+    aux_layer_ids = resolve_draft_aux_layer_ids(
+        draft_config, int(chunk.config.num_layers)
+    )
+    local_layer_ids = sorted(
+        int(layer.layer_number) - 1
+        for layer in chunk.decoder.layers
+        if int(layer.layer_number) - 1 in aux_layer_ids
+    )
+
+    needs_mask_row = (draft_config.get("speculator_type") or "eagle3") in (
+        "dflash",
+        "dspark",
+    )
+    mask_token_id = draft_config.get("mask_token_id")
+    if needs_mask_row and mask_token_id is None:
+        from transformers import AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(draft_config["model_name"]).to_dict()
+        mask_token_id = (hf_config.get("dflash_config") or {}).get(
+            "mask_token_id"
+        ) or hf_config.get("mask_token_id")
+    if needs_mask_row and mask_token_id is None:
+        raise ValueError("policy.draft.mask_token_id is required for dflash/dspark.")
+
+    # One dedicated NCCL side communicator per PP column, used by cross-host
+    # sources. dist.new_group is collective over WORLD, so every rank creates
+    # every column's group (cheap: NCCL initializes a communicator lazily on
+    # first use) and keeps its own.
+    pp_group = parallel_state.get_pipeline_model_parallel_group()
+    pp_ranks = dist.get_process_group_ranks(pp_group)
+    stride = pp_ranks[1] - pp_ranks[0]
+    if pp_ranks != [pp_ranks[0] + s * stride for s in range(len(pp_ranks))] or (
+        dist.get_world_size() != stride * len(pp_ranks)
+    ):
+        raise RuntimeError(
+            f"[draft] Unexpected PP rank layout {pp_ranks}; the tap side "
+            "communicators assume Megatron's uniform-stride pp-outermost order."
+        )
+    net_group = None
+    for column in range(stride):
+        group = dist.new_group([column + s * stride for s in range(len(pp_ranks))])
+        if column == pp_ranks[0]:
+            net_group = group
+
+    return TapChannel(
+        aux_layer_ids=aux_layer_ids,
+        local_layer_ids=local_layer_ids,
+        has_embedding=hasattr(chunk, "embedding"),
+        hidden_size=hidden_size,
+        slot_rows=tap_slot_rows(policy_cfg),
+        dtype=chunk.config.params_dtype,
+        pp_group=pp_group,
+        net_group=net_group,
+        needs_mask_row=needs_mask_row,
+        mask_token_id=None if mask_token_id is None else int(mask_token_id),
+    )
+
+
 class HiddenStateCapture:
-    """Capture policy embeddings and auxiliary hidden states for Eagle training."""
+    """Capture policy embeddings and auxiliary hidden states for draft training."""
 
     def __init__(
         self,
         model: nn.Module,
         aux_layer_indices: Optional[Tuple[int, ...]] = None,
+        tap_channel: Optional[TapChannel] = None,
     ):
         self.model = unwrap_model(model)
         self.num_layers = self.model.config.num_layers
+        # Trunk SP shards layer/embedding outputs into contiguous dim-0 chunks
+        # over TP (mcore hard-requires SP for MoE training with TP > 1). Taps
+        # are detached, so a plain all_gather restores the SP-off row layout;
+        # the draft module itself always runs with SP disabled.
+        self._sp_world = (
+            parallel_state.get_tensor_model_parallel_world_size()
+            if getattr(self.model.config, "sequence_parallel", False)
+            else 1
+        )
 
         self.aux_layer_indices = (
             aux_layer_indices
             if aux_layer_indices is not None
             else get_eagle3_aux_hidden_state_layers(self.num_layers)
         )
+        self._tap_channel = tap_channel
 
         self.pp_size = parallel_state.get_pipeline_model_parallel_world_size()
         self.pp_rank = parallel_state.get_pipeline_model_parallel_rank()
@@ -78,7 +595,6 @@ class HiddenStateCapture:
         self._global_to_local: Dict[int, int] = {}
         self._local_aux_indices: List[int] = []
         self._compute_local_layer_mapping()
-        self._layer_owner_by_global_idx = self._compute_layer_owner_map()
 
         self._captured: Dict[str, Tensor] = {}
         self._hooks: List[torch.utils.hooks.RemovableHandle] = []
@@ -90,46 +606,37 @@ class HiddenStateCapture:
                 self._global_to_local[global_idx] = local_idx
                 self._local_aux_indices.append(local_idx)
 
-    def _compute_layer_owner_map(self) -> Dict[int, int]:
-        if self.pp_size == 1 or not dist.is_initialized():
-            return {layer_idx: 0 for layer_idx in range(self.num_layers)}
+    def _full_rows(self, t: Tensor) -> Tensor:
+        """Return an owned copy of a captured tensor with full sequence rows.
 
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
-        local_owner_mask = torch.zeros(
-            self.num_layers,
-            dtype=torch.int64,
-            device=torch.cuda.current_device(),
+        Under trunk SP the collective is safe inside forward hooks (including
+        the recompute replay): TP peers fire the same hooks at the same layer
+        boundaries, so the all_gather order matches across the group.
+        """
+        if self._sp_world == 1:
+            return t.clone()
+        out = t.new_empty((t.shape[0] * self._sp_world, *t.shape[1:]))
+        dist.all_gather_into_tensor(
+            out,
+            t.contiguous(),
+            group=parallel_state.get_tensor_model_parallel_group(),
         )
-        for layer in self.model.decoder.layers:
-            global_idx = int(layer.layer_number) - 1
-            if 0 <= global_idx < self.num_layers:
-                local_owner_mask[global_idx] = 1
-
-        gathered_owner_masks = [
-            torch.zeros_like(local_owner_mask) for _ in range(self.pp_size)
-        ]
-        dist.all_gather(gathered_owner_masks, local_owner_mask, group=pp_group)
-
-        owner_map: Dict[int, int] = {}
-        for global_idx in range(self.num_layers):
-            for rank_idx, owner_mask in enumerate(gathered_owner_masks):
-                if int(owner_mask[global_idx].item()) == 1:
-                    owner_map[global_idx] = rank_idx
-                    break
-        return owner_map
+        return out
 
     def _make_layer_output_hook(self, global_idx: int):
         def hook(_module, _args, output):
             hidden_states = output[0] if isinstance(output, tuple) else output
             if hidden_states is None:
                 return
-            self._captured[f"layer_{global_idx}"] = hidden_states.detach().clone()
+            self._captured[f"layer_{global_idx}"] = self._full_rows(
+                hidden_states.detach()
+            )
 
         return hook
 
     def _make_embedding_hook(self):
         def hook(_module, _args, output):
-            self._captured["embeds"] = output.detach().clone()
+            self._captured["embeds"] = self._full_rows(output.detach())
 
         return hook
 
@@ -179,145 +686,48 @@ class HiddenStateCapture:
             inputs_embeds=embeds,
         )
 
-    def _owner_rank_for_global_layer(self, global_layer_idx: int) -> int:
-        if self.pp_size == 1:
-            return 0
-        if global_layer_idx in self._layer_owner_by_global_idx:
-            return self._layer_owner_by_global_idx[global_layer_idx]
-        layers_per_rank = max(1, self.num_layers // self.pp_size)
-        return min(global_layer_idx // layers_per_rank, self.pp_size - 1)
-
-    @staticmethod
-    def _send_tensor(
-        tensor: Tensor,
-        dst_rank: int,
-        group: dist.ProcessGroup,
-    ) -> None:
-        dtype_code = _DTYPE_TO_CODE.get(tensor.dtype)
-        if dtype_code is None:
-            raise ValueError(f"Unsupported tensor dtype for send/recv: {tensor.dtype}")
-
-        metadata = torch.tensor(
-            [tensor.shape[0], tensor.shape[1], tensor.shape[2], dtype_code],
-            dtype=torch.int64,
-            device=tensor.device,
-        )
-        dist.send(metadata, dst=dst_rank, group=group)
-        dist.send(tensor.contiguous(), dst=dst_rank, group=group)
-
-    @staticmethod
-    def _recv_tensor(
-        src_rank: int,
-        group: dist.ProcessGroup,
-        device: torch.device,
-    ) -> Tensor:
-        metadata = torch.empty(4, dtype=torch.int64, device=device)
-        dist.recv(metadata, src=src_rank, group=group)
-        seq_len, batch_size, hidden_size, dtype_code = [
-            int(x) for x in metadata.tolist()
-        ]
-        dtype = _CODE_TO_DTYPE.get(dtype_code)
-        if dtype is None:
-            raise ValueError(
-                f"Unsupported tensor dtype code in send/recv: {dtype_code}"
-            )
-
-        received = torch.empty(
-            seq_len,
-            batch_size,
-            hidden_size,
-            dtype=dtype,
-            device=device,
-        )
-        dist.recv(received, src=src_rank, group=group)
-        return received
-
-    def _gather_distributed(self) -> CapturedStates:
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
-        last_rank = self.pp_size - 1
-        recv_device = torch.device("cuda", torch.cuda.current_device())
-
-        sample_tensor = None
-        for tensor in self._captured.values():
-            if tensor is not None:
-                sample_tensor = tensor
-                break
-
-        if sample_tensor is None and not self.is_last_stage:
-            return CapturedStates()
-
-        gathered_hidden_by_layer: Dict[int, Tensor] = {}
-
-        for global_idx in self.aux_layer_indices:
-            owner_rank = self._owner_rank_for_global_layer(global_idx)
-            key = f"layer_{global_idx}"
-
-            if self.pp_rank == owner_rank:
-                layer_tensor = self._captured.get(key)
-                if layer_tensor is None:
-                    continue
-                if self.is_last_stage:
-                    gathered_hidden_by_layer[global_idx] = layer_tensor
-                else:
-                    self._send_tensor(layer_tensor, dst_rank=last_rank, group=pp_group)
-            elif self.is_last_stage:
-                received = self._recv_tensor(
-                    src_rank=owner_rank,
-                    group=pp_group,
-                    device=recv_device,
-                )
-                gathered_hidden_by_layer[global_idx] = received
-
-        gathered_embeds = None
-        if self.is_first_stage:
-            embeds = self._captured.get("embeds")
-            if embeds is not None:
-                if self.is_last_stage:
-                    gathered_embeds = embeds
-                else:
-                    self._send_tensor(embeds, dst_rank=last_rank, group=pp_group)
-        elif self.is_last_stage:
-            gathered_embeds = self._recv_tensor(
-                src_rank=0,
-                group=pp_group,
-                device=recv_device,
-            )
-
-        if not self.is_last_stage:
-            return CapturedStates()
-
-        if gathered_hidden_by_layer:
-            hidden_states = torch.cat(
-                [
-                    gathered_hidden_by_layer[layer]
-                    for layer in sorted(gathered_hidden_by_layer.keys())
-                ],
-                dim=-1,
-            )
-        else:
-            hidden_states = None
-
-        return CapturedStates(
-            hidden_states=hidden_states,
-            inputs_embeds=gathered_embeds,
-        )
-
     def get_captured_states(self) -> CapturedStates:
         if self.pp_size == 1:
             return self._assemble_local_states()
-        return self._gather_distributed()
+        if self._tap_channel is None:
+            raise RuntimeError(
+                "Draft hidden-state capture with pipeline_model_parallel_size > 1 "
+                "requires the tap channel built at worker setup."
+            )
+        local = self._assemble_local_states()
+        if not self.is_last_stage:
+            # Embeds-first matches the channel's slot layout; the consumer
+            # splits the first stage's chunk back apart in TapChannel.get.
+            parts = [
+                t for t in (local.inputs_embeds, local.hidden_states) if t is not None
+            ]
+            if parts:
+                self._tap_channel.put(
+                    torch.cat(parts, dim=-1) if len(parts) > 1 else parts[0]
+                )
+            return CapturedStates()
+        local_hidden = [local.hidden_states] if local.hidden_states is not None else []
+        inputs_embeds, hidden_states = self._tap_channel.get(local_hidden)
+        return CapturedStates(hidden_states=hidden_states, inputs_embeds=inputs_embeds)
 
 
 def get_capture_context(
     model: nn.Module,
     enabled: bool = False,
     aux_layer_indices: Optional[Tuple[int, ...]] = None,
+    tap_channel: Optional[TapChannel] = None,
 ) -> Tuple[ContextManager, Optional[HiddenStateCapture]]:
     """Return a no-op context unless draft training needs hidden-state capture for this step."""
     if not enabled:
         return nullcontext(), None
+    if tap_channel is not None:
+        # Single source of truth under PP > 1: source stages have no draft
+        # model to read the ids from, and a mismatch would silently capture
+        # (and train on) the wrong layers.
+        aux_layer_indices = tap_channel.aux_layer_ids
     capture = HiddenStateCapture(
         model=model,
         aux_layer_indices=aux_layer_indices,
+        tap_channel=tap_channel,
     )
     return capture.capture_context(), capture

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -1194,8 +1194,8 @@ def get_policy_embedding_row(
         embedding_owner = getattr(language_model, "embedding", None)
     if embedding_owner is None:
         raise RuntimeError(
-            "[draft] Block draft training requires the policy embedding on "
-            "this rank (pipeline_model_parallel_size must be 1)."
+            "[draft] The policy embedding does not live on this rank; under "
+            "PP > 1 the mask row is fetched via TapChannel.begin_pass instead."
         )
     device = embedding_owner.word_embeddings.weight.device
     return embedding_owner.word_embeddings(
@@ -1213,8 +1213,11 @@ def register_draft_grad_norm_group() -> None:
     gradient norm (see MegatronOptimizer.clip_grad_norm and the 'mtp'
     precedent in multi_token_prediction.py), so the draft head's large
     early-training gradients do not shrink the policy update through the
-    shared global clip. Only called when a draft model is built, so baseline
-    (no-draft) runs keep Megatron's stock clipping behavior.
+    shared global clip. Must run on every rank when draft training is
+    enabled — including PP stages that never build the draft module — because
+    has_grad_norm_group all-reduces a per-group flag over the grad-stats
+    group (spans PP under the distributed optimizer); baseline (no-draft)
+    runs never call this and keep Megatron's stock clipping behavior.
     """
     from megatron.core.optimizer import optimizer as mcore_optimizer
 
@@ -1390,12 +1393,6 @@ def _build_block_draft_model(
             "policy.draft.speculator_type must be one of "
             f"{SUPPORTED_BLOCK_SPECULATOR_TYPES}, got '{speculator_type}'."
         )
-    if int(model_provider.pipeline_model_parallel_size or 1) != 1:
-        raise ValueError(
-            "policy.draft.speculator_type=dflash/dspark requires "
-            "pipeline_model_parallel_size == 1 (the policy embedding row for "
-            "the mask token must live on the draft owner rank)."
-        )
     if bool(model_provider.sequence_parallel):
         raise ValueError(
             "policy.draft.speculator_type=dflash/dspark requires sequence_parallel == false."
@@ -1463,7 +1460,10 @@ def _build_block_draft_model(
         hidden_dropout=0.0,
         attention_softmax_in_fp32=False,
         tensor_model_parallel_size=model_provider.tensor_model_parallel_size,
-        pipeline_model_parallel_size=model_provider.pipeline_model_parallel_size,
+        # Not the policy's PP size: the draft lives whole on its owner stage,
+        # and TransformerBlock would otherwise split (and assert on) the
+        # draft's few layers across pipeline stages.
+        pipeline_model_parallel_size=1,
         expert_tensor_parallel_size=model_provider.expert_tensor_parallel_size,
         sequence_parallel=model_provider.sequence_parallel,
         use_cpu_initialization=model_provider.use_cpu_initialization,

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -1155,7 +1155,7 @@ def get_policy_lm_head_weight(policy_model_chunk: MegatronModule) -> torch.Tenso
 
 
 def _get_draft_output_layer(draft_model: MegatronModule):
-    # Block drafts (DFlash) expose the LM head as `output_layer`;
+    # Block drafts (DFlash/DSpark) expose the LM head as `output_layer`;
     # the Eagle path keeps modelopt's `eagle_module.eagle_output_layer`.
     block_output_layer = getattr(draft_model, "output_layer", None)
     if block_output_layer is not None:
@@ -1406,7 +1406,11 @@ def _build_block_draft_model(
     pg_collection: ProcessGroupCollection,
     policy_model_chunk: MegatronModule,
 ) -> MegatronModule:
-    """Build a DFlash block draft model (full implementation in ``draft/dflash.py``)."""
+    """Build a DFlash/DSpark block draft model.
+
+    The full implementation lives in ``draft/dflash.py``; DSpark subclasses
+    it in ``draft/dspark.py``.
+    """
     from transformers import AutoConfig
 
     from nemo_rl.models.megatron.draft.dflash import SUPPORTED_BLOCK_SPECULATOR_TYPES
@@ -1422,28 +1426,40 @@ def _build_block_draft_model(
         )
     if int(model_provider.pipeline_model_parallel_size or 1) != 1:
         raise ValueError(
-            "policy.draft.speculator_type=dflash requires "
+            "policy.draft.speculator_type=dflash/dspark requires "
             "pipeline_model_parallel_size == 1 (the policy embedding row for "
             "the mask token must live on the draft owner rank)."
         )
     if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
         raise ValueError(
-            "policy.draft.speculator_type=dflash requires context_parallel_size == 1."
+            "policy.draft.speculator_type=dflash/dspark requires "
+            "context_parallel_size == 1."
         )
     if bool(model_provider.sequence_parallel):
         raise ValueError(
-            "policy.draft.speculator_type=dflash requires sequence_parallel == false."
+            "policy.draft.speculator_type=dflash/dspark requires "
+            "sequence_parallel == false."
         )
 
     model_name = draft_config.get("model_name")
     hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
     hf_drafter_config = dict(hf_config.get("dflash_config") or {})
+    # Official DSpark configs keep the drafter fields flat at the top level
+    # of config.json (no dflash_config sub-dict); sub-dict keys win.
+    for drafter_key in (
+        "mask_token_id",
+        "target_layer_ids",
+        "block_size",
+        "markov_rank",
+    ):
+        if drafter_key not in hf_drafter_config and drafter_key in hf_config:
+            hf_drafter_config[drafter_key] = hf_config[drafter_key]
 
     # Training implements full non-causal block attention with no sliding
-    # window / attention sink. A checkpoint requesting a different
-    # serving-side structure (vLLM resolves these fields in
-    # qwen3_dflash._resolve_layer_attention) would silently train a
-    # mismatched draft — reject it.
+    # window / attention sink and (DSpark) no bonus-anchor slot. A checkpoint
+    # requesting a different serving-side structure (vLLM resolves these
+    # fields in qwen3_dflash._resolve_layer_attention and the DSpark
+    # speculator) would silently train a mismatched draft — reject it.
     unsupported_structure: list[str] = []
     if hf_drafter_config.get("causal"):
         unsupported_structure.append("dflash_config.causal=true")
@@ -1458,6 +1474,8 @@ def _build_block_draft_model(
         "add_swa_attention_sink_bias"
     ):
         unsupported_structure.append("SWA attention-sink bias")
+    if speculator_type == "dspark" and hf_config.get("dspark_bonus_anchor"):
+        unsupported_structure.append("dspark_bonus_anchor=true")
     if unsupported_structure:
         raise NotImplementedError(
             "[draft] Block draft training does not implement the checkpoint's "
@@ -1469,7 +1487,7 @@ def _build_block_draft_model(
         mask_token_id = hf_drafter_config.get("mask_token_id")
     if mask_token_id is None:
         raise ValueError(
-            "policy.draft.mask_token_id is required for dflash (pick a "
+            "policy.draft.mask_token_id is required for dflash/dspark (pick a "
             "reserved, unused-in-data token id; its target embedding row "
             "becomes the mask embedding)."
         )
@@ -1551,11 +1569,11 @@ def _build_block_draft_model(
             f"(vocab_size={config.vocab_size})."
         )
 
-    # Block width vs the checkpoint (gamma + the bonus anchor slot) — a
-    # mismatch would train blocks vLLM never runs.
+    # Block width vs the checkpoint (dspark: gamma slots; dflash: gamma + the
+    # bonus anchor slot) — a mismatch would train blocks vLLM never runs.
     gamma = int(draft_config["gamma"])
     ckpt_block_size = hf_drafter_config.get("block_size")
-    expected_block_size = gamma + 1
+    expected_block_size = gamma if speculator_type == "dspark" else gamma + 1
     if ckpt_block_size is not None and int(ckpt_block_size) != expected_block_size:
         raise ValueError(
             f"[draft] policy.draft.gamma={gamma} implies {speculator_type} "
@@ -1595,9 +1613,21 @@ def _build_block_draft_model(
         target_hidden_size=model_provider.hidden_size,
         trunk_chunk=int(draft_config.get("trunk_chunk") or 1024),
     )
-    from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+    if speculator_type == "dflash":
+        from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
 
-    draft_model = DFlashDraftModel(**shared_kwargs)
+        draft_model = DFlashDraftModel(**shared_kwargs)
+    else:
+        from nemo_rl.models.megatron.draft.dspark import DSparkDraftModel
+
+        # Checkpoint config wins (its weight shapes must match); the recipe
+        # value only seeds checkpoint-less builds.
+        markov_rank = (
+            hf_drafter_config.get("markov_rank")
+            or draft_config.get("markov_rank")
+            or 64
+        )
+        draft_model = DSparkDraftModel(markov_rank=int(markov_rank), **shared_kwargs)
     tp_group = getattr(pg_collection, "tp", None)
     if tp_group is not None:
         for module in draft_model.modules():
@@ -1635,7 +1665,7 @@ def build_draft_model(
     pg_collection: ProcessGroupCollection,
     policy_model_chunk: MegatronModule,
 ) -> MegatronModule | None:
-    """Build a draft model (Eagle or DFlash) before parent DDP wrapping."""
+    """Build a draft model (Eagle or DFlash/DSpark) before parent DDP wrapping."""
     if not draft_config["enabled"]:
         return None
 
@@ -1804,13 +1834,13 @@ def build_draft_model(
 
 
 # ---------------------------------------------------------------------------
-# HF <-> Megatron weight mapping for DFlash block draft models.
+# HF <-> Megatron weight mapping for DFlash/DSpark block draft models.
 #
-# The checkpoint-side names are exactly what vLLM's
-# ``DFlashQwen3ForCausalLM.load_weights`` consumes (root-level ``fc.weight`` /
-# ``hidden_norm.weight`` / ``norm.weight`` /
-# ``layers.{i}.*`` in Qwen3 naming;
-# NO lm_head — official DFlash contract, vLLM shares the target's)
+# The checkpoint-side names are exactly what vLLM 0.26's
+# ``DFlashQwen3ForCausalLM.load_weights`` / ``Qwen3DSparkForCausalLM.load_weights``
+# consume (root-level ``fc.weight`` / ``hidden_norm.weight`` / ``norm.weight`` /
+# ``layers.{i}.*`` in Qwen3 naming, plus ``markov_head.markov_w{1,2}.weight``
+# for DSpark; NO lm_head — official DFlash contract, vLLM shares the target's)
 # — the trainer streams these under a ``draft.`` prefix at refit time and
 # ``vllm_backend`` routes them into the drafter. Sibling of the Eagle mapping
 # above, sharing its TP-aware primitives; the model-side names are the fixed
@@ -1836,7 +1866,9 @@ _SKIPPED_KEY_SUBSTRINGS = (
 
 
 def _block_split_axis_map(model_state: StateDict) -> dict[str, int]:
-    split_axis: dict[str, int] = {}
+    split_axis: dict[str, int] = {
+        "markov_w2.weight": 0,
+    }
     for key in model_state:
         if key.endswith("self_attention.linear_qkv.weight"):
             split_axis[key] = 0
@@ -1853,7 +1885,7 @@ def load_hf_weights_to_block_draft(
     model: torch.nn.Module,
     model_name: str,
 ) -> tuple[list[str], list[str]]:
-    """Load a DFlash HF checkpoint (local path or Hub repo) into the draft.
+    """Load a DFlash/DSpark HF checkpoint (local path or Hub repo) into the draft.
 
     Returns ``(missing_keys, unexpected_keys)`` from the (non-strict) state
     dict load, after removing the deliberately unmapped model params.
@@ -1896,6 +1928,19 @@ def load_hf_weights_to_block_draft(
         if hf_key == "norm.weight":
             mapped_state["decoder.final_layernorm.weight"] = weight
             continue
+        if hf_key == "markov_head.markov_w1.weight":
+            mapped_state["markov_w1.weight"] = weight
+            continue
+        if hf_key == "markov_head.markov_w2.weight":
+            mapped_state["markov_w2.weight"] = weight
+            continue
+        if hf_key == "confidence_head.proj.weight":
+            mapped_state["confidence_head.weight"] = weight
+            continue
+        if hf_key == "confidence_head.proj.bias":
+            mapped_state["confidence_head.bias"] = weight
+            continue
+
         layer_match = _CHECKPOINT_LAYER_KEY_PATTERN.match(hf_key)
         if layer_match is None:
             skipped.append(hf_key)
@@ -1997,7 +2042,7 @@ def load_hf_weights_to_block_draft(
 def export_block_draft_weights_to_hf(
     model: torch.nn.Module,
 ) -> list[tuple[str, Tensor]]:
-    """Export the block draft model to the vLLM DFlash HF naming."""
+    """Export the block draft model to the vLLM DFlash/DSpark HF naming."""
     unwrapped = unwrap_model(model)
     source_state = unwrapped.state_dict()
     config = unwrapped.config
@@ -2098,6 +2143,32 @@ def export_block_draft_weights_to_hf(
             )
         )
 
+    if "markov_w1.weight" in source_state:
+        hf_state.append(
+            ("markov_head.markov_w1.weight", source_state["markov_w1.weight"])
+        )
+        markov_rank = source_state["markov_w1.weight"].shape[1]
+        hf_state.append(
+            (
+                "markov_head.markov_w2.weight",
+                _gather_tp_weight_if_needed(
+                    _require_state_tensor(source_state, "markov_w2.weight"),
+                    (int(config.draft_vocab_size), markov_rank),
+                    split_axis=0,
+                ),
+            )
+        )
+
+    if "confidence_head.weight" in source_state:
+        # vLLM's drafter loader ignores these at refit (it loads the official
+        # ckpt's copies at init and skips them); kept for the HF export.
+        hf_state.append(
+            ("confidence_head.proj.weight", source_state["confidence_head.weight"])
+        )
+        hf_state.append(
+            ("confidence_head.proj.bias", source_state["confidence_head.bias"])
+        )
+
     return hf_state
 
 
@@ -2107,6 +2178,7 @@ def export_draft_weights_to_hf(
     """Export any supported draft model (Eagle or block draft) to HF naming."""
     from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
 
+    # DSparkDraftModel subclasses DFlashDraftModel, so this covers both.
     if isinstance(unwrap_model(model), DFlashDraftModel):
         return export_block_draft_weights_to_hf(model)
     return export_eagle_weights_to_hf(model)

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -85,10 +85,7 @@ class _EagleLayerLayout:
         return f"{self.model_prefix}.mlp.linear_fc2.weight"
 
 
-def _resolve_optional_key(
-    model_keys: set[str],
-    *candidates: str | None,
-) -> str | None:
+def _resolve_optional_key(model_keys: set[str], *candidates: str | None) -> str | None:
     for candidate in candidates:
         if candidate is not None and candidate in model_keys:
             return candidate
@@ -239,8 +236,7 @@ def _combine_or_shard_weight_parts(
         raise RuntimeError(incomplete_error)
 
     full_weight = torch.cat(
-        [weight for weight in component_weights if weight is not None],
-        dim=0,
+        [weight for weight in component_weights if weight is not None], dim=0
     ).contiguous()
     if target is None:
         return full_weight
@@ -367,8 +363,7 @@ def _all_gather_tp_shards(local_weight: Tensor) -> list[Tensor]:
 
 
 def _gather_tp_qkv_weight(
-    local_fused_weight: Tensor,
-    config: TransformerConfig,
+    local_fused_weight: Tensor, config: TransformerConfig
 ) -> tuple[Tensor, Tensor, Tensor]:
     """Gather TP shards of the Megatron fused qkv weight and split into HF q/k/v.
 
@@ -378,17 +373,13 @@ def _gather_tp_qkv_weight(
     :func:`_interleave_qkv`).
     """
     shards = _all_gather_tp_shards(local_fused_weight)
-    full_fused = (
-        local_fused_weight
-        if len(shards) == 1
-        else torch.cat(shards, dim=0).contiguous()
-    )
-    return _deinterleave_qkv(full_fused, config)
+    if len(shards) > 1:
+        local_fused_weight = torch.cat(shards, dim=0).contiguous()
+    return _deinterleave_qkv(local_fused_weight, config)
 
 
 def _gather_tp_gate_up_weight(
-    local_fused_weight: Tensor,
-    ffn_hidden_size: int,
+    local_fused_weight: Tensor, ffn_hidden_size: int
 ) -> tuple[Tensor, Tensor]:
     shards = _all_gather_tp_shards(local_fused_weight)
     if len(shards) == 1 and local_fused_weight.shape[0] == 2 * ffn_hidden_size:
@@ -405,8 +396,7 @@ def _gather_tp_gate_up_weight(
     local_ffn_hidden_size = ffn_hidden_size // tp_world_size
     for shard in shards:
         gate_local, up_local = shard.split(
-            [local_ffn_hidden_size, local_ffn_hidden_size],
-            dim=0,
+            [local_ffn_hidden_size, local_ffn_hidden_size], dim=0
         )
         gate_shards.append(gate_local)
         up_shards.append(up_local)
@@ -482,23 +472,17 @@ def _load_safetensors_file(checkpoint_path: Path) -> StateDict:
     from safetensors.torch import load_file as load_safetensors
 
     return _extract_tensor_state_dict(
-        load_safetensors(str(checkpoint_path)),
-        checkpoint_path,
+        load_safetensors(str(checkpoint_path)), checkpoint_path
     )
 
 
 def _load_torch_file(checkpoint_path: Path) -> StateDict:
     try:
         checkpoint_obj = torch.load(
-            str(checkpoint_path),
-            map_location="cpu",
-            weights_only=True,
+            str(checkpoint_path), map_location="cpu", weights_only=True
         )
     except TypeError:
-        checkpoint_obj = torch.load(
-            str(checkpoint_path),
-            map_location="cpu",
-        )
+        checkpoint_obj = torch.load(str(checkpoint_path), map_location="cpu")
 
     return _extract_tensor_state_dict(checkpoint_obj, checkpoint_path)
 
@@ -548,11 +532,7 @@ def _load_index_checkpoint(index_path: Path) -> StateDict:
         )
 
     shard_names = sorted(
-        {
-            shard_name
-            for shard_name in weight_map.values()
-            if isinstance(shard_name, str)
-        }
+        {name for name in weight_map.values() if isinstance(name, str)}
     )
     if not shard_names:
         raise RuntimeError(
@@ -562,17 +542,11 @@ def _load_index_checkpoint(index_path: Path) -> StateDict:
 
     if index_path.name == "model.safetensors.index.json":
         return _merge_checkpoint_shards(
-            index_path.parent,
-            shard_names,
-            _load_safetensors_file,
-            index_path.name,
+            index_path.parent, shard_names, _load_safetensors_file, index_path.name
         )
     if index_path.name == "pytorch_model.bin.index.json":
         return _merge_checkpoint_shards(
-            index_path.parent,
-            shard_names,
-            _load_torch_file,
-            index_path.name,
+            index_path.parent, shard_names, _load_torch_file, index_path.name
         )
 
     raise RuntimeError(
@@ -656,10 +630,7 @@ def _load_checkpoint_from_directory(checkpoint_dir: Path) -> StateDict:
     )
     if torch_shards:
         return _merge_checkpoint_shards(
-            checkpoint_dir,
-            torch_shards,
-            _load_torch_file,
-            str(checkpoint_dir),
+            checkpoint_dir, torch_shards, _load_torch_file, str(checkpoint_dir)
         )
 
     raise FileNotFoundError(
@@ -724,9 +695,7 @@ def _get_tp_rank() -> int:
 
 
 def _build_split_axis_by_parameter(layout: _EagleModelLayout) -> dict[str, int]:
-    split_axis_by_parameter = {
-        "eagle_module.fc.weight": 0,
-    }
+    split_axis_by_parameter = {"eagle_module.fc.weight": 0}
     if layout.lm_head_key is not None:
         split_axis_by_parameter[layout.lm_head_key] = 0
     for layer in layout.layers:
@@ -773,26 +742,13 @@ def _shard_to_local_tp(
             f"(inferred_tp={inferred_tp})"
         )
 
-    local_shard = torch.chunk(tensor, inferred_tp, dim=split_axis)[tp_rank]
-    local_shard = local_shard.contiguous()
+    local_shard = tensor.chunk(inferred_tp, dim=split_axis)[tp_rank].contiguous()
     if local_shard.shape != target.shape:
         raise RuntimeError(
             f"[draft] Invalid TP shard shape for '{parameter_name}': "
             f"got={tuple(local_shard.shape)} expected={tuple(target.shape)}"
         )
     return local_shard.to(dtype=target.dtype)
-
-
-def _assign_optional_layer_weight(
-    *,
-    model_key: str | None,
-    hf_weight: Tensor,
-    mapped_state: StateDict,
-) -> bool:
-    if model_key is None:
-        return False
-    mapped_state[model_key] = hf_weight
-    return True
 
 
 def _map_layer_hf_weight(
@@ -823,23 +779,14 @@ def _map_layer_hf_weight(
     elif layer_key == "mlp.down_proj.weight":
         mapped_state[layer.fc2_weight_key] = hf_weight
     elif layer_key == "hidden_norm.weight":
-        _assign_optional_layer_weight(
-            model_key=layer.hidden_norm_key,
-            hf_weight=hf_weight,
-            mapped_state=mapped_state,
-        )
+        if layer.hidden_norm_key is not None:
+            mapped_state[layer.hidden_norm_key] = hf_weight
     elif layer_key == "input_layernorm.weight":
-        _assign_optional_layer_weight(
-            model_key=layer.input_layernorm_key,
-            hf_weight=hf_weight,
-            mapped_state=mapped_state,
-        )
+        if layer.input_layernorm_key is not None:
+            mapped_state[layer.input_layernorm_key] = hf_weight
     elif layer_key == "post_attention_layernorm.weight":
-        _assign_optional_layer_weight(
-            model_key=layer.post_attention_layernorm_key,
-            hf_weight=hf_weight,
-            mapped_state=mapped_state,
-        )
+        if layer.post_attention_layernorm_key is not None:
+            mapped_state[layer.post_attention_layernorm_key] = hf_weight
     else:
         raise RuntimeError(
             f"[draft] Unsupported Eagle checkpoint key '{checkpoint_key}'."
@@ -911,11 +858,7 @@ def _map_hf_state_to_eagle_state(
     tp_rank = _get_tp_rank()
     for layer in layout.layers:
         pending_weights_by_layer[layer.layer_index].apply_to(
-            mapped_state,
-            layer,
-            model_state=model_state,
-            tp_rank=tp_rank,
-            config=config,
+            mapped_state, layer, model_state, tp_rank, config
         )
 
     if not mapped_state:
@@ -962,8 +905,7 @@ def load_hf_weights_to_eagle(
 
 
 def _require_state_tensor(
-    source_state: Mapping[str, Tensor],
-    parameter_name: str,
+    source_state: Mapping[str, Tensor], parameter_name: str
 ) -> Tensor:
     if parameter_name not in source_state:
         raise RuntimeError(
@@ -1172,8 +1114,7 @@ def _get_draft_output_layer(draft_model: MegatronModule):
 
 
 def _get_draft_to_target_token_mapping(
-    draft_model: MegatronModule,
-    device: torch.device,
+    draft_model: MegatronModule, device: torch.device
 ) -> torch.Tensor:
     draft_vocab_size = int(draft_model.config.draft_vocab_size)
     reverse_mapping = torch.arange(draft_vocab_size, device=device, dtype=torch.long)
@@ -1184,9 +1125,7 @@ def _get_draft_to_target_token_mapping(
 
 
 def copy_policy_lm_head_to_draft(
-    *,
-    draft_model: MegatronModule,
-    policy_model_chunk: MegatronModule,
+    *, draft_model: MegatronModule, policy_model_chunk: MegatronModule
 ) -> None:
     """Initialize the draft LM head from the policy LM head shard."""
     draft_output_layer = _get_draft_output_layer(draft_model)
@@ -1196,8 +1135,7 @@ def copy_policy_lm_head_to_draft(
     policy_lm_head_weight = get_policy_lm_head_weight(policy_model_chunk).detach()
     policy_lm_head_weight = _gather_tp_weight_if_needed(policy_lm_head_weight, tp_group)
     draft_token_mapping = _get_draft_to_target_token_mapping(
-        draft_model,
-        device=policy_lm_head_weight.device,
+        draft_model, device=policy_lm_head_weight.device
     )
     if draft_token_mapping.numel() == 0:
         raise RuntimeError("[draft] Draft token mapping is empty.")
@@ -1219,9 +1157,7 @@ def copy_policy_lm_head_to_draft(
                 )
             tp_rank = dist.get_rank(tp_group)
             selected_policy_weight = torch.chunk(
-                selected_policy_weight,
-                tp_world_size,
-                dim=0,
+                selected_policy_weight, tp_world_size, dim=0
             )[tp_rank].contiguous()
 
     if draft_output_layer.weight.shape != selected_policy_weight.shape:
@@ -1370,6 +1306,30 @@ def build_draft_optimizer_override_provider(
     )
 
 
+def _resolve_layer_windows(hf_config: Mapping[str, Any], num_layers: int) -> list[int]:
+    """Per-layer sliding windows from the checkpoint's ``layer_types`` (0 = full).
+
+    Mirrors the z-lab reference modeling code: a layer slides iff its
+    ``layer_types`` entry is "sliding_attention", and all sliding layers share
+    the top-level ``sliding_window``. No ``layer_types`` (or a checkpoint-less
+    build) means every layer uses full attention.
+    """
+    layer_types = list(hf_config.get("layer_types") or [])[:num_layers]
+    if not layer_types:
+        return [0] * num_layers
+    unknown = sorted(set(layer_types) - {"full_attention", "sliding_attention"})
+    if unknown:
+        raise NotImplementedError(f"[draft] Unsupported draft layer_types: {unknown}.")
+    window = hf_config.get("sliding_window")
+    if "sliding_attention" in layer_types and not window:
+        raise ValueError(
+            "[draft] layer_types requests sliding_attention but the checkpoint "
+            "sets no sliding_window."
+        )
+    windows = [int(window) if t == "sliding_attention" else 0 for t in layer_types]
+    return windows + [0] * (num_layers - len(windows))
+
+
 def resolve_draft_aux_layer_ids(
     draft_config: Mapping[str, Any], num_layers: int
 ) -> tuple[int, ...]:
@@ -1378,10 +1338,11 @@ def resolve_draft_aux_layer_ids(
     Every PP stage must resolve the same list: the hidden-state capture posts
     one P2P send/recv per id, so stages disagreeing about it desync the
     pipeline — and only the last stage owns a draft model to read the resolved
-    value from. Sources, in order: the draft checkpoint's
-    ``eagle_aux_hidden_state_layer_ids`` when ``model_name`` is set (a config
-    read, identical on every rank), else ``policy.draft.aux_layer_indices``,
-    else modelopt's defaults (unless the checkpoint disables aux states).
+    value from. Sources, in order: the draft checkpoint's ids when
+    ``model_name`` is set (``dflash_config.target_layer_ids`` for block
+    drafts, ``eagle_aux_hidden_state_layer_ids`` for eagle3 — a config read,
+    identical on every rank), else ``policy.draft.aux_layer_indices``, else
+    modelopt's defaults (unless the checkpoint disables aux states).
     """
     from transformers import AutoConfig
 
@@ -1391,6 +1352,14 @@ def resolve_draft_aux_layer_ids(
 
     model_name = draft_config.get("model_name")
     hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
+    if (draft_config.get("speculator_type") or "eagle3") != "eagle3":
+        hf_drafter_config = dict(hf_config.get("dflash_config") or {})
+        ids = (
+            hf_drafter_config.get("target_layer_ids")
+            or draft_config.get("aux_layer_indices")
+            or get_eagle3_aux_hidden_state_layers(num_layers)
+        )
+        return tuple(int(i) for i in ids)
     if model_name is not None:
         ids = hf_config.get("eagle_aux_hidden_state_layer_ids", [])
     else:
@@ -1414,9 +1383,6 @@ def _build_block_draft_model(
     from transformers import AutoConfig
 
     from nemo_rl.models.megatron.draft.dflash import SUPPORTED_BLOCK_SPECULATOR_TYPES
-    from nemo_rl.models.megatron.draft.hidden_capture import (
-        get_eagle3_aux_hidden_state_layers,
-    )
 
     speculator_type = draft_config["speculator_type"]
     if speculator_type not in SUPPORTED_BLOCK_SPECULATOR_TYPES:
@@ -1430,15 +1396,9 @@ def _build_block_draft_model(
             "pipeline_model_parallel_size == 1 (the policy embedding row for "
             "the mask token must live on the draft owner rank)."
         )
-    if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
-        raise ValueError(
-            "policy.draft.speculator_type=dflash/dspark requires "
-            "context_parallel_size == 1."
-        )
     if bool(model_provider.sequence_parallel):
         raise ValueError(
-            "policy.draft.speculator_type=dflash/dspark requires "
-            "sequence_parallel == false."
+            "policy.draft.speculator_type=dflash/dspark requires sequence_parallel == false."
         )
 
     model_name = draft_config.get("model_name")
@@ -1455,21 +1415,19 @@ def _build_block_draft_model(
         if drafter_key not in hf_drafter_config and drafter_key in hf_config:
             hf_drafter_config[drafter_key] = hf_config[drafter_key]
 
-    # Training implements full non-causal block attention with no sliding
-    # window / attention sink and (DSpark) no bonus-anchor slot. A checkpoint
-    # requesting a different serving-side structure (vLLM resolves these
-    # fields in qwen3_dflash._resolve_layer_attention and the DSpark
-    # speculator) would silently train a mismatched draft — reject it.
+    # Sliding-window layers (top-level layer_types + sliding_window, the
+    # z-lab convention) are supported and resolved into layer_windows below.
+    # Any other serving-side structure vLLM can express (see
+    # qwen3_dflash._resolve_layer_attention and the DSpark speculator) but
+    # training does not implement would silently train a mismatched draft —
+    # reject it.
     unsupported_structure: list[str] = []
     if hf_drafter_config.get("causal"):
         unsupported_structure.append("dflash_config.causal=true")
-    layer_types = hf_config.get("layer_types")
-    if layer_types:
-        draft_layer_types = layer_types[: int(hf_config.get("num_hidden_layers", 1))]
-        if any(layer_type != "full_attention" for layer_type in draft_layer_types):
-            unsupported_structure.append(f"layer_types={draft_layer_types}")
-    if hf_drafter_config.get("swa_window_size") or hf_config.get("sliding_window"):
-        unsupported_structure.append("sliding-window attention")
+    if hf_drafter_config.get("use_swa"):
+        unsupported_structure.append("dflash_config.use_swa (all-layer non-causal SWA)")
+    if hf_drafter_config.get("swa_window_size"):
+        unsupported_structure.append("dflash_config.swa_window_size")
     if hf_drafter_config.get("add_swa_attention_sink_bias") or hf_config.get(
         "add_swa_attention_sink_bias"
     ):
@@ -1581,14 +1539,11 @@ def _build_block_draft_model(
             f"block_size={ckpt_block_size}."
         )
 
-    aux_layer_ids = [
-        int(i)
-        for i in (
-            hf_drafter_config.get("target_layer_ids")
-            or draft_config.get("aux_layer_indices")
-            or get_eagle3_aux_hidden_state_layers(model_provider.num_layers)
-        )
-    ]
+    # Shared with the worker's capture threading so every PP stage resolves
+    # the same list (see resolve_draft_aux_layer_ids).
+    aux_layer_ids = list(
+        resolve_draft_aux_layer_ids(draft_config, model_provider.num_layers)
+    )
     num_policy_layers = int(model_provider.num_layers)
     if (
         not aux_layer_ids
@@ -1605,6 +1560,7 @@ def _build_block_draft_model(
         )
     config.eagle_aux_hidden_state_layer_ids = list(aux_layer_ids)
 
+    layer_windows = _resolve_layer_windows(hf_config, int(config.num_layers))
     shared_kwargs = dict(
         config=config,
         gamma=gamma,
@@ -1612,6 +1568,7 @@ def _build_block_draft_model(
         num_aux_hidden_states=len(aux_layer_ids),
         target_hidden_size=model_provider.hidden_size,
         trunk_chunk=int(draft_config.get("trunk_chunk") or 1024),
+        layer_windows=layer_windows,
     )
     if speculator_type == "dflash":
         from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
@@ -1767,18 +1724,19 @@ def build_draft_model(
     config.use_mtp_layernorm = config.parallel_draft_heads_num_layers = None
     config.has_lm_head = True
 
-    raw_ttt_steps = draft_config.get("ttt_steps", 1)
-    ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
-    if ttt_steps > 1:
-        # The TTT attention/loss path slices sequences locally and stashes
-        # per-pass KV; both require every rank to see the full sequence.
-        if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
-            raise ValueError(
-                "policy.draft.ttt_steps > 1 requires context_parallel_size == 1."
-            )
+    ttt_steps = int(draft_config.get("ttt_steps", 1) or 1)
+    cp_size = int(getattr(model_provider, "context_parallel_size", 1) or 1)
+    if ttt_steps > 1 or cp_size > 1:
+        # Both routes go through TTTDraftCoreAttention (multi-pass KV stash /
+        # zigzag ring), which owns its own sequence layout; MCore SP's
+        # scatter-gather around the attention has not been threaded through
+        # it. CP > 1 additionally requires sequence packing at runtime (the
+        # ring needs the THD zigzag layout) — the core attention enforces
+        # that per forward.
         if bool(model_provider.sequence_parallel):
             raise ValueError(
-                "policy.draft.ttt_steps > 1 requires sequence_parallel == false."
+                "policy.draft with ttt_steps > 1 or context_parallel_size > 1 "
+                "requires sequence_parallel == false."
             )
 
     draft_model = EagleModel(
@@ -1804,8 +1762,7 @@ def build_draft_model(
         draft_lm_head_key = "eagle_module.eagle_output_layer.weight"
         if draft_lm_head_key in missing_keys:
             copy_policy_lm_head_to_draft(
-                draft_model=draft_model,
-                policy_model_chunk=policy_model_chunk,
+                draft_model=draft_model, policy_model_chunk=policy_model_chunk
             )
             missing_keys = [key for key in missing_keys if key != draft_lm_head_key]
             print(
@@ -1818,8 +1775,7 @@ def build_draft_model(
             print(f"[draft] Unexpected keys after draft load: {unexpected_keys}")
     else:
         copy_policy_lm_head_to_draft(
-            draft_model=draft_model,
-            policy_model_chunk=policy_model_chunk,
+            draft_model=draft_model, policy_model_chunk=policy_model_chunk
         )
         print("[draft] Initialized draft LM head from the policy output layer.")
 

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -19,11 +19,17 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping
+from typing import Any, Callable, Iterator, Mapping, Optional
 
 import torch
 import torch.distributed as dist
+from megatron.bridge.training.config import (
+    OptimizerConfigOverrideProvider,
+    OptimizerConfigOverrideProviderContext,
+)
 from megatron.core import parallel_state
+from megatron.core.optimizer import ParamKey
+from megatron.core.optimizer_param_scheduler import ParamGroupOverride
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.utils import unwrap_model
@@ -1252,6 +1258,117 @@ def register_draft_grad_norm_group() -> None:
         )
 
 
+@dataclass
+class DraftOptimizerConfigOverrideProvider(OptimizerConfigOverrideProvider):
+    """Give ``draft_model.*`` params their own optimizer param group.
+
+    The draft trains at its own lr / weight decay while the policy keeps the
+    ``megatron_cfg.optimizer`` settings; the schedule shape (warmup, decay
+    style) stays shared. mcore matches checkpointed param groups to runtime
+    groups by ``param_group_identifier_keys`` (which include ``max_lr`` /
+    ``min_lr`` / ``start_wd`` / ``end_wd`` since Megatron-LM#4705), so the
+    override must differ from the policy group in at least one of those
+    fields — indistinguishable groups collapse at load and a resumed run
+    silently swaps hyperparameters. :meth:`build_config_overrides` rejects an
+    indistinguishable override.
+    """
+
+    draft_lr: Optional[float]
+    draft_min_lr: Optional[float]
+    draft_weight_decay: Optional[float]
+
+    def build_config_overrides(
+        self, context: OptimizerConfigOverrideProviderContext
+    ) -> dict[ParamKey, ParamGroupOverride] | None:
+        overrides = super().build_config_overrides(context) or {}
+        draft_override = ParamGroupOverride()
+        if self.draft_lr is not None:
+            draft_override["max_lr"] = float(self.draft_lr)
+            # A draft head generally wants to keep a high LR even when the
+            # policy LR decays, so min_lr follows the draft LR unless set.
+            draft_override["min_lr"] = float(
+                self.draft_min_lr if self.draft_min_lr is not None else self.draft_lr
+            )
+        elif self.draft_min_lr is not None:
+            draft_override["min_lr"] = float(self.draft_min_lr)
+        if self.draft_weight_decay is not None:
+            draft_override["start_wd"] = float(self.draft_weight_decay)
+            draft_override["end_wd"] = float(self.draft_weight_decay)
+
+        base_config = context.optimizer_config
+        effective_max_lr = draft_override.get("max_lr", base_config.lr)
+        effective_min_lr = draft_override.get("min_lr", base_config.min_lr)
+        # Must differ from the policy group in at least one of mcore's
+        # param_group_identifier_keys, or the two collapse at checkpoint load
+        # and swap params. The policy group carries no start_wd/end_wd at all,
+        # so setting them on the draft is itself distinguishing.
+        distinguishes = (
+            "start_wd" in draft_override
+            or "end_wd" in draft_override
+            or (effective_max_lr, effective_min_lr)
+            != (base_config.lr, base_config.min_lr)
+        )
+        if not distinguishes:
+            raise ValueError(
+                "[draft] draft (lr, min_lr, weight_decay) must differ from the "
+                "policy's in at least one field."
+            )
+
+        overrides[ParamKey(name="*draft_model.*")] = draft_override
+        return overrides
+
+
+def build_draft_optimizer_override_provider(
+    draft_config: Mapping[str, Any],
+) -> Optional[DraftOptimizerConfigOverrideProvider]:
+    """Build the draft optimizer override provider from ``policy.draft`` config.
+
+    Returns None when the config requests no draft-specific optimizer settings,
+    so the caller falls back to megatron-bridge's default provider and the
+    optimizer param-group partition is byte-identical to a no-override run.
+    """
+    draft_lr = draft_config.get("lr")
+    draft_min_lr = draft_config.get("min_lr")
+    draft_weight_decay = draft_config.get("weight_decay")
+    if draft_lr is None and draft_min_lr is None and draft_weight_decay is None:
+        return None
+    return DraftOptimizerConfigOverrideProvider(
+        draft_lr=draft_lr,
+        draft_min_lr=draft_min_lr,
+        draft_weight_decay=draft_weight_decay,
+    )
+
+
+def resolve_draft_aux_layer_ids(
+    draft_config: Mapping[str, Any], num_layers: int
+) -> tuple[int, ...]:
+    """Resolve the policy aux-layer ids the draft taps, rank-independently.
+
+    Every PP stage must resolve the same list: the hidden-state capture posts
+    one P2P send/recv per id, so stages disagreeing about it desync the
+    pipeline — and only the last stage owns a draft model to read the resolved
+    value from. Sources, in order: the draft checkpoint's
+    ``eagle_aux_hidden_state_layer_ids`` when ``model_name`` is set (a config
+    read, identical on every rank), else ``policy.draft.aux_layer_indices``,
+    else modelopt's defaults (unless the checkpoint disables aux states).
+    """
+    from transformers import AutoConfig
+
+    from nemo_rl.models.megatron.draft.hidden_capture import (
+        get_eagle3_aux_hidden_state_layers,
+    )
+
+    model_name = draft_config.get("model_name")
+    hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
+    if model_name is not None:
+        ids = hf_config.get("eagle_aux_hidden_state_layer_ids", [])
+    else:
+        ids = draft_config.get("aux_layer_indices") or []
+    if not ids and hf_config.get("use_aux_hidden_state", True):
+        ids = get_eagle3_aux_hidden_state_layers(num_layers)
+    return tuple(int(i) for i in ids)
+
+
 def build_draft_model(
     model_provider,
     draft_config: dict[str, Any],
@@ -1265,9 +1382,6 @@ def build_draft_model(
     from transformers import AutoConfig
 
     from nemo_rl.models.megatron.draft.eagle import EagleModel
-    from nemo_rl.models.megatron.draft.hidden_capture import (
-        get_eagle3_aux_hidden_state_layers,
-    )
 
     model_name = draft_config.get("model_name")
     hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
@@ -1323,11 +1437,14 @@ def build_draft_model(
     )
     config.rotary_percent = model_provider.rotary_percent
     config.rotary_base = hf_config.get("rope_theta", model_provider.rotary_base)
+    # Official z-lab configs carry an explicit "rope_scaling": null — a
+    # present-but-null key must read as "no scaling", not crash on None.get.
+    hf_rope_scaling = (hf_config.get("rope_scaling") or {}) if hf_config else None
     config.rope_scaling = (
-        "rope_scaling" in hf_config if hf_config else model_provider.rope_scaling
+        bool(hf_rope_scaling) if hf_config else model_provider.rope_scaling
     )
     config.rope_scaling_factor = (
-        hf_config.get("rope_scaling", {}).get("factor")
+        hf_rope_scaling.get("factor", model_provider.rope_scaling_factor)
         if hf_config
         else model_provider.rope_scaling_factor
     )
@@ -1337,27 +1454,34 @@ def build_draft_model(
     )
     config.use_last_layernorm = hf_config.get("use_last_layernorm", True)
     config.use_aux_hidden_state = hf_config.get("use_aux_hidden_state", True)
-    if model_name is not None:
-        config.eagle_aux_hidden_state_layer_ids = hf_config.get(
-            "eagle_aux_hidden_state_layer_ids", []
-        )
-    else:
-        config.eagle_aux_hidden_state_layer_ids = (
-            draft_config.get("aux_layer_indices") or []
-        )
-    if (
-        config.use_aux_hidden_state
-        and len(config.eagle_aux_hidden_state_layer_ids) == 0
-    ):
-        config.eagle_aux_hidden_state_layer_ids = get_eagle3_aux_hidden_state_layers(
-            model_provider.num_layers
-        )
+    # Shared with the worker's capture threading so every PP stage resolves
+    # the same list (see resolve_draft_aux_layer_ids).
+    config.eagle_aux_hidden_state_layer_ids = list(
+        resolve_draft_aux_layer_ids(draft_config, model_provider.num_layers)
+    )
 
     config.parallel_draft_step = 1
     config.use_mtp_layernorm = config.parallel_draft_heads_num_layers = None
     config.has_lm_head = True
 
-    draft_model = EagleModel(config=config)
+    raw_ttt_steps = draft_config.get("ttt_steps", 1)
+    ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+    if ttt_steps > 1:
+        # The TTT attention/loss path slices sequences locally and stashes
+        # per-pass KV; both require every rank to see the full sequence.
+        if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
+            raise ValueError(
+                "policy.draft.ttt_steps > 1 requires context_parallel_size == 1."
+            )
+        if bool(model_provider.sequence_parallel):
+            raise ValueError(
+                "policy.draft.ttt_steps > 1 requires sequence_parallel == false."
+            )
+
+    draft_model = EagleModel(
+        config=config,
+        ttt_steps=ttt_steps,
+    )
     tp_group = getattr(pg_collection, "tp", None)
     if tp_group is not None:
         for module in draft_model.modules():

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -967,7 +967,7 @@ def _require_state_tensor(
 ) -> Tensor:
     if parameter_name not in source_state:
         raise RuntimeError(
-            f"[draft] Missing required Eagle parameter '{parameter_name}' while "
+            f"[draft] Missing required draft parameter '{parameter_name}' while "
             "exporting weights."
         )
     return source_state[parameter_name]
@@ -1155,6 +1155,11 @@ def get_policy_lm_head_weight(policy_model_chunk: MegatronModule) -> torch.Tenso
 
 
 def _get_draft_output_layer(draft_model: MegatronModule):
+    # Block drafts (DFlash) expose the LM head as `output_layer`;
+    # the Eagle path keeps modelopt's `eagle_module.eagle_output_layer`.
+    block_output_layer = getattr(draft_model, "output_layer", None)
+    if block_output_layer is not None:
+        return block_output_layer
     draft_output_layer = getattr(
         getattr(draft_model, "eagle_module", None), "eagle_output_layer", None
     )
@@ -1172,7 +1177,7 @@ def _get_draft_to_target_token_mapping(
 ) -> torch.Tensor:
     draft_vocab_size = int(draft_model.config.draft_vocab_size)
     reverse_mapping = torch.arange(draft_vocab_size, device=device, dtype=torch.long)
-    d2t = getattr(draft_model.eagle_module, "d2t", None)
+    d2t = getattr(getattr(draft_model, "eagle_module", None), "d2t", None)
     if d2t is not None:
         reverse_mapping = reverse_mapping + d2t.to(device=device, dtype=torch.long)
     return reverse_mapping
@@ -1234,6 +1239,32 @@ def copy_policy_lm_head_to_draft(
                 dtype=draft_output_layer.weight.dtype,
             )
         )
+
+
+def get_policy_embedding_row(
+    policy_model_chunk: MegatronModule, token_id: int
+) -> torch.Tensor:
+    """Look up one policy embedding row, TP-correctly, via the module forward.
+
+    Used for the block drafts' mask embedding: the official DFlash contract
+    embeds mask slots with the target's FROZEN ``embed_tokens[mask_token_id]``
+    row (callers detach; the row is never trained). The module forward handles
+    the vocab-parallel lookup + all-reduce.
+    """
+    unwrapped_policy_model = unwrap_model(policy_model_chunk)
+    embedding_owner = getattr(unwrapped_policy_model, "embedding", None)
+    if embedding_owner is None:
+        language_model = getattr(unwrapped_policy_model, "language_model", None)
+        embedding_owner = getattr(language_model, "embedding", None)
+    if embedding_owner is None:
+        raise RuntimeError(
+            "[draft] Block draft training requires the policy embedding on "
+            "this rank (pipeline_model_parallel_size must be 1)."
+        )
+    device = embedding_owner.word_embeddings.weight.device
+    return embedding_owner.word_embeddings(
+        torch.tensor([int(token_id)], device=device)
+    )[0]
 
 
 DRAFT_GRAD_NORM_GROUP = "draft"
@@ -1369,15 +1400,257 @@ def resolve_draft_aux_layer_ids(
     return tuple(int(i) for i in ids)
 
 
+def _build_block_draft_model(
+    model_provider,
+    draft_config: dict[str, Any],
+    pg_collection: ProcessGroupCollection,
+    policy_model_chunk: MegatronModule,
+) -> MegatronModule:
+    """Build a DFlash block draft model (full implementation in ``draft/dflash.py``)."""
+    from transformers import AutoConfig
+
+    from nemo_rl.models.megatron.draft.dflash import SUPPORTED_BLOCK_SPECULATOR_TYPES
+    from nemo_rl.models.megatron.draft.hidden_capture import (
+        get_eagle3_aux_hidden_state_layers,
+    )
+
+    speculator_type = draft_config["speculator_type"]
+    if speculator_type not in SUPPORTED_BLOCK_SPECULATOR_TYPES:
+        raise ValueError(
+            "policy.draft.speculator_type must be one of "
+            f"{SUPPORTED_BLOCK_SPECULATOR_TYPES}, got '{speculator_type}'."
+        )
+    if int(model_provider.pipeline_model_parallel_size or 1) != 1:
+        raise ValueError(
+            "policy.draft.speculator_type=dflash requires "
+            "pipeline_model_parallel_size == 1 (the policy embedding row for "
+            "the mask token must live on the draft owner rank)."
+        )
+    if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
+        raise ValueError(
+            "policy.draft.speculator_type=dflash requires context_parallel_size == 1."
+        )
+    if bool(model_provider.sequence_parallel):
+        raise ValueError(
+            "policy.draft.speculator_type=dflash requires sequence_parallel == false."
+        )
+
+    model_name = draft_config.get("model_name")
+    hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
+    hf_drafter_config = dict(hf_config.get("dflash_config") or {})
+
+    # Training implements full non-causal block attention with no sliding
+    # window / attention sink. A checkpoint requesting a different
+    # serving-side structure (vLLM resolves these fields in
+    # qwen3_dflash._resolve_layer_attention) would silently train a
+    # mismatched draft — reject it.
+    unsupported_structure: list[str] = []
+    if hf_drafter_config.get("causal"):
+        unsupported_structure.append("dflash_config.causal=true")
+    layer_types = hf_config.get("layer_types")
+    if layer_types:
+        draft_layer_types = layer_types[: int(hf_config.get("num_hidden_layers", 1))]
+        if any(layer_type != "full_attention" for layer_type in draft_layer_types):
+            unsupported_structure.append(f"layer_types={draft_layer_types}")
+    if hf_drafter_config.get("swa_window_size") or hf_config.get("sliding_window"):
+        unsupported_structure.append("sliding-window attention")
+    if hf_drafter_config.get("add_swa_attention_sink_bias") or hf_config.get(
+        "add_swa_attention_sink_bias"
+    ):
+        unsupported_structure.append("SWA attention-sink bias")
+    if unsupported_structure:
+        raise NotImplementedError(
+            "[draft] Block draft training does not implement the checkpoint's "
+            "requested structure: " + ", ".join(unsupported_structure)
+        )
+
+    mask_token_id = draft_config.get("mask_token_id")
+    if mask_token_id is None:
+        mask_token_id = hf_drafter_config.get("mask_token_id")
+    if mask_token_id is None:
+        raise ValueError(
+            "policy.draft.mask_token_id is required for dflash (pick a "
+            "reserved, unused-in-data token id; its target embedding row "
+            "becomes the mask embedding)."
+        )
+    hf_mask_token_id = hf_drafter_config.get("mask_token_id")
+    if hf_mask_token_id is not None and int(hf_mask_token_id) != int(mask_token_id):
+        raise ValueError(
+            f"[draft] policy.draft.mask_token_id={mask_token_id} conflicts with "
+            f"the checkpoint's dflash_config.mask_token_id={hf_mask_token_id}."
+        )
+
+    config = TransformerConfig(
+        normalization="RMSNorm",
+        activation_func=torch.nn.functional.silu,
+        gated_linear_unit=True,
+        hidden_dropout=0.0,
+        attention_softmax_in_fp32=False,
+        tensor_model_parallel_size=model_provider.tensor_model_parallel_size,
+        pipeline_model_parallel_size=model_provider.pipeline_model_parallel_size,
+        expert_tensor_parallel_size=model_provider.expert_tensor_parallel_size,
+        sequence_parallel=model_provider.sequence_parallel,
+        use_cpu_initialization=model_provider.use_cpu_initialization,
+        fp16=model_provider.fp16,
+        bf16=model_provider.bf16,
+        params_dtype=model_provider.params_dtype,
+        pipeline_dtype=model_provider.pipeline_dtype,
+        num_layers=(
+            hf_config.get("num_hidden_layers", 1)
+            if model_name is not None
+            else draft_config.get("num_layers") or 1
+        ),
+        ffn_hidden_size=hf_config.get(
+            "intermediate_size", model_provider.ffn_hidden_size
+        ),
+        num_attention_heads=hf_config.get(
+            "num_attention_heads", model_provider.num_attention_heads
+        ),
+        kv_channels=hf_config.get("head_dim", model_provider.kv_channels),
+        num_query_groups=hf_config.get(
+            "num_key_value_heads", model_provider.num_query_groups
+        ),
+        init_method_std=model_provider.init_method_std,
+        layernorm_epsilon=hf_config.get(
+            "rms_norm_eps", model_provider.layernorm_epsilon
+        ),
+        add_bias_linear=hf_config.get("attention_bias", False),
+        attention_dropout=0.0,
+        qk_layernorm=bool(draft_config.get("qk_layernorm", True)),
+    )
+    config.hidden_size = hf_config.get("hidden_size", model_provider.hidden_size)
+    config.vocab_size = hf_config.get("vocab_size", model_provider.vocab_size)
+    # v1 trains full-vocab block drafts (no d2t).
+    config.draft_vocab_size = config.vocab_size
+    config.seq_length = model_provider.seq_length
+    config.gradient_accumulation_fusion = False
+    config.apply_rope_fusion = False
+    config.position_embedding_type = "rope"
+    config.rotary_percent = model_provider.rotary_percent
+    # transformers >= 5 configs nest the theta under rope_parameters.
+    hf_rope_parameters = hf_config.get("rope_parameters") or {}
+    config.rotary_base = hf_config.get(
+        "rope_theta",
+        hf_rope_parameters.get("rope_theta", model_provider.rotary_base),
+    )
+    # Official z-lab configs carry an explicit "rope_scaling": null — a
+    # present-but-null key must read as "no scaling", not crash on None.get.
+    hf_rope_scaling = (hf_config.get("rope_scaling") or {}) if hf_config else None
+    config.rope_scaling = (
+        bool(hf_rope_scaling) if hf_config else model_provider.rope_scaling
+    )
+    config.rope_scaling_factor = (
+        hf_rope_scaling.get("factor", model_provider.rope_scaling_factor)
+        if hf_config
+        else model_provider.rope_scaling_factor
+    )
+
+    if int(mask_token_id) < 0 or int(mask_token_id) >= int(config.vocab_size):
+        raise ValueError(
+            f"[draft] mask_token_id={mask_token_id} is outside the vocab "
+            f"(vocab_size={config.vocab_size})."
+        )
+
+    # Block width vs the checkpoint (gamma + the bonus anchor slot) — a
+    # mismatch would train blocks vLLM never runs.
+    gamma = int(draft_config["gamma"])
+    ckpt_block_size = hf_drafter_config.get("block_size")
+    expected_block_size = gamma + 1
+    if ckpt_block_size is not None and int(ckpt_block_size) != expected_block_size:
+        raise ValueError(
+            f"[draft] policy.draft.gamma={gamma} implies {speculator_type} "
+            f"block_size={expected_block_size}, but the checkpoint records "
+            f"block_size={ckpt_block_size}."
+        )
+
+    aux_layer_ids = [
+        int(i)
+        for i in (
+            hf_drafter_config.get("target_layer_ids")
+            or draft_config.get("aux_layer_indices")
+            or get_eagle3_aux_hidden_state_layers(model_provider.num_layers)
+        )
+    ]
+    num_policy_layers = int(model_provider.num_layers)
+    if (
+        not aux_layer_ids
+        or aux_layer_ids != sorted(set(aux_layer_ids))
+        or aux_layer_ids[0] < 0
+        or aux_layer_ids[-1] >= num_policy_layers
+    ):
+        raise ValueError(
+            f"[draft] aux layers {aux_layer_ids} (checkpoint target_layer_ids / "
+            "policy.draft.aux_layer_indices) must be unique, ascending, and in "
+            f"[0, {num_policy_layers}) of the policy — the trainer capture "
+            "concatenates taps in ascending layer order, matching vLLM's "
+            "target_layer_ids order."
+        )
+    config.eagle_aux_hidden_state_layer_ids = list(aux_layer_ids)
+
+    shared_kwargs = dict(
+        config=config,
+        gamma=gamma,
+        mask_token_id=int(mask_token_id),
+        num_aux_hidden_states=len(aux_layer_ids),
+        target_hidden_size=model_provider.hidden_size,
+        trunk_chunk=int(draft_config.get("trunk_chunk") or 1024),
+    )
+    from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+
+    draft_model = DFlashDraftModel(**shared_kwargs)
+    tp_group = getattr(pg_collection, "tp", None)
+    if tp_group is not None:
+        for module in draft_model.modules():
+            if hasattr(module, "pg_collection"):
+                module.pg_collection = pg_collection
+            if hasattr(module, "_pg_collection"):
+                module._pg_collection = pg_collection
+            if hasattr(module, "tp_group"):
+                module.tp_group = tp_group
+            if hasattr(module, "_tp_group"):
+                module._tp_group = tp_group
+
+    if model_name is not None:
+        missing_keys, unexpected_keys = load_hf_weights_to_block_draft(
+            draft_model, model_name
+        )
+        # TE _extra_state entries (fp8 scales etc.) legitimately have no
+        # checkpoint counterpart; anything else unexplained means the draft
+        # would silently train from partially-random weights (or the mapping
+        # is out of date) — fail instead of printing.
+        missing_keys = [key for key in missing_keys if "_extra_state" not in key]
+        unexpected_keys = [key for key in unexpected_keys if "_extra_state" not in key]
+        if missing_keys or unexpected_keys:
+            raise RuntimeError(
+                "[draft] Block draft checkpoint does not match the model: "
+                f"missing keys {missing_keys}, unexpected keys {unexpected_keys}."
+            )
+
+    return draft_model
+
+
 def build_draft_model(
     model_provider,
     draft_config: dict[str, Any],
     pg_collection: ProcessGroupCollection,
     policy_model_chunk: MegatronModule,
 ) -> MegatronModule | None:
-    """Build an Eagle draft model before parent mixed-precision/DDP wrapping."""
+    """Build a draft model (Eagle or DFlash) before parent DDP wrapping."""
     if not draft_config["enabled"]:
         return None
+
+    if (draft_config.get("speculator_type") or "eagle3") != "eagle3":
+        draft_model = _build_block_draft_model(
+            model_provider=model_provider,
+            draft_config=draft_config,
+            pg_collection=pg_collection,
+            policy_model_chunk=policy_model_chunk,
+        )
+        # Same separate grad-norm group + param tagging as the Eagle path.
+        register_draft_grad_norm_group()
+        for param in draft_model.parameters():
+            param.grad_norm_group = DRAFT_GRAD_NORM_GROUP
+        return draft_model
 
     from transformers import AutoConfig
 
@@ -1528,3 +1801,312 @@ def build_draft_model(
         param.grad_norm_group = DRAFT_GRAD_NORM_GROUP
 
     return draft_model
+
+
+# ---------------------------------------------------------------------------
+# HF <-> Megatron weight mapping for DFlash block draft models.
+#
+# The checkpoint-side names are exactly what vLLM's
+# ``DFlashQwen3ForCausalLM.load_weights`` consumes (root-level ``fc.weight`` /
+# ``hidden_norm.weight`` / ``norm.weight`` /
+# ``layers.{i}.*`` in Qwen3 naming;
+# NO lm_head — official DFlash contract, vLLM shares the target's)
+# — the trainer streams these under a ``draft.`` prefix at refit time and
+# ``vllm_backend`` routes them into the drafter. Sibling of the Eagle mapping
+# above, sharing its TP-aware primitives; the model-side names are the fixed
+# ``DFlashDraftModel`` layout, so no layout detection is needed.
+# ---------------------------------------------------------------------------
+
+# Checkpoint keys that are deliberately not represented in the Megatron model.
+_SKIPPED_KEY_SUBSTRINGS = (
+    # Shared from the target at serving time; training reads the captured
+    # target embeddings directly.
+    "embed_tokens",
+    # Official DFlash contract: the draft owns no LM head (it projects
+    # through the target's live head; vLLM shares the target module with a
+    # head-less drafter). Tolerated here so pre-contract checkpoints load.
+    "lm_head",
+    # Official contract: mask slots embed via the target's frozen
+    # embed_tokens[mask_token_id] row; a separately-shipped mask embedding
+    # (interim checkpoints / trained-mask variants) is ignored.
+    "mask_embedding",
+    # Training-only vocab map of speculators-format checkpoints.
+    "t2d",
+)
+
+
+def _block_split_axis_map(model_state: StateDict) -> dict[str, int]:
+    split_axis: dict[str, int] = {}
+    for key in model_state:
+        if key.endswith("self_attention.linear_qkv.weight"):
+            split_axis[key] = 0
+        elif key.endswith("self_attention.linear_proj.weight"):
+            split_axis[key] = 1
+        elif key.endswith("mlp.linear_fc1.weight"):
+            split_axis[key] = 0
+        elif key.endswith("mlp.linear_fc2.weight"):
+            split_axis[key] = 1
+    return split_axis
+
+
+def load_hf_weights_to_block_draft(
+    model: torch.nn.Module,
+    model_name: str,
+) -> tuple[list[str], list[str]]:
+    """Load a DFlash HF checkpoint (local path or Hub repo) into the draft.
+
+    Returns ``(missing_keys, unexpected_keys)`` from the (non-strict) state
+    dict load, after removing the deliberately unmapped model params.
+    """
+    if not model_name or not model_name.strip():
+        raise ValueError(
+            "load_hf_weights_to_block_draft requires a non-empty model name or path."
+        )
+
+    hf_state = _load_checkpoint_state(model_name)
+    unwrapped = unwrap_model(model)
+    model_state = unwrapped.state_dict()
+    config = unwrapped.config
+    tp_rank = _get_tp_rank()
+
+    mapped_state: StateDict = {}
+    pending_by_layer: dict[int, _PendingLayerWeights] = {}
+    skipped: list[str] = []
+
+    for raw_key, weight in hf_state.items():
+        hf_key = raw_key.removeprefix("model.").removeprefix("draft.")
+        if hf_key.startswith("midlayer."):
+            hf_key = "layers.0." + hf_key.removeprefix("midlayer.")
+
+        if hf_key == "d2t":
+            raise NotImplementedError(
+                "Block draft training only supports full-vocab drafts; the "
+                f"checkpoint '{model_name}' ships a reduced-vocab d2t map."
+            )
+        if any(substr in hf_key for substr in _SKIPPED_KEY_SUBSTRINGS):
+            skipped.append(hf_key)
+            continue
+
+        if hf_key == "fc.weight":
+            mapped_state["fc.weight"] = weight
+            continue
+        if hf_key == "hidden_norm.weight":
+            mapped_state["hidden_norm.weight"] = weight
+            continue
+        if hf_key == "norm.weight":
+            mapped_state["decoder.final_layernorm.weight"] = weight
+            continue
+        layer_match = _CHECKPOINT_LAYER_KEY_PATTERN.match(hf_key)
+        if layer_match is None:
+            skipped.append(hf_key)
+            continue
+        layer_index = int(layer_match.group(1))
+        layer_key = layer_match.group(2)
+        prefix = f"decoder.layers.{layer_index}"
+        pending = pending_by_layer.setdefault(layer_index, _PendingLayerWeights())
+
+        if layer_key == "self_attn.q_proj.weight":
+            pending.q_weight = weight
+        elif layer_key == "self_attn.k_proj.weight":
+            pending.k_weight = weight
+        elif layer_key == "self_attn.v_proj.weight":
+            pending.v_weight = weight
+        elif layer_key == "self_attn.qkv_proj.weight":
+            pending.qkv_weight = weight
+        elif layer_key == "self_attn.o_proj.weight":
+            mapped_state[f"{prefix}.self_attention.linear_proj.weight"] = weight
+        elif layer_key == "self_attn.q_norm.weight":
+            mapped_state[f"{prefix}.self_attention.q_layernorm.weight"] = weight
+        elif layer_key == "self_attn.k_norm.weight":
+            mapped_state[f"{prefix}.self_attention.k_layernorm.weight"] = weight
+        elif layer_key == "input_layernorm.weight":
+            mapped_state[f"{prefix}.self_attention.linear_qkv.layer_norm_weight"] = (
+                weight
+            )
+        elif layer_key == "post_attention_layernorm.weight":
+            mapped_state[f"{prefix}.mlp.linear_fc1.layer_norm_weight"] = weight
+        elif layer_key == "mlp.gate_proj.weight":
+            pending.gate_weight = weight
+        elif layer_key == "mlp.up_proj.weight":
+            pending.up_weight = weight
+        elif layer_key == "mlp.gate_up_proj.weight":
+            pending.fc1_weight = weight
+        elif layer_key == "mlp.down_proj.weight":
+            mapped_state[f"{prefix}.mlp.linear_fc2.weight"] = weight
+        else:
+            raise RuntimeError(
+                f"[draft] Unsupported block-draft checkpoint key "
+                f"'layers.{layer_index}.{layer_key}'."
+            )
+
+    for layer_index, pending in pending_by_layer.items():
+        prefix = f"decoder.layers.{layer_index}"
+        qkv_key = f"{prefix}.self_attention.linear_qkv.weight"
+        if pending.qkv_weight is not None:
+            mapped_state[qkv_key] = pending.qkv_weight
+        elif (
+            pending.q_weight is not None
+            and pending.k_weight is not None
+            and pending.v_weight is not None
+        ):
+            mapped_state[qkv_key] = _interleave_qkv(
+                pending.q_weight, pending.k_weight, pending.v_weight, config
+            )
+        elif not (
+            pending.q_weight is None
+            and pending.k_weight is None
+            and pending.v_weight is None
+        ):
+            raise RuntimeError(
+                "[draft] Incomplete QKV tensors. Expected q_proj, k_proj, and v_proj."
+            )
+        fc1_key = f"{prefix}.mlp.linear_fc1.weight"
+        fc1_weight = _combine_or_shard_weight_parts(
+            parameter_name=fc1_key,
+            fused_weight=pending.fc1_weight,
+            component_weights=(pending.gate_weight, pending.up_weight),
+            target=model_state.get(fc1_key),
+            tp_rank=tp_rank,
+            incomplete_error=(
+                "[draft] Incomplete MLP tensors. Expected gate_proj and up_proj."
+            ),
+        )
+        if fc1_weight is not None:
+            mapped_state[fc1_key] = fc1_weight
+
+    if not mapped_state:
+        raise RuntimeError(
+            f"[draft] No block-draft weights were mapped from '{model_name}'."
+        )
+    if skipped:
+        print(f"[draft] Skipped block-draft checkpoint keys: {sorted(skipped)[:10]}")
+
+    split_axis_map = _block_split_axis_map(model_state)
+    for parameter_name in list(mapped_state):
+        mapped_state[parameter_name] = _shard_to_local_tp(
+            parameter_name=parameter_name,
+            tensor=mapped_state[parameter_name],
+            model_state=model_state,
+            split_axis_by_parameter=split_axis_map,
+            tp_rank=tp_rank,
+        )
+
+    return unwrapped.load_state_dict(mapped_state, strict=False)
+
+
+def export_block_draft_weights_to_hf(
+    model: torch.nn.Module,
+) -> list[tuple[str, Tensor]]:
+    """Export the block draft model to the vLLM DFlash HF naming."""
+    unwrapped = unwrap_model(model)
+    source_state = unwrapped.state_dict()
+    config = unwrapped.config
+    hidden_size = int(config.hidden_size)
+    ffn_hidden_size = int(config.ffn_hidden_size)
+
+    hf_state: list[tuple[str, Tensor]] = [
+        ("fc.weight", _require_state_tensor(source_state, "fc.weight")),
+        (
+            "hidden_norm.weight",
+            _require_state_tensor(source_state, "hidden_norm.weight"),
+        ),
+        (
+            "norm.weight",
+            _require_state_tensor(source_state, "decoder.final_layernorm.weight"),
+        ),
+    ]
+
+    layer_indices = sorted(
+        int(match.group(1))
+        for key in source_state
+        if (match := re.match(r"^decoder\.layers\.(\d+)\.", key)) is not None
+    )
+    for layer_index in sorted(set(layer_indices)):
+        prefix = f"decoder.layers.{layer_index}"
+        hf_prefix = f"layers.{layer_index}"
+
+        q_proj, k_proj, v_proj = _gather_tp_qkv_weight(
+            _require_state_tensor(
+                source_state, f"{prefix}.self_attention.linear_qkv.weight"
+            ),
+            config=config,
+        )
+        hf_state.append((f"{hf_prefix}.self_attn.q_proj.weight", q_proj))
+        hf_state.append((f"{hf_prefix}.self_attn.k_proj.weight", k_proj))
+        hf_state.append((f"{hf_prefix}.self_attn.v_proj.weight", v_proj))
+        hf_state.append(
+            (
+                f"{hf_prefix}.self_attn.o_proj.weight",
+                _gather_tp_weight_if_needed(
+                    _require_state_tensor(
+                        source_state, f"{prefix}.self_attention.linear_proj.weight"
+                    ),
+                    (hidden_size, hidden_size),
+                    split_axis=1,
+                ),
+            )
+        )
+        hf_state.append(
+            (
+                f"{hf_prefix}.self_attn.q_norm.weight",
+                _require_state_tensor(
+                    source_state, f"{prefix}.self_attention.q_layernorm.weight"
+                ),
+            )
+        )
+        hf_state.append(
+            (
+                f"{hf_prefix}.self_attn.k_norm.weight",
+                _require_state_tensor(
+                    source_state, f"{prefix}.self_attention.k_layernorm.weight"
+                ),
+            )
+        )
+        hf_state.append(
+            (
+                f"{hf_prefix}.input_layernorm.weight",
+                _require_state_tensor(
+                    source_state,
+                    f"{prefix}.self_attention.linear_qkv.layer_norm_weight",
+                ),
+            )
+        )
+        hf_state.append(
+            (
+                f"{hf_prefix}.post_attention_layernorm.weight",
+                _require_state_tensor(
+                    source_state, f"{prefix}.mlp.linear_fc1.layer_norm_weight"
+                ),
+            )
+        )
+        gate_proj, up_proj = _gather_tp_gate_up_weight(
+            _require_state_tensor(source_state, f"{prefix}.mlp.linear_fc1.weight"),
+            ffn_hidden_size=ffn_hidden_size,
+        )
+        hf_state.append((f"{hf_prefix}.mlp.gate_proj.weight", gate_proj))
+        hf_state.append((f"{hf_prefix}.mlp.up_proj.weight", up_proj))
+        hf_state.append(
+            (
+                f"{hf_prefix}.mlp.down_proj.weight",
+                _gather_tp_weight_if_needed(
+                    _require_state_tensor(
+                        source_state, f"{prefix}.mlp.linear_fc2.weight"
+                    ),
+                    (hidden_size, ffn_hidden_size),
+                    split_axis=1,
+                ),
+            )
+        )
+
+    return hf_state
+
+
+def export_draft_weights_to_hf(
+    model: torch.nn.Module,
+) -> list[tuple[str, Tensor]]:
+    """Export any supported draft model (Eagle or block draft) to HF naming."""
+    from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+
+    if isinstance(unwrap_model(model), DFlashDraftModel):
+        return export_block_draft_weights_to_hf(model)
+    return export_eagle_weights_to_hf(model)

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -242,6 +242,7 @@ from nemo_rl.models.megatron.config import (
 )
 from nemo_rl.models.megatron.draft.utils import (
     build_draft_model,
+    build_draft_optimizer_override_provider,
     find_draft_owner_chunk,
     get_attached_draft_model,
 )
@@ -2019,11 +2020,20 @@ def setup_model_and_optimizer(
     )
 
     if load_optimizer:
+        # Draft co-training may give `draft_model.*` params their own LR/WD
+        # param group (policy.draft.{lr,min_lr,weight_decay}); None keeps the
+        # stock megatron-bridge provider and param-group partition.
+        optimizer_config_override_provider = (
+            build_draft_optimizer_override_provider(policy_cfg["draft"])
+            if draft_enabled
+            else None
+        )
         optimizer, scheduler = setup_optimizer(
             optimizer_config=megatron_cfg.optimizer,
             scheduler_config=megatron_cfg.scheduler,
             model=model,
             use_gloo_process_groups=megatron_cfg.dist.use_gloo_process_groups,
+            optimizer_config_override_provider=optimizer_config_override_provider,
         )
     else:
         optimizer = None

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -245,6 +245,7 @@ from nemo_rl.models.megatron.draft.utils import (
     build_draft_optimizer_override_provider,
     find_draft_owner_chunk,
     get_attached_draft_model,
+    register_draft_grad_norm_group,
 )
 from nemo_rl.models.megatron.memory_saver import inference_model_alloc_region
 from nemo_rl.models.megatron.router_replay import (
@@ -1592,6 +1593,12 @@ def _create_draft_pre_wrap_hook(
         """Optionally preload the base policy, then attach the draft module to the owner chunk."""
         if not draft_cfg["enabled"]:
             return model
+
+        # Register on EVERY rank, not just the draft-owner PP stage: the
+        # optimizer gates each SEPARATE_GRAD_NORM_GROUPS entry on a flag
+        # all-reduce spanning PP (has_grad_norm_group), so a stage-local
+        # tuple desyncs the collective order and deadlocks optimizer.step.
+        register_draft_grad_norm_group()
 
         # Base pretrained checkpoints do not contain draft weights, so load the
         # policy weights before attaching the nested draft module.

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -670,7 +670,9 @@ class LossPostProcessor:
             cfg: Policy(-like) config; supplies sequence_packing / logprob_chunk_size.
             num_microbatches: Microbatch count, used to counteract Megatron's
                 per-microbatch loss averaging.
-            cp_normalize: Whether to divide the loss by the context-parallel size.
+            cp_normalize: Whether to divide the POLICY loss by the context-parallel
+                size (compensates the CP logprob all-gather; the rank-local
+                draft losses are exempt, see ``__call__``).
             sampling_params: Optional temperature / top-k/p for logprob losses.
             draft_model: Optional EAGLE draft model for distillation.
             prepare_fn: Optional override for the default ``prepare_loss_input``.
@@ -839,17 +841,6 @@ class LossPostProcessor:
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
             )
-            if has_draft_logits:
-                # The draft loss wraps AROUND the packing wrapper: the policy
-                # part iterates subsequences, the draft part runs once over
-                # the whole packed row (per-pass teacher roll + coord-gathered
-                # masks; see DraftCrossEntropyLossFn's packed mode).
-                loss_fn_wrapped = self._wrap_with_draft_loss(
-                    loss_fn_wrapped,
-                    prepare_loss_input_wrapped,
-                    data_dict,
-                    global_draft_pass_counts,
-                )
         else:
             loss_fn_wrapped = partial(
                 wrap_loss_fn_with_input_preparation,
@@ -859,13 +850,38 @@ class LossPostProcessor:
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
             )
-            if has_draft_logits:
-                loss_fn_wrapped = self._wrap_with_draft_loss(
-                    loss_fn_wrapped,
-                    prepare_loss_input_wrapped,
-                    data_dict,
-                    global_draft_pass_counts,
-                )
+
+        if self.cp_normalize:
+            # Policy loss only. Under CP every rank evaluates the FULL-sequence
+            # policy loss (from_parallel_logits_to_logprobs all-gathers the
+            # logprobs, and that all-gather's backward hands each local logit
+            # cp_size copies of its gradient), hence the 1/cp_size. The draft
+            # losses are rank-local numerators over a global denominator and
+            # reach the global gradient through the dp_cp grad all-reduce
+            # alone, so they must be added AFTER this division: dividing them
+            # too shrinks the draft gradient by cp_size while the draft
+            # metrics (explicitly CP-reduced) keep looking right.
+            cp_size = get_context_parallel_world_size()
+            policy_loss_fn = loss_fn_wrapped
+
+            def _div_policy_loss_by_cp_size(*args, **kwargs):
+                loss, metrics = policy_loss_fn(*args, **kwargs)
+                return loss / cp_size, metrics
+
+            loss_fn_wrapped = _div_policy_loss_by_cp_size
+
+        if has_draft_logits:
+            # The draft loss wraps AROUND the (packing-wrapped, CP-normalized)
+            # policy loss: with packing the policy part iterates subsequences
+            # while the draft part runs once over the whole packed row
+            # (per-pass teacher roll + coord-gathered masks; see
+            # DraftCrossEntropyLossFn's packed mode).
+            loss_fn_wrapped = self._wrap_with_draft_loss(
+                loss_fn_wrapped,
+                prepare_loss_input_wrapped,
+                data_dict,
+                global_draft_pass_counts,
+            )
 
         loss_fn_wrapped = partial(
             loss_fn_wrapped,
@@ -873,16 +889,6 @@ class LossPostProcessor:
             global_valid_seqs=global_valid_seqs,
             global_valid_toks=global_valid_toks,
         )
-
-        if self.cp_normalize:
-            cp_size = get_context_parallel_world_size()
-            prev_loss_fn = loss_fn_wrapped
-
-            def _div_by_cp_size(*args, **kwargs):
-                loss, metrics = prev_loss_fn(*args, **kwargs)
-                return loss / cp_size, metrics
-
-            loss_fn_wrapped = _div_by_cp_size
 
         # Counteract Megatron's default loss averaging in schedules.py,
         # which applies (* cp_size / num_microbatches) to the loss.

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -46,7 +46,6 @@ from nemo_rl.algorithms.loss import (
     wrap_loss_fn_with_input_preparation,
 )
 from nemo_rl.algorithms.loss.interfaces import LossFunction
-from nemo_rl.algorithms.loss.utils import _pack_input_ids
 from nemo_rl.algorithms.utils import mask_out_neg_inf_logprobs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
@@ -225,12 +224,17 @@ def _run_block_draft_forward(
     draft_model: MegatronModule,
     captured_states: Any,
     data_dict: BatchedDataDict[Any],
+    packed_seq_params: Optional[PackedSeqParams] = None,
 ) -> torch.Tensor:
     """Run the DFlash/DSpark block-draft forward for one microbatch.
 
-    Returns prediction-slot logits ``[B, N, gamma, V_local]`` aligned with
-    labels ``x_{p+1} .. x_{p+gamma}`` per anchor ``p`` (DFlash's bonus anchor
-    slot is dropped; DSpark's teacher-forced Markov bias is added).
+    Returns prediction-slot logits aligned with labels ``x_{p+1} ..
+    x_{p+gamma}`` per anchor ``p`` (DFlash's bonus anchor slot is dropped;
+    DSpark's teacher-forced Markov bias is added): ``[B, N, gamma, V_local]``
+    unpacked, ``[NB, gamma, V_local]`` packed — under packing each block is
+    owned by the CP rank holding its anchor's zigzag chunk (which balances
+    the staircase load the way zigzag balances causal, and keeps the anchor
+    embedding local); the flat owned coords are stashed for the loss.
 
     Following the official DFlash contract the draft owns neither an LM head
     nor a mask embedding: logits are projected through the policy's LIVE head
@@ -251,10 +255,52 @@ def _run_block_draft_forward(
     # length-bucket reorder); rebuild this microbatch's block list and stash
     # it for the loss (slot mask + teacher gather read these keys).
     anchors, anchor_valid = count_map_to_anchors(data_dict["draft_anchor_count_map"])
-    data_dict["draft_anchor_positions"] = anchors
-    data_dict["draft_anchor_valid"] = anchor_valid
 
-    method_kwargs = {}
+    method_kwargs: dict[str, Any] = {}
+    if packed_seq_params is not None:
+        cp_group = get_context_parallel_group()
+        cp_size = torch.distributed.get_world_size(cp_group)
+        cp_rank = torch.distributed.get_rank(cp_group)
+        cu_global = packed_seq_params.cu_seqlens_q_padded
+        if cu_global is None:
+            cu_global = packed_seq_params.cu_seqlens_q
+        cu_local = torch.div(cu_global, cp_size, rounding_mode="floor").to(torch.long)
+        half = ((cu_local[1:] - cu_local[:-1]) // 2).clamp(min=1)
+
+        batch_size, num_anchors = anchors.shape
+        seq_flat = (
+            torch.arange(batch_size, device=anchors.device)
+            .unsqueeze(1)
+            .expand(-1, num_anchors)
+            .reshape(-1)
+        )
+        anchors_flat = anchors.reshape(-1)
+        valid_flat = anchor_valid.reshape(-1)
+        chunk_idx = anchors_flat // half[seq_flat]
+        owner = torch.minimum(chunk_idx, 2 * cp_size - 1 - chunk_idx)
+        mine = owner == cp_rank
+        seq_flat = seq_flat[mine]
+        anchors_flat = anchors_flat[mine]
+        valid_flat = valid_flat[mine]
+        if seq_flat.numel() == 0:
+            # Every rank must field >= 1 block: the trunk ring is a CP
+            # collective and the decoder cannot run an empty stream. A dummy
+            # invalid block at this rank's front-chunk start is loss-masked.
+            seq_flat = torch.zeros(1, dtype=torch.long, device=anchors.device)
+            anchors_flat = (cp_rank * half[0]).reshape(1)
+            valid_flat = torch.zeros(1, dtype=torch.bool, device=anchors.device)
+
+        data_dict["draft_anchor_positions"] = anchors_flat
+        data_dict["draft_anchor_valid"] = valid_flat
+        data_dict["draft_block_seq_idx"] = seq_flat
+        data_dict["draft_packed_local_cu_seqlens"] = cu_local
+        method_kwargs["packed_seq_params"] = packed_seq_params
+        method_kwargs["block_seq_idx"] = seq_flat
+        anchors, anchor_valid = anchors_flat, valid_flat
+    else:
+        data_dict["draft_anchor_positions"] = anchors
+        data_dict["draft_anchor_valid"] = anchor_valid
+
     if draft_model.speculator_type == "dspark":
         # Teacher-forces the Markov/confidence heads inside the forward.
         method_kwargs["input_ids"] = data_dict["input_ids"]
@@ -272,14 +318,17 @@ def _run_block_draft_forward(
     if draft_model.speculator_type == "dflash":
         # Slot 0 is the anchor bonus slot (condition only); the gamma mask
         # slots align with labels x_{p+1} .. x_{p+gamma}.
+        if packed_seq_params is not None:
+            return draft_out[:, 1:, :]
         return draft_out[:, :, 1:, :]
     elif draft_model.speculator_type == "dspark":
         block_logits, confidence_pred = draft_out
         data_dict["draft_confidence_pred"] = confidence_pred
         return block_logits
-    raise ValueError(
-        f"Unknown block-draft speculator_type '{draft_model.speculator_type}'."
-    )
+    else:
+        raise ValueError(
+            f"Unknown block-draft speculator_type '{draft_model.speculator_type}'."
+        )
 
 
 def forward_with_post_processing_fn(
@@ -351,14 +400,14 @@ def forward_with_post_processing_fn(
 
     # Insert hook to capture hidden states and embeddings for draft model
     # training. Capture the aux layers the DRAFT was built for (checkpoint
-    # eagle_aux_hidden_state_layer_ids / policy.draft.aux_layer_indices): the
-    # serving-side drafter taps exactly these policy layers, so capturing the
-    # hard-coded defaults instead would silently train on different features
-    # (or break the fc width when the counts differ). The worker resolves the
-    # list rank-independently (resolve_draft_aux_layer_ids) and threads it in:
-    # under PP only the last stage owns a draft model to read it from, and the
-    # capture posts one P2P send/recv per id, so stages disagreeing about the
-    # list would desync the pipeline.
+    # target_layer_ids / policy.draft.aux_layer_indices): the serving-side
+    # drafter taps exactly these policy layers, so capturing the hard-coded
+    # defaults instead would silently train on different features (or break
+    # the fc width when the counts differ). The worker resolves the list
+    # rank-independently (resolve_draft_aux_layer_ids) and threads it in:
+    # under PP only the last stage owns a draft model to read it from, and
+    # the capture posts one P2P send/recv per id, so stages disagreeing about
+    # the list would desync the pipeline.
     aux_layer_indices = draft_aux_layer_indices
     if aux_layer_indices is None and draft_model is not None:
         configured_aux_layers = draft_model.config.eagle_aux_hidden_state_layer_ids
@@ -397,8 +446,6 @@ def forward_with_post_processing_fn(
             clear_router_replay(model)
 
     if capture is not None:
-        from megatron.core.transformer.multi_token_prediction import roll_tensor
-
         if use_fused_linear_logprobs:
             # The fused path never materializes the policy's full logits, so
             # there is no soft-CE teacher for the draft; the DRAFT loss prep
@@ -418,46 +465,63 @@ def forward_with_post_processing_fn(
                 draft_model=draft_model,
                 captured_states=captured_states,
                 data_dict=data_dict,
+                packed_seq_params=packed_seq_params,
             )
         else:
+            from megatron.core.transformer.multi_token_prediction import roll_tensor
+
+            from nemo_rl.algorithms.loss.utils import (
+                packed_zigzag_token_coords,
+                roll_packed_left_cp,
+            )
+
+            cp_group = get_context_parallel_group()
             if packed_seq_params is not None:
-                # Packed layout: rolling the captured embeddings would leak the
-                # next segment's first token across every packing boundary, so
-                # shift the token ids per sequence before packing and re-embed
-                # them instead (one extra embedding lookup; also yields the
-                # correct sequence-parallel layout for free). no_grad matches
-                # the capture hooks, which hand the draft detached embeddings.
-                with torch.no_grad():
-                    shifted_input_ids = _pack_input_ids(
-                        data_dict["input_ids"],
-                        packed_seq_params.cu_seqlens_q,
-                        packed_seq_params.cu_seqlens_q_padded,
-                        roll_shift=-1,
-                    )
-                    shifted_input_embeds = capture.model.embedding(
-                        input_ids=shifted_input_ids, position_ids=position_ids
-                    )
+                # Packed (THD) input: the pass-1 shift must stop at
+                # subsequence boundaries and, under CP, exchange the zigzag
+                # chunk-boundary elements. Also stash the local->(subseq,
+                # position) coords the packed draft loss uses to gather its
+                # per-pass masks from the unpacked [B, S] token_mask.
+                cp_size = torch.distributed.get_world_size(cp_group)
+                cp_rank = torch.distributed.get_rank(cp_group)
+                cu_global = packed_seq_params.cu_seqlens_q_padded
+                if cu_global is None:
+                    cu_global = packed_seq_params.cu_seqlens_q
+                cu_local = torch.div(cu_global, cp_size, rounding_mode="floor").to(
+                    torch.int32
+                )
+                seq_index, pos_in_seq = packed_zigzag_token_coords(
+                    cu_global, cp_rank, cp_size
+                )
+                data_dict["draft_packed_seq_index"] = seq_index
+                data_dict["draft_packed_pos_in_seq"] = pos_in_seq
+                data_dict["draft_packed_local_cu_seqlens"] = cu_local
+                shifted_input_embeds = roll_packed_left_cp(
+                    captured_states.inputs_embeds,
+                    cu_local,
+                    cp_group if cp_size > 1 else None,
+                )
             else:
                 shifted_input_embeds = roll_tensor(
                     captured_states.inputs_embeds,
                     shifts=-1,
                     dims=0,
-                    cp_group=get_context_parallel_group(),
+                    cp_group=cp_group,
                 )[0]
             if draft_ttt_steps > 1:
-                # Multi-pass TTT self-conditions on its own output, so it drives
-                # the draft decoder itself instead of the single forward below.
-                # The wrapper rejects packing on this path (per-pass slicing
-                # needs the unpacked [B, S] layout).
                 data_dict["student_logits_by_pass"] = draft_model.forward_ttt(
                     hidden_states=captured_states.hidden_states,
                     input_embeds=shifted_input_embeds,
+                    packed_seq_params=packed_seq_params,
                 )
             else:
                 data_dict["student_logits"] = draft_model(
                     hidden_states=captured_states.hidden_states,
                     input_embeds=shifted_input_embeds,
-                    attention_mask=attention_mask,
+                    # The draft decoder is forced onto the fused causal path
+                    # (see EagleModel); an explicit mask tensor would route TE
+                    # back to the unfused O(seq^2) backend.
+                    attention_mask=None,
                     packed_seq_params=packed_seq_params,
                 )
 
@@ -628,6 +692,74 @@ class LossPostProcessor:
             # Block drafts (DFlash/DSpark) train full-vocab in v1 (no d2t).
             self.d2t = None
 
+    def _wrap_with_draft_loss(
+        self,
+        loss_fn_wrapped: Any,
+        prepare_fn: Callable[..., Any],
+        data_dict: BatchedDataDict[Any],
+        global_draft_pass_counts: Optional[torch.Tensor],
+    ) -> "DraftLossWrapper":
+        """Wrap the (possibly packing-wrapped) policy loss with the draft loss."""
+        draft_cfg = self.cfg["draft"]
+        raw_ttt_steps = draft_cfg.get("ttt_steps", 1)
+        ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+        if ttt_steps < 1:
+            raise ValueError(
+                f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
+            )
+        # ttt_steps reaches the forward independently (the draft_ttt_steps
+        # argument threaded into megatron_forward_backward); a caller omitting
+        # it with a multi-pass config would otherwise surface as a KeyError
+        # far from the cause. Block drafts are dispatched on the logits key
+        # the forward stashed — one config selector (speculator_type), read
+        # only where the model is built.
+        multi_pass = "student_logits_by_pass" in data_dict
+        block_draft = "draft_block_logits" in data_dict
+        if block_draft and ttt_steps > 1:
+            raise ValueError(
+                "policy.draft.ttt_steps > 1 applies to the eagle3 speculator "
+                "only; block drafts predict a whole block per pass."
+            )
+        if not block_draft and multi_pass != (ttt_steps > 1):
+            raise RuntimeError(
+                f"draft forward produced "
+                f"{'multi-pass' if multi_pass else 'single-pass'} logits "
+                f"but policy.draft.ttt_steps={ttt_steps}; the "
+                "draft_ttt_steps argument threaded into "
+                "megatron_forward_backward disagrees with the config."
+            )
+        # Ctor kwargs for the draft LossFn (uniform shape; DraftLossWrapper
+        # splats them into the selected class).
+        if block_draft:
+            draft_loss_kwargs: dict[str, Any] = {
+                "slot_weights": resolve_block_draft_slot_weights(
+                    draft_cfg.get("loss_weighting"), int(draft_cfg["gamma"])
+                )
+            }
+            if "draft_confidence_pred" in data_dict:
+                for key in (
+                    "ce_loss_alpha",
+                    "tv_loss_alpha",
+                    "confidence_head_alpha",
+                ):
+                    if draft_cfg.get(key) is not None:
+                        draft_loss_kwargs[key] = float(draft_cfg[key])
+        else:
+            draft_loss_kwargs = {"pass_weights": draft_cfg.get("ttt_pass_weights")}
+        if draft_cfg.get("loss_seq_chunk_size") is not None:
+            draft_loss_kwargs["seq_chunk_size"] = int(draft_cfg["loss_seq_chunk_size"])
+        return DraftLossWrapper(
+            loss_fn=loss_fn_wrapped,
+            prepare_fn=prepare_fn,
+            data_dict=data_dict,
+            loss_weight=float(draft_cfg["loss_weight"]),
+            draft_loss_kwargs=draft_loss_kwargs,
+            global_draft_pass_counts=global_draft_pass_counts,
+            vocab_parallel_rank=get_tensor_model_parallel_rank(),
+            vocab_parallel_group=get_tensor_model_parallel_group(),
+            context_parallel_group=get_context_parallel_group(),
+        )
+
     def __call__(
         self,
         data_dict: BatchedDataDict[Any],
@@ -671,17 +803,14 @@ class LossPostProcessor:
             or "draft_block_logits" in data_dict
         )
         if pack_sequences and packed_seq_params is not None:
-            if (
-                "student_logits_by_pass" in data_dict
-                or "draft_block_logits" in data_dict
-            ):
-                # Only the single-pass head has a packed loss path below; the
-                # others would be dropped and silently never train.
-                raise NotImplementedError(
-                    "Multi-pass TTT and block draft training do not support "
-                    "sequence packing; disable policy.sequence_packing."
-                )
             fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
+            if has_draft_logits and fuse_loss:
+                # The fused policy-loss prep never materializes full logits in
+                # a form the draft's soft-CE teacher prep was validated with.
+                raise NotImplementedError(
+                    "Draft-model training with sequence packing requires "
+                    "sequence_packing.fuse_loss=false."
+                )
             if fuse_loss:
                 # The fused path prepares loss via prepare_packed_loss_input and
                 # cannot honor a custom prepare_fn (e.g. the value model's); guard
@@ -710,25 +839,16 @@ class LossPostProcessor:
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
             )
-            if "student_logits" in data_dict:
-                # draft + use_fused_linear_logprobs is rejected at setup in
-                # lm_policy.py (the fused path never materializes the full
-                # next-token logits the teacher needs), so no check here.
-                # Keep the draft head's packed logits out of the policy-loss
-                # data so the per-sequence packing slicers never see them.
-                student_logits = data_dict.pop("student_logits")
-                loss_fn_wrapped = DraftLossWrapper(
-                    loss_fn=loss_fn_wrapped,
-                    prepare_fn=None,
-                    data_dict=data_dict,
-                    loss_weight=float(self.cfg["draft"]["loss_weight"]),
-                    vocab_parallel_rank=get_tensor_model_parallel_rank(),
-                    vocab_parallel_group=get_tensor_model_parallel_group(),
-                    context_parallel_group=get_context_parallel_group(),
-                    cu_seqlens_q=packed_seq_params.cu_seqlens_q,
-                    cu_seqlens_q_padded=packed_seq_params.cu_seqlens_q_padded,
-                    d2t=self.d2t,
-                    student_logits=student_logits,
+            if has_draft_logits:
+                # The draft loss wraps AROUND the packing wrapper: the policy
+                # part iterates subsequences, the draft part runs once over
+                # the whole packed row (per-pass teacher roll + coord-gathered
+                # masks; see DraftCrossEntropyLossFn's packed mode).
+                loss_fn_wrapped = self._wrap_with_draft_loss(
+                    loss_fn_wrapped,
+                    prepare_loss_input_wrapped,
+                    data_dict,
+                    global_draft_pass_counts,
                 )
         else:
             loss_fn_wrapped = partial(
@@ -740,76 +860,11 @@ class LossPostProcessor:
                 context_parallel_group=get_context_parallel_group(),
             )
             if has_draft_logits:
-                draft_cfg = self.cfg["draft"]
-                raw_ttt_steps = draft_cfg.get("ttt_steps", 1)
-                ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
-                if ttt_steps < 1:
-                    raise ValueError(
-                        f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
-                    )
-                # ttt_steps reaches the forward independently (the
-                # draft_ttt_steps argument threaded into
-                # megatron_forward_backward); a caller omitting it with a
-                # multi-pass config would otherwise surface as a KeyError far
-                # from the cause.
-                multi_pass = "student_logits_by_pass" in data_dict
-                block_draft = "draft_block_logits" in data_dict
-                if block_draft and ttt_steps > 1:
-                    raise ValueError(
-                        "policy.draft.ttt_steps > 1 applies to the eagle3 "
-                        "speculator only; block drafts predict a whole block "
-                        "per pass."
-                    )
-                if not block_draft and multi_pass != (ttt_steps > 1):
-                    raise RuntimeError(
-                        f"draft forward produced "
-                        f"{'multi-pass' if multi_pass else 'single-pass'} logits "
-                        f"but policy.draft.ttt_steps={ttt_steps}; the "
-                        "draft_ttt_steps argument threaded into "
-                        "megatron_forward_backward disagrees with the config."
-                    )
-                # Ctor kwargs for the draft LossFn (uniform shape;
-                # DraftLossWrapper splats them into the selected class). Only
-                # the block and multi-pass classes take weights / the chunk
-                # size. Block drafts are dispatched on the logits key the
-                # forward stashed — same signal the consistency check reads.
-                if block_draft:
-                    draft_loss_kwargs: dict[str, Any] = {
-                        "slot_weights": resolve_block_draft_slot_weights(
-                            draft_cfg.get("loss_weighting"), int(draft_cfg["gamma"])
-                        )
-                    }
-                    if "draft_confidence_pred" in data_dict:
-                        for key in (
-                            "ce_loss_alpha",
-                            "tv_loss_alpha",
-                            "confidence_head_alpha",
-                        ):
-                            if draft_cfg.get(key) is not None:
-                                draft_loss_kwargs[key] = float(draft_cfg[key])
-                elif ttt_steps > 1:
-                    draft_loss_kwargs = {
-                        "pass_weights": draft_cfg.get("ttt_pass_weights")
-                    }
-                else:
-                    draft_loss_kwargs = {}
-                if (ttt_steps > 1 or block_draft) and draft_cfg.get(
-                    "loss_seq_chunk_size"
-                ) is not None:
-                    draft_loss_kwargs["seq_chunk_size"] = int(
-                        draft_cfg["loss_seq_chunk_size"]
-                    )
-                loss_fn_wrapped = DraftLossWrapper(
-                    loss_fn=loss_fn_wrapped,
-                    prepare_fn=prepare_loss_input_wrapped,
-                    data_dict=data_dict,
-                    loss_weight=float(draft_cfg["loss_weight"]),
-                    draft_loss_kwargs=draft_loss_kwargs,
-                    global_draft_pass_counts=global_draft_pass_counts,
-                    vocab_parallel_rank=get_tensor_model_parallel_rank(),
-                    vocab_parallel_group=get_tensor_model_parallel_group(),
-                    context_parallel_group=get_context_parallel_group(),
-                    ttt_steps=ttt_steps,
+                loss_fn_wrapped = self._wrap_with_draft_loss(
+                    loss_fn_wrapped,
+                    prepare_loss_input_wrapped,
+                    data_dict,
+                    global_draft_pass_counts,
                 )
 
         loss_fn_wrapped = partial(

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -42,6 +42,7 @@ from nemo_rl.algorithms.loss import (
     SequencePackingLossWrapper,
     prepare_loss_input,
     prepare_packed_loss_input,
+    resolve_block_draft_slot_weights,
     wrap_loss_fn_with_input_preparation,
 )
 from nemo_rl.algorithms.loss.interfaces import LossFunction
@@ -218,6 +219,60 @@ def apply_temperature_scaling(
     return logits
 
 
+def _run_block_draft_forward(
+    *,
+    model: MegatronModule,
+    draft_model: MegatronModule,
+    captured_states: Any,
+    data_dict: BatchedDataDict[Any],
+) -> torch.Tensor:
+    """Run the DFlash block-draft forward for one microbatch.
+
+    Returns prediction-slot logits ``[B, N, gamma, V_local]`` aligned with
+    labels ``x_{p+1} .. x_{p+gamma}`` per anchor ``p`` (DFlash's bonus anchor
+    slot is dropped).
+
+    Following the official DFlash contract the draft owns neither an LM head
+    nor a mask embedding: logits are projected through the policy's LIVE head
+    and mask slots embed via the policy's LIVE ``embed_tokens[mask_token_id]``
+    row — both passed DETACHED (the draft never trains them; serving matches
+    because vLLM shares the target's lm_head and embed_tokens with a
+    head-less/embedding-less drafter).
+    """
+    # Deferred imports mirror the worker: block-draft-path-only dependencies.
+    from nemo_rl.models.megatron.draft.dflash import count_map_to_anchors
+    from nemo_rl.models.megatron.draft.utils import (
+        get_policy_embedding_row,
+        get_policy_lm_head_weight,
+    )
+
+    # Anchors travel through the batch as a [B, S] count map (the only layout
+    # that survives dynamic batching's sequence-dim validation/truncation and
+    # length-bucket reorder); rebuild this microbatch's block list and stash
+    # it for the loss (slot mask + teacher gather read these keys).
+    anchors, anchor_valid = count_map_to_anchors(data_dict["draft_anchor_count_map"])
+    data_dict["draft_anchor_positions"] = anchors
+    data_dict["draft_anchor_valid"] = anchor_valid
+
+    draft_out = draft_model(
+        taps=captured_states.hidden_states,
+        input_embeds=captured_states.inputs_embeds,
+        anchors=anchors,
+        anchor_valid=anchor_valid,
+        lm_head_weight=get_policy_lm_head_weight(model).detach(),
+        mask_embedding=get_policy_embedding_row(
+            model, draft_model.mask_token_id
+        ).detach(),
+    )
+    if draft_model.speculator_type == "dflash":
+        # Slot 0 is the anchor bonus slot (condition only); the gamma mask
+        # slots align with labels x_{p+1} .. x_{p+gamma}.
+        return draft_out[:, :, 1:, :]
+    raise ValueError(
+        f"Unknown block-draft speculator_type '{draft_model.speculator_type}'."
+    )
+
+
 def forward_with_post_processing_fn(
     data_iterator: Iterator[ProcessedMicrobatch],
     model: GPTModel,
@@ -345,46 +400,54 @@ def forward_with_post_processing_fn(
             )
 
         captured_states = capture.get_captured_states()
-        if packed_seq_params is not None:
-            # Packed layout: rolling the captured embeddings would leak the
-            # next segment's first token across every packing boundary, so
-            # shift the token ids per sequence before packing and re-embed
-            # them instead (one extra embedding lookup; also yields the
-            # correct sequence-parallel layout for free). no_grad matches the
-            # capture hooks, which hand the draft detached embeddings.
-            with torch.no_grad():
-                shifted_input_ids = _pack_input_ids(
-                    data_dict["input_ids"],
-                    packed_seq_params.cu_seqlens_q,
-                    packed_seq_params.cu_seqlens_q_padded,
-                    roll_shift=-1,
-                )
-                shifted_input_embeds = capture.model.embedding(
-                    input_ids=shifted_input_ids, position_ids=position_ids
-                )
-        else:
-            shifted_input_embeds = roll_tensor(
-                captured_states.inputs_embeds,
-                shifts=-1,
-                dims=0,
-                cp_group=get_context_parallel_group(),
-            )[0]
-        if draft_ttt_steps > 1:
-            # Multi-pass TTT self-conditions on its own output, so it drives the
-            # draft decoder itself instead of the single forward below. The
-            # wrapper rejects packing on this path (per-pass slicing needs the
-            # unpacked [B, S] layout).
-            data_dict["student_logits_by_pass"] = draft_model.forward_ttt(
-                hidden_states=captured_states.hidden_states,
-                input_embeds=shifted_input_embeds,
+        if getattr(draft_model, "speculator_type", "eagle3") == "dflash":
+            data_dict["draft_block_logits"] = _run_block_draft_forward(
+                model=model,
+                draft_model=draft_model,
+                captured_states=captured_states,
+                data_dict=data_dict,
             )
         else:
-            data_dict["student_logits"] = draft_model(
-                hidden_states=captured_states.hidden_states,
-                input_embeds=shifted_input_embeds,
-                attention_mask=attention_mask,
-                packed_seq_params=packed_seq_params,
-            )
+            if packed_seq_params is not None:
+                # Packed layout: rolling the captured embeddings would leak the
+                # next segment's first token across every packing boundary, so
+                # shift the token ids per sequence before packing and re-embed
+                # them instead (one extra embedding lookup; also yields the
+                # correct sequence-parallel layout for free). no_grad matches
+                # the capture hooks, which hand the draft detached embeddings.
+                with torch.no_grad():
+                    shifted_input_ids = _pack_input_ids(
+                        data_dict["input_ids"],
+                        packed_seq_params.cu_seqlens_q,
+                        packed_seq_params.cu_seqlens_q_padded,
+                        roll_shift=-1,
+                    )
+                    shifted_input_embeds = capture.model.embedding(
+                        input_ids=shifted_input_ids, position_ids=position_ids
+                    )
+            else:
+                shifted_input_embeds = roll_tensor(
+                    captured_states.inputs_embeds,
+                    shifts=-1,
+                    dims=0,
+                    cp_group=get_context_parallel_group(),
+                )[0]
+            if draft_ttt_steps > 1:
+                # Multi-pass TTT self-conditions on its own output, so it drives
+                # the draft decoder itself instead of the single forward below.
+                # The wrapper rejects packing on this path (per-pass slicing
+                # needs the unpacked [B, S] layout).
+                data_dict["student_logits_by_pass"] = draft_model.forward_ttt(
+                    hidden_states=captured_states.hidden_states,
+                    input_embeds=shifted_input_embeds,
+                )
+            else:
+                data_dict["student_logits"] = draft_model(
+                    hidden_states=captured_states.hidden_states,
+                    input_embeds=shifted_input_embeds,
+                    attention_mask=attention_mask,
+                    packed_seq_params=packed_seq_params,
+                )
 
     # Apply temperature scaling only for sampling-oriented post-processors.
     # Loss computation should use unscaled logits.
@@ -550,6 +613,7 @@ class LossPostProcessor:
         if eagle_module is not None:
             self.d2t = getattr(eagle_module, "d2t", None)
         else:
+            # Block drafts (DFlash) train full-vocab in v1 (no d2t).
             self.d2t = None
 
     def __call__(
@@ -590,15 +654,20 @@ class LossPostProcessor:
         # wrap loss function with loss input preparation
         pack_sequences = self.cfg["sequence_packing"]["enabled"]
         has_draft_logits = (
-            "student_logits" in data_dict or "student_logits_by_pass" in data_dict
+            "student_logits" in data_dict
+            or "student_logits_by_pass" in data_dict
+            or "draft_block_logits" in data_dict
         )
         if pack_sequences and packed_seq_params is not None:
-            if "student_logits_by_pass" in data_dict:
+            if (
+                "student_logits_by_pass" in data_dict
+                or "draft_block_logits" in data_dict
+            ):
                 # Only the single-pass head has a packed loss path below; the
-                # multi-pass logits would be dropped and silently never train.
+                # others would be dropped and silently never train.
                 raise NotImplementedError(
-                    "Multi-pass TTT draft training does not support sequence "
-                    "packing; disable policy.sequence_packing."
+                    "Multi-pass TTT and block draft training do not support "
+                    "sequence packing; disable policy.sequence_packing."
                 )
             fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
             if fuse_loss:
@@ -672,7 +741,14 @@ class LossPostProcessor:
                 # multi-pass config would otherwise surface as a KeyError far
                 # from the cause.
                 multi_pass = "student_logits_by_pass" in data_dict
-                if multi_pass != (ttt_steps > 1):
+                block_draft = "draft_block_logits" in data_dict
+                if block_draft and ttt_steps > 1:
+                    raise ValueError(
+                        "policy.draft.ttt_steps > 1 applies to the eagle3 "
+                        "speculator only; block drafts predict a whole block "
+                        "per pass."
+                    )
+                if not block_draft and multi_pass != (ttt_steps > 1):
                     raise RuntimeError(
                         f"draft forward produced "
                         f"{'multi-pass' if multi_pass else 'single-pass'} logits "
@@ -682,13 +758,24 @@ class LossPostProcessor:
                     )
                 # Ctor kwargs for the draft LossFn (uniform shape;
                 # DraftLossWrapper splats them into the selected class). Only
-                # the multi-pass class takes pass weights and the chunk size.
-                draft_loss_kwargs: dict[str, Any] = (
-                    {"pass_weights": draft_cfg.get("ttt_pass_weights")}
-                    if ttt_steps > 1
-                    else {}
-                )
-                if ttt_steps > 1 and draft_cfg.get("loss_seq_chunk_size") is not None:
+                # the block and multi-pass classes take weights / the chunk
+                # size. Block drafts are dispatched on the logits key the
+                # forward stashed — same signal the consistency check reads.
+                if block_draft:
+                    draft_loss_kwargs: dict[str, Any] = {
+                        "slot_weights": resolve_block_draft_slot_weights(
+                            draft_cfg.get("loss_weighting"), int(draft_cfg["gamma"])
+                        )
+                    }
+                elif ttt_steps > 1:
+                    draft_loss_kwargs = {
+                        "pass_weights": draft_cfg.get("ttt_pass_weights")
+                    }
+                else:
+                    draft_loss_kwargs = {}
+                if (ttt_steps > 1 or block_draft) and draft_cfg.get(
+                    "loss_seq_chunk_size"
+                ) is not None:
                     draft_loss_kwargs["seq_chunk_size"] = int(
                         draft_cfg["loss_seq_chunk_size"]
                     )

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -225,10 +225,13 @@ def forward_with_post_processing_fn(
     defer_fp32_logits: Optional[bool] = False,
     global_valid_seqs: Optional[torch.Tensor] = None,
     global_valid_toks: Optional[torch.Tensor] = None,
+    global_draft_pass_counts: Optional[torch.Tensor] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    draft_ttt_steps: int = 1,
+    draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -250,6 +253,9 @@ def forward_with_post_processing_fn(
         straggler_timer: Straggler detector for profiling the forward pass
         draft_model: Draft model for online draft model training
         enable_hidden_capture: Whether to enable hidden state capture for draft model training
+        draft_aux_layer_indices: Aux-layer ids to capture, resolved
+            rank-independently by the worker (every PP stage must agree; see
+            resolve_draft_aux_layer_ids)
 
     Returns:
         tuple: (output_tensor, post_processing_fn_wrapped)
@@ -279,8 +285,24 @@ def forward_with_post_processing_fn(
             )
         set_router_replay_forward(model, routed_experts_cp_sharded)
 
-    # Insert hook to capture hidden states and embeddings for draft model training if draft_model is provided
-    capture_context, capture = get_capture_context(model, enable_hidden_capture)
+    # Insert hook to capture hidden states and embeddings for draft model
+    # training. Capture the aux layers the DRAFT was built for (checkpoint
+    # eagle_aux_hidden_state_layer_ids / policy.draft.aux_layer_indices): the
+    # serving-side drafter taps exactly these policy layers, so capturing the
+    # hard-coded defaults instead would silently train on different features
+    # (or break the fc width when the counts differ). The worker resolves the
+    # list rank-independently (resolve_draft_aux_layer_ids) and threads it in:
+    # under PP only the last stage owns a draft model to read it from, and the
+    # capture posts one P2P send/recv per id, so stages disagreeing about the
+    # list would desync the pipeline.
+    aux_layer_indices = draft_aux_layer_indices
+    if aux_layer_indices is None and draft_model is not None:
+        configured_aux_layers = draft_model.config.eagle_aux_hidden_state_layer_ids
+        if configured_aux_layers:
+            aux_layer_indices = tuple(int(i) for i in configured_aux_layers)
+    capture_context, capture = get_capture_context(
+        model, enable_hidden_capture, aux_layer_indices=aux_layer_indices
+    )
     try:
         with capture_context:
             output_tensor = model_forward(
@@ -313,6 +335,15 @@ def forward_with_post_processing_fn(
     if capture is not None:
         from megatron.core.transformer.multi_token_prediction import roll_tensor
 
+        if use_fused_linear_logprobs:
+            # The fused path never materializes the policy's full logits, so
+            # there is no soft-CE teacher for the draft; the DRAFT loss prep
+            # would silently treat fused logprobs as logits.
+            raise RuntimeError(
+                "Draft-model training requires the policy's full logits; "
+                "disable megatron_cfg.use_fused_linear_logprobs."
+            )
+
         captured_states = capture.get_captured_states()
         if packed_seq_params is not None:
             # Packed layout: rolling the captured embeddings would leak the
@@ -338,12 +369,22 @@ def forward_with_post_processing_fn(
                 dims=0,
                 cp_group=get_context_parallel_group(),
             )[0]
-        data_dict["student_logits"] = draft_model(
-            hidden_states=captured_states.hidden_states,
-            input_embeds=shifted_input_embeds,
-            attention_mask=attention_mask,
-            packed_seq_params=packed_seq_params,
-        )
+        if draft_ttt_steps > 1:
+            # Multi-pass TTT self-conditions on its own output, so it drives the
+            # draft decoder itself instead of the single forward below. The
+            # wrapper rejects packing on this path (per-pass slicing needs the
+            # unpacked [B, S] layout).
+            data_dict["student_logits_by_pass"] = draft_model.forward_ttt(
+                hidden_states=captured_states.hidden_states,
+                input_embeds=shifted_input_embeds,
+            )
+        else:
+            data_dict["student_logits"] = draft_model(
+                hidden_states=captured_states.hidden_states,
+                input_embeds=shifted_input_embeds,
+                attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
+            )
 
     # Apply temperature scaling only for sampling-oriented post-processors.
     # Loss computation should use unscaled logits.
@@ -363,6 +404,7 @@ def forward_with_post_processing_fn(
             packed_seq_params=packed_seq_params,
             global_valid_seqs=global_valid_seqs,
             global_valid_toks=global_valid_toks,
+            global_draft_pass_counts=global_draft_pass_counts,
         )
     elif isinstance(post_processing_fn, LogprobsPostProcessor):
         assert original_seq_length is not None
@@ -398,10 +440,13 @@ def megatron_forward_backward(
     defer_fp32_logits: Optional[bool] = False,
     global_valid_seqs: Optional[torch.Tensor] = None,
     global_valid_toks: Optional[torch.Tensor] = None,
+    global_draft_pass_counts: Optional[torch.Tensor] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    draft_ttt_steps: int = 1,
+    draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -437,10 +482,13 @@ def megatron_forward_backward(
         defer_fp32_logits=defer_fp32_logits,
         global_valid_seqs=global_valid_seqs,
         global_valid_toks=global_valid_toks,
+        global_draft_pass_counts=global_draft_pass_counts,
         sampling_params=sampling_params,
         straggler_timer=straggler_timer,
         draft_model=draft_model,
         enable_hidden_capture=enable_hidden_capture,
+        draft_ttt_steps=draft_ttt_steps,
+        draft_aux_layer_indices=draft_aux_layer_indices,
         use_fused_linear_logprobs=use_fused_linear_logprobs,
         use_router_replay=use_router_replay,
         router_replay_train=router_replay_train,
@@ -498,8 +546,9 @@ class LossPostProcessor:
         self.cp_normalize = cp_normalize
         self.sampling_params = sampling_params
         self.prepare_fn = prepare_fn
-        if draft_model is not None and draft_model.eagle_module is not None:
-            self.d2t = getattr(draft_model.eagle_module, "d2t", None)
+        eagle_module = getattr(draft_model, "eagle_module", None)
+        if eagle_module is not None:
+            self.d2t = getattr(eagle_module, "d2t", None)
         else:
             self.d2t = None
 
@@ -509,6 +558,7 @@ class LossPostProcessor:
         packed_seq_params: Optional[PackedSeqParams] = None,
         global_valid_seqs: Optional[torch.Tensor] = None,
         global_valid_toks: Optional[torch.Tensor] = None,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, Any]]]:
         """Create a loss post-processing function for training.
 
@@ -539,7 +589,17 @@ class LossPostProcessor:
 
         # wrap loss function with loss input preparation
         pack_sequences = self.cfg["sequence_packing"]["enabled"]
+        has_draft_logits = (
+            "student_logits" in data_dict or "student_logits_by_pass" in data_dict
+        )
         if pack_sequences and packed_seq_params is not None:
+            if "student_logits_by_pass" in data_dict:
+                # Only the single-pass head has a packed loss path below; the
+                # multi-pass logits would be dropped and silently never train.
+                raise NotImplementedError(
+                    "Multi-pass TTT draft training does not support sequence "
+                    "packing; disable policy.sequence_packing."
+                )
             fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
             if fuse_loss:
                 # The fused path prepares loss via prepare_packed_loss_input and
@@ -598,15 +658,51 @@ class LossPostProcessor:
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
             )
-            if "student_logits" in data_dict:
+            if has_draft_logits:
+                draft_cfg = self.cfg["draft"]
+                raw_ttt_steps = draft_cfg.get("ttt_steps", 1)
+                ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+                if ttt_steps < 1:
+                    raise ValueError(
+                        f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
+                    )
+                # ttt_steps reaches the forward independently (the
+                # draft_ttt_steps argument threaded into
+                # megatron_forward_backward); a caller omitting it with a
+                # multi-pass config would otherwise surface as a KeyError far
+                # from the cause.
+                multi_pass = "student_logits_by_pass" in data_dict
+                if multi_pass != (ttt_steps > 1):
+                    raise RuntimeError(
+                        f"draft forward produced "
+                        f"{'multi-pass' if multi_pass else 'single-pass'} logits "
+                        f"but policy.draft.ttt_steps={ttt_steps}; the "
+                        "draft_ttt_steps argument threaded into "
+                        "megatron_forward_backward disagrees with the config."
+                    )
+                # Ctor kwargs for the draft LossFn (uniform shape;
+                # DraftLossWrapper splats them into the selected class). Only
+                # the multi-pass class takes pass weights and the chunk size.
+                draft_loss_kwargs: dict[str, Any] = (
+                    {"pass_weights": draft_cfg.get("ttt_pass_weights")}
+                    if ttt_steps > 1
+                    else {}
+                )
+                if ttt_steps > 1 and draft_cfg.get("loss_seq_chunk_size") is not None:
+                    draft_loss_kwargs["seq_chunk_size"] = int(
+                        draft_cfg["loss_seq_chunk_size"]
+                    )
                 loss_fn_wrapped = DraftLossWrapper(
                     loss_fn=loss_fn_wrapped,
                     prepare_fn=prepare_loss_input_wrapped,
                     data_dict=data_dict,
-                    loss_weight=float(self.cfg["draft"]["loss_weight"]),
+                    loss_weight=float(draft_cfg["loss_weight"]),
+                    draft_loss_kwargs=draft_loss_kwargs,
+                    global_draft_pass_counts=global_draft_pass_counts,
                     vocab_parallel_rank=get_tensor_model_parallel_rank(),
                     vocab_parallel_group=get_tensor_model_parallel_group(),
                     context_parallel_group=get_context_parallel_group(),
+                    ttt_steps=ttt_steps,
                 )
 
         loss_fn_wrapped = partial(

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -226,11 +226,11 @@ def _run_block_draft_forward(
     captured_states: Any,
     data_dict: BatchedDataDict[Any],
 ) -> torch.Tensor:
-    """Run the DFlash block-draft forward for one microbatch.
+    """Run the DFlash/DSpark block-draft forward for one microbatch.
 
     Returns prediction-slot logits ``[B, N, gamma, V_local]`` aligned with
     labels ``x_{p+1} .. x_{p+gamma}`` per anchor ``p`` (DFlash's bonus anchor
-    slot is dropped).
+    slot is dropped; DSpark's teacher-forced Markov bias is added).
 
     Following the official DFlash contract the draft owns neither an LM head
     nor a mask embedding: logits are projected through the policy's LIVE head
@@ -254,6 +254,10 @@ def _run_block_draft_forward(
     data_dict["draft_anchor_positions"] = anchors
     data_dict["draft_anchor_valid"] = anchor_valid
 
+    method_kwargs = {}
+    if draft_model.speculator_type == "dspark":
+        # Teacher-forces the Markov/confidence heads inside the forward.
+        method_kwargs["input_ids"] = data_dict["input_ids"]
     draft_out = draft_model(
         taps=captured_states.hidden_states,
         input_embeds=captured_states.inputs_embeds,
@@ -263,11 +267,16 @@ def _run_block_draft_forward(
         mask_embedding=get_policy_embedding_row(
             model, draft_model.mask_token_id
         ).detach(),
+        **method_kwargs,
     )
     if draft_model.speculator_type == "dflash":
         # Slot 0 is the anchor bonus slot (condition only); the gamma mask
         # slots align with labels x_{p+1} .. x_{p+gamma}.
         return draft_out[:, :, 1:, :]
+    elif draft_model.speculator_type == "dspark":
+        block_logits, confidence_pred = draft_out
+        data_dict["draft_confidence_pred"] = confidence_pred
+        return block_logits
     raise ValueError(
         f"Unknown block-draft speculator_type '{draft_model.speculator_type}'."
     )
@@ -400,7 +409,10 @@ def forward_with_post_processing_fn(
             )
 
         captured_states = capture.get_captured_states()
-        if getattr(draft_model, "speculator_type", "eagle3") == "dflash":
+        if getattr(draft_model, "speculator_type", "eagle3") in (
+            "dflash",
+            "dspark",
+        ):
             data_dict["draft_block_logits"] = _run_block_draft_forward(
                 model=model,
                 draft_model=draft_model,
@@ -613,7 +625,7 @@ class LossPostProcessor:
         if eagle_module is not None:
             self.d2t = getattr(eagle_module, "d2t", None)
         else:
-            # Block drafts (DFlash) train full-vocab in v1 (no d2t).
+            # Block drafts (DFlash/DSpark) train full-vocab in v1 (no d2t).
             self.d2t = None
 
     def __call__(
@@ -767,6 +779,14 @@ class LossPostProcessor:
                             draft_cfg.get("loss_weighting"), int(draft_cfg["gamma"])
                         )
                     }
+                    if "draft_confidence_pred" in data_dict:
+                        for key in (
+                            "ce_loss_alpha",
+                            "tv_loss_alpha",
+                            "confidence_head_alpha",
+                        ):
+                            if draft_cfg.get(key) is not None:
+                                draft_loss_kwargs[key] = float(draft_cfg[key])
                 elif ttt_steps > 1:
                     draft_loss_kwargs = {
                         "pass_weights": draft_cfg.get("ttt_pass_weights")

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -57,6 +57,7 @@ from nemo_rl.distributed.model_utils import (
 from nemo_rl.models.megatron.config import MegatronModule
 from nemo_rl.models.megatron.data import ProcessedMicrobatch
 from nemo_rl.models.megatron.draft.hidden_capture import (
+    TapChannel,
     get_capture_context,
 )
 from nemo_rl.models.megatron.router_replay import (
@@ -225,6 +226,7 @@ def _run_block_draft_forward(
     captured_states: Any,
     data_dict: BatchedDataDict[Any],
     packed_seq_params: Optional[PackedSeqParams] = None,
+    tap_channel: Optional[TapChannel] = None,
 ) -> torch.Tensor:
     """Run the DFlash/DSpark block-draft forward for one microbatch.
 
@@ -310,8 +312,12 @@ def _run_block_draft_forward(
         anchors=anchors,
         anchor_valid=anchor_valid,
         lm_head_weight=get_policy_lm_head_weight(model).detach(),
-        mask_embedding=get_policy_embedding_row(
-            model, draft_model.mask_token_id
+        # Under PP > 1 the embedding lives on the first stage;
+        # TapChannel.begin_pass broadcast this pass's live row here.
+        mask_embedding=(
+            tap_channel.mask_row
+            if tap_channel is not None
+            else get_policy_embedding_row(model, draft_model.mask_token_id)
         ).detach(),
         **method_kwargs,
     )
@@ -343,6 +349,7 @@ def forward_with_post_processing_fn(
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    tap_channel: Optional[TapChannel] = None,
     draft_ttt_steps: int = 1,
     draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
@@ -414,7 +421,10 @@ def forward_with_post_processing_fn(
         if configured_aux_layers:
             aux_layer_indices = tuple(int(i) for i in configured_aux_layers)
     capture_context, capture = get_capture_context(
-        model, enable_hidden_capture, aux_layer_indices=aux_layer_indices
+        model,
+        enable_hidden_capture,
+        aux_layer_indices=aux_layer_indices,
+        tap_channel=tap_channel,
     )
     try:
         with capture_context:
@@ -455,7 +465,12 @@ def forward_with_post_processing_fn(
                 "disable megatron_cfg.use_fused_linear_logprobs."
             )
 
+        # PP > 1 source stages push their taps to the draft stage inside
+        # get_captured_states and come back empty; only the draft owner rank
+        # (the one with draft_model attached) runs the draft forward below.
         captured_states = capture.get_captured_states()
+
+    if capture is not None and draft_model is not None:
         if getattr(draft_model, "speculator_type", "eagle3") in (
             "dflash",
             "dspark",
@@ -466,6 +481,7 @@ def forward_with_post_processing_fn(
                 captured_states=captured_states,
                 data_dict=data_dict,
                 packed_seq_params=packed_seq_params,
+                tap_channel=tap_channel,
             )
         else:
             from megatron.core.transformer.multi_token_prediction import roll_tensor
@@ -584,6 +600,7 @@ def megatron_forward_backward(
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    tap_channel: Optional[TapChannel] = None,
     draft_ttt_steps: int = 1,
     draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
@@ -626,12 +643,17 @@ def megatron_forward_backward(
         straggler_timer=straggler_timer,
         draft_model=draft_model,
         enable_hidden_capture=enable_hidden_capture,
+        tap_channel=tap_channel,
         draft_ttt_steps=draft_ttt_steps,
         draft_aux_layer_indices=draft_aux_layer_indices,
         use_fused_linear_logprobs=use_fused_linear_logprobs,
         use_router_replay=use_router_replay,
         router_replay_train=router_replay_train,
     )
+    if tap_channel is not None and enable_hidden_capture:
+        # Outside the schedule: prune writer refs and broadcast this pass's
+        # live mask-embedding row from the first stage to the draft stage.
+        tap_channel.begin_pass(model)
     forward_backward_func = get_forward_backward_func()
     if use_router_replay:
         clear_router_replay(model)

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -511,12 +511,37 @@ class DraftConfig(TypedDict):
     ttt_steps: NotRequired[int]
     # Per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0.
     ttt_pass_weights: NotRequired[list[float] | None]
-    # Sequence-dim chunk size for the multi-pass draft loss internals (the
-    # fp32 soft-CE buffers and the d2t full-vocab TP gather). Trades a few
-    # extra TP collectives for peak memory; does not affect results. Only
-    # used when ttt_steps > 1 (the single-pass loss keeps the stock unchunked
-    # path). Default in the exemplar YAML: 4096.
+    # Sequence-dim chunk size for the multi-pass / block draft loss internals
+    # (the fp32 soft-CE buffers and the d2t full-vocab TP gather). Trades a
+    # few extra TP collectives for peak memory; does not affect results. The
+    # stock single-pass eagle3 loss keeps the unchunked path. Default in the
+    # exemplar YAML: 4096.
     loss_seq_chunk_size: NotRequired[int | None]
+    # Speculator family: "eagle3" (default), or the block drafter "dflash"
+    # (vLLM >= 0.25 serving; anchor + mask-token blocks, bidirectional
+    # in-block attention, trunk truncated at the anchor; additionally
+    # requires PP == 1). Matches vLLM's speculative_config method naming.
+    speculator_type: NotRequired[str]
+    # ---- dflash only ----
+    # Speculated tokens per block (vLLM num_speculative_tokens).
+    gamma: NotRequired[int]
+    # Anchors sampled per sequence (static shape).
+    anchors_per_seq: NotRequired[int]
+    # Restrict anchors to generation segments (token_loss_mask == 1 labels).
+    anchor_from_generation_only: NotRequired[bool]
+    # Reserved, unused-in-data token id (required for dflash). Mask
+    # slots embed via the target's FROZEN embedding row at this id (official
+    # DFlash contract; never trained).
+    mask_token_id: NotRequired[int | None]
+    # Named slot-weighting scheme for the block-draft loss: null/"uniform",
+    # or "exp" = the DFlash paper's exponentially decaying weight
+    # w_j = exp(-j / gamma_d), gamma_d tabulated by block size (b8 -> 4,
+    # b10 -> 5, b16 -> 7; interpolated otherwise).
+    loss_weighting: NotRequired[str | None]
+    # Trunk-attention bucketing granularity in tokens (correctness-neutral).
+    trunk_chunk: NotRequired[int]
+    # Per-head q/k RMSNorm in the draft attention (Qwen3 style).
+    qk_layernorm: NotRequired[bool]
     # Draft-only optimizer param group (separate from the policy's
     # megatron_cfg.optimizer settings). All null = share the policy optimizer
     # settings and keep the stock param-group partition.

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -517,19 +517,20 @@ class DraftConfig(TypedDict):
     # stock single-pass eagle3 loss keeps the unchunked path. Default in the
     # exemplar YAML: 4096.
     loss_seq_chunk_size: NotRequired[int | None]
-    # Speculator family: "eagle3" (default), or the block drafter "dflash"
-    # (vLLM >= 0.25 serving; anchor + mask-token blocks, bidirectional
-    # in-block attention, trunk truncated at the anchor; additionally
-    # requires PP == 1). Matches vLLM's speculative_config method naming.
+    # Speculator family: "eagle3" (default), or the block drafters "dflash"
+    # (vLLM >= 0.25 serving) / "dspark" (vLLM >= 0.26): anchor + mask-token
+    # blocks, bidirectional in-block attention, trunk truncated at the
+    # anchor; additionally require PP == 1. Matches vLLM's speculative_config
+    # method naming.
     speculator_type: NotRequired[str]
-    # ---- dflash only ----
+    # ---- dflash/dspark only ----
     # Speculated tokens per block (vLLM num_speculative_tokens).
     gamma: NotRequired[int]
     # Anchors sampled per sequence (static shape).
     anchors_per_seq: NotRequired[int]
     # Restrict anchors to generation segments (token_loss_mask == 1 labels).
     anchor_from_generation_only: NotRequired[bool]
-    # Reserved, unused-in-data token id (required for dflash). Mask
+    # Reserved, unused-in-data token id (required for dflash/dspark). Mask
     # slots embed via the target's FROZEN embedding row at this id (official
     # DFlash contract; never trained).
     mask_token_id: NotRequired[int | None]
@@ -538,6 +539,15 @@ class DraftConfig(TypedDict):
     # w_j = exp(-j / gamma_d), gamma_d tabulated by block size (b8 -> 4,
     # b10 -> 5, b16 -> 7; interpolated otherwise).
     loss_weighting: NotRequired[str | None]
+    # DSpark Markov-head rank. Null = the checkpoint config's markov_rank
+    # (64 for checkpoint-less builds); an explicit value must match the ckpt.
+    markov_rank: NotRequired[int | None]
+    # DSpark loss mix: ce * hard-label CE + tv * TV distillation
+    # + confidence * BCE(confidence head, TV acceptance rate).
+    # Defaults = official dspark_qwen3_8b (0.1 / 0.9 / 1.0).
+    ce_loss_alpha: NotRequired[float]
+    tv_loss_alpha: NotRequired[float]
+    confidence_head_alpha: NotRequired[float]
     # Trunk-attention bucketing granularity in tokens (correctness-neutral).
     trunk_chunk: NotRequired[int]
     # Per-head q/k RMSNorm in the draft attention (Qwen3 style).

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -502,6 +502,27 @@ class DraftConfig(TypedDict):
     loss_weight: NotRequired[float]
     num_layers: NotRequired[int | None]
     aux_layer_indices: NotRequired[list[int] | None]
+    # Multi-pass TTT draft training. ttt_steps=1 (default) keeps the stock
+    # single-pass path; >1 runs that many sequential draft passes with the
+    # trunk+branch two-part attention (requires CP=1, no sequence parallel,
+    # no sequence packing, no fused linear logprobs). Pass-d RoPE positions
+    # are offset by d-1 (inference-aligned, matching modelopt's reference
+    # TTT) — not configurable.
+    ttt_steps: NotRequired[int]
+    # Per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0.
+    ttt_pass_weights: NotRequired[list[float] | None]
+    # Sequence-dim chunk size for the multi-pass draft loss internals (the
+    # fp32 soft-CE buffers and the d2t full-vocab TP gather). Trades a few
+    # extra TP collectives for peak memory; does not affect results. Only
+    # used when ttt_steps > 1 (the single-pass loss keeps the stock unchunked
+    # path). Default in the exemplar YAML: 4096.
+    loss_seq_chunk_size: NotRequired[int | None]
+    # Draft-only optimizer param group (separate from the policy's
+    # megatron_cfg.optimizer settings). All null = share the policy optimizer
+    # settings and keep the stock param-group partition.
+    lr: NotRequired[float | None]
+    min_lr: NotRequired[float | None]
+    weight_decay: NotRequired[float | None]
 
 
 class TokenizerConfig(TypedDict):

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -173,6 +173,52 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "which the fused path never materializes. Disable one of the "
                 "two."
             )
+        if draft_enabled:
+            raw_ttt_steps = config["draft"].get("ttt_steps", 1)
+            draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+            if draft_ttt_steps < 1:
+                raise ValueError(
+                    f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
+                )
+            draft_pass_weights = config["draft"].get("ttt_pass_weights")
+            if (
+                draft_pass_weights is not None
+                and len(draft_pass_weights) != draft_ttt_steps
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_pass_weights must have ttt_steps="
+                    f"{draft_ttt_steps} entries, got {len(draft_pass_weights)}."
+                )
+            if draft_ttt_steps > 1 and bool(
+                config.get("sequence_packing", {}).get("enabled", False)
+            ):
+                # Multi-pass TTT slices the unshifted teacher per pass to build
+                # its targets, which assumes the [B, S] layout; the packed
+                # draft loss pre-shifts and packs a single mask instead.
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 does not support sequence packing "
+                    "yet. Set policy.draft.ttt_steps=1 or disable "
+                    "policy.sequence_packing."
+                )
+            # The TTT attention slices sequences locally and stashes per-pass
+            # KV; both need every rank to see the full sequence
+            # (build_draft_model re-checks on the worker).
+            if (
+                draft_ttt_steps > 1
+                and int(config["megatron_cfg"].get("context_parallel_size", 1) or 1)
+                != 1
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 requires "
+                    "policy.megatron_cfg.context_parallel_size=1."
+                )
+            if draft_ttt_steps > 1 and bool(
+                config["megatron_cfg"].get("sequence_parallel")
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 requires "
+                    "policy.megatron_cfg.sequence_parallel=false."
+                )
         if megatron_enable:
             worker_builder_cls_fqn = resolve_policy_worker_cls(
                 "nemo_rl.models.policy.workers.megatron_policy_worker.MegatronPolicyWorker",

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -134,31 +134,19 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "policy.draft.enabled=true is only supported with the Megatron backend. "
                 "Set policy.megatron_cfg.enabled=true or disable policy.draft."
             )
-        if draft_enabled and config["megatron_cfg"]["context_parallel_size"] > 1:
-            # Sequence packing itself is supported with the draft; CP is not:
-            # the hidden-state capture and the per-segment shifts assume each
-            # packed sequence lives whole on one rank.
-            raise ValueError(
-                "policy.draft.enabled=true does not support context parallelism "
-                "yet. Set policy.megatron_cfg.context_parallel_size=1 or disable "
-                "policy.draft."
+        if draft_enabled:
+            packing_enabled = bool(
+                config.get("sequence_packing", {}).get("enabled", False)
             )
-        if (
-            draft_enabled
-            # sequence_packing is NotRequired in PolicyConfig, so tolerate its
-            # absence; the parallel sizes are required megatron_cfg keys.
-            and bool(config.get("sequence_packing", {}).get("enabled", False))
-            and config["megatron_cfg"]["pipeline_model_parallel_size"] > 1
-        ):
-            # The packed draft path re-embeds the per-segment-shifted token ids
-            # via the model's embedding, which MCore constructs only on the
-            # first pipeline stage while the draft runs on the last.
-            raise ValueError(
-                "policy.draft.enabled=true with sequence packing does not "
-                "support pipeline parallelism yet. Set "
-                "policy.megatron_cfg.pipeline_model_parallel_size=1, or disable "
-                "policy.sequence_packing or policy.draft."
+            draft_cp_size = int(
+                config.get("megatron_cfg", {}).get("context_parallel_size", 1) or 1
             )
+            if draft_cp_size > 1 and not packing_enabled:
+                raise ValueError(
+                    "policy.draft with context_parallel_size > 1 requires "
+                    "sequence packing (the trunk ring needs the THD zigzag "
+                    "layout). Enable policy.sequence_packing.enabled."
+                )
         if draft_enabled and bool(
             # use_fused_linear_logprobs is NotRequired in MegatronConfig.
             config["megatron_cfg"].get("use_fused_linear_logprobs", False)
@@ -174,7 +162,6 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "two."
             )
         if draft_enabled:
-            speculator_type = config["draft"].get("speculator_type") or "eagle3"
             raw_ttt_steps = config["draft"].get("ttt_steps", 1)
             draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
             if draft_ttt_steps < 1:
@@ -190,31 +177,9 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                     "policy.draft.ttt_pass_weights must have ttt_steps="
                     f"{draft_ttt_steps} entries, got {len(draft_pass_weights)}."
                 )
-            if bool(config.get("sequence_packing", {}).get("enabled", False)) and (
-                draft_ttt_steps > 1 or speculator_type != "eagle3"
-            ):
-                # Multi-pass TTT and block drafts slice the unshifted teacher
-                # per pass/slot to build their targets, which assumes the
-                # [B, S] layout; the packed draft loss pre-shifts and packs a
-                # single mask instead.
-                raise ValueError(
-                    "Only single-pass eagle3 draft training supports sequence "
-                    "packing. Set policy.draft.ttt_steps=1 and "
-                    "policy.draft.speculator_type=eagle3, or disable "
-                    "policy.sequence_packing."
-                )
-            # The TTT attention slices sequences locally and stashes per-pass
-            # KV; both need every rank to see the full sequence
-            # (build_draft_model re-checks on the worker).
-            if (
-                draft_ttt_steps > 1
-                and int(config["megatron_cfg"].get("context_parallel_size", 1) or 1)
-                != 1
-            ):
-                raise ValueError(
-                    "policy.draft.ttt_steps > 1 requires "
-                    "policy.megatron_cfg.context_parallel_size=1."
-                )
+            # The TTT attention stashes per-pass KV per full local (sub)row;
+            # SP would shard rows across TP ranks (build_draft_model re-checks
+            # on the worker).
             if draft_ttt_steps > 1 and bool(
                 config["megatron_cfg"].get("sequence_parallel")
             ):

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -174,6 +174,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "two."
             )
         if draft_enabled:
+            speculator_type = config["draft"].get("speculator_type") or "eagle3"
             raw_ttt_steps = config["draft"].get("ttt_steps", 1)
             draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
             if draft_ttt_steps < 1:
@@ -189,15 +190,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                     "policy.draft.ttt_pass_weights must have ttt_steps="
                     f"{draft_ttt_steps} entries, got {len(draft_pass_weights)}."
                 )
-            if draft_ttt_steps > 1 and bool(
-                config.get("sequence_packing", {}).get("enabled", False)
+            if bool(config.get("sequence_packing", {}).get("enabled", False)) and (
+                draft_ttt_steps > 1 or speculator_type != "eagle3"
             ):
-                # Multi-pass TTT slices the unshifted teacher per pass to build
-                # its targets, which assumes the [B, S] layout; the packed
-                # draft loss pre-shifts and packs a single mask instead.
+                # Multi-pass TTT and block drafts slice the unshifted teacher
+                # per pass/slot to build their targets, which assumes the
+                # [B, S] layout; the packed draft loss pre-shifts and packs a
+                # single mask instead.
                 raise ValueError(
-                    "policy.draft.ttt_steps > 1 does not support sequence packing "
-                    "yet. Set policy.draft.ttt_steps=1 or disable "
+                    "Only single-pass eagle3 draft training supports sequence "
+                    "packing. Set policy.draft.ttt_steps=1 and "
+                    "policy.draft.speculator_type=eagle3, or disable "
                     "policy.sequence_packing."
                 )
             # The TTT attention slices sequences locally and stashes per-pass

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -894,6 +894,12 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             aggregated_results["mtp_metrics"] = results[0]["mtp_metrics"]
         if "draft_grad_norm" in results[0]:
             aggregated_results["draft_grad_norm"] = results[0]["draft_grad_norm"]
+        # Each deduped result carries its replica's PP-group max tap wait
+        # (reduced worker-side); the slowest replica is the wait actually
+        # exposed to the step.
+        tap_waits = [r["draft_tap_wait_s"] for r in results if "draft_tap_wait_s" in r]
+        if tap_waits:
+            aggregated_results["draft_tap_wait_s"] = max(tap_waits)
 
         if self.flops_tracker is not None:
             aggregated_results["total_flops"] = self.flops_tracker.total_flops

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -52,6 +52,7 @@ from transformers import PreTrainedTokenizerBase
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.loss.utils import (
+    compute_block_draft_slot_valid_counts,
     compute_draft_pass_valid_counts,
 )
 from nemo_rl.data.multimodal_utils import (
@@ -861,12 +862,12 @@ class MegatronPolicyWorkerImpl(
                 global_valid_seqs = gb_result["global_valid_seqs"]
                 global_valid_toks = gb_result["global_valid_toks"]
 
-                # Draft (TTT) loss normalization: the draft's valid-token
-                # counts differ from the policy's (per-pass masks shift by
-                # d+1), so it gets its own global per-pass counts, all-reduced
-                # over DP only. The loss derives its gradient denominator
-                # (sum_d alpha_d * count_d) and the per-pass metric
-                # denominators from this vector.
+                # Draft loss normalization: the draft's valid-token counts
+                # differ from the policy's (TTT per-pass masks shift by d+1;
+                # block slots only cover anchored spans), so it gets its own
+                # global counts, all-reduced over DP only. The loss derives
+                # its gradient denominator (sum_d alpha_d * count_d) and the
+                # per-pass metric denominators from this vector.
                 draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
                 raw_ttt_steps = (
                     self.cfg["draft"].get("ttt_steps", 1) if draft_enabled else 1
@@ -883,17 +884,61 @@ class MegatronPolicyWorkerImpl(
                     if draft_enabled
                     else None
                 )
+                draft_speculator_type = (
+                    (self.cfg["draft"].get("speculator_type") or "eagle3")
+                    if draft_enabled
+                    else "eagle3"
+                )
                 global_draft_pass_counts = None
-                if (
-                    draft_ttt_steps > 1
-                    and "token_mask" in batch
-                    and "sample_mask" in batch
-                ):
-                    global_draft_pass_counts = compute_draft_pass_valid_counts(
-                        batch["token_mask"],
-                        batch["sample_mask"],
-                        ttt_steps=draft_ttt_steps,
-                    ).to(device=global_valid_toks.device)
+                if draft_enabled and "token_mask" in batch and "sample_mask" in batch:
+                    if draft_speculator_type == "dflash":
+                        # Deferred import: the dflash module pulls mcore
+                        # transformer pieces only needed on this path.
+                        from nemo_rl.models.megatron.draft.dflash import (
+                            anchors_to_count_map,
+                            sample_block_anchors,
+                        )
+
+                        # Sample block anchors ONCE for the whole local batch
+                        # (deterministic from the batch content, identical on
+                        # every TP rank). They travel through the batch as a
+                        # [B, S] per-position count map: dim 1 must be the
+                        # sequence dim for every batch tensor (dynamic
+                        # batching validates, truncates, and length-bucket
+                        # reorders along it), which a [B, N] position tensor
+                        # cannot survive. The train loop rebuilds per-mb
+                        # block lists from the map. The per-slot counts are
+                        # the block analogue of the per-pass TTT counts.
+                        anchors, anchor_valid = sample_block_anchors(
+                            token_mask=batch["token_mask"],
+                            sample_mask=batch["sample_mask"],
+                            input_ids=batch["input_ids"],
+                            num_anchors=int(self.cfg["draft"]["anchors_per_seq"]),
+                            generation_only=bool(
+                                self.cfg["draft"].get(
+                                    "anchor_from_generation_only", True
+                                )
+                            ),
+                        )
+                        batch["draft_anchor_count_map"] = anchors_to_count_map(
+                            anchors, anchor_valid, batch["token_mask"].shape[1]
+                        )
+                        global_draft_pass_counts = (
+                            compute_block_draft_slot_valid_counts(
+                                batch["token_mask"],
+                                batch["sample_mask"],
+                                anchors,
+                                anchor_valid,
+                                gamma=int(self.cfg["draft"]["gamma"]),
+                            ).to(device=global_valid_toks.device)
+                        )
+                    elif draft_ttt_steps > 1:
+                        global_draft_pass_counts = compute_draft_pass_valid_counts(
+                            batch["token_mask"],
+                            batch["sample_mask"],
+                            ttt_steps=draft_ttt_steps,
+                        ).to(device=global_valid_toks.device)
+                if global_draft_pass_counts is not None:
                     torch.distributed.all_reduce(
                         global_draft_pass_counts,
                         group=parallel_state.get_data_parallel_group(),
@@ -2475,9 +2520,9 @@ class MegatronPolicyWorkerImpl(
             yield name, tensor
 
         if include_draft and self.draft_model is not None:
-            from nemo_rl.models.megatron.draft import export_eagle_weights_to_hf
+            from nemo_rl.models.megatron.draft import export_draft_weights_to_hf
 
-            draft_weights = export_eagle_weights_to_hf(
+            draft_weights = export_draft_weights_to_hf(
                 self.draft_model,
             )
             for name, tensor in draft_weights:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -891,7 +891,7 @@ class MegatronPolicyWorkerImpl(
                 )
                 global_draft_pass_counts = None
                 if draft_enabled and "token_mask" in batch and "sample_mask" in batch:
-                    if draft_speculator_type == "dflash":
+                    if draft_speculator_type in ("dflash", "dspark"):
                         # Deferred import: the dflash module pulls mcore
                         # transformer pieces only needed on this path.
                         from nemo_rl.models.megatron.draft.dflash import (

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -51,6 +51,9 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.loss.utils import (
+    compute_draft_pass_valid_counts,
+)
 from nemo_rl.data.multimodal_utils import (
     attach_media_token_validity_mask,
     chunks_accept_media_token_validity_mask,
@@ -74,6 +77,7 @@ from nemo_rl.models.megatron.data import (
     get_microbatch_iterator,
     process_global_batch,
 )
+from nemo_rl.models.megatron.draft.utils import resolve_draft_aux_layer_ids
 from nemo_rl.models.megatron.pipeline_parallel import (
     broadcast_loss_metrics_from_last_stage,
     broadcast_obj_from_pp_rank,
@@ -857,6 +861,44 @@ class MegatronPolicyWorkerImpl(
                 global_valid_seqs = gb_result["global_valid_seqs"]
                 global_valid_toks = gb_result["global_valid_toks"]
 
+                # Draft (TTT) loss normalization: the draft's valid-token
+                # counts differ from the policy's (per-pass masks shift by
+                # d+1), so it gets its own global per-pass counts, all-reduced
+                # over DP only. The loss derives its gradient denominator
+                # (sum_d alpha_d * count_d) and the per-pass metric
+                # denominators from this vector.
+                draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+                raw_ttt_steps = (
+                    self.cfg["draft"].get("ttt_steps", 1) if draft_enabled else 1
+                )
+                draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+                # Aux-layer ids are resolved rank-independently: under PP only
+                # the last stage owns the draft model, but every stage's
+                # capture must post the same P2P schedule (one send/recv per
+                # id), so each rank derives the list from the shared config.
+                draft_aux_layer_ids = (
+                    resolve_draft_aux_layer_ids(
+                        self.cfg["draft"], self._get_model_config().num_layers
+                    )
+                    if draft_enabled
+                    else None
+                )
+                global_draft_pass_counts = None
+                if (
+                    draft_ttt_steps > 1
+                    and "token_mask" in batch
+                    and "sample_mask" in batch
+                ):
+                    global_draft_pass_counts = compute_draft_pass_valid_counts(
+                        batch["token_mask"],
+                        batch["sample_mask"],
+                        ttt_steps=draft_ttt_steps,
+                    ).to(device=global_valid_toks.device)
+                    torch.distributed.all_reduce(
+                        global_draft_pass_counts,
+                        group=parallel_state.get_data_parallel_group(),
+                    )
+
                 # Pre-compute the MTP loss mask, only when MTP is enabled, so
                 # process_microbatch can pack it.
                 model_config = self._get_model_config()
@@ -924,7 +966,6 @@ class MegatronPolicyWorkerImpl(
                     self._set_mtp_grad_scale_func(lambda: mtp_scale)
 
                     # Forward pass.
-                    draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
                     use_router_replay = _should_use_router_replay(
                         enabled=self._router_replay_enabled,
                         data=batch,
@@ -943,10 +984,13 @@ class MegatronPolicyWorkerImpl(
                             defer_fp32_logits=self.defer_fp32_logits,
                             global_valid_seqs=global_valid_seqs,
                             global_valid_toks=global_valid_toks,
+                            global_draft_pass_counts=global_draft_pass_counts,
                             sampling_params=self.sampling_params,
                             straggler_timer=self.mcore_state.straggler_timer,
                             draft_model=self.draft_model,
                             enable_hidden_capture=draft_enabled,
+                            draft_ttt_steps=draft_ttt_steps,
+                            draft_aux_layer_indices=draft_aux_layer_ids,
                             use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
                                 "use_fused_linear_logprobs", False
                             ),
@@ -1507,6 +1551,30 @@ class MegatronPolicyWorkerImpl(
         placeholder_n = torch.tensor(1.0, device="cuda")
 
         draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+        # With TTT enabled the draft's core attention is the multi-pass module,
+        # so the forward MUST run through forward_ttt even here (the plain
+        # single-pass forward would trip its begin_pass guard).
+        raw_ttt_steps = self.cfg["draft"].get("ttt_steps", 1) if draft_enabled else 1
+        draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+        if draft_ttt_steps > 1:
+            # This path never computes global_draft_pass_counts, and its
+            # placeholder-N contract (loss returns un-normalized sums, one
+            # global 1/N rescale at finish) cannot express the multi-pass
+            # denominator sum_d alpha_d * count_d alongside the policy's
+            # global_valid_toks — the draft gradient would silently mis-scale
+            # by roughly sum_d alpha_d.
+            raise NotImplementedError(
+                "policy.draft.ttt_steps > 1 is not supported on the split "
+                "train-step path (single controller); use the batched train() "
+                "path."
+            )
+        draft_aux_layer_ids = (
+            resolve_draft_aux_layer_ids(
+                self.cfg["draft"], self._get_model_config().num_layers
+            )
+            if draft_enabled
+            else None
+        )
         use_router_replay = _should_use_router_replay(
             enabled=self._router_replay_enabled,
             data=data,
@@ -1537,6 +1605,8 @@ class MegatronPolicyWorkerImpl(
                     straggler_timer=self.mcore_state.straggler_timer,
                     draft_model=self.draft_model,
                     enable_hidden_capture=draft_enabled,
+                    draft_ttt_steps=draft_ttt_steps,
+                    draft_aux_layer_indices=draft_aux_layer_ids,
                     use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
                         "use_fused_linear_logprobs", False
                     ),

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -589,6 +589,22 @@ class MegatronPolicyWorkerImpl(
         self.checkpointing_context = model_and_optimizer_state.checkpointing_context
         param_sync_func = model_and_optimizer_state.param_sync_func
         self.draft_model = model_and_optimizer_state.draft_model
+        # PP > 1 draft co-training: every PP rank joins the tap channel (source
+        # stages write taps one-sided, the draft stage lands them); PP == 1
+        # keeps the rank-local capture path and needs no channel.
+        self.tap_channel = None
+        if (
+            "draft" in self.cfg
+            and self.cfg["draft"]["enabled"]
+            and parallel_state.get_pipeline_model_parallel_world_size() > 1
+        ):
+            from nemo_rl.models.megatron.draft.hidden_capture import (
+                build_tap_channel,
+            )
+
+            self.tap_channel = build_tap_channel(
+                self.model, draft_config=self.cfg["draft"], policy_cfg=self.cfg
+            )
         self._colocated_reshard_plan = model_and_optimizer_state.colocated_reshard_plan
         log_gpu_memory_diagnostics(
             label="after_model_setup", worker_type="MegatronPolicyWorker"
@@ -1034,6 +1050,7 @@ class MegatronPolicyWorkerImpl(
                             straggler_timer=self.mcore_state.straggler_timer,
                             draft_model=self.draft_model,
                             enable_hidden_capture=draft_enabled,
+                            tap_channel=self.tap_channel,
                             draft_ttt_steps=draft_ttt_steps,
                             draft_aux_layer_indices=draft_aux_layer_ids,
                             use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
@@ -1212,6 +1229,25 @@ class MegatronPolicyWorkerImpl(
         self._collect_mtp_metrics(metrics, total_num_microbatches, mtp_grad_norm)
         if draft_grad_norm is not None:
             metrics["draft_grad_norm"] = torch.tensor([draft_grad_norm])
+        if self.tap_channel is not None:
+            # Only the draft stage accumulates rendezvous wait, but result
+            # collection dedups to one worker per tied group (PP rank 0), so
+            # max-reduce across the PP group to make it visible there.
+            wait = torch.tensor(
+                [
+                    self.tap_channel.pop_rendezvous_wait_s()
+                    if self.tap_channel.is_last_stage
+                    else 0.0
+                ],
+                dtype=torch.float32,
+                device="cuda",
+            )
+            torch.distributed.all_reduce(
+                wait,
+                op=torch.distributed.ReduceOp.MAX,
+                group=parallel_state.get_pipeline_model_parallel_group(),
+            )
+            metrics["draft_tap_wait_s"] = wait.item()
 
         # Skip FLOPs estimation when sequence packing is enabled: gbs counts original
         # samples but each packed sequence spans max_total_sequence_length tokens,
@@ -1650,6 +1686,7 @@ class MegatronPolicyWorkerImpl(
                     straggler_timer=self.mcore_state.straggler_timer,
                     draft_model=self.draft_model,
                     enable_hidden_capture=draft_enabled,
+                    tap_channel=self.tap_channel,
                     draft_ttt_steps=draft_ttt_steps,
                     draft_aux_layer_indices=draft_aux_layer_ids,
                     use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
@@ -2470,16 +2507,20 @@ class MegatronPolicyWorkerImpl(
             return broadcast_obj_from_pp_rank(size_in_bytes)
 
         for task in self.refit_conversion_tasks:
-            param_info.append(
-                (
-                    task.param_name,
-                    calculate_size_in_bytes(
-                        task.param_weight,
-                        task.mapping.tp_size,
-                        task.mapping.ep_size if task.mapping.is_expert else 1,
-                    ),
+            try:
+                size_in_bytes = calculate_size_in_bytes(
+                    task.param_weight,
+                    task.mapping.tp_size,
+                    task.mapping.ep_size if task.mapping.is_expert else 1,
                 )
-            )
+            except ValueError as e:
+                # The bare helper error doesn't say WHICH param broke the
+                # one-owner-per-PP-group invariant; that name is the whole
+                # diagnosis (tied embedding vs task-list desync).
+                raise ValueError(
+                    f"refit param info failed for {task.param_name!r}: {e}"
+                ) from e
+            param_info.append((task.param_name, size_in_bytes))
         return param_info
 
     def _iter_params_with_optional_kv_scales(
@@ -2519,12 +2560,38 @@ class MegatronPolicyWorkerImpl(
         for name, tensor in base_iter:
             yield name, tensor
 
-        if include_draft and self.draft_model is not None:
+        if include_draft and "draft" in self.cfg and self.cfg["draft"]["enabled"]:
             from nemo_rl.models.megatron.draft import export_draft_weights_to_hf
 
-            draft_weights = export_draft_weights_to_hf(
-                self.draft_model,
+            # The draft lives on the last PP stage only, but every rank's
+            # iterator must yield the same key set: the refit metadata and each
+            # vLLM engine's IPC sender are rank-local, so a first-stage sender
+            # that skipped draft.* would leave its paired engine's drafter
+            # silently stale (and the metadata would miss the keys the last
+            # stage sends). Broadcast the exported weights across PP.
+            draft_weights = (
+                [
+                    (name, tensor.detach().to("cuda").contiguous())
+                    for name, tensor in export_draft_weights_to_hf(self.draft_model)
+                ]
+                if self.draft_model is not None
+                else None
             )
+            if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+                meta = broadcast_obj_from_pp_rank(
+                    None
+                    if draft_weights is None
+                    else [(n, t.shape, t.dtype) for n, t in draft_weights]
+                )
+                if draft_weights is None:
+                    draft_weights = [
+                        (name, torch.empty(shape, dtype=dtype, device="cuda"))
+                        for name, shape, dtype in meta
+                    ]
+                pp_group = parallel_state.get_pipeline_model_parallel_group()
+                src = torch.distributed.get_process_group_ranks(pp_group)[-1]
+                for _, tensor in draft_weights:
+                    torch.distributed.broadcast(tensor, src=src, group=pp_group)
             for name, tensor in draft_weights:
                 yield f"draft.{name}", tensor
 

--- a/tests/unit/algorithms/test_block_draft_loss.py
+++ b/tests/unit/algorithms/test_block_draft_loss.py
@@ -20,6 +20,7 @@ import torch.nn.functional as F
 
 from nemo_rl.algorithms.loss.loss_functions import (
     BlockDraftLossFn,
+    DSparkBlockLossFn,
     resolve_block_draft_slot_weights,
 )
 from nemo_rl.algorithms.loss.utils import (
@@ -27,6 +28,7 @@ from nemo_rl.algorithms.loss.utils import (
     compute_block_draft_slot_valid_counts,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.model_utils import ChunkedDistributedLabelCEAndTV
 
 
 def _make_block_data(batch_size=2, num_anchors=3, gamma=4, seq_len=16):
@@ -208,6 +210,186 @@ def test_draft_loss_wrapper_block_dispatch(mock_block_loss_cls):
     call_kwargs = block_loss_fn.call_args.kwargs
     assert torch.equal(call_kwargs["student_block_logits"], block_logits)
     assert not call_kwargs["teacher_logits"].requires_grad
+
+
+def test_chunked_label_ce_and_tv_matches_reference():
+    """Chunked custom Function == plain-autograd hard CE + TV (values + grads)."""
+    torch.manual_seed(3)
+    batch, rows, vocab = 2, 11, 17
+    student = torch.randn(batch, rows, vocab, dtype=torch.bfloat16)
+    teacher = torch.randn(batch, rows, vocab, dtype=torch.bfloat16)
+    labels = torch.randint(0, vocab, (batch, rows))
+
+    student_a = student.clone().requires_grad_(True)
+    ce, tv = ChunkedDistributedLabelCEAndTV.apply(
+        student_a, teacher, labels, 0, vocab, 4, None
+    )
+    # Uneven downstream weights exercise both grad_output paths.
+    ce_w = torch.linspace(0.1, 1.0, rows).repeat(batch, 1)
+    tv_w = torch.linspace(1.0, 0.2, rows).repeat(batch, 1)
+    (ce * ce_w + tv * tv_w).sum().backward()
+
+    student_b = student.clone().requires_grad_(True)
+    s32 = student_b.float()
+    t32 = teacher.float()
+    ce_ref = F.cross_entropy(
+        s32.reshape(-1, vocab), labels.reshape(-1), reduction="none"
+    ).reshape(batch, rows)
+    tv_ref = (F.softmax(s32, dim=-1) - F.softmax(t32, dim=-1)).abs().sum(dim=-1)
+    (ce_ref * ce_w + tv_ref * tv_w).sum().backward()
+
+    assert torch.allclose(ce, ce_ref, atol=1e-4), (ce, ce_ref)
+    assert torch.allclose(tv, tv_ref, atol=1e-4)
+    assert torch.allclose(student_a.grad.float(), student_b.grad.float(), atol=2e-3), (
+        (student_a.grad - student_b.grad).abs().max()
+    )
+
+
+def test_dspark_block_loss_matches_official_reference():
+    """DSparkBlockLossFn == the DeepSpec loss math (hard CE + TV + confidence)."""
+    torch.manual_seed(2)
+    batch_size, num_anchors, gamma, seq_len, vocab = 2, 3, 4, 16, 13
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data(
+        batch_size, num_anchors, gamma, seq_len
+    )
+    input_ids = torch.randint(0, vocab, (batch_size, seq_len))
+    teacher_logits = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, num_anchors, gamma, vocab, requires_grad=True)
+    confidence_pred = torch.randn(batch_size, num_anchors, gamma, requires_grad=True)
+    # Official decay exp(-j/4) at block 7 == the "exp" scheme; any weights work.
+    slot_weights = [math.exp(-j / 4.0) for j in range(gamma)]
+    ce_alpha, tv_alpha, conf_alpha = 0.1, 0.9, 1.0
+
+    slot_mask = block_draft_slot_mask(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    ).float()
+    local_counts = slot_mask.sum(dim=(0, 1))
+
+    loss_fn = DSparkBlockLossFn(
+        vocab_parallel_group=None,
+        vocab_parallel_rank=0,
+        slot_weights=slot_weights,
+        ce_loss_alpha=ce_alpha,
+        tv_loss_alpha=tv_alpha,
+        confidence_head_alpha=conf_alpha,
+    )
+    data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "draft_anchor_positions": anchors,
+            "draft_anchor_valid": anchor_valid,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "draft_confidence_pred": confidence_pred,
+        }
+    )
+    loss, metrics = loss_fn(
+        teacher_logits=teacher_logits,
+        student_block_logits=student,
+        data=data,
+        global_valid_seqs=torch.tensor(2.0),
+        global_valid_toks=torch.tensor(100.0),
+        global_draft_pass_counts=local_counts,
+    )
+
+    weights = torch.tensor(slot_weights)
+    denominator = (weights * local_counts).sum()
+    ce_num = torch.zeros(())
+    tv_num = torch.zeros(())
+    conf_num = torch.zeros(())
+    for b in range(batch_size):
+        for n in range(num_anchors):
+            for j in range(gamma):
+                if slot_mask[b, n, j] == 0:
+                    continue
+                teacher_pos = min(int(anchors[b, n]) + j, seq_len - 1)
+                label_pos = min(int(anchors[b, n]) + 1 + j, seq_len - 1)
+                label = input_ids[b, label_pos]
+                ce = F.cross_entropy(
+                    student.detach()[b, n, j], label.unsqueeze(0).squeeze(0)
+                )
+                draft_probs = F.softmax(student.detach()[b, n, j], dim=-1)
+                target_probs = F.softmax(teacher_logits[b, teacher_pos], dim=-1)
+                tv = (draft_probs - target_probs).abs().sum()
+                accept = (1.0 - 0.5 * tv).clamp(0.0, 1.0)
+                bce = F.binary_cross_entropy_with_logits(
+                    confidence_pred.detach()[b, n, j], accept
+                )
+                ce_num = ce_num + weights[j] * ce
+                tv_num = tv_num + weights[j] * tv
+                conf_num = conf_num + weights[j] * bce
+    expected = (
+        ce_alpha * ce_num + tv_alpha * tv_num + conf_alpha * conf_num
+    ) / denominator
+
+    assert torch.allclose(loss, expected, atol=1e-5), (loss, expected)
+    assert math.isclose(
+        metrics["dspark_ce_loss"], float((ce_num / denominator)), rel_tol=1e-4
+    )
+    assert math.isclose(
+        metrics["dspark_tv_loss"], float((tv_num / denominator)), rel_tol=1e-4
+    )
+    for key in (
+        "dspark_confidence_loss",
+        "dspark_confidence_abs_error",
+        "dspark_confidence_bias",
+        "dspark_tau_probabilistic",
+        "accept_rate_slot_0",
+        f"draft_loss_slot_{gamma - 1}",
+    ):
+        assert key in metrics
+    assert metrics["dspark_tau_probabilistic"] >= 1.0
+    assert 0.0 <= metrics["accept_rate_slot_0"] <= 1.0
+
+    loss.backward()
+    assert torch.isfinite(student.grad).all()
+    # Masked slots receive no gradient (block [1, 2] is a dummy anchor).
+    assert torch.all(student.grad[1, 2] == 0)
+    assert torch.all(confidence_pred.grad[1, 2] == 0)
+    assert torch.isfinite(confidence_pred.grad).all()
+    assert confidence_pred.grad.abs().sum() > 0
+
+
+@patch("nemo_rl.algorithms.loss.wrapper.DSparkBlockLossFn")
+def test_draft_loss_wrapper_dspark_dispatch(mock_dspark_loss_cls):
+    """A confidence-carrying block batch routes through DSparkBlockLossFn."""
+    from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
+
+    data = BatchedDataDict(
+        {
+            "draft_block_logits": torch.randn(1, 2, 3, 7),
+            "draft_confidence_pred": torch.rand(1, 2, 3),
+        }
+    )
+    dspark_loss_fn = MagicMock(return_value=(torch.tensor(2.0), {}))
+    mock_dspark_loss_cls.return_value = dspark_loss_fn
+
+    wrapper = DraftLossWrapper(
+        loss_fn=MagicMock(return_value=(torch.tensor(1.0), {})),
+        prepare_fn=MagicMock(),
+        data_dict=data,
+        loss_weight=1.0,
+        draft_loss_kwargs={
+            "slot_weights": [1.0, 0.5, 0.25],
+            "ce_loss_alpha": 0.1,
+            "tv_loss_alpha": 0.9,
+            "confidence_head_alpha": 1.0,
+        },
+    )
+    wrapper(
+        next_token_logits=torch.randn(1, 4, 7),
+        data=data,
+        global_valid_seqs=torch.tensor(1),
+        global_valid_toks=torch.tensor(1),
+    )
+    mock_dspark_loss_cls.assert_called_once_with(
+        vocab_parallel_group=None,
+        vocab_parallel_rank=None,
+        slot_weights=[1.0, 0.5, 0.25],
+        ce_loss_alpha=0.1,
+        tv_loss_alpha=0.9,
+        confidence_head_alpha=1.0,
+    )
 
 
 def test_resolve_block_draft_slot_weights_schemes():

--- a/tests/unit/algorithms/test_block_draft_loss.py
+++ b/tests/unit/algorithms/test_block_draft_loss.py
@@ -205,7 +205,9 @@ def test_draft_loss_wrapper_block_dispatch(mock_block_loss_cls):
     assert metrics["draft_loss"] == draft_loss.item()
     prepare_fn.assert_not_called()
     mock_block_loss_cls.assert_called_once_with(
-        vocab_parallel_group=None, slot_weights=[1.0, 0.5, 0.25]
+        vocab_parallel_group=None,
+        context_parallel_group=None,
+        slot_weights=[1.0, 0.5, 0.25],
     )
     call_kwargs = block_loss_fn.call_args.kwargs
     assert torch.equal(call_kwargs["student_block_logits"], block_logits)
@@ -385,11 +387,180 @@ def test_draft_loss_wrapper_dspark_dispatch(mock_dspark_loss_cls):
     mock_dspark_loss_cls.assert_called_once_with(
         vocab_parallel_group=None,
         vocab_parallel_rank=None,
+        context_parallel_group=None,
         slot_weights=[1.0, 0.5, 0.25],
         ce_loss_alpha=0.1,
         tv_loss_alpha=0.9,
         confidence_head_alpha=1.0,
     )
+
+
+def test_packed_zigzag_local_index_and_halo_cp1():
+    from nemo_rl.algorithms.loss.utils import (
+        packed_zigzag_local_index,
+        packed_zigzag_successor_halo,
+    )
+
+    # cp=2 arithmetic: seq of local len 8 (half 4). Rank 1 owns chunks 1 and 2
+    # (global positions 4..7 and 8..11) at local rows 0..3 and 4..7.
+    cu_local = torch.tensor([0, 8])
+    seq_idx = torch.tensor([0, 0, 0, 0])
+    pos = torch.tensor([4, 7, 8, 11])
+    rows = packed_zigzag_local_index(seq_idx, pos, cu_local, cp_rank=1, cp_size=2)
+    assert rows.tolist() == [0, 3, 4, 7]
+
+    # cp=1 halo: front chunk's successor is the own back chunk head, the back
+    # chunk's successor is past the sequence end (zeros).
+    tensor = torch.arange(24, dtype=torch.float32).reshape(12, 2)
+    cu = torch.tensor([0, 4, 12])
+    halo = packed_zigzag_successor_halo(tensor, cu, halo=2, cp_group=None)
+    assert halo.shape == (2, 2, 2, 2)
+    torch.testing.assert_close(halo[0, 0], tensor[2:4])  # seq 0 back head
+    torch.testing.assert_close(halo[1, 0], tensor[8:10])  # seq 1 back head
+    assert torch.all(halo[:, 1] == 0)
+
+    # Halo larger than the smallest chunk must refuse loudly.
+    try:
+        packed_zigzag_successor_halo(tensor, cu, halo=3, cp_group=None)
+    except ValueError as err:
+        assert "halo" in str(err)
+    else:
+        raise AssertionError("expected ValueError for oversized halo")
+
+
+def _packed_variant(anchors, anchor_valid, batch_size, seq_len):
+    """Flat-block coords + packed cu for a batch of equal-length rows."""
+    num_anchors = anchors.shape[1]
+    seq_idx = torch.arange(batch_size).unsqueeze(1).expand(-1, num_anchors).reshape(-1)
+    cu = torch.arange(0, batch_size + 1, dtype=torch.long) * seq_len
+    return seq_idx, anchors.reshape(-1), anchor_valid.reshape(-1), cu
+
+
+def test_block_draft_loss_packed_matches_unpacked():
+    """Packed (flat blocks + halo teacher gather) == unpacked, loss + metrics."""
+    torch.manual_seed(4)
+    batch_size, num_anchors, gamma, seq_len, vocab = 2, 3, 4, 16, 13
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data(
+        batch_size, num_anchors, gamma, seq_len
+    )
+    teacher_logits = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, num_anchors, gamma, vocab)
+    slot_weights = [1.0, 0.5, 0.25, 0.125]
+    counts = compute_block_draft_slot_valid_counts(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+
+    loss_fn = BlockDraftLossFn(vocab_parallel_group=None, slot_weights=slot_weights)
+    data = BatchedDataDict(
+        {
+            "draft_anchor_positions": anchors,
+            "draft_anchor_valid": anchor_valid,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+        }
+    )
+    loss_ref, metrics_ref = loss_fn(
+        teacher_logits=teacher_logits,
+        student_block_logits=student,
+        data=data,
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+
+    seq_idx, anchors_flat, valid_flat, cu = _packed_variant(
+        anchors, anchor_valid, batch_size, seq_len
+    )
+    packed_data = BatchedDataDict(
+        {
+            "draft_anchor_positions": anchors_flat,
+            "draft_anchor_valid": valid_flat,
+            "draft_block_seq_idx": seq_idx,
+            "draft_packed_local_cu_seqlens": cu,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+        }
+    )
+    loss_packed, metrics_packed = loss_fn(
+        teacher_logits=teacher_logits.reshape(1, batch_size * seq_len, vocab),
+        student_block_logits=student.reshape(-1, gamma, vocab),
+        data=packed_data,
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+
+    torch.testing.assert_close(loss_packed, loss_ref)
+    assert metrics_packed.keys() == metrics_ref.keys()
+    for key in metrics_ref:
+        assert math.isclose(metrics_packed[key], metrics_ref[key], rel_tol=1e-5), key
+
+
+def test_dspark_block_loss_packed_matches_unpacked():
+    """DSpark packed mode (halo teacher + flat labels/confidence) == unpacked."""
+    torch.manual_seed(6)
+    batch_size, num_anchors, gamma, seq_len, vocab = 2, 3, 4, 16, 13
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data(
+        batch_size, num_anchors, gamma, seq_len
+    )
+    input_ids = torch.randint(0, vocab, (batch_size, seq_len))
+    teacher_logits = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, num_anchors, gamma, vocab)
+    confidence_pred = torch.randn(batch_size, num_anchors, gamma)
+    counts = compute_block_draft_slot_valid_counts(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+
+    loss_fn = DSparkBlockLossFn(vocab_parallel_group=None, vocab_parallel_rank=0)
+    data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "draft_anchor_positions": anchors,
+            "draft_anchor_valid": anchor_valid,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "draft_confidence_pred": confidence_pred,
+        }
+    )
+    loss_ref, metrics_ref = loss_fn(
+        teacher_logits=teacher_logits,
+        student_block_logits=student,
+        data=data,
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+
+    seq_idx, anchors_flat, valid_flat, cu = _packed_variant(
+        anchors, anchor_valid, batch_size, seq_len
+    )
+    packed_data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "draft_anchor_positions": anchors_flat,
+            "draft_anchor_valid": valid_flat,
+            "draft_block_seq_idx": seq_idx,
+            "draft_packed_local_cu_seqlens": cu,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "draft_confidence_pred": confidence_pred.reshape(-1, gamma),
+        }
+    )
+    loss_packed, metrics_packed = loss_fn(
+        teacher_logits=teacher_logits.reshape(1, batch_size * seq_len, vocab),
+        student_block_logits=student.reshape(-1, gamma, vocab),
+        data=packed_data,
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+
+    torch.testing.assert_close(loss_packed, loss_ref)
+    assert metrics_packed.keys() == metrics_ref.keys()
+    for key in metrics_ref:
+        assert math.isclose(
+            metrics_packed[key], metrics_ref[key], rel_tol=1e-5, abs_tol=1e-7
+        ), key
 
 
 def test_resolve_block_draft_slot_weights_schemes():

--- a/tests/unit/algorithms/test_block_draft_loss.py
+++ b/tests/unit/algorithms/test_block_draft_loss.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn.functional as F
+
+from nemo_rl.algorithms.loss.loss_functions import (
+    BlockDraftLossFn,
+    resolve_block_draft_slot_weights,
+)
+from nemo_rl.algorithms.loss.utils import (
+    block_draft_slot_mask,
+    compute_block_draft_slot_valid_counts,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _make_block_data(batch_size=2, num_anchors=3, gamma=4, seq_len=16):
+    torch.manual_seed(0)
+    token_mask = torch.zeros(batch_size, seq_len)
+    token_mask[:, 6:] = 1.0
+    sample_mask = torch.ones(batch_size)
+    anchors = torch.tensor([[5, 8, 13], [6, 10, 0]], dtype=torch.int64)
+    anchor_valid = torch.tensor([[True, True, True], [True, True, False]])
+    return token_mask, sample_mask, anchors, anchor_valid
+
+
+def test_block_draft_slot_mask_semantics():
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data()
+    gamma = 4
+    mask = block_draft_slot_mask(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+    assert mask.shape == (2, 3, gamma)
+
+    # Anchor p=5: labels at 6..9, all trained -> every slot valid.
+    assert mask[0, 0].tolist() == [True, True, True, True]
+    # Anchor p=13 (seq_len=16): labels at 14, 15 valid; 16, 17 out of bounds.
+    assert mask[0, 2].tolist() == [True, True, False, False]
+    # Invalid (dummy) anchor -> all slots masked.
+    assert mask[1, 2].tolist() == [False, False, False, False]
+    # sample_mask zeroes a whole row.
+    sample_mask_zero = sample_mask.clone()
+    sample_mask_zero[1] = 0.0
+    mask_zeroed = block_draft_slot_mask(
+        token_mask, sample_mask_zero, anchors, anchor_valid, gamma=gamma
+    )
+    assert not mask_zeroed[1].any()
+
+    counts = compute_block_draft_slot_valid_counts(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+    assert torch.equal(counts, mask.float().sum(dim=(0, 1)))
+
+
+def test_block_draft_slot_mask_is_prefix_contiguous_across_holes():
+    """Slots beyond a token_mask hole must stay invalid (a serving-time block
+    never spans a user/tool span, so training must not resurrect the far
+    side of the hole)."""
+    seq_len = 12
+    token_mask = torch.zeros(1, seq_len)
+    # Labels for anchor p=2 sit at 3..8; punch a hole at 5..6:
+    # per-slot validity would be [1, 1, 0, 0, 1, 1].
+    token_mask[0, 3:5] = 1.0
+    token_mask[0, 7:9] = 1.0
+    sample_mask = torch.ones(1)
+    anchors = torch.tensor([[2]], dtype=torch.int64)
+    anchor_valid = torch.tensor([[True]])
+
+    mask = block_draft_slot_mask(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=6
+    )
+    assert mask[0, 0].tolist() == [True, True, False, False, False, False]
+
+
+def test_block_draft_loss_matches_naive_reference():
+    torch.manual_seed(1)
+    batch_size, num_anchors, gamma, seq_len, vocab = 2, 3, 4, 16, 13
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data(
+        batch_size, num_anchors, gamma, seq_len
+    )
+    teacher_logits = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, num_anchors, gamma, vocab, requires_grad=True)
+    slot_weights = [0.8**j for j in range(gamma)]
+
+    slot_mask = block_draft_slot_mask(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    ).float()
+    local_counts = slot_mask.sum(dim=(0, 1))
+
+    loss_fn = BlockDraftLossFn(vocab_parallel_group=None, slot_weights=slot_weights)
+    data = BatchedDataDict(
+        {
+            "draft_anchor_positions": anchors,
+            "draft_anchor_valid": anchor_valid,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+        }
+    )
+    loss, metrics = loss_fn(
+        teacher_logits=teacher_logits,
+        student_block_logits=student,
+        data=data,
+        global_valid_seqs=torch.tensor(2.0),
+        global_valid_toks=torch.tensor(100.0),
+        global_draft_pass_counts=local_counts,
+    )
+
+    # Naive reference: soft CE against teacher at position p + j.
+    weights = torch.tensor(slot_weights)
+    numerator = torch.zeros(())
+    for b in range(batch_size):
+        for n in range(num_anchors):
+            for j in range(gamma):
+                if slot_mask[b, n, j] == 0:
+                    continue
+                teacher_pos = min(int(anchors[b, n]) + j, seq_len - 1)
+                target = F.softmax(teacher_logits[b, teacher_pos], dim=-1)
+                logprobs = F.log_softmax(student[b, n, j], dim=-1)
+                numerator = numerator + weights[j] * -(target * logprobs).sum()
+    denominator = (weights * local_counts).sum()
+    expected = numerator / denominator
+
+    assert torch.allclose(loss, expected, atol=1e-5), (loss, expected)
+    # Per-slot metrics are normalized by the per-slot counts.
+    assert f"draft_loss_slot_{gamma - 1}" in metrics
+    loss.backward()
+    assert torch.isfinite(student.grad).all()
+    # Masked slots receive no gradient.
+    assert torch.all(student.grad[1, 2] == 0)
+
+
+def test_block_draft_loss_rejects_bad_weight_length():
+    token_mask, sample_mask, anchors, anchor_valid = _make_block_data()
+    loss_fn = BlockDraftLossFn(vocab_parallel_group=None, slot_weights=[1.0])
+    data = BatchedDataDict(
+        {
+            "draft_anchor_positions": anchors,
+            "draft_anchor_valid": anchor_valid,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+        }
+    )
+    try:
+        loss_fn(
+            teacher_logits=torch.randn(2, 16, 13),
+            student_block_logits=torch.randn(2, 3, 4, 13),
+            data=data,
+            global_valid_seqs=torch.tensor(1.0),
+            global_valid_toks=torch.tensor(1.0),
+        )
+        raise AssertionError("expected ValueError for mismatched slot_weights")
+    except ValueError:
+        pass
+
+
+@patch("nemo_rl.algorithms.loss.wrapper.BlockDraftLossFn")
+def test_draft_loss_wrapper_block_dispatch(mock_block_loss_cls):
+    """A block-draft batch routes through BlockDraftLossFn without prepare_fn."""
+    from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
+
+    policy_loss = torch.tensor(1.0)
+    draft_loss = torch.tensor(2.0)
+    next_token_logits = torch.randn(1, 4, 7)
+    block_logits = torch.randn(1, 2, 3, 7)
+    data = BatchedDataDict({"draft_block_logits": block_logits})
+    global_valid = torch.tensor(1)
+
+    policy_loss_fn = MagicMock(return_value=(policy_loss, {}))
+    prepare_fn = MagicMock()
+    block_loss_fn = MagicMock(return_value=(draft_loss, {"draft_loss_slot_0": 2.0}))
+    mock_block_loss_cls.return_value = block_loss_fn
+
+    wrapper = DraftLossWrapper(
+        loss_fn=policy_loss_fn,
+        prepare_fn=prepare_fn,
+        data_dict=data,
+        loss_weight=0.5,
+        draft_loss_kwargs={"slot_weights": [1.0, 0.5, 0.25]},
+    )
+    combined_loss, metrics = wrapper(
+        next_token_logits=next_token_logits,
+        data=data,
+        global_valid_seqs=global_valid,
+        global_valid_toks=global_valid,
+    )
+
+    assert combined_loss.item() == 2.0
+    assert metrics["draft_loss"] == draft_loss.item()
+    prepare_fn.assert_not_called()
+    mock_block_loss_cls.assert_called_once_with(
+        vocab_parallel_group=None, slot_weights=[1.0, 0.5, 0.25]
+    )
+    call_kwargs = block_loss_fn.call_args.kwargs
+    assert torch.equal(call_kwargs["student_block_logits"], block_logits)
+    assert not call_kwargs["teacher_logits"].requires_grad
+
+
+def test_resolve_block_draft_slot_weights_schemes():
+    assert resolve_block_draft_slot_weights(None, 4) == [1.0] * 4
+    assert resolve_block_draft_slot_weights("uniform", 3) == [1.0] * 3
+
+    # gamma=15 <-> block 16: paper gamma_d = 7, so w_1 = e^{-1/7}, w_14 = e^{-2}.
+    weights = resolve_block_draft_slot_weights("exp", 15)
+    assert len(weights) == 15
+    assert weights[0] == 1.0
+    assert math.isclose(weights[1], math.exp(-1 / 7))
+    assert math.isclose(weights[14], math.exp(-2))
+    assert all(a > b for a, b in zip(weights, weights[1:]))
+
+    # Tabulated block sizes: b8 -> gamma_d 4, b10 -> gamma_d 5.
+    assert math.isclose(resolve_block_draft_slot_weights("exp", 7)[1], math.exp(-1 / 4))
+    assert math.isclose(resolve_block_draft_slot_weights("exp", 9)[1], math.exp(-1 / 5))
+    # Interpolated (b9 -> 4.5) and extrapolated (b22 -> 9) block sizes.
+    assert math.isclose(
+        resolve_block_draft_slot_weights("exp", 8)[1], math.exp(-1 / 4.5)
+    )
+    assert math.isclose(
+        resolve_block_draft_slot_weights("exp", 21)[1], math.exp(-1 / 9)
+    )
+
+
+def test_resolve_block_draft_slot_weights_rejects_unknown_scheme():
+    try:
+        resolve_block_draft_slot_weights("linear", 8)
+    except ValueError as err:
+        assert "loss_weighting" in str(err)
+    else:
+        raise AssertionError("expected ValueError for unknown scheme")

--- a/tests/unit/algorithms/test_draft_loss_wrapper.py
+++ b/tests/unit/algorithms/test_draft_loss_wrapper.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
 from unittest.mock import MagicMock, patch
 
-import pytest
 import torch
 
-from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
 def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
     """DraftLossWrapper should add the weighted draft loss to the policy loss."""
     from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
@@ -44,7 +42,6 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.5,
-        ttt_steps=2,
     )
 
     combined_loss, combined_metrics = wrapper(
@@ -60,7 +57,7 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
     assert combined_metrics["policy_metric"] == metrics["policy_metric"]
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
 def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     mock_draft_loss_cls,
 ):
@@ -83,7 +80,6 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.0,
-        ttt_steps=2,
     )
 
     combined_loss, metrics = wrapper(
@@ -97,7 +93,7 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     assert metrics["draft_loss"] == draft_loss.item()
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
 def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
     """The wrapper must hand the global per-pass counts to the draft loss fn."""
     from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
@@ -118,7 +114,6 @@ def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
         loss_weight=1.0,
         draft_loss_kwargs={"pass_weights": [1.0, 0.5]},
         global_draft_pass_counts=draft_pass_counts,
-        ttt_steps=2,
     )
     wrapper(
         next_token_logits=torch.randn(1, 2, 3),
@@ -129,6 +124,7 @@ def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
 
     mock_draft_loss_cls.assert_called_once_with(
         vocab_parallel_group=None,
+        context_parallel_group=None,
         pass_weights=[1.0, 0.5],
     )
     call_kwargs = draft_loss_fn.call_args[1]
@@ -139,7 +135,7 @@ def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
 def test_draft_cross_entropy_loss_uses_distributed_path_for_tp(
     mock_distributed_ce,
 ):
-    """DraftTTTCrossEntropyLossFn should delegate to the chunked distributed CE."""
+    """DraftCrossEntropyLossFn should delegate to the chunked distributed CE."""
     seq_len = 4
     # Pass 1 slices to valid_len = S - 2 = 2 positions.
     teacher_logits = torch.randn(2, seq_len, 5)
@@ -150,7 +146,7 @@ def test_draft_cross_entropy_loss_uses_distributed_path_for_tp(
     per_token_loss = torch.full((2, 2), 2.0)
     mock_distributed_ce.return_value = per_token_loss
 
-    loss_fn = DraftTTTCrossEntropyLossFn(vocab_parallel_group=MagicMock())
+    loss_fn = DraftCrossEntropyLossFn(vocab_parallel_group=MagicMock())
     loss, metrics = loss_fn(
         teacher_logits=teacher_logits,
         student_logits_by_pass=[student_logits],
@@ -168,144 +164,3 @@ def test_draft_cross_entropy_loss_uses_distributed_path_for_tp(
     # 4 valid positions x loss 2.0 / global_valid_toks 4.0
     assert loss.item() == 2.0
     assert metrics["draft_loss_pass_1"] == 2.0
-
-
-def test_roll_packed_seq_dim_respects_segment_boundaries():
-    """The packed roll must not leak rows across padded segment boundaries."""
-    from nemo_rl.algorithms.loss.utils import roll_packed_seq_dim
-
-    cu_seqlens_padded = torch.tensor([0, 4, 8])
-    tensor = torch.arange(1, 9, dtype=torch.float32).reshape(1, 8, 1)
-
-    rolled = roll_packed_seq_dim(tensor, cu_seqlens_padded, seq_dim=1)
-
-    expected = torch.tensor([2.0, 3.0, 4.0, 0.0, 6.0, 7.0, 8.0, 0.0]).reshape(1, 8, 1)
-    assert torch.equal(rolled, expected)
-
-
-def test_pack_rolled_draft_token_mask_clamps_inflated_last_segment():
-    """The packer absorbs bin-alignment padding into the last sequence's
-    effective length, so cu_seqlens can exceed the unpacked row width; only
-    the real tokens may carry mask."""
-    from nemo_rl.algorithms.loss.utils import pack_rolled_draft_token_mask
-
-    token_mask = torch.tensor([[0.0, 1.0, 1.0]])  # row width 3
-    sample_mask = torch.ones(1)
-    cu_seqlens = torch.tensor([0, 5])  # inflated past the row width
-    cu_seqlens_padded = torch.tensor([0, 8])
-
-    packed = pack_rolled_draft_token_mask(
-        token_mask, sample_mask, cu_seqlens, cu_seqlens_padded
-    )
-
-    # Left-shifted real mask at the segment start; every slot past the real
-    # tokens (including the inflated tail) stays zero.
-    expected = torch.tensor([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
-    assert torch.equal(packed, expected)
-
-
-def _zero_policy_loss(
-    next_token_logits, data, global_valid_seqs, global_valid_toks, **kwargs
-):
-    return torch.zeros(()), {}
-
-
-def _build_draft_batch(draft_vocab_size, d2t):
-    """Synthetic 3-sequence batch in both unpacked [B, S] and packed layouts."""
-    torch.manual_seed(17)
-    vocab_size = 11
-    seq_lens = [5, 7, 4]
-    padded_lens = [8, 8, 4]  # per-sequence pad to a multiple of 4
-    max_len = max(seq_lens)
-
-    cu_seqlens = torch.tensor([0, 5, 12, 16])
-    cu_seqlens_padded = torch.tensor([0, 8, 16, 20])
-    total_packed = int(cu_seqlens_padded[-1].item())
-
-    batch_size = len(seq_lens)
-    logits = torch.zeros(batch_size, max_len, vocab_size)
-    student = torch.zeros(batch_size, max_len, draft_vocab_size)
-    token_mask = torch.zeros(batch_size, max_len)
-    for i, seq_len in enumerate(seq_lens):
-        logits[i, :seq_len] = torch.randn(seq_len, vocab_size)
-        student[i, :seq_len] = torch.randn(seq_len, draft_vocab_size)
-        token_mask[i, 2:seq_len] = 1.0  # first two tokens are "prompt"
-    sample_mask = torch.tensor([1.0, 1.0, 0.0])  # last sequence filtered out
-
-    packed_logits = torch.zeros(1, total_packed, vocab_size)
-    packed_student = torch.zeros(1, total_packed, draft_vocab_size)
-    for i, seq_len in enumerate(seq_lens):
-        start = int(cu_seqlens_padded[i].item())
-        packed_logits[0, start : start + seq_len] = logits[i, :seq_len]
-        packed_student[0, start : start + seq_len] = student[i, :seq_len]
-
-    data = BatchedDataDict(
-        {
-            "token_mask": token_mask,
-            "sample_mask": sample_mask,
-            "student_logits": student,
-        }
-    )
-    global_valid_toks = (token_mask * sample_mask.unsqueeze(-1)).sum()
-    return {
-        "logits": logits,
-        "data": data,
-        "packed_logits": packed_logits,
-        "packed_student": packed_student,
-        "cu_seqlens": cu_seqlens,
-        "cu_seqlens_padded": cu_seqlens_padded,
-        "global_valid_toks": global_valid_toks,
-        "d2t": d2t,
-        "padded_lens": padded_lens,
-    }
-
-
-@pytest.mark.parametrize(
-    "draft_vocab_size,d2t",
-    [
-        (11, None),  # full-vocab draft (scratch)
-        (5, torch.tensor([0, 2, 4, 5, 6])),  # pruned draft vocab (d2t mapping)
-    ],
-)
-def test_packed_draft_loss_matches_unpacked(draft_vocab_size, d2t):
-    """The packed draft CE must equal the unpacked reference on the same batch."""
-    from nemo_rl.algorithms.loss.utils import prepare_loss_input
-    from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
-
-    batch = _build_draft_batch(draft_vocab_size, d2t)
-
-    reference_wrapper = DraftLossWrapper(
-        loss_fn=_zero_policy_loss,
-        prepare_fn=partial(
-            prepare_loss_input, sampling_params=None, d2t=d2t, chunk_size=None
-        ),
-        data_dict=batch["data"],
-    )
-    reference_loss, reference_metrics = reference_wrapper(
-        next_token_logits=batch["logits"],
-        data=batch["data"],
-        global_valid_seqs=None,
-        global_valid_toks=batch["global_valid_toks"],
-    )
-
-    packed_wrapper = DraftLossWrapper(
-        loss_fn=_zero_policy_loss,
-        prepare_fn=None,
-        data_dict=batch["data"],
-        cu_seqlens_q=batch["cu_seqlens"],
-        cu_seqlens_q_padded=batch["cu_seqlens_padded"],
-        d2t=d2t,
-        student_logits=batch["packed_student"],
-    )
-    packed_loss, packed_metrics = packed_wrapper(
-        next_token_logits=batch["packed_logits"],
-        data=batch["data"],
-        global_valid_seqs=None,
-        global_valid_toks=batch["global_valid_toks"],
-    )
-
-    assert torch.allclose(packed_loss, reference_loss, rtol=1e-5, atol=1e-6)
-    assert packed_metrics["draft_loss"] == pytest.approx(
-        reference_metrics["draft_loss"], rel=1e-5
-    )
-    assert packed_metrics["draft_loss"] > 0.0

--- a/tests/unit/algorithms/test_draft_loss_wrapper.py
+++ b/tests/unit/algorithms/test_draft_loss_wrapper.py
@@ -18,11 +18,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
 def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
     """DraftLossWrapper should add the weighted draft loss to the policy loss."""
     from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
@@ -36,7 +36,7 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
 
     policy_loss_fn = MagicMock(return_value=(policy_loss, metrics.copy()))
     prepare_fn = MagicMock(return_value=({"prepared": torch.tensor(1.0)}, data))
-    draft_loss_fn = MagicMock(return_value=draft_loss)
+    draft_loss_fn = MagicMock(return_value=(draft_loss, {"draft_loss_pass_1": 2.0}))
     mock_draft_loss_cls.return_value = draft_loss_fn
 
     wrapper = DraftLossWrapper(
@@ -44,6 +44,7 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.5,
+        ttt_steps=2,
     )
 
     combined_loss, combined_metrics = wrapper(
@@ -55,10 +56,11 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
 
     assert combined_loss.item() == 4.0
     assert combined_metrics["draft_loss"] == draft_loss.item()
+    assert combined_metrics["draft_loss_pass_1"] == 2.0
     assert combined_metrics["policy_metric"] == metrics["policy_metric"]
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
 def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     mock_draft_loss_cls,
 ):
@@ -73,7 +75,7 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
 
     policy_loss_fn = MagicMock(return_value=(policy_loss, {}))
     prepare_fn = MagicMock(return_value=({"prepared": torch.tensor(1.0)}, data))
-    draft_loss_fn = MagicMock(return_value=draft_loss)
+    draft_loss_fn = MagicMock(return_value=(draft_loss, {}))
     mock_draft_loss_cls.return_value = draft_loss_fn
 
     wrapper = DraftLossWrapper(
@@ -81,6 +83,7 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.0,
+        ttt_steps=2,
     )
 
     combined_loss, metrics = wrapper(
@@ -94,31 +97,77 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     assert metrics["draft_loss"] == draft_loss.item()
 
 
-@patch("nemo_rl.algorithms.loss.loss_functions.DistributedCrossEntropy.apply")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
+def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
+    """The wrapper must hand the global per-pass counts to the draft loss fn."""
+    from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
+
+    data = BatchedDataDict({})
+    global_valid = torch.tensor(1)
+    draft_pass_counts = torch.tensor([42.0, 17.0])
+
+    policy_loss_fn = MagicMock(return_value=(torch.tensor(1.0), {}))
+    prepare_fn = MagicMock(return_value=({}, data))
+    draft_loss_fn = MagicMock(return_value=(torch.tensor(0.5), {}))
+    mock_draft_loss_cls.return_value = draft_loss_fn
+
+    wrapper = DraftLossWrapper(
+        loss_fn=policy_loss_fn,
+        prepare_fn=prepare_fn,
+        data_dict=data,
+        loss_weight=1.0,
+        draft_loss_kwargs={"pass_weights": [1.0, 0.5]},
+        global_draft_pass_counts=draft_pass_counts,
+        ttt_steps=2,
+    )
+    wrapper(
+        next_token_logits=torch.randn(1, 2, 3),
+        data=data,
+        global_valid_seqs=global_valid,
+        global_valid_toks=global_valid,
+    )
+
+    mock_draft_loss_cls.assert_called_once_with(
+        vocab_parallel_group=None,
+        pass_weights=[1.0, 0.5],
+    )
+    call_kwargs = draft_loss_fn.call_args[1]
+    assert call_kwargs["global_draft_pass_counts"] is draft_pass_counts
+
+
+@patch("nemo_rl.algorithms.loss.loss_functions.ChunkedDistributedCrossEntropy.apply")
 def test_draft_cross_entropy_loss_uses_distributed_path_for_tp(
     mock_distributed_ce,
 ):
-    """DraftCrossEntropyLossFn should delegate to DistributedCrossEntropy under TP."""
-    teacher_logits = torch.randn(2, 3, 5)
-    student_logits = torch.randn(2, 3, 5)
-    token_mask = torch.ones(2, 3)
+    """DraftTTTCrossEntropyLossFn should delegate to the chunked distributed CE."""
+    seq_len = 4
+    # Pass 1 slices to valid_len = S - 2 = 2 positions.
+    teacher_logits = torch.randn(2, seq_len, 5)
+    student_logits = torch.randn(2, seq_len, 5)
+    token_mask = torch.ones(2, seq_len)
     sample_mask = torch.ones(2)
-    global_valid = torch.tensor(6.0)
-    per_token_loss = torch.full((2, 3), 2.0)
+    global_valid = torch.tensor(4.0)
+    per_token_loss = torch.full((2, 2), 2.0)
     mock_distributed_ce.return_value = per_token_loss
 
-    loss_fn = DraftCrossEntropyLossFn(vocab_parallel_group=MagicMock())
-    loss = loss_fn(
+    loss_fn = DraftTTTCrossEntropyLossFn(vocab_parallel_group=MagicMock())
+    loss, metrics = loss_fn(
         teacher_logits=teacher_logits,
-        student_logits=student_logits,
-        token_mask=token_mask,
-        data=BatchedDataDict({"sample_mask": sample_mask}),
+        student_logits_by_pass=[student_logits],
+        data=BatchedDataDict({"sample_mask": sample_mask, "token_mask": token_mask}),
         global_valid_seqs=global_valid,
         global_valid_toks=global_valid,
     )
 
     mock_distributed_ce.assert_called_once()
+    student_arg, teacher_arg = mock_distributed_ce.call_args[0][:2]
+    assert student_arg.shape == (2, 2, 5)
+    assert teacher_arg.shape == (2, 2, 5)
+    assert torch.equal(student_arg, student_logits[:, :2])
+    assert torch.equal(teacher_arg, teacher_logits[:, 1:3])
+    # 4 valid positions x loss 2.0 / global_valid_toks 4.0
     assert loss.item() == 2.0
+    assert metrics["draft_loss_pass_1"] == 2.0
 
 
 def test_roll_packed_seq_dim_respects_segment_boundaries():

--- a/tests/unit/algorithms/test_draft_ttt_loss.py
+++ b/tests/unit/algorithms/test_draft_ttt_loss.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Index/mask/normalization tests for the multi-pass (TTT) draft loss.
+
+Convention under test: pass-d student logits at position ``i`` predict token
+``x_{i+d+1}``; the teacher is the policy's logits at position ``i + d``; the
+mask is ``token_mask[i + d + 1] * sample_mask``.
+"""
+
+import torch
+
+from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
+from nemo_rl.algorithms.loss.utils import (
+    compute_draft_pass_valid_counts,
+    draft_pass_token_mask,
+    prepare_loss_input,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _soft_ce(student_row: torch.Tensor, teacher_row: torch.Tensor) -> torch.Tensor:
+    teacher_probs = torch.softmax(teacher_row, dim=-1)
+    student_log_probs = torch.log_softmax(student_row, dim=-1)
+    return -(teacher_probs * student_log_probs).sum(dim=-1)
+
+
+def _manual_draft_loss(
+    teacher_logits: torch.Tensor,
+    student_logits_by_pass: list[torch.Tensor],
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    pass_weights: list[float],
+    denominator: float,
+) -> float:
+    """Direct positional transcription of the pass-d index convention."""
+    batch_size, seq_len, _ = teacher_logits.shape
+    total = 0.0
+    for pass_index, student_logits in enumerate(student_logits_by_pass):
+        ttt_pass = pass_index + 1
+        for b in range(batch_size):
+            for i in range(seq_len):
+                target_index = i + ttt_pass + 1
+                if target_index >= seq_len:
+                    continue
+                mask = float(token_mask[b, target_index]) * float(sample_mask[b])
+                if mask == 0.0:
+                    continue
+                ce = _soft_ce(
+                    student_logits[b, i], teacher_logits[b, i + ttt_pass]
+                ).item()
+                total += pass_weights[pass_index] * ce * mask
+    return total / max(denominator, 1.0)
+
+
+def test_draft_pass_token_mask_is_shifted_by_pass_plus_one():
+    token_mask = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]])
+    assert torch.equal(draft_pass_token_mask(token_mask, 1), token_mask[:, 2:])
+    assert torch.equal(draft_pass_token_mask(token_mask, 2), token_mask[:, 3:])
+    assert draft_pass_token_mask(token_mask, 5).shape == (1, 0)
+
+
+def test_compute_draft_pass_valid_counts_counts_shifted_masks():
+    token_mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0]])
+    sample_mask = torch.tensor([1.0, 0.0])
+    # Pass 1: token_mask[:, 2:] -> row0 [1,0,1]*1 = 2, row1 masked out = 0.
+    # Pass 2: token_mask[:, 3:] -> row0 [0,1]*1 = 1, row1 = 0.
+    counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=2)
+    assert counts.tolist() == [2.0, 1.0]
+
+
+def test_single_pass_loss_matches_manual_soft_ce():
+    torch.manual_seed(0)
+    batch_size, seq_len, vocab = 2, 6, 7
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, seq_len, vocab)
+    token_mask = torch.tensor(
+        [[0.0, 1.0, 1.0, 1.0, 0.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+    )
+    sample_mask = torch.tensor([1.0, 1.0])
+    pass_counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=1)
+
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss, _ = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=[student],
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=pass_counts,
+    )
+    expected = _manual_draft_loss(
+        teacher, [student], token_mask, sample_mask, [1.0], pass_counts[0].item()
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_multi_pass_loss_applies_weights_and_draft_denominator():
+    torch.manual_seed(1)
+    batch_size, seq_len, vocab = 2, 8, 5
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    students = [torch.randn(batch_size, seq_len, vocab) for _ in range(3)]
+    token_mask = (torch.rand(batch_size, seq_len) > 0.3).float()
+    sample_mask = torch.tensor([1.0, 1.0])
+    pass_weights = [1.0, 0.5, 0.25]
+    pass_counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=3)
+    denominator = sum(
+        w * c for w, c in zip(pass_weights, pass_counts.tolist(), strict=True)
+    )
+
+    loss_fn = DraftTTTCrossEntropyLossFn(pass_weights=pass_weights)
+    loss, metrics = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=students,
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=pass_counts,
+    )
+    expected = _manual_draft_loss(
+        teacher, students, token_mask, sample_mask, pass_weights, denominator
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+    # Per-pass metrics are pass_sum / global pass count so the driver's
+    # sum-over-microbatches aggregation yields a global per-token mean.
+    for ttt_pass in (1, 2, 3):
+        expected_metric = _manual_draft_loss(
+            teacher,
+            [torch.zeros_like(students[0])] * (ttt_pass - 1) + [students[ttt_pass - 1]],
+            token_mask,
+            sample_mask,
+            [0.0] * (ttt_pass - 1) + [1.0],
+            pass_counts[ttt_pass - 1].item(),
+        )
+        torch.testing.assert_close(
+            metrics[f"draft_loss_pass_{ttt_pass}"],
+            expected_metric,
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+
+def test_masked_positions_do_not_affect_loss():
+    torch.manual_seed(2)
+    batch_size, seq_len, vocab = 1, 6, 5
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, seq_len, vocab)
+    token_mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0, 0.0]])
+    sample_mask = torch.tensor([1.0])
+    data = BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask})
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    kwargs = dict(
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([3.0]),
+    )
+
+    loss_a, _ = loss_fn(
+        teacher_logits=teacher, student_logits_by_pass=[student], data=data, **kwargs
+    )
+
+    # Pass 1 position i is masked iff token_mask[i + 2] == 0: perturb the
+    # student at masked positions (i = 1, 3, 4, 5) and the loss must not move.
+    student_perturbed = student.clone()
+    student_perturbed[0, 1] += 100.0
+    student_perturbed[0, 3:] -= 50.0
+    loss_b, _ = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=[student_perturbed],
+        data=data,
+        **kwargs,
+    )
+    torch.testing.assert_close(loss_a.item(), loss_b.item(), atol=1e-6, rtol=1e-6)
+
+
+def test_out_of_bounds_pass_is_skipped():
+    torch.manual_seed(3)
+    seq_len = 3
+    teacher = torch.randn(1, seq_len, 4)
+    students = [torch.randn(1, seq_len, 4) for _ in range(3)]
+    token_mask = torch.ones(1, seq_len)
+    sample_mask = torch.ones(1)
+
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss, metrics = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=students,
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([1.0, 0.0, 0.0]),
+    )
+    # Passes 2 and 3 have no in-bounds target (S - d - 1 <= 0) and contribute 0.
+    assert torch.isfinite(loss)
+    assert metrics["draft_loss_pass_2"] == 0.0
+    assert metrics["draft_loss_pass_3"] == 0.0
+    expected = _manual_draft_loss(
+        teacher, students, token_mask, sample_mask, [1.0, 1.0, 1.0], 1.0
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_chunked_ce_matches_unchunked_loss_and_grads():
+    """Sequence-chunked soft CE must match the single-chunk result exactly.
+
+    Covers both the loss value and the gradient w.r.t. the student logits
+    (the chunked Function recomputes softmaxes in backward instead of saving
+    the fp32 probability tensors).
+    """
+    torch.manual_seed(4)
+    batch_size, seq_len, vocab = 2, 11, 6
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    students = [
+        torch.randn(batch_size, seq_len, vocab, requires_grad=True) for _ in range(2)
+    ]
+    token_mask = (torch.rand(batch_size, seq_len) > 0.2).float()
+    sample_mask = torch.ones(batch_size)
+    data = BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask})
+    kwargs = dict(
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([4.0, 3.0]),
+    )
+
+    # Single chunk covers the whole sequence.
+    loss_a, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=seq_len)(
+        teacher_logits=teacher,
+        student_logits_by_pass=list(students),
+        data=data,
+        **kwargs,
+    )
+    grads_a = torch.autograd.grad(loss_a, students, retain_graph=False)
+
+    # Uneven multi-chunk split (11 = 3 + 3 + 3 + 2).
+    loss_b, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=3)(
+        teacher_logits=teacher,
+        student_logits_by_pass=list(students),
+        data=data,
+        **kwargs,
+    )
+    grads_b = torch.autograd.grad(loss_b, students)
+
+    torch.testing.assert_close(loss_a, loss_b, atol=1e-6, rtol=1e-6)
+    for grad_a, grad_b in zip(grads_a, grads_b):
+        torch.testing.assert_close(grad_a, grad_b, atol=1e-6, rtol=1e-6)
+
+
+def test_chunked_ce_grad_matches_plain_autograd():
+    """Hand-rolled chunked backward vs plain torch autograd on the same math."""
+    from nemo_rl.distributed.model_utils import ChunkedDistributedCrossEntropy
+
+    torch.manual_seed(5)
+    student = torch.randn(1, 9, 5, requires_grad=True)
+    teacher = torch.randn(1, 9, 5)
+    weights = torch.rand(1, 9)
+
+    per_token = ChunkedDistributedCrossEntropy.apply(student, teacher, 4, None, False)
+    (per_token * weights).sum().backward()
+
+    student_ref = student.detach().clone().requires_grad_()
+    ce_ref = -(
+        torch.softmax(teacher, dim=-1) * torch.log_softmax(student_ref, dim=-1)
+    ).sum(-1)
+    (ce_ref * weights).sum().backward()
+
+    torch.testing.assert_close(student.grad, student_ref.grad, atol=1e-6, rtol=1e-6)
+
+
+def test_prepare_loss_input_keeps_teacher_unshifted_and_detached():
+    logits = torch.randn(1, 5, 6, requires_grad=True)
+    student = torch.randn(1, 5, 6)
+    data = BatchedDataDict(
+        {
+            "student_logits_by_pass": [student, student],
+            "token_mask": torch.ones(1, 5),
+            "sample_mask": torch.ones(1),
+        }
+    )
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_input, _ = prepare_loss_input(logits=logits, data=data, loss_fn=loss_fn)
+
+    assert torch.equal(loss_input["teacher_logits"], logits.detach())
+    assert not loss_input["teacher_logits"].requires_grad
+    assert len(loss_input["student_logits_by_pass"]) == 2

--- a/tests/unit/algorithms/test_draft_ttt_loss.py
+++ b/tests/unit/algorithms/test_draft_ttt_loss.py
@@ -21,7 +21,7 @@ mask is ``token_mask[i + d + 1] * sample_mask``.
 
 import torch
 
-from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
 from nemo_rl.algorithms.loss.utils import (
     compute_draft_pass_valid_counts,
     draft_pass_token_mask,
@@ -91,7 +91,7 @@ def test_single_pass_loss_matches_manual_soft_ce():
     sample_mask = torch.tensor([1.0, 1.0])
     pass_counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=1)
 
-    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_fn = DraftCrossEntropyLossFn()
     loss, _ = loss_fn(
         teacher_logits=teacher,
         student_logits_by_pass=[student],
@@ -119,7 +119,7 @@ def test_multi_pass_loss_applies_weights_and_draft_denominator():
         w * c for w, c in zip(pass_weights, pass_counts.tolist(), strict=True)
     )
 
-    loss_fn = DraftTTTCrossEntropyLossFn(pass_weights=pass_weights)
+    loss_fn = DraftCrossEntropyLossFn(pass_weights=pass_weights)
     loss, metrics = loss_fn(
         teacher_logits=teacher,
         student_logits_by_pass=students,
@@ -159,7 +159,7 @@ def test_masked_positions_do_not_affect_loss():
     token_mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0, 0.0]])
     sample_mask = torch.tensor([1.0])
     data = BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask})
-    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_fn = DraftCrossEntropyLossFn()
     kwargs = dict(
         global_valid_seqs=torch.tensor(1.0),
         global_valid_toks=torch.tensor(1.0),
@@ -192,7 +192,7 @@ def test_out_of_bounds_pass_is_skipped():
     token_mask = torch.ones(1, seq_len)
     sample_mask = torch.ones(1)
 
-    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_fn = DraftCrossEntropyLossFn()
     loss, metrics = loss_fn(
         teacher_logits=teacher,
         student_logits_by_pass=students,
@@ -234,7 +234,7 @@ def test_chunked_ce_matches_unchunked_loss_and_grads():
     )
 
     # Single chunk covers the whole sequence.
-    loss_a, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=seq_len)(
+    loss_a, _ = DraftCrossEntropyLossFn(seq_chunk_size=seq_len)(
         teacher_logits=teacher,
         student_logits_by_pass=list(students),
         data=data,
@@ -243,7 +243,7 @@ def test_chunked_ce_matches_unchunked_loss_and_grads():
     grads_a = torch.autograd.grad(loss_a, students, retain_graph=False)
 
     # Uneven multi-chunk split (11 = 3 + 3 + 3 + 2).
-    loss_b, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=3)(
+    loss_b, _ = DraftCrossEntropyLossFn(seq_chunk_size=3)(
         teacher_logits=teacher,
         student_logits_by_pass=list(students),
         data=data,
@@ -287,9 +287,26 @@ def test_prepare_loss_input_keeps_teacher_unshifted_and_detached():
             "sample_mask": torch.ones(1),
         }
     )
-    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_fn = DraftCrossEntropyLossFn()
     loss_input, _ = prepare_loss_input(logits=logits, data=data, loss_fn=loss_fn)
 
     assert torch.equal(loss_input["teacher_logits"], logits.detach())
     assert not loss_input["teacher_logits"].requires_grad
     assert len(loss_input["student_logits_by_pass"]) == 2
+
+
+def test_prepare_loss_input_falls_back_to_single_pass_key():
+    logits = torch.randn(1, 4, 6)
+    student = torch.randn(1, 4, 6)
+    data = BatchedDataDict(
+        {
+            "student_logits": student,
+            "token_mask": torch.ones(1, 4),
+            "sample_mask": torch.ones(1),
+        }
+    )
+    loss_fn = DraftCrossEntropyLossFn()
+    loss_input, _ = prepare_loss_input(logits=logits, data=data, loss_fn=loss_fn)
+
+    assert len(loss_input["student_logits_by_pass"]) == 1
+    assert loss_input["student_logits_by_pass"][0] is student

--- a/tests/unit/models/generation/test_vllm_draft_lm_head_unshare.py
+++ b/tests/unit/models/generation/test_vllm_draft_lm_head_unshare.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Un-sharing the vLLM drafter lm_head before draft refit.
+
+vLLM 0.26's spec-decode proposer aliases the drafter's ``lm_head`` module to
+the target's when their weights are identical at engine init
+(``SpecDecodeBaseProposer._maybe_share_lm_head``). With a co-training draft,
+loading the trained (diverged) draft head through that alias would overwrite
+the serving target's head. ``_unshare_draft_lm_head`` must detect the alias
+and give the drafter private storage — and must not touch anything otherwise.
+"""
+
+import types
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.vllm
+
+pytest.importorskip("vllm", reason="vllm_backend requires a vLLM install")
+
+from nemo_rl.models.generation.vllm.vllm_backend import (  # noqa: E402
+    VllmInternalWorkerExtension,
+)
+
+
+def _make_backend(target_lm_head):
+    backend = types.SimpleNamespace(
+        model_runner=types.SimpleNamespace(
+            model=types.SimpleNamespace(lm_head=target_lm_head)
+        )
+    )
+    backend._unshare_draft_lm_head = types.MethodType(
+        VllmInternalWorkerExtension._unshare_draft_lm_head, backend
+    )
+    return backend
+
+
+def _lm_head(weight):
+    head = torch.nn.Module()
+    head.weight = torch.nn.Parameter(weight, requires_grad=False)
+    return head
+
+
+def test_aliased_lm_head_is_unshared_and_target_protected():
+    target_head = _lm_head(torch.randn(16, 8))
+    # vLLM attaches loader metadata to parameters via set_weight_attrs; the
+    # private copy must keep it, or the next load_weights on the drafter fails.
+    target_head.weight.weight_loader = lambda param, loaded: None
+    draft_model = types.SimpleNamespace(lm_head=target_head)  # vLLM-style alias
+    backend = _make_backend(target_head)
+
+    backend._unshare_draft_lm_head(draft_model)
+
+    assert draft_model.lm_head is not target_head
+    assert (
+        draft_model.lm_head.weight.untyped_storage().data_ptr()
+        != target_head.weight.untyped_storage().data_ptr()
+    )
+    torch.testing.assert_close(draft_model.lm_head.weight, target_head.weight)
+    assert draft_model.lm_head.weight.weight_loader is target_head.weight.weight_loader
+
+    # A subsequent draft-head update must leave the target untouched.
+    before = target_head.weight.detach().clone()
+    with torch.no_grad():
+        draft_model.lm_head.weight += 1.0
+    torch.testing.assert_close(target_head.weight.detach(), before)
+
+
+def test_distinct_lm_head_is_left_alone():
+    target_head = _lm_head(torch.randn(16, 8))
+    own_head = _lm_head(torch.randn(16, 8))
+    draft_model = types.SimpleNamespace(lm_head=own_head)
+    backend = _make_backend(target_head)
+
+    backend._unshare_draft_lm_head(draft_model)
+
+    assert draft_model.lm_head is own_head  # no copy when not aliased
+
+
+def test_missing_lm_head_is_a_noop():
+    backend = _make_backend(target_lm_head=None)
+    draft_model = types.SimpleNamespace()
+    backend._unshare_draft_lm_head(draft_model)  # must not raise
+
+
+def _make_refit_backend(model_runner):
+    backend = types.SimpleNamespace(model_runner=model_runner)
+    backend._get_drafter_model = types.MethodType(
+        VllmInternalWorkerExtension._get_drafter_model, backend
+    )
+    backend._load_draft_weights = types.MethodType(
+        VllmInternalWorkerExtension._load_draft_weights, backend
+    )
+    return backend
+
+
+def test_speculator_attribute_is_a_drafter_fallback():
+    # The V2 model runner names the owner `speculator` instead of `drafter`.
+    model = types.SimpleNamespace()
+    runner = types.SimpleNamespace(
+        drafter=None, speculator=types.SimpleNamespace(model=model)
+    )
+    assert _make_refit_backend(runner)._get_drafter_model() is model
+
+
+def test_missing_drafter_raises_on_last_pp_rank(monkeypatch):
+    import nemo_rl.models.generation.vllm.vllm_backend as vllm_backend_module
+
+    monkeypatch.setattr(
+        vllm_backend_module,
+        "get_pp_group",
+        lambda: types.SimpleNamespace(is_last_rank=True),
+    )
+    backend = _make_refit_backend(types.SimpleNamespace(drafter=None))
+    with pytest.raises(RuntimeError, match="no vLLM drafter"):
+        backend._load_draft_weights([("lm_head.weight", torch.zeros(1))])
+
+
+def test_missing_drafter_is_expected_on_earlier_pp_ranks(monkeypatch):
+    import nemo_rl.models.generation.vllm.vllm_backend as vllm_backend_module
+
+    monkeypatch.setattr(
+        vllm_backend_module,
+        "get_pp_group",
+        lambda: types.SimpleNamespace(is_last_rank=False),
+    )
+    backend = _make_refit_backend(types.SimpleNamespace(drafter=None))
+    backend._load_draft_weights([("lm_head.weight", torch.zeros(1))])  # must not raise

--- a/tests/unit/models/megatron/test_block_attention.py
+++ b/tests/unit/models/megatron/test_block_attention.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Numeric equivalence tests for the DFlash block draft attention.
+"""Numeric equivalence tests for the DFlash/DSpark block draft attention.
 
 The custom two-part (bucketed dense FA + varlen FA, joint-LSE merged)
 attention must match a dense fp32 softmax over the explicit staircase mask —
@@ -188,7 +188,8 @@ def test_trunk_kv_weight_slice_matches_deinterleave():
 
 
 @requires_gpu_flash
-def test_block_draft_model_forward_backward(tmp_path):
+@pytest.mark.parametrize("method", ["dflash", "dspark"])
+def test_block_draft_model_forward_backward(method, tmp_path):
     """End-to-end module smoke: taps -> trunk KV -> block stream -> logits."""
     import torch.distributed as dist
     from megatron.core import parallel_state
@@ -196,6 +197,7 @@ def test_block_draft_model_forward_backward(tmp_path):
     from megatron.core.transformer import TransformerConfig
 
     from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+    from nemo_rl.models.megatron.draft.dspark import DSparkDraftModel
 
     created_process_group = False
     try:
@@ -250,7 +252,10 @@ def test_block_draft_model_forward_backward(tmp_path):
             target_hidden_size=target_hidden,
             trunk_chunk=8,
         )
-        model = DFlashDraftModel(**shared_kwargs).cuda()
+        if method == "dflash":
+            model = DFlashDraftModel(**shared_kwargs).cuda()
+        else:
+            model = DSparkDraftModel(markov_rank=8, **shared_kwargs).cuda()
 
         seq_len, batch = 32, 2
         taps = torch.randn(
@@ -266,6 +271,11 @@ def test_block_draft_model_forward_backward(tmp_path):
         lm_head_weight = torch.randn(vocab, hidden, device="cuda", dtype=torch.bfloat16)
         mask_embedding = torch.randn(hidden, device="cuda", dtype=torch.bfloat16)
 
+        method_kwargs = {}
+        if method == "dspark":
+            method_kwargs["input_ids"] = torch.randint(
+                0, vocab, (batch, seq_len), device="cuda"
+            )
         out = model(
             taps=taps,
             input_embeds=embeds,
@@ -273,10 +283,18 @@ def test_block_draft_model_forward_backward(tmp_path):
             anchor_valid=anchor_valid,
             lm_head_weight=lm_head_weight,
             mask_embedding=mask_embedding,
+            **method_kwargs,
         )
-        logits = out
-        expected_width = gamma + 1
-        loss = logits.float().sum()
+        if method == "dflash":
+            logits = out
+            expected_width = gamma + 1
+            loss = logits.float().sum()
+        else:
+            # Markov-biased logits + confidence prediction, both from forward.
+            logits, confidence_pred = out
+            expected_width = gamma
+            assert confidence_pred.shape == (batch, anchors.shape[1], gamma)
+            loss = logits.float().sum() + confidence_pred.sum()
         assert logits.shape == (batch, anchors.shape[1], expected_width, vocab)
         loss.backward()
 
@@ -285,6 +303,116 @@ def test_block_draft_model_forward_backward(tmp_path):
         assert torch.isfinite(model.fc.weight.grad).all()
         qkv_grad = model.decoder.layers[0].self_attention.linear_qkv.weight.grad
         assert qkv_grad is not None and torch.isfinite(qkv_grad).all()
+        if method == "dspark":
+            assert model.markov_w1.weight.grad is not None
+            assert model.markov_w2.weight.grad is not None
+            assert model.confidence_head.weight.grad is not None
+    finally:
+        parallel_state.destroy_model_parallel()
+        if created_process_group and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@requires_gpu_flash
+def test_dspark_hf_checkpoint_roundtrip(tmp_path):
+    """export -> safetensors -> load restores every tensor (markov +
+    confidence heads included) with no missing/unexpected keys."""
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+    from megatron.core.transformer import TransformerConfig
+    from safetensors.torch import save_file
+
+    from nemo_rl.models.megatron.draft.dspark import DSparkDraftModel
+    from nemo_rl.models.megatron.draft.utils import (
+        export_block_draft_weights_to_hf,
+        load_hf_weights_to_block_draft,
+    )
+
+    created_process_group = False
+    try:
+        torch.cuda.set_device(0)
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmp_path / 'mcore_pg_init'}",
+            )
+            created_process_group = True
+        parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+        model_parallel_cuda_manual_seed(123)
+        torch.manual_seed(7)
+
+        hidden, target_hidden, vocab = 64, 96, 128
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=hidden,
+            ffn_hidden_size=128,
+            num_attention_heads=4,
+            num_query_groups=2,
+            kv_channels=16,
+            normalization="RMSNorm",
+            activation_func=torch.nn.functional.silu,
+            gated_linear_unit=True,
+            add_bias_linear=False,
+            qk_layernorm=True,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.bfloat16,
+        )
+        config.vocab_size = vocab
+        config.draft_vocab_size = vocab
+        config.apply_rope_fusion = False
+        config.rotary_base = 10000
+        config.gradient_accumulation_fusion = False
+
+        model = DSparkDraftModel(
+            config=config,
+            gamma=3,
+            mask_token_id=vocab - 1,
+            num_aux_hidden_states=3,
+            target_hidden_size=target_hidden,
+            trunk_chunk=8,
+            markov_rank=8,
+        ).cuda()
+
+        hf_state = dict(export_block_draft_weights_to_hf(model))
+        for key in (
+            "confidence_head.proj.weight",
+            "confidence_head.proj.bias",
+            "markov_head.markov_w1.weight",
+            "markov_head.markov_w2.weight",
+        ):
+            assert key in hf_state, key
+        ckpt_dir = tmp_path / "dspark_ckpt"
+        ckpt_dir.mkdir()
+        save_file(
+            {k: v.contiguous().cpu() for k, v in hf_state.items()},
+            str(ckpt_dir / "model.safetensors"),
+        )
+
+        reference = {
+            k: v.clone()
+            for k, v in model.state_dict().items()
+            if "_extra_state" not in k
+        }
+        with torch.no_grad():
+            for p in model.parameters():
+                p.normal_()
+        missing, unexpected = load_hf_weights_to_block_draft(model, str(ckpt_dir))
+        missing = [k for k in missing if "_extra_state" not in k]
+        unexpected = [k for k in unexpected if "_extra_state" not in k]
+        assert not missing and not unexpected, (missing, unexpected)
+        restored = model.state_dict()
+        for key, ref in reference.items():
+            torch.testing.assert_close(restored[key], ref, rtol=0, atol=0)
     finally:
         parallel_state.destroy_model_parallel()
         if created_process_group and dist.is_initialized():

--- a/tests/unit/models/megatron/test_block_attention.py
+++ b/tests/unit/models/megatron/test_block_attention.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numeric equivalence tests for the DFlash block draft attention.
+
+The custom two-part (bucketed dense FA + varlen FA, joint-LSE merged)
+attention must match a dense fp32 softmax over the explicit staircase mask —
+forward and gradients — including the edge cases: empty trunk (anchor 0),
+anchor below one chunk (no dense part), and anchors spread over multiple
+chunk buckets.
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mcore
+
+from nemo_rl.models.megatron.draft.dflash import (  # noqa: E402
+    block_draft_attention,
+)
+from nemo_rl.models.megatron.draft.utils import (  # noqa: E402
+    _deinterleave_qkv,
+    _interleave_qkv,
+)
+
+requires_gpu_flash = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA + flash-attn"
+)
+
+
+def _dense_reference(q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, scale):
+    """Per-block fp32 softmax over [trunk[:p]; own block] (bidirectional)."""
+    num_blocks, block_width, num_q_heads, _ = q.shape
+    num_kv_heads = k_own.shape[2]
+    group = num_q_heads // num_kv_heads
+    outs = []
+    for block in range(num_blocks):
+        row = int(block_row[block])
+        prefix = int(vis_len[block])
+        keys = torch.cat([trunk_k[row, :prefix], k_own[block]], dim=0).float()
+        vals = torch.cat([trunk_v[row, :prefix], v_own[block]], dim=0).float()
+        keys = keys.repeat_interleave(group, dim=1)
+        vals = vals.repeat_interleave(group, dim=1)
+        scores = torch.einsum("whd,lhd->hwl", q[block].float(), keys) * scale
+        probs = torch.softmax(scores, dim=-1)
+        outs.append(torch.einsum("hwl,lhd->whd", probs, vals))
+    return torch.stack(outs)
+
+
+def _make_inputs(vis_len_values, *, block_width=4, seq_len=64, batch=2, seed=0):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_q_heads, num_kv_heads, head_dim = 4, 2, 32
+    vis_len = torch.tensor(vis_len_values, device=device, dtype=torch.int64)
+    num_blocks = vis_len.shape[0]
+    block_row = torch.arange(num_blocks, device=device) % batch
+
+    def leaf(*shape):
+        return torch.randn(*shape, device=device, dtype=dtype).requires_grad_(True)
+
+    q = leaf(num_blocks, block_width, num_q_heads, head_dim)
+    k_own = leaf(num_blocks, block_width, num_kv_heads, head_dim)
+    v_own = leaf(num_blocks, block_width, num_kv_heads, head_dim)
+    trunk_k = leaf(batch, seq_len, num_kv_heads, head_dim)
+    trunk_v = leaf(batch, seq_len, num_kv_heads, head_dim)
+    return q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len
+
+
+@requires_gpu_flash
+@pytest.mark.parametrize(
+    "vis_len_values,chunk",
+    [
+        # Multi-bucket: full chunks + partial remainders (chunk=16, S=64).
+        ([5, 17, 33, 48, 63, 21], 16),
+        # Everything below one chunk: dense part A never runs.
+        ([0, 1, 7, 15], 16),
+        # Exactly on chunk boundaries: empty partial remainders.
+        ([16, 32, 48, 0], 16),
+    ],
+)
+def test_block_attention_matches_dense_reference(vis_len_values, chunk):
+    q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len = _make_inputs(vis_len_values)
+    scale = q.shape[-1] ** -0.5
+
+    out = block_draft_attention(
+        q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, chunk=chunk
+    )
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+    grads = [t.grad.clone() for t in (q, k_own, v_own, trunk_k, trunk_v)]
+    for t in (q, k_own, v_own, trunk_k, trunk_v):
+        t.grad = None
+
+    ref_inputs = [
+        t.detach().clone().requires_grad_(True)
+        for t in (q, k_own, v_own, trunk_k, trunk_v)
+    ]
+    ref_out = _dense_reference(*ref_inputs, block_row, vis_len, scale)
+    ref_out.backward(grad_out.float())
+    ref_grads = [t.grad.clone() for t in ref_inputs]
+
+    torch.testing.assert_close(out.float(), ref_out, atol=2e-2, rtol=2e-2)
+    names = ["q", "k_own", "v_own", "trunk_k", "trunk_v"]
+    for name, grad, ref_grad in zip(names, grads, ref_grads):
+        # The reference leaves are bf16, so their grads come back bf16;
+        # compare values in fp32.
+        torch.testing.assert_close(
+            grad.float(),
+            ref_grad.float(),
+            atol=5e-2,
+            rtol=5e-2,
+            msg=lambda m, name=name: f"grad mismatch in {name}: {m}",
+        )
+
+
+@requires_gpu_flash
+def test_block_attention_trunk_isolation_across_rows():
+    """A block must only read its own batch row's trunk."""
+    q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len = _make_inputs(
+        [32, 32], batch=2, seed=3
+    )
+    out = block_draft_attention(
+        q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, chunk=16
+    )
+    # Perturb row 1's trunk; block 0 (row 0) must be unaffected.
+    trunk_k2 = trunk_k.detach().clone()
+    trunk_k2[1] += 1.0
+    out2 = block_draft_attention(
+        q,
+        k_own,
+        v_own,
+        trunk_k2.requires_grad_(True),
+        trunk_v,
+        block_row,
+        vis_len,
+        chunk=16,
+    )
+    torch.testing.assert_close(out[0], out2[0])
+    assert not torch.allclose(out[1], out2[1])
+
+
+class _SliceConfig:
+    """Minimal config stub for the interleave helpers."""
+
+    def __init__(self, heads, groups, head_dim, hidden):
+        self.num_attention_heads = heads
+        self.num_query_groups = groups
+        self.kv_channels = head_dim
+        self.hidden_size = hidden
+
+
+def test_trunk_kv_weight_slice_matches_deinterleave():
+    """The grouped-view K/V slice used by _project_trunk_kv equals the
+    canonical de-interleave of Megatron's fused qkv layout."""
+    heads, groups, head_dim, hidden = 8, 2, 16, 64
+    config = _SliceConfig(heads, groups, head_dim, hidden)
+    q_w = torch.randn(heads * head_dim, hidden)
+    k_w = torch.randn(groups * head_dim, hidden)
+    v_w = torch.randn(groups * head_dim, hidden)
+    fused = _interleave_qkv(q_w, k_w, v_w, config)
+
+    # The slice arithmetic from DFlashDraftModel._project_trunk_kv.
+    heads_per_group = heads // groups
+    grouped = fused.view(groups, (heads_per_group + 2) * head_dim, -1)
+    k_slice = grouped[
+        :, heads_per_group * head_dim : (heads_per_group + 1) * head_dim
+    ].reshape(groups * head_dim, -1)
+    v_slice = grouped[:, (heads_per_group + 1) * head_dim :].reshape(
+        groups * head_dim, -1
+    )
+
+    q_ref, k_ref, v_ref = _deinterleave_qkv(fused, config)
+    torch.testing.assert_close(k_slice, k_ref)
+    torch.testing.assert_close(v_slice, v_ref)
+    torch.testing.assert_close(q_ref, q_w)
+
+
+@requires_gpu_flash
+def test_block_draft_model_forward_backward(tmp_path):
+    """End-to-end module smoke: taps -> trunk KV -> block stream -> logits."""
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+    from megatron.core.transformer import TransformerConfig
+
+    from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+
+    created_process_group = False
+    try:
+        torch.cuda.set_device(0)
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmp_path / 'mcore_pg_init'}",
+            )
+            created_process_group = True
+        parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+        model_parallel_cuda_manual_seed(123)
+        torch.manual_seed(7)
+
+        hidden, target_hidden, vocab = 64, 96, 128
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=hidden,
+            ffn_hidden_size=128,
+            num_attention_heads=4,
+            num_query_groups=2,
+            kv_channels=16,
+            normalization="RMSNorm",
+            activation_func=torch.nn.functional.silu,
+            gated_linear_unit=True,
+            add_bias_linear=False,
+            qk_layernorm=True,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.bfloat16,
+        )
+        config.vocab_size = vocab
+        config.draft_vocab_size = vocab
+        config.apply_rope_fusion = False
+        config.rotary_base = 10000
+        config.gradient_accumulation_fusion = False
+
+        gamma = 3
+        shared_kwargs = dict(
+            config=config,
+            gamma=gamma,
+            mask_token_id=vocab - 1,
+            num_aux_hidden_states=3,
+            target_hidden_size=target_hidden,
+            trunk_chunk=8,
+        )
+        model = DFlashDraftModel(**shared_kwargs).cuda()
+
+        seq_len, batch = 32, 2
+        taps = torch.randn(
+            seq_len, batch, 3 * target_hidden, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_(True)
+        embeds = torch.randn(
+            seq_len, batch, hidden, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_(True)
+        anchors = torch.tensor([[5, 10, 20], [0, 15, 29]], device="cuda")
+        anchor_valid = torch.ones_like(anchors, dtype=torch.bool)
+        # The policy's LM head and frozen mask-token embed row, passed
+        # detached (the draft owns neither; official DFlash contract).
+        lm_head_weight = torch.randn(vocab, hidden, device="cuda", dtype=torch.bfloat16)
+        mask_embedding = torch.randn(hidden, device="cuda", dtype=torch.bfloat16)
+
+        out = model(
+            taps=taps,
+            input_embeds=embeds,
+            anchors=anchors,
+            anchor_valid=anchor_valid,
+            lm_head_weight=lm_head_weight,
+            mask_embedding=mask_embedding,
+        )
+        logits = out
+        expected_width = gamma + 1
+        loss = logits.float().sum()
+        assert logits.shape == (batch, anchors.shape[1], expected_width, vocab)
+        loss.backward()
+
+        assert torch.isfinite(taps.grad).all()
+        assert torch.isfinite(embeds.grad).all()
+        assert torch.isfinite(model.fc.weight.grad).all()
+        qkv_grad = model.decoder.layers[0].self_attention.linear_qkv.weight.grad
+        assert qkv_grad is not None and torch.isfinite(qkv_grad).all()
+    finally:
+        parallel_state.destroy_model_parallel()
+        if created_process_group and dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/unit/models/megatron/test_block_attention.py
+++ b/tests/unit/models/megatron/test_block_attention.py
@@ -17,55 +17,110 @@
 The custom two-part (bucketed dense FA + varlen FA, joint-LSE merged)
 attention must match a dense fp32 softmax over the explicit staircase mask —
 forward and gradients — including the edge cases: empty trunk (anchor 0),
-anchor below one chunk (no dense part), and anchors spread over multiple
-chunk buckets.
+anchor below one chunk (no dense part), anchors spread over multiple chunk
+buckets, unequal packed subsequences, and the CP=2 zigzag ring.
 """
+
+import os
 
 import pytest
 import torch
+import torch.multiprocessing as mp
 
 pytestmark = pytest.mark.mcore
 
-from nemo_rl.models.megatron.draft.dflash import (  # noqa: E402
-    block_draft_attention,
-)
+from nemo_rl.models.megatron.draft.dflash import BlockDraftAttention  # noqa: E402
 from nemo_rl.models.megatron.draft.utils import (  # noqa: E402
     _deinterleave_qkv,
     _interleave_qkv,
 )
 
+
+def block_draft_attention(*args, chunk, window=0, cp_group=None):
+    """Test-local wrapper over ``BlockDraftAttention.apply`` (defaulted scale).
+
+    ``args`` = (q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu).
+    """
+    scale = args[0].shape[-1] ** -0.5
+    return BlockDraftAttention.apply(*args, chunk, window, scale, cp_group)
+
+
 requires_gpu_flash = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="requires CUDA + flash-attn"
 )
+requires_2_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="requires 2 GPUs"
+)
+requires_4_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 4, reason="requires 4 GPUs"
+)
+
+# CP sizes for the ring-parity spawn tests. CP=2 is degenerate in one way —
+# every rank is simultaneously the first AND last rank — so only CP=4
+# exercises the interior-rank paths: halo neighbors on both sides, ring steps
+# with genuinely earlier AND later chunks in flight. The paired chunk value
+# keeps the dense-bucket path alive at CP=4 (the local segments shrink below
+# the CP=2 chunk).
+CP_RING_CASES = [
+    pytest.param(2, 8, id="cp2"),
+    pytest.param(4, 2, id="cp4", marks=requires_4_gpus),
+]
+CP_SIZES = [
+    pytest.param(2, id="cp2"),
+    pytest.param(4, id="cp4", marks=requires_4_gpus),
+]
 
 
-def _dense_reference(q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, scale):
-    """Per-block fp32 softmax over [trunk[:p]; own block] (bidirectional)."""
-    num_blocks, block_width, num_q_heads, _ = q.shape
+def _dense_reference(
+    q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu, scale, window=0
+):
+    """Per-block fp32 softmax over [trunk[seq, :p]; own block] (bidirectional).
+
+    ``window > 0`` restricts each query to the causal band
+    ``0 <= q_pos - k_pos <= window - 1`` (vLLM resolves sliding draft layers
+    as causal), which also makes block-internal attention lower-triangular.
+    """
+    num_blocks = q.shape[0]
+    block_width = q.shape[1]
+    num_q_heads = q.shape[2]
     num_kv_heads = k_own.shape[2]
     group = num_q_heads // num_kv_heads
     outs = []
     for block in range(num_blocks):
-        row = int(block_row[block])
+        start = int(cu[int(block_seq[block])])
         prefix = int(vis_len[block])
-        keys = torch.cat([trunk_k[row, :prefix], k_own[block]], dim=0).float()
-        vals = torch.cat([trunk_v[row, :prefix], v_own[block]], dim=0).float()
+        keys = torch.cat([trunk_k[start : start + prefix], k_own[block]], dim=0).float()
+        vals = torch.cat([trunk_v[start : start + prefix], v_own[block]], dim=0).float()
         keys = keys.repeat_interleave(group, dim=1)
         vals = vals.repeat_interleave(group, dim=1)
         scores = torch.einsum("whd,lhd->hwl", q[block].float(), keys) * scale
+        if window:
+            offsets = torch.arange(block_width, device=q.device)
+            q_pos = prefix + offsets
+            k_pos = torch.cat([torch.arange(prefix, device=q.device), q_pos])
+            dist_qk = q_pos[:, None] - k_pos[None, :]
+            visible = (dist_qk >= 0) & (dist_qk <= window - 1)
+            scores = scores.masked_fill(~visible.unsqueeze(0), float("-inf"))
         probs = torch.softmax(scores, dim=-1)
         outs.append(torch.einsum("hwl,lhd->whd", probs, vals))
     return torch.stack(outs)
 
 
-def _make_inputs(vis_len_values, *, block_width=4, seq_len=64, batch=2, seed=0):
+def _make_inputs(
+    vis_len_values, *, block_width=4, seq_lens=(64, 64), block_seq_values=None, seed=0
+):
     torch.manual_seed(seed)
     device = "cuda"
     dtype = torch.bfloat16
     num_q_heads, num_kv_heads, head_dim = 4, 2, 32
     vis_len = torch.tensor(vis_len_values, device=device, dtype=torch.int64)
     num_blocks = vis_len.shape[0]
-    block_row = torch.arange(num_blocks, device=device) % batch
+    if block_seq_values is None:
+        block_seq = torch.arange(num_blocks, device=device) % len(seq_lens)
+    else:
+        block_seq = torch.tensor(block_seq_values, device=device, dtype=torch.int64)
+    cu = torch.zeros(len(seq_lens) + 1, device=device, dtype=torch.long)
+    cu[1:] = torch.cumsum(torch.tensor(seq_lens, device=device), dim=0)
 
     def leaf(*shape):
         return torch.randn(*shape, device=device, dtype=dtype).requires_grad_(True)
@@ -73,29 +128,27 @@ def _make_inputs(vis_len_values, *, block_width=4, seq_len=64, batch=2, seed=0):
     q = leaf(num_blocks, block_width, num_q_heads, head_dim)
     k_own = leaf(num_blocks, block_width, num_kv_heads, head_dim)
     v_own = leaf(num_blocks, block_width, num_kv_heads, head_dim)
-    trunk_k = leaf(batch, seq_len, num_kv_heads, head_dim)
-    trunk_v = leaf(batch, seq_len, num_kv_heads, head_dim)
-    return q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len
+    trunk_k = leaf(int(cu[-1]), num_kv_heads, head_dim)
+    trunk_v = leaf(int(cu[-1]), num_kv_heads, head_dim)
+    return q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu
 
 
-@requires_gpu_flash
-@pytest.mark.parametrize(
-    "vis_len_values,chunk",
-    [
-        # Multi-bucket: full chunks + partial remainders (chunk=16, S=64).
-        ([5, 17, 33, 48, 63, 21], 16),
-        # Everything below one chunk: dense part A never runs.
-        ([0, 1, 7, 15], 16),
-        # Exactly on chunk boundaries: empty partial remainders.
-        ([16, 32, 48, 0], 16),
-    ],
-)
-def test_block_attention_matches_dense_reference(vis_len_values, chunk):
-    q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len = _make_inputs(vis_len_values)
+def _compare_against_dense(inputs, chunk, cp_group=None, window=0):
+    q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu = inputs
     scale = q.shape[-1] ** -0.5
 
     out = block_draft_attention(
-        q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, chunk=chunk
+        q,
+        k_own,
+        v_own,
+        trunk_k,
+        trunk_v,
+        block_seq,
+        vis_len,
+        cu,
+        chunk=chunk,
+        window=window,
+        cp_group=cp_group,
     )
     grad_out = torch.randn_like(out)
     out.backward(grad_out)
@@ -107,7 +160,7 @@ def test_block_attention_matches_dense_reference(vis_len_values, chunk):
         t.detach().clone().requires_grad_(True)
         for t in (q, k_own, v_own, trunk_k, trunk_v)
     ]
-    ref_out = _dense_reference(*ref_inputs, block_row, vis_len, scale)
+    ref_out = _dense_reference(*ref_inputs, block_seq, vis_len, cu, scale, window)
     ref_out.backward(grad_out.float())
     ref_grads = [t.grad.clone() for t in ref_inputs]
 
@@ -126,29 +179,292 @@ def test_block_attention_matches_dense_reference(vis_len_values, chunk):
 
 
 @requires_gpu_flash
+@pytest.mark.parametrize(
+    "vis_len_values,chunk",
+    [
+        # Multi-bucket: full chunks + partial remainders (chunk=16, S=64).
+        ([5, 17, 33, 48, 63, 21], 16),
+        # Everything below one chunk: dense part A never runs.
+        ([0, 1, 7, 15], 16),
+        # Exactly on chunk boundaries: empty partial remainders.
+        ([16, 32, 48, 0], 16),
+    ],
+)
+def test_block_attention_matches_dense_reference(vis_len_values, chunk):
+    _compare_against_dense(_make_inputs(vis_len_values), chunk)
+
+
+@requires_gpu_flash
+def test_block_attention_packed_unequal_subsequences():
+    """A THD pack of unequal subsequences; anchors near each seq's end."""
+    _compare_against_dense(
+        _make_inputs(
+            [0, 7, 23, 3, 39, 12],
+            seq_lens=(24, 40),
+            block_seq_values=[0, 0, 0, 1, 1, 1],
+            seed=5,
+        ),
+        chunk=16,
+    )
+
+
+@requires_gpu_flash
+@pytest.mark.parametrize(
+    "window,vis_len_values",
+    [
+        # Anchors inside, straddling, and far beyond the window.
+        (24, [0, 5, 23, 24, 30, 47, 63]),
+        # Window below one chunk.
+        (8, [7, 32, 63]),
+        # Degenerate window < block width: block-internal pairs clip too.
+        (3, [16, 40]),
+    ],
+)
+def test_block_attention_sliding_matches_dense_reference(window, vis_len_values):
+    _compare_against_dense(
+        _make_inputs(vis_len_values, seed=11), chunk=16, window=window
+    )
+
+
+@requires_gpu_flash
+def test_block_attention_sliding_packed_unequal_subsequences():
+    _compare_against_dense(
+        _make_inputs(
+            [0, 7, 23, 3, 39, 12],
+            seq_lens=(24, 40),
+            block_seq_values=[0, 0, 0, 1, 1, 1],
+            seed=6,
+        ),
+        chunk=16,
+        window=16,
+    )
+
+
+@requires_gpu_flash
+def test_block_attention_sliding_blocks_are_causal():
+    """Sliding layers are causal: a later own key must not affect earlier slots."""
+    inputs = _make_inputs([16, 40], seed=13)
+    q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu = inputs
+    out = block_draft_attention(*inputs, chunk=16, window=24)
+    k_own2 = k_own.detach().clone()
+    k_own2[:, -1] += 1.0
+    out2 = block_draft_attention(
+        q,
+        k_own2.requires_grad_(True),
+        v_own,
+        trunk_k,
+        trunk_v,
+        block_seq,
+        vis_len,
+        cu,
+        chunk=16,
+        window=24,
+    )
+    torch.testing.assert_close(out[:, :-1], out2[:, :-1])
+    assert not torch.allclose(out[:, -1], out2[:, -1])
+
+
+@requires_gpu_flash
 def test_block_attention_trunk_isolation_across_rows():
-    """A block must only read its own batch row's trunk."""
-    q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len = _make_inputs(
-        [32, 32], batch=2, seed=3
-    )
+    """A block must only read its own subsequence's trunk."""
+    inputs = _make_inputs([32, 32], block_seq_values=[0, 1], seed=3)
+    q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu = inputs
     out = block_draft_attention(
-        q, k_own, v_own, trunk_k, trunk_v, block_row, vis_len, chunk=16
+        q, k_own, v_own, trunk_k, trunk_v, block_seq, vis_len, cu, chunk=16
     )
-    # Perturb row 1's trunk; block 0 (row 0) must be unaffected.
+    # Perturb seq 1's trunk; block 0 (seq 0) must be unaffected.
     trunk_k2 = trunk_k.detach().clone()
-    trunk_k2[1] += 1.0
+    trunk_k2[int(cu[1]) :] += 1.0
     out2 = block_draft_attention(
         q,
         k_own,
         v_own,
         trunk_k2.requires_grad_(True),
         trunk_v,
-        block_row,
+        block_seq,
         vis_len,
+        cu,
         chunk=16,
     )
     torch.testing.assert_close(out[0], out2[0])
     assert not torch.allclose(out[1], out2[1])
+
+
+def _run_block_attention_cp_rank(
+    rank: int, world_size: int, init_file: str, chunk: int, window: int = 0
+) -> None:
+    """CP ring vs the single-rank global run of the SAME inputs.
+
+    Blocks are assigned to the rank owning their anchor's zigzag chunk. The
+    ring's outputs must match the global run's rows for the owned blocks, and
+    — because dK/dV travel one full loop back to their owner — the local
+    trunk-shard gradients must equal the global gradient's zigzag slice
+    (contributions from EVERY rank's blocks included).
+
+    ``window > 0`` runs the sliding path instead: trunk K/V is all-gathered
+    to global order for the one windowed call, and trunk grads come home via
+    reduce-scatter, so the same zigzag-slice comparison applies.
+    """
+    import torch.distributed as dist
+
+    from nemo_rl.algorithms.loss.utils import packed_zigzag_token_coords
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"file://{init_file}",
+    )
+    cp_group = dist.new_group(list(range(world_size)))
+
+    seq_lens = (16, 24)  # multiples of 2*cp for cp in {2, 4}
+    vis_values = [0, 5, 9, 15, 3, 11, 17, 23]
+    seq_values = [0, 0, 0, 0, 1, 1, 1, 1]
+    inputs = _make_inputs(
+        vis_values, seq_lens=seq_lens, block_seq_values=seq_values, seed=17
+    )
+    q_g, k_own_g, v_own_g, trunk_k_g, trunk_v_g, block_seq, vis_len, cu = inputs
+
+    # ---- Global reference (identical on every rank; same seed).
+    out_ref = block_draft_attention(
+        q_g,
+        k_own_g,
+        v_own_g,
+        trunk_k_g,
+        trunk_v_g,
+        block_seq,
+        vis_len,
+        cu,
+        chunk=chunk,
+        window=window,
+    )
+    torch.manual_seed(99)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    ref_grads = {
+        "q": q_g.grad.clone(),
+        "k_own": k_own_g.grad.clone(),
+        "v_own": v_own_g.grad.clone(),
+        "trunk_k": trunk_k_g.grad.clone(),
+        "trunk_v": trunk_v_g.grad.clone(),
+    }
+
+    # ---- CP ring: zigzag trunk shard + owned blocks.
+    cu_local = cu // world_size
+    seq_index, pos = packed_zigzag_token_coords(cu.cpu(), rank, world_size)
+    global_row = (cu[:-1].cpu()[seq_index] + pos).cuda()
+    half = ((cu_local[1:] - cu_local[:-1]) // 2)[block_seq]
+    chunk_idx = vis_len // half
+    owner = torch.minimum(chunk_idx, 2 * world_size - 1 - chunk_idx)
+    mine = owner == rank
+    assert int(mine.sum()) > 0, f"rank {rank} owns no blocks; adjust the test data"
+
+    def local_leaf(t, index):
+        return t.detach()[index].clone().requires_grad_(True)
+
+    q_l = local_leaf(q_g, mine)
+    k_own_l = local_leaf(k_own_g, mine)
+    v_own_l = local_leaf(v_own_g, mine)
+    trunk_k_l = local_leaf(trunk_k_g, global_row)
+    trunk_v_l = local_leaf(trunk_v_g, global_row)
+
+    out_local = block_draft_attention(
+        q_l,
+        k_own_l,
+        v_own_l,
+        trunk_k_l,
+        trunk_v_l,
+        block_seq[mine],
+        vis_len[mine],
+        cu_local,
+        chunk=chunk,
+        window=window,
+        cp_group=cp_group,
+    )
+    torch.testing.assert_close(
+        out_local.float(), out_ref.detach()[mine].float(), atol=2e-2, rtol=2e-2
+    )
+    out_local.backward(grad_out[mine])
+
+    torch.testing.assert_close(
+        q_l.grad.float(), ref_grads["q"][mine].float(), atol=5e-2, rtol=5e-2
+    )
+    torch.testing.assert_close(
+        k_own_l.grad.float(), ref_grads["k_own"][mine].float(), atol=5e-2, rtol=5e-2
+    )
+    torch.testing.assert_close(
+        v_own_l.grad.float(), ref_grads["v_own"][mine].float(), atol=5e-2, rtol=5e-2
+    )
+    torch.testing.assert_close(
+        trunk_k_l.grad.float(),
+        ref_grads["trunk_k"][global_row].float(),
+        atol=5e-2,
+        rtol=5e-2,
+    )
+    torch.testing.assert_close(
+        trunk_v_l.grad.float(),
+        ref_grads["trunk_v"][global_row].float(),
+        atol=5e-2,
+        rtol=5e-2,
+    )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@requires_2_gpus
+@requires_gpu_flash
+@pytest.mark.parametrize("world_size,chunk", CP_RING_CASES)
+def test_block_attention_cp_matches_single_rank(tmp_path, world_size, chunk):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29511")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / f"block_cp{world_size}_init")
+    procs = []
+    for rank in range(world_size):
+        proc = ctx.Process(
+            target=_run_block_attention_cp_rank,
+            args=(rank, world_size, init_file, chunk),
+        )
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=600)
+    for rank, proc in enumerate(procs):
+        assert proc.exitcode == 0, f"rank {rank} exited with {proc.exitcode}"
+
+
+# window=5 straddles zigzag chunk boundaries (halves are 4/6 at cp2, 2/3 at
+# cp4); window=64 covers every trunk position, isolating the causal own-block
+# handling from the windowing.
+CP_SLIDING_CASES = [
+    pytest.param(2, 5, id="cp2-w5"),
+    pytest.param(2, 64, id="cp2-w64"),
+    pytest.param(4, 5, id="cp4-w5", marks=requires_4_gpus),
+]
+
+
+@requires_2_gpus
+@requires_gpu_flash
+@pytest.mark.parametrize("world_size,window", CP_SLIDING_CASES)
+def test_block_attention_sliding_cp_matches_single_rank(tmp_path, world_size, window):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29511")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / f"block_swa_cp{world_size}_w{window}_init")
+    procs = []
+    for rank in range(world_size):
+        proc = ctx.Process(
+            target=_run_block_attention_cp_rank,
+            args=(rank, world_size, init_file, 8, window),
+        )
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=600)
+    for rank, proc in enumerate(procs):
+        assert proc.exitcode == 0, f"rank {rank} exited with {proc.exitcode}"
 
 
 class _SliceConfig:
@@ -189,7 +505,8 @@ def test_trunk_kv_weight_slice_matches_deinterleave():
 
 @requires_gpu_flash
 @pytest.mark.parametrize("method", ["dflash", "dspark"])
-def test_block_draft_model_forward_backward(method, tmp_path):
+@pytest.mark.parametrize("layer_windows", [None, [16, 0]], ids=["full", "sliding"])
+def test_block_draft_model_forward_backward(method, layer_windows, tmp_path):
     """End-to-end module smoke: taps -> trunk KV -> block stream -> logits."""
     import torch.distributed as dist
     from megatron.core import parallel_state
@@ -251,6 +568,7 @@ def test_block_draft_model_forward_backward(method, tmp_path):
             num_aux_hidden_states=3,
             target_hidden_size=target_hidden,
             trunk_chunk=8,
+            layer_windows=layer_windows,
         )
         if method == "dflash":
             model = DFlashDraftModel(**shared_kwargs).cuda()
@@ -311,6 +629,396 @@ def test_block_draft_model_forward_backward(method, tmp_path):
         parallel_state.destroy_model_parallel()
         if created_process_group and dist.is_initialized():
             dist.destroy_process_group()
+
+
+def test_resolve_layer_windows():
+    """Checkpoint layer_types/sliding_window -> per-layer window list."""
+    from nemo_rl.models.megatron.draft.utils import _resolve_layer_windows
+
+    ckpt_35b = {
+        "layer_types": ["sliding_attention"] * 5 + ["full_attention"],
+        "sliding_window": 4096,
+    }
+    assert _resolve_layer_windows(ckpt_35b, 6) == [4096] * 5 + [0]
+    assert _resolve_layer_windows({}, 3) == [0, 0, 0]
+    all_full = {"layer_types": ["full_attention"] * 2, "sliding_window": None}
+    assert _resolve_layer_windows(all_full, 2) == [0, 0]
+    with pytest.raises(ValueError):
+        _resolve_layer_windows({"layer_types": ["sliding_attention"]}, 1)
+    with pytest.raises(NotImplementedError):
+        _resolve_layer_windows(
+            {"layer_types": ["linear_attention"], "sliding_window": 8}, 1
+        )
+
+
+def _make_draft_config():
+    from megatron.core.transformer import TransformerConfig
+
+    hidden, vocab = 64, 128
+    config = TransformerConfig(
+        num_layers=2,
+        hidden_size=hidden,
+        ffn_hidden_size=128,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=16,
+        normalization="RMSNorm",
+        activation_func=torch.nn.functional.silu,
+        gated_linear_unit=True,
+        add_bias_linear=False,
+        qk_layernorm=True,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+    )
+    config.vocab_size = vocab
+    config.draft_vocab_size = vocab
+    config.apply_rope_fusion = False
+    config.rotary_base = 10000
+    config.gradient_accumulation_fusion = False
+    return config
+
+
+def _make_block_model(method, config, gamma=3, target_hidden=96, layer_windows=None):
+    from nemo_rl.models.megatron.draft.dflash import DFlashDraftModel
+    from nemo_rl.models.megatron.draft.dspark import DSparkDraftModel
+
+    shared_kwargs = dict(
+        config=config,
+        gamma=gamma,
+        mask_token_id=config.vocab_size - 1,
+        num_aux_hidden_states=3,
+        target_hidden_size=target_hidden,
+        trunk_chunk=8,
+        layer_windows=layer_windows,
+    )
+    if method == "dflash":
+        return DFlashDraftModel(**shared_kwargs).cuda()
+    return DSparkDraftModel(markov_rank=8, **shared_kwargs).cuda()
+
+
+@requires_gpu_flash
+@pytest.mark.parametrize("method", ["dflash", "dspark"])
+@pytest.mark.parametrize("layer_windows", [None, [16, 0]], ids=["full", "sliding"])
+def test_block_draft_model_packed_matches_unpacked(method, layer_windows, tmp_path):
+    """Packed THD forward (flat blocks) == unpacked forward on the same data."""
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.packed_seq_params import PackedSeqParams
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    created_process_group = False
+    try:
+        torch.cuda.set_device(0)
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmp_path / 'mcore_pg_init'}",
+            )
+            created_process_group = True
+        parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+        model_parallel_cuda_manual_seed(123)
+        torch.manual_seed(7)
+
+        config = _make_draft_config()
+        hidden, vocab, target_hidden, gamma = 64, 128, 96, 3
+        model = _make_block_model(
+            method, config, gamma=gamma, layer_windows=layer_windows
+        )
+
+        seq_len, batch = 32, 2
+        taps = torch.randn(
+            seq_len, batch, 3 * target_hidden, device="cuda", dtype=torch.bfloat16
+        )
+        embeds = torch.randn(
+            seq_len, batch, hidden, device="cuda", dtype=torch.bfloat16
+        )
+        anchors = torch.tensor([[5, 10, 20], [0, 15, 29]], device="cuda")
+        anchor_valid = torch.ones_like(anchors, dtype=torch.bool)
+        lm_head_weight = torch.randn(vocab, hidden, device="cuda", dtype=torch.bfloat16)
+        mask_embedding = torch.randn(hidden, device="cuda", dtype=torch.bfloat16)
+        input_ids = torch.randint(0, vocab, (batch, seq_len), device="cuda")
+
+        method_kwargs = {"input_ids": input_ids} if method == "dspark" else {}
+        with torch.no_grad():
+            out_ref = model(
+                taps=taps,
+                input_embeds=embeds,
+                anchors=anchors,
+                anchor_valid=anchor_valid,
+                lm_head_weight=lm_head_weight,
+                mask_embedding=mask_embedding,
+                **method_kwargs,
+            )
+
+        # Pack the two equal-length rows batch-major (the layout the unpacked
+        # path normalizes to) and rerun with flat block coords.
+        cu = torch.tensor([0, seq_len, 2 * seq_len], device="cuda", dtype=torch.int32)
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            cu_seqlens_q_padded=cu,
+            cu_seqlens_kv_padded=cu,
+            max_seqlen_q=seq_len,
+            max_seqlen_kv=seq_len,
+        )
+        taps_packed = taps.permute(1, 0, 2).reshape(batch * seq_len, 1, -1)
+        embeds_packed = embeds.permute(1, 0, 2).reshape(batch * seq_len, 1, -1)
+        block_seq = torch.tensor([0, 0, 0, 1, 1, 1], device="cuda")
+        anchors_flat = anchors.reshape(-1)
+        with torch.no_grad():
+            out_packed = model(
+                taps=taps_packed,
+                input_embeds=embeds_packed,
+                anchors=anchors_flat,
+                anchor_valid=anchor_valid.reshape(-1),
+                lm_head_weight=lm_head_weight,
+                mask_embedding=mask_embedding,
+                packed_seq_params=psp,
+                block_seq_idx=block_seq,
+                **method_kwargs,
+            )
+
+        if method == "dflash":
+            torch.testing.assert_close(
+                out_packed.float(), out_ref.reshape(*out_packed.shape).float()
+            )
+        else:
+            logits_ref, conf_ref = out_ref
+            logits_packed, conf_packed = out_packed
+            torch.testing.assert_close(
+                logits_packed.float(), logits_ref.reshape(*logits_packed.shape).float()
+            )
+            torch.testing.assert_close(
+                conf_packed, conf_ref.reshape(*conf_packed.shape)
+            )
+    finally:
+        parallel_state.destroy_model_parallel()
+        if created_process_group and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_block_model_cp_rank(rank: int, world_size: int, init_file: str) -> None:
+    """CP packed model + DSpark loss vs the CP=1 global run of the SAME data.
+
+    Phase 1 initializes model parallel with CP=1 (every rank computes the
+    identical global packed forward + loss over ALL blocks). Phase 2
+    re-initializes with CP=world_size, rebuilds the model from the same
+    seeds, feeds each rank its zigzag shard and OWNED blocks, and checks the
+    local logits/confidence rows and the CP-summed loss against the global
+    reference — covering the trunk ring, the anchor-owner block placement,
+    the loss's successor-halo teacher gather, and the CP metric reduction.
+    """
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.packed_seq_params import PackedSeqParams
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    from nemo_rl.algorithms.loss.loss_functions import DSparkBlockLossFn
+    from nemo_rl.algorithms.loss.utils import (
+        compute_block_draft_slot_valid_counts,
+        packed_zigzag_token_coords,
+    )
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"file://{init_file}",
+    )
+
+    hidden, vocab, target_hidden, gamma = 64, 128, 96, 3
+    # Multiples of 2*cp for cp in {2, 4}; at cp=4 the smallest chunk (16/8=2)
+    # still covers the gamma-1=2 successor halo exactly.
+    lengths = [16, 24]
+    seq_len = max(lengths)
+    total = sum(lengths)
+    cu_cpu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(), dtype=torch.int32
+    )
+    torch.manual_seed(11)
+    taps_g = torch.randn(total, 1, 3 * target_hidden, dtype=torch.bfloat16).cuda()
+    embeds_g = torch.randn(total, 1, hidden, dtype=torch.bfloat16).cuda()
+    teacher_g = torch.randn(total, vocab, dtype=torch.bfloat16).cuda()
+    lm_head_weight = torch.randn(vocab, hidden, dtype=torch.bfloat16).cuda()
+    mask_embedding = torch.randn(hidden, dtype=torch.bfloat16).cuda()
+    input_ids = torch.randint(0, vocab, (2, seq_len)).cuda()
+    token_mask = torch.ones(2, seq_len).cuda()
+    token_mask[0, lengths[0] :] = 0.0  # seq 0 is shorter than the padded S
+    sample_mask = torch.ones(2).cuda()
+
+    anchors = torch.tensor([[0, 5, 9, 15], [3, 11, 17, 23]]).cuda()
+    anchor_valid = torch.ones_like(anchors, dtype=torch.bool)
+    block_seq_all = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1]).cuda()
+    anchors_all = anchors.reshape(-1)
+    valid_all = anchor_valid.reshape(-1)
+    counts = compute_block_draft_slot_valid_counts(
+        token_mask, sample_mask, anchors, anchor_valid, gamma=gamma
+    )
+
+    def make_psp(cu):
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            cu_seqlens_q_padded=cu,
+            cu_seqlens_kv_padded=cu,
+            max_seqlen_q=seq_len,
+            max_seqlen_kv=seq_len,
+        )
+
+    def run_loss(logits, confidence, seq_idx, anchors_f, valid_f, cu_local, cp_group):
+        data = {
+            "draft_anchor_positions": anchors_f,
+            "draft_anchor_valid": valid_f,
+            "draft_block_seq_idx": seq_idx,
+            "draft_packed_local_cu_seqlens": cu_local,
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "input_ids": input_ids,
+            "draft_confidence_pred": confidence,
+        }
+        loss_fn = DSparkBlockLossFn(context_parallel_group=cp_group)
+        teacher_local = (
+            teacher_g if cp_group is None else teacher_g[global_row]
+        ).unsqueeze(0)
+        return loss_fn(
+            teacher_logits=teacher_local,
+            student_block_logits=logits,
+            data=data,
+            global_valid_seqs=None,
+            global_valid_toks=torch.tensor(1.0).cuda(),
+            global_draft_pass_counts=counts.cuda(),
+        )
+
+    # ---- Phase 1: CP=1 (DP=2) global reference, identical on both ranks.
+    parallel_state.destroy_model_parallel()
+    parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+    )
+    model_parallel_cuda_manual_seed(123)
+    torch.manual_seed(7)
+    config = _make_draft_config()
+    model = _make_block_model("dspark", config, gamma=gamma)
+    global_row = None
+    with torch.no_grad():
+        logits_ref, conf_ref = model(
+            taps=taps_g,
+            input_embeds=embeds_g,
+            anchors=anchors_all,
+            anchor_valid=valid_all,
+            lm_head_weight=lm_head_weight,
+            mask_embedding=mask_embedding,
+            input_ids=input_ids,
+            packed_seq_params=make_psp(cu_cpu.cuda()),
+            block_seq_idx=block_seq_all,
+        )
+        loss_ref, metrics_ref = run_loss(
+            logits_ref,
+            conf_ref,
+            block_seq_all,
+            anchors_all,
+            valid_all,
+            cu_cpu.cuda().long(),
+            None,
+        )
+    del model
+    dist.barrier()
+
+    # ---- Phase 2: CP=2, same seeds -> same weights, zigzag-local inputs.
+    parallel_state.destroy_model_parallel()
+    parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=world_size,
+    )
+    cp_group = parallel_state.get_context_parallel_group()
+    cp_rank = cp_group.rank()
+    model_parallel_cuda_manual_seed(123)
+    torch.manual_seed(7)
+    config = _make_draft_config()
+    model = _make_block_model("dspark", config, gamma=gamma)
+
+    seq_index, pos = packed_zigzag_token_coords(cu_cpu, cp_rank, world_size)
+    global_row = (cu_cpu[:-1].to(torch.long)[seq_index] + pos).cuda()
+    cu_local = (cu_cpu.cuda().long()) // world_size
+    half = ((cu_local[1:] - cu_local[:-1]) // 2)[block_seq_all]
+    chunk_idx = anchors_all // half
+    owner = torch.minimum(chunk_idx, 2 * world_size - 1 - chunk_idx)
+    mine = owner == cp_rank
+    assert int(mine.sum()) > 0
+
+    with torch.no_grad():
+        logits_loc, conf_loc = model(
+            taps=taps_g[global_row],
+            input_embeds=embeds_g[global_row],
+            anchors=anchors_all[mine],
+            anchor_valid=valid_all[mine],
+            lm_head_weight=lm_head_weight,
+            mask_embedding=mask_embedding,
+            input_ids=input_ids,
+            packed_seq_params=make_psp(cu_cpu.cuda()),
+            block_seq_idx=block_seq_all[mine],
+        )
+        loss_loc, metrics_loc = run_loss(
+            logits_loc,
+            conf_loc,
+            block_seq_all[mine],
+            anchors_all[mine],
+            valid_all[mine],
+            cu_local,
+            cp_group,
+        )
+
+    torch.testing.assert_close(
+        logits_loc.float(), logits_ref[mine].float(), atol=3e-2, rtol=3e-2
+    )
+    torch.testing.assert_close(
+        conf_loc.float(), conf_ref[mine].float(), atol=3e-2, rtol=3e-2
+    )
+    loss_sum = loss_loc.clone()
+    dist.all_reduce(loss_sum, group=cp_group)
+    torch.testing.assert_close(loss_sum, loss_ref, atol=2e-3, rtol=2e-3)
+    # CP-reduced metrics must reproduce the global reference's.
+    for key in ("dspark_ce_loss", "dspark_tv_loss", "dspark_confidence_loss"):
+        assert abs(metrics_loc[key] - metrics_ref[key]) <= 2e-3 + 2e-3 * abs(
+            metrics_ref[key]
+        ), key
+
+    dist.barrier()
+    parallel_state.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+@requires_2_gpus
+@requires_gpu_flash
+@pytest.mark.parametrize("world_size", CP_SIZES)
+def test_block_model_cp_matches_global(tmp_path, world_size):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29512")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / f"block_model_cp{world_size}_init")
+    procs = []
+    for rank in range(world_size):
+        proc = ctx.Process(
+            target=_run_block_model_cp_rank, args=(rank, world_size, init_file)
+        )
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=600)
+    for rank, proc in enumerate(procs):
+        assert proc.exitcode == 0, f"rank {rank} exited with {proc.exitcode}"
 
 
 @requires_gpu_flash

--- a/tests/unit/models/megatron/test_block_draft_sampling.py
+++ b/tests/unit/models/megatron/test_block_draft_sampling.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mcore
+
+from nemo_rl.models.megatron.draft.dflash import sample_block_anchors  # noqa: E402
+
+
+def _make_batch(batch_size=3, seq_len=32, gen_start=(10, 20, 31)):
+    token_mask = torch.zeros(batch_size, seq_len)
+    for row, start in enumerate(gen_start):
+        token_mask[row, start:] = 1.0
+    sample_mask = torch.ones(batch_size)
+    input_ids = torch.arange(batch_size * seq_len).reshape(batch_size, seq_len)
+    return token_mask, sample_mask, input_ids
+
+
+def test_sample_block_anchors_candidates_and_determinism():
+    token_mask, sample_mask, input_ids = _make_batch()
+    anchors_a, valid_a = sample_block_anchors(
+        token_mask=token_mask,
+        sample_mask=sample_mask,
+        input_ids=input_ids,
+        num_anchors=8,
+        generation_only=True,
+    )
+    anchors_b, valid_b = sample_block_anchors(
+        token_mask=token_mask,
+        sample_mask=sample_mask,
+        input_ids=input_ids,
+        num_anchors=8,
+        generation_only=True,
+    )
+    # Deterministic given identical batch content (TP-rank agreement).
+    assert torch.equal(anchors_a, anchors_b)
+    assert torch.equal(valid_a, valid_b)
+
+    # Every anchor p must have token_mask[p + 1] == 1 (its first label is a
+    # trained generation token).
+    for row in range(token_mask.shape[0]):
+        for anchor in anchors_a[row][valid_a[row]].tolist():
+            assert token_mask[row, anchor + 1] == 1.0
+
+    # Row 2 has exactly one candidate (p = 30, label 31): resampling pads to
+    # the requested static shape with duplicates, all valid.
+    assert valid_a[2].all()
+    assert set(anchors_a[2].tolist()) == {30}
+
+
+def test_sample_block_anchors_rows_without_candidates_are_invalid():
+    token_mask, sample_mask, input_ids = _make_batch()
+    token_mask[1] = 0.0  # no generation tokens
+    sample_mask[2] = 0.0  # invalid sample
+    anchors, valid = sample_block_anchors(
+        token_mask=token_mask,
+        sample_mask=sample_mask,
+        input_ids=input_ids,
+        num_anchors=4,
+        generation_only=True,
+    )
+    assert valid[0].all()
+    assert not valid[1].any()
+    assert not valid[2].any()
+    # Dummy anchors are in-range so downstream static-shape code stays safe.
+    assert int(anchors.max()) < token_mask.shape[1]
+
+
+def test_sample_block_anchors_changes_with_batch_content():
+    token_mask, sample_mask, input_ids = _make_batch()
+    anchors_a, _ = sample_block_anchors(
+        token_mask=token_mask,
+        sample_mask=sample_mask,
+        input_ids=input_ids,
+        num_anchors=8,
+        generation_only=True,
+    )
+    anchors_b, _ = sample_block_anchors(
+        token_mask=token_mask,
+        sample_mask=sample_mask,
+        input_ids=input_ids + 1,
+        num_anchors=8,
+        generation_only=True,
+    )
+    assert not torch.equal(anchors_a, anchors_b)
+
+
+def test_anchor_count_map_round_trip_preserves_duplicates():
+    from nemo_rl.models.megatron.draft.dflash import (
+        anchors_to_count_map,
+        count_map_to_anchors,
+    )
+
+    seq_len = 12
+    anchors = torch.tensor([[3, 3, 7, 0], [5, 6, 7, 8]], dtype=torch.int64)
+    anchor_valid = torch.tensor([[True, True, True, False], [True, True, True, True]])
+    count_map = anchors_to_count_map(anchors, anchor_valid, seq_len)
+    assert count_map.shape == (2, seq_len)
+    # Duplicates accumulate; invalid anchors contribute nothing.
+    assert count_map[0, 3] == 2 and count_map[0, 7] == 1 and count_map[0, 0] == 0
+    assert count_map.sum() == 3 + 4
+
+    rebuilt, rebuilt_valid = count_map_to_anchors(count_map)
+    # Multiset equality per row (order within a row is irrelevant).
+    for row in range(2):
+        original = sorted(anchors[row][anchor_valid[row]].tolist())
+        recovered = sorted(rebuilt[row][rebuilt_valid[row]].tolist())
+        assert original == recovered, (row, original, recovered)
+    # Row 0 has 3 blocks, row 1 has 4 -> padded to 4 with invalid dummies.
+    assert rebuilt.shape == (2, 4)
+    assert rebuilt_valid[0].sum() == 3 and rebuilt_valid[1].sum() == 4
+
+    # Truncation along the sequence dim (what dynamic batching does per
+    # microbatch) never drops blocks: anchors only sit on valid positions.
+    truncated = count_map[:, :9]
+    rebuilt_t, rebuilt_valid_t = count_map_to_anchors(truncated)
+    assert int(rebuilt_valid_t.sum()) == 7
+
+
+def test_count_map_to_anchors_handles_empty_microbatch():
+    from nemo_rl.models.megatron.draft.dflash import count_map_to_anchors
+
+    count_map = torch.zeros((2, 8), dtype=torch.int32)
+    anchors, anchor_valid = count_map_to_anchors(count_map)
+    # Non-degenerate static shape with everything masked.
+    assert anchors.shape == (2, 1)
+    assert not anchor_valid.any()

--- a/tests/unit/models/megatron/test_draft_optimizer_overrides.py
+++ b/tests/unit/models/megatron/test_draft_optimizer_overrides.py
@@ -212,3 +212,43 @@ def test_draft_override_distinctness_guard():
     )
     overrides = distinct_min_lr_provider.build_config_overrides(context)
     assert overrides is not None
+
+
+def test_grad_norm_group_registered_on_non_owner_pp_stage(monkeypatch):
+    """Regression test: PP stages without the draft module must still register.
+
+    has_grad_norm_group gates each SEPARATE_GRAD_NORM_GROUPS entry on a flag
+    all-reduce spanning PP, so a stage-local tuple desyncs the optimizer's
+    collective order and deadlocks step() (seen live as a watchdog timeout on
+    INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP on every last-stage rank).
+    """
+    from types import SimpleNamespace
+
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+
+    from nemo_rl.models.megatron.setup import _create_draft_pre_wrap_hook
+
+    monkeypatch.setattr(mcore_optimizer, "SEPARATE_GRAD_NORM_GROUPS", ("mtp",))
+    # A model list with no post-process chunk = a non-last PP stage; the hook
+    # returns before building the draft module.
+    non_owner_model = [SimpleNamespace(post_process=False, language_model=None)]
+
+    hook = _create_draft_pre_wrap_hook(
+        {"draft": {"enabled": True}},
+        None,
+        None,
+        preload_policy_from_pretrained=False,
+    )
+    assert hook(non_owner_model) is non_owner_model
+    assert "draft" in mcore_optimizer.SEPARATE_GRAD_NORM_GROUPS
+
+    # Baseline runs must keep Megatron's stock tuple.
+    monkeypatch.setattr(mcore_optimizer, "SEPARATE_GRAD_NORM_GROUPS", ("mtp",))
+    disabled_hook = _create_draft_pre_wrap_hook(
+        {"draft": {"enabled": False}},
+        None,
+        None,
+        preload_policy_from_pretrained=False,
+    )
+    disabled_hook(non_owner_model)
+    assert "draft" not in mcore_optimizer.SEPARATE_GRAD_NORM_GROUPS

--- a/tests/unit/models/megatron/test_draft_optimizer_overrides.py
+++ b/tests/unit/models/megatron/test_draft_optimizer_overrides.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fnmatch
+
+import pytest
+
+# draft.utils imports megatron at module top, so every test here needs mcore.
+pytestmark = pytest.mark.mcore
+
+
+def test_build_provider_returns_none_when_no_draft_optimizer_settings():
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    assert (
+        build_draft_optimizer_override_provider(
+            {"enabled": True, "model_name": None, "lr": None}
+        )
+        is None
+    )
+    assert build_draft_optimizer_override_provider({"enabled": True}) is None
+
+
+def test_draft_override_group_values_and_standard_overrides_preserved():
+    from megatron.bridge.training.config import (
+        OptimizerConfigOverrideProviderContext,
+    )
+    from megatron.core.optimizer import OptimizerConfig, ParamKey
+
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 5e-5, "min_lr": None, "weight_decay": 0.0}
+    )
+    assert provider is not None
+
+    optimizer_config = OptimizerConfig(optimizer="adam", lr=1e-6, min_lr=1e-7)
+    context = OptimizerConfigOverrideProviderContext(
+        scheduler_config=None, optimizer_config=optimizer_config, model=None
+    )
+    overrides = provider.build_config_overrides(context)
+
+    draft_key = ParamKey(name="*draft_model.*")
+    assert draft_key in overrides
+    draft_override = overrides[draft_key]
+    assert draft_override["max_lr"] == 5e-5
+    # min_lr defaults to the draft lr when unset.
+    assert draft_override["min_lr"] == 5e-5
+    assert draft_override["start_wd"] == 0.0
+    assert draft_override["end_wd"] == 0.0
+
+    # The standard megatron-bridge overrides must survive the merge.
+    from megatron.core.optimizer import get_standard_config_overrides
+
+    standard = get_standard_config_overrides(config=optimizer_config) or {}
+    for key in standard:
+        assert key in overrides
+
+    # The glob must match DDP-prefixed draft param names but not policy params.
+    assert fnmatch.fnmatch(
+        "module.module.draft_model.eagle_module.fc.weight", "*draft_model.*"
+    )
+    assert not fnmatch.fnmatch(
+        "module.module.decoder.layers.0.mlp.linear_fc1.weight", "*draft_model.*"
+    )
+
+
+def _make_param_group(*, params, **overrides):
+    """A param group shaped like mcore's ``_get_param_groups`` output.
+
+    Keys are derived from the live ``param_group_identifier_keys`` tuple (with
+    shared defaults) so the fakes track upstream instead of hard-coding a
+    snapshot of the tuple; a future key added upstream lands as a shared
+    default and stays collision-free.
+    """
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+
+    defaults = {
+        "wd_mult": 1.0,
+        "lr_mult": 1.0,
+        "is_expert_parallel": False,
+        "is_decoupled_lr": False,
+        "optimizer": "adam",
+        "max_lr": 1e-6,
+        "min_lr": 1e-7,
+        "start_wd": 0.01,
+        "end_wd": 0.01,
+    }
+    group = {
+        key: defaults.get(key) for key in mcore_optimizer.param_group_identifier_keys
+    }
+    group.update(overrides)
+    group["params"] = params
+    return group
+
+
+def test_upstream_identifier_keys_cover_draft_group_identity():
+    """Pin the upstream premise the draft group's resume safety relies on.
+
+    mcore matches checkpointed optimizer param groups to runtime groups by
+    ``param_group_identifier_keys``; the draft group differs from the policy
+    group only in max_lr/min_lr/start_wd/end_wd, so those must be part of the
+    identity or a resumed run silently swaps the two groups' hyperparameters
+    (observed pre-fix: policy at 50x LR). Upstream added them in
+    Megatron-LM#4705; a submodule regression should fail loudly here instead
+    of corrupting a resume. distrib_optimizer holds its own binding via
+    ``from ... import``, so every consuming module is checked.
+    """
+    from megatron.core import optimizer as mcore_optimizer_pkg
+    from megatron.core.optimizer import distrib_optimizer as mcore_distrib_optimizer
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+
+    for module in (mcore_optimizer, mcore_distrib_optimizer, mcore_optimizer_pkg):
+        keys = set(module.param_group_identifier_keys)
+        assert {"max_lr", "min_lr", "start_wd", "end_wd"} <= keys
+
+
+def test_resume_group_matching_keeps_policy_and_draft_hyperparams():
+    """Regression test: resume must not conflate the policy and draft groups.
+
+    The draft param group differs from the policy group only in
+    max_lr/min_lr/wd endpoints. ``param_group_identifier_keys`` includes those
+    fields (see the premise test above), so ``_filter_and_reorder_param_groups``
+    must map each saved group back onto its own runtime group even when the
+    saved order is flipped. ``DistributedOptimizer.load_state_dict`` builds an
+    equivalent dict keyed by the same tuple, so this exercises the shared
+    matching mechanism for both load paths.
+    """
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    policy_group = _make_param_group(max_lr=1e-6, min_lr=1e-7, params=[0, 1])
+    draft_group = _make_param_group(max_lr=5e-5, min_lr=5e-5, params=[2])
+    current_groups = [policy_group, draft_group]
+    saved_groups = [dict(draft_group), dict(policy_group)]  # reversed on disk
+
+    reordered = MegatronOptimizer._filter_and_reorder_param_groups(
+        current_groups, saved_groups
+    )
+    assert reordered[0]["max_lr"] == 1e-6
+    assert reordered[0]["min_lr"] == 1e-7
+    assert reordered[1]["max_lr"] == 5e-5
+    assert reordered[1]["min_lr"] == 5e-5
+    # Only the hyperparameters follow the identity matching; ``params`` keep
+    # state-dict positional order (upstream contract — they map the saved
+    # optimizer state onto the current groups).
+    assert reordered[0]["params"] == [2]
+    assert reordered[1]["params"] == [0, 1]
+
+    # The identity must be collision-free over these groups, which is what
+    # DistributedOptimizer.load_state_dict's dict-based mapping needs.
+    identifier_keys = mcore_optimizer.param_group_identifier_keys
+    identity_tuples = {tuple(g[k] for k in identifier_keys) for g in saved_groups}
+    assert len(identity_tuples) == len(saved_groups)
+
+
+def test_draft_override_distinctness_guard():
+    from megatron.bridge.training.config import (
+        OptimizerConfigOverrideProviderContext,
+    )
+    from megatron.core.optimizer import OptimizerConfig, ParamKey
+
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    optimizer_config = OptimizerConfig(optimizer="adam", lr=1e-6, min_lr=1e-7)
+    context = OptimizerConfigOverrideProviderContext(
+        scheduler_config=None, optimizer_config=optimizer_config, model=None
+    )
+
+    # weight_decay-only override: start_wd/end_wd are identifier keys, so the
+    # group is distinguishable at resume and the config must be accepted.
+    wd_only_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": None, "min_lr": None, "weight_decay": 0.01}
+    )
+    assert wd_only_provider is not None
+    wd_only_overrides = wd_only_provider.build_config_overrides(context)
+    wd_only_override = wd_only_overrides[ParamKey(name="*draft_model.*")]
+    assert wd_only_override["start_wd"] == 0.01
+    assert wd_only_override["end_wd"] == 0.01
+    assert "max_lr" not in wd_only_override
+
+    # Draft lr/min_lr numerically equal to the policy's and no weight decay:
+    # nothing distinguishes the groups at resume, so this must be rejected.
+    same_lr_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 1e-6, "min_lr": 1e-7, "weight_decay": None}
+    )
+    assert same_lr_provider is not None
+    with pytest.raises(ValueError, match="must differ from the policy's"):
+        same_lr_provider.build_config_overrides(context)
+
+    # Draft lr equal to the policy lr but min_lr defaulting to the draft lr
+    # (!= policy min_lr) keeps the pair distinct and is allowed.
+    distinct_min_lr_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 1e-6, "min_lr": None, "weight_decay": None}
+    )
+    overrides = distinct_min_lr_provider.build_config_overrides(context)
+    assert overrides is not None

--- a/tests/unit/models/megatron/test_hidden_capture_aux_layers.py
+++ b/tests/unit/models/megatron/test_hidden_capture_aux_layers.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hidden-state capture must tap the aux layers the draft was built for.
+
+The drafter checkpoint's ``target_layer_ids`` (or
+``policy.draft.aux_layer_indices``) decide which policy layers feed the draft
+at serving time; the trainer capture must hook the same layers, not the
+hard-coded defaults (silent feature mismatch when the counts match, fc width
+mismatch when they don't).
+"""
+
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = pytest.mark.mcore
+
+from megatron.core import parallel_state  # noqa: E402
+
+from nemo_rl.models.megatron.draft.hidden_capture import (  # noqa: E402
+    get_capture_context,
+    get_eagle3_aux_hidden_state_layers,
+)
+
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA (parallel_state init)"
+)
+
+
+def _make_policy_stub(num_layers: int) -> torch.nn.Module:
+    model = torch.nn.Module()
+    model.config = types.SimpleNamespace(num_layers=num_layers)
+    model.decoder = torch.nn.Module()
+    layers = []
+    for layer_idx in range(num_layers):
+        layer = torch.nn.Identity()
+        layer.layer_number = layer_idx + 1  # mcore layer_number is 1-based
+        layers.append(layer)
+    model.decoder.layers = torch.nn.ModuleList(layers)
+    return model
+
+
+@requires_gpu
+def test_capture_hooks_follow_configured_aux_layers(tmp_path):
+    created_process_group = False
+    try:
+        torch.cuda.set_device(0)
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmp_path / 'capture_pg_init'}",
+            )
+            created_process_group = True
+        parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+        model = _make_policy_stub(num_layers=8)
+
+        # Configured ids (e.g. an external checkpoint's target_layer_ids)
+        # must reach the hooks verbatim.
+        context, capture = get_capture_context(
+            model, enabled=True, aux_layer_indices=(2, 5)
+        )
+        assert capture.aux_layer_indices == (2, 5)
+        assert capture._local_aux_indices == [2, 5]
+        with context:
+            # One hook per aux layer (the stub has no embedding module).
+            assert len(capture._hooks) == 2
+
+        # Without configured ids the default formula applies.
+        _, default_capture = get_capture_context(model, enabled=True)
+        assert default_capture.aux_layer_indices == get_eagle3_aux_hidden_state_layers(
+            8
+        )
+    finally:
+        parallel_state.destroy_model_parallel()
+        if created_process_group and dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/unit/models/megatron/test_tap_channel.py
+++ b/tests/unit/models/megatron/test_tap_channel.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PP > 1 tap-channel tests: one-sided transport, ring reuse, capture wiring."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+
+pytestmark = pytest.mark.mcore
+
+from megatron.core import parallel_state  # noqa: E402
+
+from nemo_rl.models.megatron.draft.hidden_capture import (  # noqa: E402
+    HiddenStateCapture,
+    TapChannel,
+)
+from nemo_rl.models.megatron.draft.utils import (  # noqa: E402
+    resolve_draft_aux_layer_ids,
+)
+
+requires_2_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs >= 2 GPUs"
+)
+requires_4_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 4, reason="needs >= 4 GPUs"
+)
+
+HIDDEN = 16
+# (seq_len, batch) per microbatch; 6 microbatches wrap the default pp=2 ring
+# (2 * pp_size = 4 slots) and exercise varying shapes within one slot budget.
+MB_SHAPES = [(8, 2), (16, 1), (5, 3), (12, 2), (16, 2), (3, 1)]
+
+
+def _init_pp(rank: int, world: int, init_file: str) -> None:
+    # File rendezvous: fixed TCP ports fall inside the cluster's ephemeral
+    # range (9000-65000) and collide with lingering sockets of earlier tests.
+    dist.init_process_group(
+        "nccl", rank=rank, world_size=world, init_method=f"file://{init_file}"
+    )
+    torch.cuda.set_device(rank)
+    parallel_state.initialize_model_parallel(pipeline_model_parallel_size=world)
+
+
+def _teardown() -> None:
+    dist.barrier()
+    parallel_state.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+def _pattern(tag: float, seq_len: int, batch: int, width: int) -> torch.Tensor:
+    base = torch.arange(seq_len * batch * width, device="cuda", dtype=torch.float32)
+    return (base.view(seq_len, batch, width) * 1e-3 + tag).to(torch.bfloat16)
+
+
+def _make_channel(rank: int, local_layer_ids, net=None, **kwargs) -> TapChannel:
+    """net: list of source ranks forced onto the NCCL side channel (None = all IPC)."""
+    net_group = (
+        dist.new_group(list(range(dist.get_world_size()))) if net is not None else None
+    )
+    return TapChannel(
+        aux_layer_ids=kwargs.pop("aux_layer_ids", [1, 3]),
+        local_layer_ids=local_layer_ids,
+        has_embedding=rank == 0,
+        hidden_size=HIDDEN,
+        slot_rows=kwargs.pop("slot_rows", 64),
+        dtype=torch.bfloat16,
+        pp_group=parallel_state.get_pipeline_model_parallel_group(),
+        net_group=net_group,
+        net_sources_override=net,
+        get_timeout_s=30.0,
+        **kwargs,
+    )
+
+
+def _roundtrip_worker(rank: int, world: int, init_file: str, net) -> None:
+    _init_pp(rank, world, init_file)
+    channel = _make_channel(rank, local_layer_ids=[1] if rank == 0 else [3], net=net)
+    for i, (seq_len, batch) in enumerate(MB_SHAPES):
+        if rank == 0:
+            channel.put(_pattern(i, seq_len, batch, 2 * HIDDEN))
+        else:
+            local = _pattern(i + 1000.0, seq_len, batch, HIDDEN)
+            embeds, hidden = channel.get([local])
+            ref = _pattern(i, seq_len, batch, 2 * HIDDEN)
+            torch.testing.assert_close(embeds, ref[..., :HIDDEN])
+            torch.testing.assert_close(
+                hidden, torch.cat([ref[..., HIDDEN:], local], dim=-1)
+            )
+    _teardown()
+
+
+@requires_2_gpus
+@pytest.mark.parametrize("net", [None, [0]], ids=["ipc", "net"])
+def test_channel_roundtrip_pp2(net, tmp_path):
+    mp.spawn(
+        _roundtrip_worker, args=(2, str(tmp_path / "pg_init"), net), nprocs=2, join=True
+    )
+
+
+def _pp4_worker(rank: int, world: int, init_file: str, net) -> None:
+    _init_pp(rank, world, init_file)
+    # Stage 2 owns no tap layers -> inactive source (EAGLE-3-at-PP=4 shape).
+    local_ids = {0: [1], 1: [4, 5], 2: [], 3: [7]}[rank]
+    channel = _make_channel(
+        rank, local_layer_ids=local_ids, aux_layer_ids=[1, 4, 5, 7], net=net
+    )
+    assert channel.sources == [0, 1]
+    for i, (seq_len, batch) in enumerate(MB_SHAPES[:3]):
+        if rank == 0:
+            channel.put(_pattern(i, seq_len, batch, 2 * HIDDEN))
+        elif rank == 1:
+            channel.put(_pattern(i + 10.0, seq_len, batch, 2 * HIDDEN))
+        elif rank == 3:
+            local = _pattern(i + 1000.0, seq_len, batch, HIDDEN)
+            embeds, hidden = channel.get([local])
+            ref0 = _pattern(i, seq_len, batch, 2 * HIDDEN)
+            ref1 = _pattern(i + 10.0, seq_len, batch, 2 * HIDDEN)
+            torch.testing.assert_close(embeds, ref0[..., :HIDDEN])
+            torch.testing.assert_close(
+                hidden, torch.cat([ref0[..., HIDDEN:], ref1, local], dim=-1)
+            )
+    _teardown()
+
+
+@requires_4_gpus
+@pytest.mark.parametrize("net", [None, [0], [0, 1]], ids=["ipc", "mixed", "net"])
+def test_channel_pp4_uneven_and_inactive_source(net, tmp_path):
+    mp.spawn(_pp4_worker, args=(4, str(tmp_path / "pg_init"), net), nprocs=4, join=True)
+
+
+def _overrun_worker(rank: int, world: int, init_file: str, net) -> None:
+    _init_pp(rank, world, init_file)
+    # The net path only backs up once the payload exceeds NCCL's per-connection
+    # FIFO buffering (tiny sends complete without a matched recv), so its
+    # variant uses a multi-MB chunk; IPC blocks on the header regardless.
+    rows = (1 << 20) if net is not None else 4
+    channel = _make_channel(
+        rank,
+        local_layer_ids=[1] if rank == 0 else [3],
+        net=net,
+        slot_rows=rows,
+        ring_slots=1,
+        put_timeout_s=0.5,
+    )
+    if rank == 0:
+        channel.put(_pattern(0.0, rows, 1, 2 * HIDDEN))
+        try:
+            channel.put(_pattern(1.0, rows, 1, 2 * HIDDEN))  # slot never freed
+            raise AssertionError("second put into a full ring should time out")
+        except RuntimeError as e:
+            assert "still unconsumed" in str(e), str(e)
+    else:
+        time.sleep(2.0)  # let rank 0 hit its put timeout first
+        channel.get([_pattern(1000.0, rows, 1, HIDDEN)])  # then drain put #1
+    _teardown()
+
+
+@requires_2_gpus
+@pytest.mark.parametrize("net", [None, [0]], ids=["ipc", "net"])
+def test_channel_slot_overrun_raises(net, tmp_path):
+    mp.spawn(
+        _overrun_worker, args=(2, str(tmp_path / "pg_init"), net), nprocs=2, join=True
+    )
+
+
+class _AddLayer(nn.Module):
+    """Stand-in decoder layer: output = input + layer_number (1-based, global)."""
+
+    def __init__(self, layer_number: int):
+        super().__init__()
+        self.layer_number = layer_number
+
+    def forward(self, x):
+        return x + float(self.layer_number)
+
+
+class _FakeTrunk(nn.Module):
+    def __init__(self, layer_numbers, with_embedding: bool):
+        super().__init__()
+        self.config = SimpleNamespace(num_layers=4)
+        self.decoder = SimpleNamespace(
+            layers=nn.ModuleList([_AddLayer(n) for n in layer_numbers])
+        )
+        if with_embedding:
+            self.embedding = nn.Identity()
+
+
+# layer_number (1-based) per stage; PP=4 mirrors the dflash-8b shape scaled
+# down: uneven remote taps (1/2/0 layers), an inactive middle source stage,
+# and one tap local to the draft stage. Embeds always come from stage 0.
+_CAPTURE_LAYERS = {
+    2: {0: (1, 2), 1: (3, 4)},
+    4: {0: (1, 2), 1: (3, 4), 2: (5, 6), 3: (7, 8)},
+}
+_CAPTURE_AUX = {2: (1, 3), 4: (1, 2, 3, 7)}
+
+
+def _stage_chain(layer_numbers, x):
+    """Replay a stage's _AddLayer chain bf16-exactly: {global_layer_idx: output}."""
+    outputs, h = {}, x
+    for n in layer_numbers:
+        h = h + float(n)
+        outputs[n - 1] = h
+    return outputs
+
+
+def _capture_worker(rank: int, world: int, init_file: str, net) -> None:
+    _init_pp(rank, world, init_file)
+    layers = _CAPTURE_LAYERS[world]
+    aux = _CAPTURE_AUX[world]
+    local_ids = [n - 1 for n in layers[rank] if n - 1 in aux]
+    channel = _make_channel(
+        rank, local_layer_ids=local_ids, aux_layer_ids=list(aux), net=net
+    )
+    trunk = _FakeTrunk(layers[rank], with_embedding=rank == 0)
+    capture = HiddenStateCapture(
+        model=trunk, aux_layer_indices=aux, tap_channel=channel
+    )
+    for i, (seq_len, batch) in enumerate(MB_SHAPES[:3]):
+        x = _pattern(i + 50.0 * rank, seq_len, batch, HIDDEN)  # this stage's input
+        with capture.capture_context():
+            h = trunk.embedding(x) if rank == 0 else x
+            for layer in trunk.decoder.layers:
+                h = layer(h)
+        states = capture.get_captured_states()
+        if rank < world - 1:
+            assert states.hidden_states is None and states.inputs_embeds is None
+        else:
+            x0 = _pattern(i, seq_len, batch, HIDDEN)
+            torch.testing.assert_close(states.inputs_embeds, x0)
+            owner = {n - 1: r for r, nums in layers.items() for n in nums}
+            chains = {
+                r: _stage_chain(
+                    layers[r], _pattern(i + 50.0 * r, seq_len, batch, HIDDEN)
+                )
+                for r in {owner[g] for g in aux}
+            }
+            expected = torch.cat([chains[owner[g]][g] for g in sorted(aux)], dim=-1)
+            torch.testing.assert_close(states.hidden_states, expected)
+    _teardown()
+
+
+@requires_2_gpus
+@pytest.mark.parametrize("net", [None, [0]], ids=["ipc", "net"])
+def test_capture_pp2_matches_local_semantics(net, tmp_path):
+    mp.spawn(
+        _capture_worker, args=(2, str(tmp_path / "pg_init"), net), nprocs=2, join=True
+    )
+
+
+@requires_4_gpus
+@pytest.mark.parametrize("net", [None, [0, 1]], ids=["ipc", "net"])
+def test_capture_pp4_uneven_and_inactive_source(net, tmp_path):
+    mp.spawn(
+        _capture_worker, args=(4, str(tmp_path / "pg_init"), net), nprocs=4, join=True
+    )
+
+
+def _mask_row_worker(rank: int, world: int, init_file: str) -> None:
+    _init_pp(rank, world, init_file)
+    channel = _make_channel(
+        rank,
+        local_layer_ids=[1] if rank == 0 else [3],
+        needs_mask_row=True,
+        mask_token_id=5,
+    )
+    torch.manual_seed(7)  # same weights on both ranks for the reference
+    table = nn.Embedding(11, HIDDEN).cuda().to(torch.bfloat16)
+    chunk = SimpleNamespace(embedding=SimpleNamespace(word_embeddings=table))
+    channel.begin_pass(chunk if rank == 0 else None)
+    torch.testing.assert_close(channel.mask_row, table.weight[5].detach())
+    _teardown()
+
+
+@requires_2_gpus
+def test_begin_pass_broadcasts_mask_row(tmp_path):
+    mp.spawn(_mask_row_worker, args=(2, str(tmp_path / "pg_init")), nprocs=2, join=True)
+
+
+def test_resolve_draft_aux_layer_ids_cpu():
+    """The tap channel and the builders must agree on the aux ids on every rank."""
+    explicit = {"speculator_type": "dflash", "aux_layer_indices": [1, 9, 17]}
+    assert resolve_draft_aux_layer_ids(explicit, 36) == (1, 9, 17)
+    defaults = {"speculator_type": "eagle3"}
+    assert resolve_draft_aux_layer_ids(defaults, 36) == (1, 17, 32)

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -707,21 +707,23 @@ class TestForwardWithPostProcessingFn:
         draft_model.assert_called_once_with(
             hidden_states=hidden_states,
             input_embeds=shifted_embeds,
-            attention_mask=attention_mask,
+            # The draft decoder is forced onto the fused causal path (see
+            # EagleModel); the forward must pass attention_mask=None.
+            attention_mask=None,
             packed_seq_params=None,
         )
         assert data_dict["student_logits"] is student_logits
 
-    @patch("nemo_rl.models.megatron.train._pack_input_ids")
+    @patch("nemo_rl.models.megatron.train.get_context_parallel_group")
     @patch("nemo_rl.models.megatron.train.get_capture_context")
     @patch("nemo_rl.models.megatron.train.model_forward")
-    def test_forward_with_draft_model_packed_shifts_ids_and_reembeds(
+    def test_forward_with_draft_model_packed_rolls_within_subsequences(
         self,
         mock_model_forward,
         mock_get_capture_context,
-        mock_pack_input_ids,
+        mock_get_cp_group,
     ):
-        """Packed draft forward must shift ids per segment, re-embed, and pass packed_seq_params."""
+        """Packed draft forward must shift embeds per segment and stash packed coords."""
         from nemo_rl.models.megatron.data import ProcessedMicrobatch
         from nemo_rl.models.megatron.train import (
             LogprobsPostProcessor,
@@ -731,8 +733,8 @@ class TestForwardWithPostProcessingFn:
         output_tensor = torch.randn(1, 6, 5)
         student_logits = torch.randn(1, 6, 5)
         hidden_states = torch.randn(6, 1, 4)
-        shifted_input_ids = torch.tensor([[2, 3, 0, 5, 6, 0]])
-        shifted_embeds = torch.randn(6, 1, 4)
+        # Rows valued 1..6 so the expected per-segment shift is exact.
+        inputs_embeds = torch.arange(1.0, 7.0).view(6, 1, 1).repeat(1, 1, 4)
         position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]])
         packed_seq_params = SimpleNamespace(
             cu_seqlens_q=torch.tensor([0, 3, 6]),
@@ -740,13 +742,12 @@ class TestForwardWithPostProcessingFn:
         )
 
         mock_model_forward.return_value = output_tensor
-        mock_pack_input_ids.return_value = shifted_input_ids
+        mock_get_cp_group.return_value = MagicMock()
         mock_capture = MagicMock()
         mock_capture.get_captured_states.return_value = SimpleNamespace(
             hidden_states=hidden_states,
-            inputs_embeds=None,
+            inputs_embeds=inputs_embeds,
         )
-        mock_capture.model.embedding.return_value = shifted_embeds
         mock_get_capture_context.return_value = (nullcontext(), mock_capture)
 
         data_dict = {"input_ids": torch.tensor([[1, 2, 3], [4, 5, 6]])}
@@ -766,7 +767,11 @@ class TestForwardWithPostProcessingFn:
         )
         draft_model = MagicMock(return_value=student_logits)
 
-        with patch.object(post_processor, "__call__", return_value=MagicMock()):
+        with (
+            patch.object(post_processor, "__call__", return_value=MagicMock()),
+            patch("torch.distributed.get_world_size", return_value=1),
+            patch("torch.distributed.get_rank", return_value=0),
+        ):
             forward_with_post_processing_fn(
                 data_iterator=iter([processed_mb]),
                 model=MagicMock(),
@@ -774,21 +779,25 @@ class TestForwardWithPostProcessingFn:
                 draft_model=draft_model,
             )
 
-        mock_pack_input_ids.assert_called_once_with(
-            data_dict["input_ids"],
-            packed_seq_params.cu_seqlens_q,
-            packed_seq_params.cu_seqlens_q_padded,
-            roll_shift=-1,
+        assert torch.equal(
+            data_dict["draft_packed_seq_index"], torch.tensor([0, 0, 0, 1, 1, 1])
         )
-        mock_capture.model.embedding.assert_called_once_with(
-            input_ids=shifted_input_ids, position_ids=position_ids
+        assert torch.equal(
+            data_dict["draft_packed_pos_in_seq"], torch.tensor([0, 1, 2, 0, 1, 2])
         )
-        draft_model.assert_called_once_with(
-            hidden_states=hidden_states,
-            input_embeds=shifted_embeds,
-            attention_mask=attention_mask,
-            packed_seq_params=packed_seq_params,
+        assert torch.equal(
+            data_dict["draft_packed_local_cu_seqlens"],
+            torch.tensor([0, 3, 6], dtype=torch.int32),
         )
+        kwargs = draft_model.call_args.kwargs
+        assert kwargs["hidden_states"] is hidden_states
+        assert kwargs["attention_mask"] is None
+        assert kwargs["packed_seq_params"] is packed_seq_params
+        # The shift must stop at the packing boundary: [1,2,3|4,5,6] ->
+        # [2,3,0|5,6,0], never leaking row 4 into the first segment.
+        expected_embeds = torch.roll(inputs_embeds, shifts=-1, dims=0)
+        expected_embeds[[2, 5]] = 0
+        torch.testing.assert_close(kwargs["input_embeds"], expected_embeds)
         assert data_dict["student_logits"] is student_logits
 
     @patch("megatron.core.transformer.multi_token_prediction.roll_tensor")
@@ -853,6 +862,7 @@ class TestForwardWithPostProcessingFn:
         draft_model.forward_ttt.assert_called_once_with(
             hidden_states=hidden_states,
             input_embeds=shifted_embeds,
+            packed_seq_params=None,
         )
         draft_model.assert_not_called()
         assert data_dict["student_logits_by_pass"] is logits_by_pass

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -791,6 +791,73 @@ class TestForwardWithPostProcessingFn:
         )
         assert data_dict["student_logits"] is student_logits
 
+    @patch("megatron.core.transformer.multi_token_prediction.roll_tensor")
+    @patch("nemo_rl.models.megatron.train.get_context_parallel_group")
+    @patch("nemo_rl.models.megatron.train.get_capture_context")
+    @patch("nemo_rl.models.megatron.train.model_forward")
+    def test_forward_with_ttt_draft_model_uses_forward_ttt(
+        self,
+        mock_model_forward,
+        mock_get_capture_context,
+        mock_get_cp_group,
+        mock_roll_tensor,
+    ):
+        """draft_ttt_steps > 1 must route through forward_ttt with per-pass logits."""
+        from nemo_rl.models.megatron.data import ProcessedMicrobatch
+        from nemo_rl.models.megatron.train import (
+            LogprobsPostProcessor,
+            forward_with_post_processing_fn,
+        )
+
+        hidden_states = torch.randn(3, 1, 4)
+        inputs_embeds = torch.randn(3, 1, 4)
+        shifted_embeds = torch.randn(3, 1, 4)
+        logits_by_pass = [torch.randn(1, 3, 5), torch.randn(1, 3, 5)]
+
+        mock_model_forward.return_value = torch.randn(1, 3, 5)
+        mock_get_cp_group.return_value = MagicMock()
+        mock_roll_tensor.return_value = (shifted_embeds, None)
+        mock_capture = MagicMock()
+        mock_capture.get_captured_states.return_value = SimpleNamespace(
+            hidden_states=hidden_states,
+            inputs_embeds=inputs_embeds,
+        )
+        mock_get_capture_context.return_value = (nullcontext(), mock_capture)
+
+        data_dict = {"input_ids": torch.tensor([[1, 2, 3]])}
+        processed_mb = ProcessedMicrobatch(
+            data_dict=data_dict,
+            input_ids=torch.tensor([[1, 2, 3]]),
+            input_ids_cp_sharded=torch.tensor([[1, 2, 3]]),
+            attention_mask=None,
+            position_ids=torch.tensor([[0, 1, 2]]),
+            packed_seq_params=None,
+            cu_seqlens_padded=None,
+            original_seq_length=3,
+        )
+        post_processor = LogprobsPostProcessor(
+            cfg={"sequence_packing": {"enabled": False}}
+        )
+        draft_model = MagicMock()
+        draft_model.forward_ttt.return_value = logits_by_pass
+
+        with patch.object(post_processor, "__call__", return_value=MagicMock()):
+            forward_with_post_processing_fn(
+                data_iterator=iter([processed_mb]),
+                model=MagicMock(),
+                post_processing_fn=post_processor,
+                draft_model=draft_model,
+                draft_ttt_steps=2,
+            )
+
+        draft_model.forward_ttt.assert_called_once_with(
+            hidden_states=hidden_states,
+            input_embeds=shifted_embeds,
+        )
+        draft_model.assert_not_called()
+        assert data_dict["student_logits_by_pass"] is logits_by_pass
+        assert "student_logits" not in data_dict
+
 
 class TestMegatronForwardBackward:
     """Tests for megatron_forward_backward function."""

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -32,6 +32,7 @@ import torch
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossInputType
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 pytestmark = pytest.mark.mcore
 
@@ -1309,6 +1310,58 @@ class TestLossPostProcessor:
 
         # Loss should be scaled by num_microbatches / (cp_size * cp_size) = 4 / (2 * 2) = 1.0
         assert torch.isclose(loss, torch.tensor(1.0))
+
+    @patch(
+        "nemo_rl.models.megatron.train.get_tensor_model_parallel_rank", return_value=0
+    )
+    @patch("nemo_rl.models.megatron.train.get_tensor_model_parallel_group")
+    @patch("nemo_rl.models.megatron.train.get_context_parallel_group")
+    @patch(
+        "nemo_rl.models.megatron.train.get_context_parallel_world_size", return_value=2
+    )
+    @patch("nemo_rl.models.megatron.train.prepare_loss_input")
+    @patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
+    def test_cp_normalize_divides_policy_loss_only(
+        self,
+        mock_draft_loss_cls,
+        mock_prepare_loss_input,
+        mock_cp_size,
+        mock_cp_grp,
+        mock_tp_grp,
+        mock_tp_rank,
+    ):
+        """The 1/cp_size compensates the policy logprob all-gather; the rank-local draft loss must not see it."""
+        from nemo_rl.models.megatron.train import LossPostProcessor
+
+        mock_tp_grp.return_value = MagicMock()
+        mock_cp_grp.return_value = MagicMock()
+        mock_prepare_loss_input.side_effect = lambda logits, data, loss_fn, **_: (
+            {},
+            data,
+        )
+        mock_draft_loss_cls.return_value = MagicMock(
+            return_value=(torch.tensor(2.0), {"draft_loss_pass_1": 2.0})
+        )
+
+        policy_loss_fn = MagicMock(return_value=(torch.tensor(8.0), {}))
+        policy_loss_fn.input_type = LossInputType.LOGIT
+        cfg = {"sequence_packing": {"enabled": False}, "draft": {"loss_weight": 1.0}}
+        processor = LossPostProcessor(
+            loss_fn=policy_loss_fn, cfg=cfg, num_microbatches=1, cp_normalize=True
+        )
+
+        wrapped_fn = processor(
+            data_dict=BatchedDataDict({"student_logits": torch.zeros(1, 3, 5)}),
+            global_valid_seqs=torch.tensor(1),
+            global_valid_toks=torch.tensor(3),
+        )
+        loss, metrics = wrapped_fn(torch.zeros(1, 3, 5))
+
+        # (policy / cp + draft) * num_microbatches / cp: only the policy term is
+        # divided; the trailing factor cancels mcore's own cp / num_microbatches.
+        # Dividing the combined loss instead would give (8 + 2) / 2 / 2 = 2.5.
+        assert torch.isclose(loss, torch.tensor((8.0 / 2 + 2.0) / 2))
+        assert metrics["draft_loss"] == 2.0
 
     @patch(
         "nemo_rl.models.megatron.train.get_tensor_model_parallel_rank", return_value=0

--- a/tests/unit/models/megatron/test_ttt_attention.py
+++ b/tests/unit/models/megatron/test_ttt_attention.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerics tests for the two-part TTT draft attention.
+
+The reference is a dense fp32 joint softmax over the concatenated trunk
+(causal pass-1) and branch (same-anchor diagonal) key sets — the staircase
+mask materialized — with native autograd. The kernel path must match it in
+both outputs and all input gradients (including the cross-pass gradient
+accumulation into the stashed pass-1 KV).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nemo_rl.models.megatron.draft.eagle import (
+    TTTDraftCoreAttention,
+    TwoPartTTTAttention,
+)
+
+# The module under test is torch-only, but importing it goes through the
+# draft package __init__, which pulls in megatron.core.
+pytestmark = pytest.mark.mcore
+
+
+def _flash_attn_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import flash_attn  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_flash_attn = pytest.mark.skipif(
+    not _flash_attn_available(), reason="Requires CUDA and flash-attn"
+)
+
+
+def dense_two_part_reference(
+    q: torch.Tensor,
+    k1: torch.Tensor,
+    v1: torch.Tensor,
+    kb: torch.Tensor,
+    vb: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Joint softmax over causal trunk + diagonal branch keys, materialized.
+
+    Shapes follow TwoPartTTTAttention: q ``[B,S,Hq,D]``, k1/v1 ``[B,S,Hkv,D]``,
+    kb/vb ``[B,S,Hkv,P,D]`` (P may be 0 for a pure causal pass).
+    """
+    batch, seqlen, num_q_heads, _ = q.shape
+    group = num_q_heads // k1.shape[2]
+    k1e = k1.repeat_interleave(group, dim=2)
+    v1e = v1.repeat_interleave(group, dim=2)
+    kbe = kb.repeat_interleave(group, dim=2)
+    vbe = vb.repeat_interleave(group, dim=2)
+
+    scores_trunk = torch.einsum("bihd,bjhd->bhij", q, k1e) * softmax_scale
+    causal = torch.tril(torch.ones(seqlen, seqlen, dtype=torch.bool, device=q.device))
+    scores_trunk = scores_trunk.masked_fill(~causal, float("-inf"))
+    scores_branch = torch.einsum("bihd,bihpd->bhip", q, kbe) * softmax_scale
+
+    probs = torch.softmax(torch.cat([scores_trunk, scores_branch], dim=-1), dim=-1)
+    out_trunk = torch.einsum("bhij,bjhd->bihd", probs[..., :seqlen], v1e)
+    out_branch = torch.einsum("bhip,bihpd->bihd", probs[..., seqlen:], vbe)
+    return out_trunk + out_branch
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    actual = actual.float()
+    expected = expected.float()
+    max_diff = (actual - expected).abs().max().item()
+    scale = expected.abs().max().clamp(min=1e-6).item()
+    assert max_diff <= 3e-2 + 3e-2 * scale, (
+        f"{name}: max abs diff {max_diff:.4e} (ref scale {scale:.4e})"
+    )
+
+
+@requires_flash_attn
+@pytest.mark.parametrize("num_kv_heads", [8, 4])  # MHA and GQA (group = 2)
+def test_two_part_function_matches_dense(num_kv_heads):
+    torch.manual_seed(0)
+    batch, seqlen, num_q_heads, head_dim, num_branch = 2, 97, 8, 64, 2
+    softmax_scale = head_dim**-0.5
+
+    def make(*shape):
+        return torch.randn(
+            *shape, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+
+    q = make(batch, seqlen, num_q_heads, head_dim)
+    k1 = make(batch, seqlen, num_kv_heads, head_dim)
+    v1 = make(batch, seqlen, num_kv_heads, head_dim)
+    kb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
+    vb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
+
+    out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k1, v1, kb, vb), dout)
+
+    refs = [t.detach().float().requires_grad_() for t in (q, k1, v1, kb, vb)]
+    out_ref = dense_two_part_reference(*refs, softmax_scale)
+    ref_grads = torch.autograd.grad(out_ref, refs, dout.float())
+
+    _assert_close(out, out_ref, "out")
+    for grad, ref_grad, name in zip(
+        grads, ref_grads, ("dq", "dk1", "dv1", "dkb", "dvb")
+    ):
+        _assert_close(grad, ref_grad, name)
+
+
+@requires_flash_attn
+def test_module_multi_pass_matches_dense_and_accumulates_trunk_grads():
+    """Three TTT passes through the core-attention module vs the dense oracle.
+
+    The pass-1 KV gradient must accumulate contributions from all passes
+    (trunk reuse), which is the property the KV stash exists for.
+    """
+    torch.manual_seed(1)
+    num_passes = 3
+    seqlen, batch, num_q_heads, num_kv_heads, head_dim = 64, 2, 4, 2, 32
+    softmax_scale = head_dim**-0.5
+
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+
+    # sbhd layout, as handed to core_attention by MCore SelfAttention.
+    qs = [
+        torch.randn(
+            seqlen, batch, num_q_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    ks = [
+        torch.randn(
+            seqlen, batch, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    vs = [
+        torch.randn(
+            seqlen, batch, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+
+    outs = []
+    for ttt_pass in range(1, num_passes + 1):
+        module.begin_pass(ttt_pass)
+        outs.append(module(qs[ttt_pass - 1], ks[ttt_pass - 1], vs[ttt_pass - 1], None))
+    module.reset()
+
+    dout = [torch.randn_like(o) for o in outs]
+    grads = torch.autograd.grad(outs, qs + ks + vs, dout, allow_unused=False)
+
+    # Dense reference on fp32 leaf copies (bshd layout).
+    def to_bshd(t):
+        return t.detach().float().transpose(0, 1).contiguous().requires_grad_()
+
+    qs_ref = [to_bshd(t) for t in qs]
+    ks_ref = [to_bshd(t) for t in ks]
+    vs_ref = [to_bshd(t) for t in vs]
+    outs_ref = []
+    for ttt_pass in range(1, num_passes + 1):
+        branch_k = ks_ref[1:ttt_pass]
+        if branch_k:
+            kb = torch.stack(branch_k, dim=3)
+            vb = torch.stack(vs_ref[1:ttt_pass], dim=3)
+        else:
+            kb = ks_ref[0].new_zeros(batch, seqlen, num_kv_heads, 0, head_dim)
+            vb = kb.clone()
+        out_ref = dense_two_part_reference(
+            qs_ref[ttt_pass - 1], ks_ref[0], vs_ref[0], kb, vb, softmax_scale
+        )
+        # bshd -> [S, B, H*D] to match the module output contract.
+        outs_ref.append(
+            out_ref.transpose(0, 1).reshape(seqlen, batch, num_q_heads * head_dim)
+        )
+    grads_ref = torch.autograd.grad(
+        outs_ref, qs_ref + ks_ref + vs_ref, [d.float() for d in dout]
+    )
+
+    for out, out_ref in zip(outs, outs_ref):
+        _assert_close(out, out_ref, "pass output")
+    for grad, grad_ref, name in zip(
+        grads,
+        grads_ref,
+        [f"dq{i}" for i in range(num_passes)]
+        + [f"dk{i}" for i in range(num_passes)]
+        + [f"dv{i}" for i in range(num_passes)],
+    ):
+        # Reference grads are bshd; module grads are sbhd.
+        _assert_close(grad, grad_ref.transpose(0, 1), name)
+
+    # The cross-pass property: pass-1 KV must receive gradient from passes 2/3
+    # too — compare against a single-pass-only reference to prove they differ.
+    single_pass_ref = torch.autograd.grad(
+        dense_two_part_reference(
+            to_bshd(qs[0]),
+            (k_only := to_bshd(ks[0])),
+            to_bshd(vs[0]),
+            k_only.new_zeros(batch, seqlen, num_kv_heads, 0, head_dim),
+            k_only.new_zeros(batch, seqlen, num_kv_heads, 0, head_dim),
+            softmax_scale,
+        )
+        .transpose(0, 1)
+        .reshape(seqlen, batch, num_q_heads * head_dim),
+        k_only,
+        dout[0].float(),
+    )[0]
+    assert not torch.allclose(
+        grads[num_passes].float(), single_pass_ref.transpose(0, 1), atol=1e-3
+    ), "pass-1 K grad shows no cross-pass contribution"
+
+
+@requires_flash_attn
+def test_two_part_matches_modelopt_multistep_mask_oracle():
+    """External oracle: modelopt's own TTT mask must reproduce our attention.
+
+    modelopt's ``set_multi_step_attention_mask`` (megatron_eagle.py) is the
+    NVIDIA reference for EAGLE multi-step training: one dense attention over
+    the K-fold concatenated sequence with a staircase mask. Its layout shifts
+    the hidden stream down one row per pass, so its pass-(p) block row ``r``
+    hosts our (pass p, anchor i = r - (p-1)) entry. Feeding the SAME per-pass
+    q/k/v to both sides and comparing row-by-row pins our trunk/branch
+    correspondence and the LSE merge against an implementation we did not
+    write. RoPE is bypassed (raw q/k/v), so this checks mask semantics only.
+    """
+    from modelopt.torch.speculative.plugins.megatron_eagle import (
+        set_multi_step_attention_mask,
+    )
+
+    torch.manual_seed(7)
+    seqlen, num_heads, head_dim, num_passes = 8, 2, 16, 3
+    softmax_scale = head_dim**-0.5
+    device = "cuda"
+
+    qs = [
+        torch.randn(seqlen, 1, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+        for _ in range(num_passes)
+    ]
+    ks = [torch.randn_like(qs[0]) for _ in range(num_passes)]
+    vs = [torch.randn_like(qs[0]) for _ in range(num_passes)]
+
+    # --- Our side: per-pass two-part attention -> [S, 1, H*D] per pass.
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+    ours = []
+    for ttt_pass in range(1, num_passes + 1):
+        module.begin_pass(ttt_pass)
+        ours.append(
+            module(qs[ttt_pass - 1], ks[ttt_pass - 1], vs[ttt_pass - 1], None).float()
+        )
+    module.reset()
+
+    # --- Oracle side: modelopt runs S query rows per ttt step against the
+    # KV cache of all previous blocks; set_multi_step_attention_mask(base, p)
+    # returns the [S, (p+1)S] mask for block p's queries. Block p row r hosts
+    # our (pass p+1, anchor i = r - p); rows with no valid anchor stay zero
+    # and are never compared.
+    def place_block(stream, block):
+        placed = torch.zeros(
+            seqlen, num_heads, head_dim, device=device, dtype=torch.float32
+        )
+        for row in range(block, seqlen):
+            placed[row] = stream[block][row - block, 0].float()
+        return placed
+
+    # Base causal mask (True = masked) + modelopt's pass-1 edge adjustment
+    # (their pass-1 stream carries rolled input_ids, so the mask is shifted
+    # diagonally and the padding row/col is masked out).
+    causal = torch.triu(
+        torch.ones(seqlen, seqlen, dtype=torch.bool, device=device), diagonal=1
+    )[None, None]
+    base = causal.clone()
+    base[:, :, :-1, :-1] = causal[:, :, 1:, 1:]
+    base[:, :, -1, :] = True
+    base[:, :, :, -1] = True
+
+    for block in range(num_passes):
+        qc = place_block(qs, block)
+        kc = torch.cat([place_block(ks, b) for b in range(block + 1)], dim=0)
+        vc = torch.cat([place_block(vs, b) for b in range(block + 1)], dim=0)
+        mask = set_multi_step_attention_mask(base.clone(), block)[0, 0]
+        assert mask.shape == (seqlen, (block + 1) * seqlen)
+
+        scores = torch.einsum("ihd,jhd->hij", qc, kc) * softmax_scale
+        scores = scores.masked_fill(mask.unsqueeze(0), float("-inf"))
+        oracle = torch.einsum("hij,jhd->ihd", torch.softmax(scores, dim=-1), vc)
+
+        # Compare on rows that are valid on both sides: modelopt unmasks the
+        # block-p self-diagonal only for rows in [p, S-2].
+        for row in range(block, seqlen - 1):
+            anchor = row - block
+            mine = ours[block][anchor, 0].view(num_heads, head_dim)
+            ref = oracle[row]
+            max_diff = (mine - ref).abs().max().item()
+            assert max_diff < 2e-2, (
+                f"pass {block + 1} anchor {anchor} (oracle row {row}): "
+                f"max diff {max_diff:.4e}"
+            )
+
+
+def test_module_guards_do_not_require_gpu():
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+    q = torch.randn(4, 1, 2, 8)
+
+    with pytest.raises(RuntimeError, match="begin_pass"):
+        module(q, q, q, None)
+
+    module.begin_pass(1)
+    with pytest.raises(RuntimeError, match="in order"):
+        module.begin_pass(3)
+
+    with pytest.raises(NotImplementedError, match="sequence packing"):
+        module(q, q, q, None, packed_seq_params=object())
+
+    with pytest.raises(ValueError, match="attention_mask"):
+        module(q, q, q, torch.ones(1))
+
+
+def test_module_rejects_attention_dropout():
+    with pytest.raises(ValueError, match="dropout"):
+        TTTDraftCoreAttention(
+            SimpleNamespace(
+                attention_dropout=0.1, context_parallel_size=1, softmax_scale=None
+            )
+        )

--- a/tests/unit/models/megatron/test_ttt_attention.py
+++ b/tests/unit/models/megatron/test_ttt_attention.py
@@ -18,7 +18,9 @@ The reference is a dense fp32 joint softmax over the concatenated trunk
 (causal pass-1) and branch (same-anchor diagonal) key sets — the staircase
 mask materialized — with native autograd. The kernel path must match it in
 both outputs and all input gradients (including the cross-pass gradient
-accumulation into the stashed pass-1 KV).
+accumulation into the stashed pass-1 KV). Packed (THD) inputs must match the
+per-subsequence references; the CP=2 ring is covered in
+test_ttt_packing_cp.py.
 """
 
 from types import SimpleNamespace
@@ -51,6 +53,40 @@ requires_flash_attn = pytest.mark.skipif(
 )
 
 
+def _attn_config() -> SimpleNamespace:
+    return SimpleNamespace(softmax_scale=None)
+
+
+def apply_two_part_bshd(
+    q: torch.Tensor,
+    k1: torch.Tensor,
+    v1: torch.Tensor,
+    kb: torch.Tensor,
+    vb: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Drive the THD kernel entry with batched [B, S, ...] tensors.
+
+    Flattens the batch into B equal-length packed subsequences (the same
+    layout TTTDraftCoreAttention builds for unpacked input) and reshapes the
+    output back; autograd flows through the views to the [B, S, ...] leaves.
+    """
+    batch, seqlen = q.shape[0], q.shape[1]
+    cu_seqlens = torch.arange(0, batch + 1, device=q.device, dtype=torch.int32) * seqlen
+    out = TwoPartTTTAttention.apply(
+        q.reshape(batch * seqlen, *q.shape[2:]),
+        k1.reshape(batch * seqlen, *k1.shape[2:]),
+        v1.reshape(batch * seqlen, *v1.shape[2:]),
+        kb.reshape(batch * seqlen, *kb.shape[2:]) if kb is not None else None,
+        vb.reshape(batch * seqlen, *vb.shape[2:]) if vb is not None else None,
+        cu_seqlens,
+        seqlen,
+        softmax_scale,
+        None,
+    )
+    return out.view(batch, seqlen, *out.shape[1:])
+
+
 def dense_two_part_reference(
     q: torch.Tensor,
     k1: torch.Tensor,
@@ -61,8 +97,8 @@ def dense_two_part_reference(
 ) -> torch.Tensor:
     """Joint softmax over causal trunk + diagonal branch keys, materialized.
 
-    Shapes follow TwoPartTTTAttention: q ``[B,S,Hq,D]``, k1/v1 ``[B,S,Hkv,D]``,
-    kb/vb ``[B,S,Hkv,P,D]`` (P may be 0 for a pure causal pass).
+    Shapes: q ``[B,S,Hq,D]``, k1/v1 ``[B,S,Hkv,D]``, kb/vb ``[B,S,Hkv,P,D]``
+    (P may be 0 for a pure causal pass).
     """
     batch, seqlen, num_q_heads, _ = q.shape
     group = num_q_heads // k1.shape[2]
@@ -110,7 +146,7 @@ def test_two_part_function_matches_dense(num_kv_heads):
     kb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
     vb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
 
-    out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+    out = apply_two_part_bshd(q, k1, v1, kb, vb, softmax_scale)
     dout = torch.randn_like(out)
     grads = torch.autograd.grad(out, (q, k1, v1, kb, vb), dout)
 
@@ -119,6 +155,60 @@ def test_two_part_function_matches_dense(num_kv_heads):
     ref_grads = torch.autograd.grad(out_ref, refs, dout.float())
 
     _assert_close(out, out_ref, "out")
+    for grad, ref_grad, name in zip(
+        grads, ref_grads, ("dq", "dk1", "dv1", "dkb", "dvb")
+    ):
+        _assert_close(grad, ref_grad, name)
+
+
+@requires_flash_attn
+def test_two_part_function_packed_matches_per_sequence():
+    """A packed row of unequal subsequences vs each subsequence run alone.
+
+    Both the varlen trunk (causal restart at cu boundaries) and the branch
+    diagonals (purely index-local, so untouched by packing) must reproduce
+    the per-subsequence dense oracle in outputs and all gradients.
+    """
+    torch.manual_seed(3)
+    lengths = [48, 80, 32]
+    num_q_heads, num_kv_heads, head_dim, num_branch = 8, 4, 64, 2
+    softmax_scale = head_dim**-0.5
+    total = sum(lengths)
+    cu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    def make(*shape):
+        return torch.randn(
+            *shape, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+
+    q = make(total, num_q_heads, head_dim)
+    k1 = make(total, num_kv_heads, head_dim)
+    v1 = make(total, num_kv_heads, head_dim)
+    kb = make(total, num_kv_heads, num_branch, head_dim)
+    vb = make(total, num_kv_heads, num_branch, head_dim)
+
+    out = TwoPartTTTAttention.apply(
+        q, k1, v1, kb, vb, cu, max(lengths), softmax_scale, None
+    )
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k1, v1, kb, vb), dout)
+
+    refs = [t.detach().float().requires_grad_() for t in (q, k1, v1, kb, vb)]
+    ref_grads = [torch.zeros_like(r) for r in refs]
+    for seq_idx, length in enumerate(lengths):
+        start, end = int(cu[seq_idx]), int(cu[seq_idx + 1])
+        seq_refs = [r[start:end].unsqueeze(0) for r in refs]
+        out_ref = dense_two_part_reference(*seq_refs, softmax_scale)
+        _assert_close(out[start:end], out_ref[0], f"out seq {seq_idx}")
+        seq_grads = torch.autograd.grad(
+            out_ref, refs, dout[start:end].unsqueeze(0).float(), retain_graph=True
+        )
+        for acc, g in zip(ref_grads, seq_grads):
+            acc += g
     for grad, ref_grad, name in zip(
         grads, ref_grads, ("dq", "dk1", "dv1", "dkb", "dvb")
     ):
@@ -137,11 +227,7 @@ def test_module_multi_pass_matches_dense_and_accumulates_trunk_grads():
     seqlen, batch, num_q_heads, num_kv_heads, head_dim = 64, 2, 4, 2, 32
     softmax_scale = head_dim**-0.5
 
-    module = TTTDraftCoreAttention(
-        SimpleNamespace(
-            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
-        )
-    )
+    module = TTTDraftCoreAttention(_attn_config())
 
     # sbhd layout, as handed to core_attention by MCore SelfAttention.
     qs = [
@@ -233,6 +319,114 @@ def test_module_multi_pass_matches_dense_and_accumulates_trunk_grads():
 
 
 @requires_flash_attn
+def test_module_packed_multi_pass_matches_unpacked():
+    """Packed THD multi-pass module runs == per-subsequence unpacked runs.
+
+    Feeds the module the exact tensors MCore hands it in THD mode ([T, H, D]
+    with packed_seq_params) and checks outputs AND gradients against separate
+    unpacked runs of each subsequence.
+    """
+    torch.manual_seed(5)
+    num_passes = 3
+    lengths = [40, 72]
+    num_q_heads, num_kv_heads, head_dim = 4, 2, 32
+    total = sum(lengths)
+    cu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu,
+        cu_seqlens_q_padded=cu,
+        max_seqlen_q=max(lengths),
+    )
+
+    qs = [
+        torch.randn(
+            total, num_q_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    ks = [
+        torch.randn(
+            total, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    vs = [
+        torch.randn(
+            total, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+
+    module = TTTDraftCoreAttention(_attn_config())
+    outs = []
+    for ttt_pass in range(1, num_passes + 1):
+        module.begin_pass(ttt_pass)
+        outs.append(
+            module(
+                qs[ttt_pass - 1],
+                ks[ttt_pass - 1],
+                vs[ttt_pass - 1],
+                None,
+                packed_seq_params=packed_seq_params,
+            )
+        )
+    module.reset()
+    assert outs[0].shape == (total, num_q_heads * head_dim)
+    douts = [torch.randn_like(o) for o in outs]
+    grads = torch.autograd.grad(outs, qs + ks + vs, douts)
+
+    # Reference: run each subsequence through its own module, unpacked
+    # ([L, 1, H, D] sbhd), and scatter outputs/grads back into packed rows.
+    outs_ref = [torch.zeros_like(o) for o in outs]
+    grads_ref = [torch.zeros_like(t) for t in qs + ks + vs]
+    for seq_idx, length in enumerate(lengths):
+        start, end = int(cu[seq_idx]), int(cu[seq_idx + 1])
+        seq_leaves = [
+            t[start:end].detach().clone().requires_grad_() for t in qs + ks + vs
+        ]
+        seq_qs = seq_leaves[:num_passes]
+        seq_ks = seq_leaves[num_passes : 2 * num_passes]
+        seq_vs = seq_leaves[2 * num_passes :]
+        ref_module = TTTDraftCoreAttention(_attn_config())
+        seq_outs = []
+        for ttt_pass in range(1, num_passes + 1):
+            ref_module.begin_pass(ttt_pass)
+            seq_outs.append(
+                ref_module(
+                    seq_qs[ttt_pass - 1].unsqueeze(1),
+                    seq_ks[ttt_pass - 1].unsqueeze(1),
+                    seq_vs[ttt_pass - 1].unsqueeze(1),
+                    None,
+                )
+            )
+        ref_module.reset()
+        seq_grads = torch.autograd.grad(
+            seq_outs,
+            seq_leaves,
+            [d[start:end].unsqueeze(1) for d in douts],
+        )
+        for out_ref, seq_out in zip(outs_ref, seq_outs):
+            out_ref[start:end] = seq_out.squeeze(1)
+        for acc, g in zip(grads_ref, seq_grads):
+            acc[start:end] = g
+
+    for out, out_ref in zip(outs, outs_ref):
+        _assert_close(out, out_ref, "packed pass output")
+    names = (
+        [f"dq{i}" for i in range(num_passes)]
+        + [f"dk{i}" for i in range(num_passes)]
+        + [f"dv{i}" for i in range(num_passes)]
+    )
+    for grad, grad_ref, name in zip(grads, grads_ref, names):
+        _assert_close(grad, grad_ref, f"packed {name}")
+
+
+@requires_flash_attn
 def test_two_part_matches_modelopt_multistep_mask_oracle():
     """External oracle: modelopt's own TTT mask must reproduce our attention.
 
@@ -262,11 +456,7 @@ def test_two_part_matches_modelopt_multistep_mask_oracle():
     vs = [torch.randn_like(qs[0]) for _ in range(num_passes)]
 
     # --- Our side: per-pass two-part attention -> [S, 1, H*D] per pass.
-    module = TTTDraftCoreAttention(
-        SimpleNamespace(
-            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
-        )
-    )
+    module = TTTDraftCoreAttention(_attn_config())
     ours = []
     for ttt_pass in range(1, num_passes + 1):
         module.begin_pass(ttt_pass)
@@ -324,11 +514,7 @@ def test_two_part_matches_modelopt_multistep_mask_oracle():
 
 
 def test_module_guards_do_not_require_gpu():
-    module = TTTDraftCoreAttention(
-        SimpleNamespace(
-            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
-        )
-    )
+    module = TTTDraftCoreAttention(_attn_config())
     q = torch.randn(4, 1, 2, 8)
 
     with pytest.raises(RuntimeError, match="begin_pass"):
@@ -338,17 +524,23 @@ def test_module_guards_do_not_require_gpu():
     with pytest.raises(RuntimeError, match="in order"):
         module.begin_pass(3)
 
+    with pytest.raises(NotImplementedError, match="thd"):
+        module(q, q, q, None, packed_seq_params=SimpleNamespace(qkv_format="bshd"))
+
+    # CP without packing has no zigzag metadata to ring over.
+    module.pg_collection = SimpleNamespace(cp=SimpleNamespace(size=lambda: 2))
     with pytest.raises(NotImplementedError, match="sequence packing"):
-        module(q, q, q, None, packed_seq_params=object())
+        module(q, q, q, None)
 
     with pytest.raises(ValueError, match="attention_mask"):
         module(q, q, q, torch.ones(1))
+
+    with pytest.raises(ValueError, match="attention_bias"):
+        module(q, q, q, None, attention_bias=torch.ones(1))
 
 
 def test_module_rejects_attention_dropout():
     with pytest.raises(ValueError, match="dropout"):
         TTTDraftCoreAttention(
-            SimpleNamespace(
-                attention_dropout=0.1, context_parallel_size=1, softmax_scale=None
-            )
+            SimpleNamespace(softmax_scale=None, attention_dropout=0.1)
         )

--- a/tests/unit/models/megatron/test_ttt_packing_cp.py
+++ b/tests/unit/models/megatron/test_ttt_packing_cp.py
@@ -1,0 +1,564 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sequence packing + context parallelism for the TTT draft path.
+
+Covers the pure helpers (zigzag coords, per-subsequence CP-aware roll), the
+CP=2 zigzag-ring two-part attention against a single-rank global reference
+(forward AND all gradients, including the dK/dV ring return-to-owner), and
+the packed draft cross-entropy loss against the unpacked slice path.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from nemo_rl.algorithms.loss.utils import (
+    packed_zigzag_token_coords,
+    roll_packed_left_cp,
+)
+
+pytestmark = pytest.mark.mcore
+
+requires_2_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="requires 2 GPUs (CP=2)"
+)
+
+
+def _flash_attn_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import flash_attn  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def test_packed_zigzag_token_coords_manual():
+    """cp=2, two subsequences of 8 and 16 tokens: hand-checked zigzag coords."""
+    cu = torch.tensor([0, 8, 24], dtype=torch.int32)
+
+    seq_index, pos = packed_zigzag_token_coords(cu, cp_rank=0, cp_size=2)
+    assert seq_index.tolist() == [0] * 4 + [1] * 8
+    assert pos.tolist() == [0, 1, 6, 7] + [0, 1, 2, 3, 12, 13, 14, 15]
+
+    seq_index, pos = packed_zigzag_token_coords(cu, cp_rank=1, cp_size=2)
+    assert seq_index.tolist() == [0] * 4 + [1] * 8
+    assert pos.tolist() == [2, 3, 4, 5] + [4, 5, 6, 7, 8, 9, 10, 11]
+
+    # cp=1 degenerates to the identity layout.
+    seq_index, pos = packed_zigzag_token_coords(cu, cp_rank=0, cp_size=1)
+    assert seq_index.tolist() == [0] * 8 + [1] * 16
+    assert pos.tolist() == list(range(8)) + list(range(16))
+
+    # Every rank's coords tile the global row exactly once.
+    covered = set()
+    for rank in range(2):
+        seq_index, pos = packed_zigzag_token_coords(cu, cp_rank=rank, cp_size=2)
+        covered.update(
+            (int(s), int(p)) for s, p in zip(seq_index.tolist(), pos.tolist())
+        )
+    assert covered == {(0, p) for p in range(8)} | {(1, p) for p in range(16)}
+
+
+def _reference_packed_roll(tensor: torch.Tensor, cu: torch.Tensor) -> torch.Tensor:
+    """Per-subsequence left shift with zero tail, on an UNSHARDED row."""
+    out = torch.zeros_like(tensor)
+    for i in range(cu.numel() - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        out[start : end - 1] = tensor[start + 1 : end]
+    return out
+
+
+def test_roll_packed_left_cp_single_rank():
+    torch.manual_seed(0)
+    cu = torch.tensor([0, 5, 12, 14], dtype=torch.int32)
+    x = torch.randn(14, 3)
+    rolled = roll_packed_left_cp(x, cu, None)
+    torch.testing.assert_close(rolled, _reference_packed_roll(x, cu))
+
+
+def _run_cp2_rank(rank: int, world_size: int, init_file: str) -> None:
+    import torch.distributed as dist
+
+    from nemo_rl.models.megatron.draft.eagle import TwoPartTTTAttention
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"file://{init_file}",
+    )
+    cp_group = dist.group.WORLD
+    device = torch.device("cuda", rank)
+
+    # Identical global data on both ranks (seeded CPU generator).
+    torch.manual_seed(11)
+    lengths = [32, 64]  # multiples of 2*cp
+    cu_global = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(), dtype=torch.int32
+    ).to(device)
+    total = sum(lengths)
+    num_q_heads, num_kv_heads, head_dim, num_branch = 4, 2, 32, 2
+    softmax_scale = head_dim**-0.5
+
+    def make(*shape):
+        return torch.randn(*shape, dtype=torch.bfloat16).to(device)
+
+    q_g = make(total, num_q_heads, head_dim)
+    k1_g = make(total, num_kv_heads, head_dim)
+    v1_g = make(total, num_kv_heads, head_dim)
+    kb_g = make(total, num_kv_heads, num_branch, head_dim)
+    vb_g = make(total, num_kv_heads, num_branch, head_dim)
+    dout_g = make(total, num_q_heads, head_dim)
+
+    # Local zigzag shard via the coords helper (also validates it end to end:
+    # global_row maps each local row to its global packed position).
+    seq_index, pos = packed_zigzag_token_coords(cu_global, rank, world_size)
+    global_row = (cu_global[:-1].to(torch.long)[seq_index] + pos).to(device)
+    cu_local = torch.div(cu_global, world_size, rounding_mode="floor").to(torch.int32)
+    max_local = max(lengths) // world_size
+
+    def tol(actual, expected, name):
+        actual, expected = actual.float(), expected.float()
+        max_diff = (actual - expected).abs().max().item()
+        scale = expected.abs().max().clamp(min=1e-6).item()
+        assert max_diff <= 3e-2 + 3e-2 * scale, (
+            f"rank {rank} {name}: max abs diff {max_diff:.4e} (scale {scale:.4e})"
+        )
+
+    # --- roll_packed_left_cp: local roll+boundary exchange == global roll.
+    x_g = torch.randn(total, 5, dtype=torch.float32).to(device)
+    ref = _reference_packed_roll(x_g, cu_global)
+    rolled_local = roll_packed_left_cp(x_g[global_row], cu_local, cp_group)
+    torch.testing.assert_close(rolled_local, ref[global_row])
+
+    # --- two-part attention, pass 1 (no branch) and pass >= 2 (branch).
+    for has_branch in (False, True):
+        leaves_g = [
+            t.detach().clone().requires_grad_() for t in (q_g, k1_g, v1_g, kb_g, vb_g)
+        ]
+        out_ref = TwoPartTTTAttention.apply(
+            leaves_g[0],
+            leaves_g[1],
+            leaves_g[2],
+            leaves_g[3] if has_branch else None,
+            leaves_g[4] if has_branch else None,
+            cu_global,
+            max(lengths),
+            softmax_scale,
+            None,
+        )
+        ref_inputs = leaves_g[: 5 if has_branch else 3]
+        grads_ref = torch.autograd.grad(out_ref, ref_inputs, dout_g)
+
+        leaves_l = [
+            t[global_row].detach().clone().requires_grad_()
+            for t in (q_g, k1_g, v1_g, kb_g, vb_g)
+        ]
+        out_local = TwoPartTTTAttention.apply(
+            leaves_l[0],
+            leaves_l[1],
+            leaves_l[2],
+            leaves_l[3] if has_branch else None,
+            leaves_l[4] if has_branch else None,
+            cu_local,
+            max_local,
+            softmax_scale,
+            cp_group,
+        )
+        tol(out_local, out_ref[global_row], f"out(branch={has_branch})")
+        local_inputs = leaves_l[: 5 if has_branch else 3]
+        grads_local = torch.autograd.grad(out_local, local_inputs, dout_g[global_row])
+        names = ("dq", "dk1", "dv1", "dkb", "dvb")
+        for g_local, g_ref, name in zip(grads_local, grads_ref, names):
+            tol(g_local, g_ref[global_row], f"{name}(branch={has_branch})")
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@requires_2_gpus
+@pytest.mark.skipif(not _flash_attn_available(), reason="Requires flash-attn")
+def test_two_part_attention_cp2_matches_single_rank(tmp_path):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / "ttt_cp2_init")
+    procs = []
+    for rank in range(2):
+        proc = ctx.Process(target=_run_cp2_rank, args=(rank, 2, init_file))
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=600)
+    for rank, proc in enumerate(procs):
+        assert proc.exitcode == 0, f"rank {rank} exited with {proc.exitcode}"
+
+
+def test_draft_ce_loss_packed_matches_unpacked():
+    """Packed-mode loss (teacher roll + coord-gathered masks) == slice mode.
+
+    The same student leaves feed both paths (the packed row is a gathered
+    view), so loss values AND student gradients must agree.
+    """
+    from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
+    from nemo_rl.algorithms.loss.utils import compute_draft_pass_valid_counts
+
+    torch.manual_seed(2)
+    batch, seq_len, vocab, num_passes = 2, 24, 32, 2
+    lengths = torch.tensor([20, 24])
+
+    teacher = torch.randn(batch, seq_len, vocab)
+    students = [
+        torch.randn(batch, seq_len, vocab, requires_grad=True)
+        for _ in range(num_passes)
+    ]
+    # Assistant span starts at 6 / 3; zero outside the valid lengths and at
+    # position 0 (never a next-token target in practice, keeps it realistic).
+    token_mask = torch.zeros(batch, seq_len)
+    token_mask[0, 6:20] = 1.0
+    token_mask[1, 3:24] = 1.0
+    sample_mask = torch.ones(batch)
+    counts = compute_draft_pass_valid_counts(
+        token_mask, sample_mask, ttt_steps=num_passes
+    )
+
+    loss_fn = DraftCrossEntropyLossFn()
+    unpacked_loss, unpacked_metrics = loss_fn(
+        teacher_logits=teacher.detach(),
+        student_logits_by_pass=list(students),
+        data={"token_mask": token_mask, "sample_mask": sample_mask},
+        global_valid_seqs=None,
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+    unpacked_loss.backward()
+    unpacked_grads = [s.grad.detach().clone() for s in students]
+    for s in students:
+        s.grad = None
+
+    # Packed layout: concatenate the valid prefixes (cp=1, no padding).
+    cu = torch.tensor([0, 20, 44], dtype=torch.int32)
+    seq_index, pos_in_seq = packed_zigzag_token_coords(cu, cp_rank=0, cp_size=1)
+
+    def pack(t):
+        return torch.cat([t[0, :20], t[1, :24]], dim=0).unsqueeze(0)
+
+    packed_students = [pack(s) for s in students]
+    packed_loss, packed_metrics = loss_fn(
+        teacher_logits=pack(teacher).detach(),
+        student_logits_by_pass=packed_students,
+        data={
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "input_lengths": lengths,
+            "draft_packed_seq_index": seq_index,
+            "draft_packed_pos_in_seq": pos_in_seq,
+            "draft_packed_local_cu_seqlens": cu,
+        },
+        global_valid_seqs=None,
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=counts,
+    )
+    torch.testing.assert_close(packed_loss, unpacked_loss, rtol=1e-5, atol=1e-6)
+    for ttt_pass in range(1, num_passes + 1):
+        assert packed_metrics[f"draft_loss_pass_{ttt_pass}"] == pytest.approx(
+            unpacked_metrics[f"draft_loss_pass_{ttt_pass}"], rel=1e-4
+        )
+    packed_loss.backward()
+    for s, ref in zip(students, unpacked_grads):
+        torch.testing.assert_close(s.grad, ref, rtol=1e-5, atol=1e-6)
+
+
+def _run_forward_ttt_packed_rank(rank: int, world_size: int, init_file: str) -> None:
+    """Whole-module check: packed forward_ttt == per-subsequence unpacked runs.
+
+    Exercises the pieces the operator-level tests cannot: the per-pass packed
+    RoPE (positions restart per subsequence, offset d-1), the CP-aware packed
+    embedding roll between passes, and packed_seq_params threading through
+    modelopt's EagleModule into the core attention.
+    """
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.packed_seq_params import PackedSeqParams
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"file://{init_file}",
+    )
+    parallel_state.destroy_model_parallel()
+    parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+    )
+
+    hidden, vocab = 64, 128
+    draft = _make_eagle_model(hidden, vocab, ttt_steps=3)
+
+    lengths = [24, 40]
+    total = sum(lengths)
+    cu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        cu_seqlens_q_padded=cu,
+        cu_seqlens_kv_padded=cu,
+        max_seqlen_q=max(lengths),
+        max_seqlen_kv=max(lengths),
+    )
+    taps = torch.randn(total, 1, 3 * hidden, device="cuda", dtype=torch.bfloat16)
+    embeds = torch.randn(total, 1, hidden, device="cuda", dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        packed_logits = draft.forward_ttt(
+            hidden_states=taps,
+            input_embeds=embeds,
+            packed_seq_params=packed_seq_params,
+        )
+        assert all(t.shape == (1, total, vocab) for t in packed_logits)
+
+        for seq_idx, length in enumerate(lengths):
+            start, end = int(cu[seq_idx]), int(cu[seq_idx + 1])
+            ref_logits = draft.forward_ttt(
+                hidden_states=taps[start:end],
+                input_embeds=embeds[start:end],
+            )
+            for ttt_pass, (packed_pass, ref_pass) in enumerate(
+                zip(packed_logits, ref_logits), start=1
+            ):
+                actual = packed_pass[0, start:end].float()
+                expected = ref_pass[0].float()
+                # Positions past the subsequence tail feed rolled-in zeros in
+                # the packed run vs rolled-in zeros in the unpacked run — the
+                # inputs match, so ALL rows must agree.
+                max_diff = (actual - expected).abs().max().item()
+                scale = expected.abs().max().clamp(min=1e-6).item()
+                assert max_diff <= 3e-2 + 3e-2 * scale, (
+                    f"seq {seq_idx} pass {ttt_pass}: max diff {max_diff:.4e} "
+                    f"(scale {scale:.4e})"
+                )
+
+    dist.barrier()
+    parallel_state.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not _flash_attn_available(), reason="Requires flash-attn")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="requires a GPU")
+def test_forward_ttt_packed_matches_per_sequence(tmp_path):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / "ttt_fwd_packed_init")
+    proc = ctx.Process(target=_run_forward_ttt_packed_rank, args=(0, 1, init_file))
+    proc.start()
+    proc.join(timeout=600)
+    assert proc.exitcode == 0, f"forward_ttt packed worker exited with {proc.exitcode}"
+
+
+def _make_eagle_model(hidden: int, vocab: int, ttt_steps: int):
+    """Shared tiny EagleModel builder for the forward_ttt equivalence tests."""
+    import torch.nn.functional as F
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+    from megatron.core.transformer import TransformerConfig
+
+    from nemo_rl.models.megatron.draft.eagle import EagleModel
+
+    # force_reset_rng: the tracker survives destroy_model_parallel(), so a
+    # second build in the same process would otherwise draw from leftover
+    # RNG state and get different weights.
+    model_parallel_cuda_manual_seed(123, force_reset_rng=True)
+    torch.manual_seed(7)
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden,
+        ffn_hidden_size=128,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=16,
+        normalization="RMSNorm",
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        add_bias_linear=False,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+    )
+    config.transformer_layer_spec = None
+    config.vocab_size = vocab
+    config.draft_vocab_size = vocab
+    config.seq_length = 256
+    config.gradient_accumulation_fusion = False
+    config.position_embedding_type = "rope"
+    config.rotary_percent = 1.0
+    config.rotary_base = 10000
+    config.rope_scaling = False
+    config.rope_scaling_factor = 8.0
+    config.use_input_layernorm_in_first_layer = True
+    config.use_last_layernorm = True
+    config.use_aux_hidden_state = True
+    config.eagle_aux_hidden_state_layer_ids = [0, 1, 2]
+    config.parallel_draft_step = 1
+    config.use_mtp_layernorm = None
+    config.parallel_draft_heads_num_layers = None
+    config.has_lm_head = True
+    config.apply_rope_fusion = False
+    model = EagleModel(config=config, ttt_steps=ttt_steps).cuda()
+    # modelopt's EagleModule builds fc with init_method=(lambda w: None) —
+    # deliberately UNinitialized (production always loads a checkpoint), so
+    # its weight is whatever memory the allocator hands back and differs
+    # between builds. Give it a deterministic value for build-vs-build
+    # equivalence tests.
+    fc_weight = model.eagle_module.fc.weight
+    with torch.no_grad():
+        fc_weight.copy_(
+            torch.randn(
+                fc_weight.shape, generator=torch.Generator().manual_seed(21)
+            ).to(dtype=fc_weight.dtype, device=fc_weight.device)
+            * 0.02
+        )
+    return model
+
+
+def _run_forward_ttt_cp2_rank(rank: int, world_size: int, init_file: str) -> None:
+    """CP=2 forward_ttt end-to-end vs the CP=1 global run of the SAME weights.
+
+    Phase 1 initializes model parallel with CP=1 (world becomes DP=2, both
+    ranks compute the identical global packed forward). Phase 2 re-initializes
+    with CP=2, rebuilds the model from the same seeds, feeds each rank its
+    zigzag shard, and checks the local per-pass logits against the global
+    reference's zigzag slice — covering the ring attention, the CP rotary
+    slicing, and the CP boundary exchange of the inter-pass embed roll inside
+    the real decoder stack.
+    """
+    import torch.distributed as dist
+    from megatron.core import parallel_state
+    from megatron.core.packed_seq_params import PackedSeqParams
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"file://{init_file}",
+    )
+
+    hidden, vocab, ttt_steps = 64, 128, 3
+    lengths = [24, 40]  # multiples of 2*cp = 4
+    total = sum(lengths)
+    cu_cpu = torch.tensor(
+        [0] + torch.cumsum(torch.tensor(lengths), 0).tolist(), dtype=torch.int32
+    )
+    torch.manual_seed(11)
+    taps_g = torch.randn(total, 1, 3 * hidden, dtype=torch.bfloat16).cuda()
+    embeds_g = torch.randn(total, 1, hidden, dtype=torch.bfloat16).cuda()
+
+    def make_psp(cu):
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            cu_seqlens_q_padded=cu,
+            cu_seqlens_kv_padded=cu,
+            max_seqlen_q=max(lengths),
+            max_seqlen_kv=max(lengths),
+        )
+
+    # ---- Phase 1: CP=1 (DP=2) global reference, identical on both ranks.
+    parallel_state.destroy_model_parallel()
+    parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+    )
+    draft = _make_eagle_model(hidden, vocab, ttt_steps)
+    with torch.no_grad():
+        ref_logits = draft.forward_ttt(
+            hidden_states=taps_g,
+            input_embeds=embeds_g,
+            packed_seq_params=make_psp(cu_cpu.cuda()),
+        )
+    ref_logits = [t.clone() for t in ref_logits]
+    del draft
+    dist.barrier()
+
+    # ---- Phase 2: CP=2, same seeds -> same weights, zigzag-local inputs.
+    parallel_state.destroy_model_parallel()
+    parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=2,
+    )
+    cp_group = parallel_state.get_context_parallel_group()
+    cp_rank = cp_group.rank()
+    draft = _make_eagle_model(hidden, vocab, ttt_steps)
+    assert draft._ttt_attn_modules, "CP=2 must install the custom core attention"
+    # Mirror build_draft_model's pg_collection attribute pass.
+    from types import SimpleNamespace
+
+    for module in draft.modules():
+        if hasattr(module, "pg_collection"):
+            module.pg_collection = SimpleNamespace(cp=cp_group)
+
+    seq_index, pos = packed_zigzag_token_coords(cu_cpu, cp_rank, 2)
+    global_row = (cu_cpu[:-1].to(torch.long)[seq_index] + pos).cuda()
+    with torch.no_grad():
+        local_logits = draft.forward_ttt(
+            hidden_states=taps_g[global_row],
+            input_embeds=embeds_g[global_row],
+            packed_seq_params=make_psp(cu_cpu.cuda()),
+        )
+
+    for ttt_pass, (local_pass, ref_pass) in enumerate(
+        zip(local_logits, ref_logits), start=1
+    ):
+        actual = local_pass[0].float()
+        expected = ref_pass[0, global_row].float()
+        max_diff = (actual - expected).abs().max().item()
+        scale = expected.abs().max().clamp(min=1e-6).item()
+        assert max_diff <= 3e-2 + 3e-2 * scale, (
+            f"rank {cp_rank} pass {ttt_pass}: max diff {max_diff:.4e} "
+            f"(scale {scale:.4e})"
+        )
+
+    dist.barrier()
+    parallel_state.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+@requires_2_gpus
+@pytest.mark.skipif(not _flash_attn_available(), reason="Requires flash-attn")
+def test_forward_ttt_cp2_matches_global(tmp_path):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    ctx = mp.get_context("spawn")
+    init_file = str(tmp_path / "ttt_fwd_cp2_init")
+    procs = []
+    for rank in range(2):
+        proc = ctx.Process(target=_run_forward_ttt_cp2_rank, args=(rank, 2, init_file))
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=600)
+    for rank, proc in enumerate(procs):
+        assert proc.exitcode == 0, f"rank {rank} exited with {proc.exitcode}"

--- a/tests/unit/models/policy/test_lm_policy_draft_guards.py
+++ b/tests/unit/models/policy/test_lm_policy_draft_guards.py
@@ -46,30 +46,17 @@ def _init_policy(config):
     )
 
 
-def test_draft_with_context_parallelism_is_rejected():
-    """Online draft training must reject CP>1 at setup."""
-    with pytest.raises(ValueError, match="context parallelism"):
-        _init_policy(_draft_config(context_parallel_size=2))
-
-
-def test_draft_with_packing_and_pipeline_parallelism_is_rejected():
-    """Packed draft training must reject PP>1: the re-embed of the shifted
-    token ids needs the model embedding, which MCore constructs only on the
-    first pipeline stage while the draft runs on the last."""
-    with pytest.raises(ValueError, match="pipeline parallelism"):
-        _init_policy(_draft_config(pipeline_model_parallel_size=2))
-
-
-def test_draft_without_packing_allows_pipeline_parallelism_past_guard():
-    """PP>1 without packing must not trip the packed-PP guard (it fails later
-    on unrelated config plumbing, not with the guard's ValueError)."""
-    config = _draft_config(
-        pipeline_model_parallel_size=2, sequence_packing_enabled=False
-    )
+def test_draft_with_context_parallelism_requires_packing():
+    """The trunk ring needs the THD zigzag layout, so CP>1 rejects unpacked
+    batches at setup and passes the guard once sequence packing is on."""
+    with pytest.raises(ValueError, match="requires sequence packing"):
+        _init_policy(
+            _draft_config(context_parallel_size=2, sequence_packing_enabled=False)
+        )
     try:
-        _init_policy(config)
+        _init_policy(_draft_config(context_parallel_size=2))
     except ValueError as e:
-        assert "pipeline parallelism" not in str(e)
+        assert "requires sequence packing" not in str(e)
     except Exception:
         # Reaching config plumbing beyond the draft guards is sufficient.
         pass

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -313,6 +313,12 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1
+    ttt_pass_weights: null
+    loss_seq_chunk_size: 4096
+    lr: null
+    min_lr: null
+    weight_decay: null
 
   # See docs/design-docs/sequence-packing-and-dynamic-batching.md
   # for more details on dynamic batching and sequence packing.

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -309,6 +309,7 @@ policy:
 
   draft:
     enabled: false
+    speculator_type: eagle3
     model_name: null
     loss_weight: 0.1
     num_layers: null


### PR DESCRIPTION
# What does this PR do ?

Draft co-training with `megatron_cfg.pipeline_model_parallel_size > 1` (**Megatron** policy backend). The draft lives whole on the last pipeline stage, but what it consumes — the aux hidden states ("taps") of a few policy layers and the pass-1 input embeddings — is produced on earlier stages. This PR adds a one-sided **tap channel** that delivers them per microbatch without touching the pipeline schedule.

This is the PP half of the training-system work in our paper (https://arxiv.org/abs/2609.07108); the CP/packing half is #4059.

**Why not send/recv inside the schedule.** Taps are a detached data flow — no gradient crosses stages — but they are produced inside forwards that the 1F1B schedule is already driving with its own P2P. Blocking send/recv in forward hooks shares communicators and ordering with Megatron's pipeline P2P and can interleave with (or deadlock against) it, and the previous per-id gather assumed every stage could pair up per tensor. Multi-node PP additionally makes every stage pair cross-host (pp is Megatron's outermost rank dimension), so the transport has to work over the wire too.

**How this PR does it.**

- **Rings on the draft stage, one-sided writes from the sources.** At setup the last stage allocates one ring of landing slots per source stage — `ring_slots × slot_rows × width`, where width covers that stage's tap layers (plus the embeddings on the first stage); the reservation is exact and static. Intra-node, the ring is exported over CUDA IPC and each source's capture hook writes its microbatch's tap straight into the next slot on a side stream, then stamps a header the consumer polls: no recv, no pairing, no message ordering. Cross-node, the same put/get runs over a *dedicated* NCCL communicator per PP column (GPUDirect RDMA on the wire); it never shares a communicator with the schedule's P2P and both ends post ops in the same monotone microbatch order, so it cannot deadlock the schedule either.
- **Rendezvous by position, checked by stamp.** With a non-interleaved schedule every stage forwards microbatches in the same order, so the writer's *n*-th put and the draft stage's *n*-th get are the same microbatch; the header carries the writer's sequence number, and a mismatch raises instead of silently training on another microbatch's taps. Sources never block on the draft stage; the draft stage waits only when a tap has not landed yet (reported as `draft_tap_wait_s`, max over the PP group). A source running more than `ring_slots` microbatches ahead (slot overrun) and interleaved (virtual) PP are rejected rather than handled.
- **Mask row for block drafters.** DFlash/DSpark read the policy's *live* mask-token embedding, which lives on the first stage; `begin_pass` broadcasts that row over the PP group once per step, outside the schedule.
- **PP correctness fixes uncovered along the way.** The optimizer all-reduces a per-group flag across PP, so the `draft` grad-norm group must be registered on every rank, not only the owner stage (otherwise the collective order desyncs and `optimizer.step` deadlocks; regression test included). The block draft's `TransformerConfig` gets `pipeline_model_parallel_size=1` so `TransformerBlock` does not split its few layers across stages, and the PP == 1 guard is dropped. Refit broadcasts the exported draft weights across PP so every rank yields the same `draft.*` key set to its paired vLLM engine.

Limits: interleaved (virtual) pipeline schedules are rejected (the channel matches microbatches by per-stage forward order); the async GRPO loop is not wired for the new metric yet.

# Issues

Part of #3698 (5/5). **Stacked on #4059 (CP/packing)** → #3713 → #3712 → #3699 — until those merge, this diff includes their commits; review only the last commit (`feat(spec-decode): pipeline parallelism for draft co-training via a one-sided tap channel`).

# Usage

```yaml
policy:
  megatron_cfg:
    pipeline_model_parallel_size: 2   # draft on the last stage; taps arrive over the channel
    batch_p2p_sync: false             # drop Megatron-Core's device-wide sync after each pipeline p2p (see below)
  draft:
    enabled: true
    speculator_type: eagle3           # or dflash / dspark
```

The per-step rendezvous wait shows up as `draft_tap_wait_s` (max over the PP group, then over replicas).

**`batch_p2p_sync: false`** (new `megatron_cfg` key; omit = Megatron-Core's default `true`). Megatron-Core ends every batched pipeline p2p with `torch.cuda.synchronize()`, a guard for an old PyTorch `batch_isend_irecv` race. The sync is device-wide, so on a tap source stage it also waits for the tap send parked on the channel's side stream, which cannot complete before the draft stage posts the matching receive for that microbatch: the source stages get pinned to the last stage's schedule with no 1F1B slack (+170 ms/microbatch on every stage on a Qwen3.5-35B-A3B TP2/PP4 probe; step time 1.41x -> 1.17x of the no-draft baseline with the sync off, and on Qwen3.5-122B TP4/PP4/CP2 the update overhead went 1.60x -> 1.00x together with a 13/13/13/9 layer split). Ordering safety stays with the stream-level `Work.wait()` Megatron keeps either way. The principled fix, receiver-side pre-posted receives in the channel, is future work.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Draft for visibility.

Tests: channel round-trip / uneven-stage / slot-overrun / mask-row broadcast (2–4 GPUs, IPC and NCCL transports), capture-vs-local-semantics parity under PP2/PP4, and the grad-norm-group regression test. This is the code path behind the paper's PP experiments (see the paper for the full set of configurations), ported onto the stacked series.

