### PR TITLE
build: use vLLM Super Omni RADIO LayerNorm fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ nemo_run = { git = "https://github.com/NVIDIA-NeMo/Run", rev = "414f0077c648fde2
 # from these sources, and Docker installs them through uv like any other extra.
 # Keep these sources scoped to the vllm extra: sglang and mcore intentionally
 # resolve different FlashInfer versions from their normal package indexes.
-vllm = { git = "https://github.com/TomerBN-Nvidia/vllm.git", branch = "super_vl_rl_v0.25.1", extra = "vllm" }
+vllm = { git = "https://github.com/TomerBN-Nvidia/vllm.git", branch = "codex/fix-radio-final-layernorm", extra = "vllm" }
 flashinfer-python = { git = "https://github.com/TomerBN-Nvidia/flashinfer.git", branch = "super_vl_rl_v0.6.13", extra = "vllm" }
 flashinfer-cubin = { git = "https://github.com/TomerBN-Nvidia/flashinfer.git", branch = "super_vl_rl_v0.6.13", subdirectory = "flashinfer-cubin", extra = "vllm" }
 # torch/torchvision/triton all come from the torch index in order to pick up aarch64 wheels

--- a/uv.lock
+++ b/uv.lock
@@ -4253,7 +4253,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn" },
     { name = "uvloop" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=super_vl_rl_v0.25.1" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=codex%2Ffix-radio-final-layernorm" },
     { name = "wandb" },
     { name = "yappi", specifier = ">=1.7.6" },
 ]
@@ -4547,7 +4547,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'automodel'", specifier = ">=5.5.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'sglang'", specifier = "==5.6.0" },
     { name = "triton", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", index = "https://download.pytorch.org/whl/cu130" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=super_vl_rl_v0.25.1" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=codex%2Ffix-radio-final-layernorm" },
     { name = "wandb", specifier = ">=0.28.0" },
     { name = "zstandard" },
 ]
@@ -8378,7 +8378,7 @@ wheels = [
 [[package]]
 name = "vllm"
 version = "0.25.1"
-source = { git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=super_vl_rl_v0.25.1#6f11a9c5f95e1259a21c4d416b421fcb598b37bf" }
+source = { git = "https://github.com/TomerBN-Nvidia/vllm.git?branch=codex%2Ffix-radio-final-layernorm#10908b9f6669cd4306ea1ba676472a6c3c4769c2" }
 dependencies = [
     { name = "aiohttp", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
# What does this PR do ?

Switch the vLLM source to codex/fix-radio-final-layernorm and lock it to 10908b9f6669. This adds only the checkpoint-backed RADIO final LayerNorm fix on top of the previous vLLM pin; retain all other dependency versions.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
