### PR TITLE
fix(qwen3.5): freeze vision modules in text-only recipes

### DIFF
--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2-fp8.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2-fp8.yaml
@@ -14,10 +14,6 @@ policy:
   megatron_cfg:
     context_parallel_size: 1
     moe_router_dtype: fp32
-    freeze_config:
-      freeze_vision_model: true
-      freeze_vision_projection: true
-      freeze_language_model: false
     fp8_cfg:
       enabled: true
     optimizer:

--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2.yaml
@@ -15,6 +15,10 @@ policy:
     context_parallel_size: 2
     sequence_parallel: true
     expert_model_parallel_size: 16
+    freeze_config:
+      freeze_vision_model: true
+      freeze_vision_projection: true
+      freeze_language_model: false
     apply_rope_fusion: false
     activation_checkpointing: true
     defer_fp32_logits: true

--- a/tests/unit/models/generation/test_vllm_qwen35_bf16_trtllm_recipe.py
+++ b/tests/unit/models/generation/test_vllm_qwen35_bf16_trtllm_recipe.py
@@ -69,3 +69,13 @@ def test_qwen35_bf16_trtllm_recipe_uses_supported_expert_layout() -> None:
         "moe_backend": "flashinfer_trtllm",
         "expert_placement_strategy": "linear",
     }
+
+
+def test_qwen35_bf16_trtllm_recipe_freezes_unused_vision_modules() -> None:
+    recipe = _load_recipe()
+
+    assert recipe["policy"]["megatron_cfg"]["freeze_config"] == {
+        "freeze_vision_model": True,
+        "freeze_vision_projection": True,
+        "freeze_language_model": False,
+    }

--- a/tests/unit/models/generation/test_vllm_qwen35_bf16_trtllm_recipe.py
+++ b/tests/unit/models/generation/test_vllm_qwen35_bf16_trtllm_recipe.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 from omegaconf import OmegaConf
 
 from nemo_rl.utils.config import (
@@ -24,11 +25,15 @@ from nemo_rl.utils.config import (
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
 RECIPE_NAME = "grpo-qwen3.5-35ba3b-6n4g-async-1off-bf16-trtllm.yaml"
+TEXT_RECIPE_NAMES = (
+    RECIPE_NAME,
+    "grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2-fp8.yaml",
+)
 
 
-def _load_recipe() -> dict[str, Any]:
+def _load_recipe(recipe_name: str = RECIPE_NAME) -> dict[str, Any]:
     register_omegaconf_resolvers()
-    recipe_path = PROJECT_ROOT / "examples/configs/recipes/llm" / RECIPE_NAME
+    recipe_path = PROJECT_ROOT / "examples/configs/recipes/llm" / recipe_name
     recipe = OmegaConf.to_container(
         load_config_with_inheritance(recipe_path), resolve=True
     )
@@ -71,8 +76,11 @@ def test_qwen35_bf16_trtllm_recipe_uses_supported_expert_layout() -> None:
     }
 
 
-def test_qwen35_bf16_trtllm_recipe_freezes_unused_vision_modules() -> None:
-    recipe = _load_recipe()
+@pytest.mark.parametrize("recipe_name", TEXT_RECIPE_NAMES)
+def test_qwen35_text_recipe_freezes_unused_vision_modules(
+    recipe_name: str,
+) -> None:
+    recipe = _load_recipe(recipe_name)
 
     assert recipe["policy"]["megatron_cfg"]["freeze_config"] == {
         "freeze_vision_model": True,


### PR DESCRIPTION
## Problem

Qwen3.5 text-only Megatron recipes instantiate the vision modules but did not freeze them in the shared base recipe. Text batches never execute those modules, so DDP saw only 307 of 640 parameters in one gradient bucket and failed when the next training step reset the bucket.

## Change

Freeze the vision model and projection in the shared Qwen3.5 text recipe before DDP and optimizer setup. BF16, FP8, and MXFP8 child recipes now inherit the same trainable parameter set. Remove the duplicate FP8-only settings.

## Test

- [x] Regression test before the fix: 1 failed, 2 passed (freeze_config missing)
- [x] GB200 regression test after the fix: 4 passed
- [x] Qwen3.5 Async NCCL Reshard, MXFP8 training (fp8_param=true) + MXFP8 rollout, FlashInfer TRTLLM: 2/2 steps completed; generation KL error was 0.0012 at both steps
- [ ] 20-step follow-up is queued

W&B: https://wandb.ai/nvidia/nemo-rl-mxfp8-training/runs/oz68ga7p