### PR TITLE
fix(megatron): preserve HybridEP packed-input alignment

### DIFF
--- a/docs/design-docs/sequence-packing-and-dynamic-batching.md
+++ b/docs/design-docs/sequence-packing-and-dynamic-batching.md
@@ -255,8 +255,9 @@ interleave with expert-parameter collectives and hang.
 The option is not enabled by default because this NeMo-RL-owned pre-padding
 path does not currently support pipeline parallelism or MTP. NeMo-RL rejects
 unsupported combinations during setup. When the option is omitted or `false`,
-no uneven-input alignment is applied, so HybridEP with packed sequences requires
-this option.
+NeMo-RL enables Megatron-Core's per-layer uneven-input padding instead. This
+fallback supports layouts that cannot use the one-time pre-padding path and
+ensures that HybridEP collectives always receive aligned input lengths.
 
 ## Dynamic Batching
 

--- a/nemo_rl/models/megatron/hybridep.py
+++ b/nemo_rl/models/megatron/hybridep.py
@@ -24,7 +24,6 @@ from megatron.core.parallel_state import (
 from nemo_rl.distributed.model_utils import _get_tokens_on_this_cp_rank
 from nemo_rl.models.megatron.common import _round_up_to_multiple
 
-
 _HYBRIDEP_DISPATCH_PADDING_FIELDS = (
     "moe_hybridep_pad_uneven_dispatch_inputs",
     "moe_hybridep_pad_variable_tokens",

--- a/nemo_rl/models/megatron/hybridep.py
+++ b/nemo_rl/models/megatron/hybridep.py
@@ -61,6 +61,20 @@ def configure_hybridep_packed_input_padding(
             raise ValueError(
                 "HybridEP input prepadding currently requires MTP disabled."
             )
+        return
+
+    if not (
+        sequence_packing_enabled and uses_hybridep_flex_dispatcher(megatron_cfg)
+    ):
+        return
+
+    padding_attr = "moe_hybridep_pad_uneven_dispatch_inputs"
+    if not hasattr(model_cfg, padding_attr):
+        raise RuntimeError(
+            "This Megatron-Core version does not support uneven-input padding "
+            "for HybridEP packed sequences."
+        )
+    setattr(model_cfg, padding_attr, True)
 
 
 def _get_hybridep_aligned_seq_len(

--- a/nemo_rl/models/megatron/hybridep.py
+++ b/nemo_rl/models/megatron/hybridep.py
@@ -25,11 +25,32 @@ from nemo_rl.distributed.model_utils import _get_tokens_on_this_cp_rank
 from nemo_rl.models.megatron.common import _round_up_to_multiple
 
 
+_HYBRIDEP_DISPATCH_PADDING_FIELDS = (
+    "moe_hybridep_pad_uneven_dispatch_inputs",
+    "moe_hybridep_pad_variable_tokens",
+)
+
+
 def uses_hybridep_flex_dispatcher(megatron_cfg: Mapping[str, object]) -> bool:
     return (
         megatron_cfg.get("moe_token_dispatcher_type") == "flex"
         and megatron_cfg.get("moe_flex_dispatcher_backend") == "hybridep"
     )
+
+
+def set_hybridep_dispatch_padding(model_cfg: Any, *, enabled: bool) -> None:
+    supported_fields = [
+        field
+        for field in _HYBRIDEP_DISPATCH_PADDING_FIELDS
+        if hasattr(model_cfg, field)
+    ]
+    if enabled and not supported_fields:
+        raise RuntimeError(
+            "This Megatron-Core version does not support uneven-input padding "
+            "for HybridEP packed sequences."
+        )
+    for field in supported_fields:
+        setattr(model_cfg, field, enabled)
 
 
 def configure_hybridep_packed_input_padding(
@@ -66,13 +87,7 @@ def configure_hybridep_packed_input_padding(
     if not (sequence_packing_enabled and uses_hybridep_flex_dispatcher(megatron_cfg)):
         return
 
-    padding_attr = "moe_hybridep_pad_uneven_dispatch_inputs"
-    if not hasattr(model_cfg, padding_attr):
-        raise RuntimeError(
-            "This Megatron-Core version does not support uneven-input padding "
-            "for HybridEP packed sequences."
-        )
-    setattr(model_cfg, padding_attr, True)
+    set_hybridep_dispatch_padding(model_cfg, enabled=True)
 
 
 def _get_hybridep_aligned_seq_len(

--- a/nemo_rl/models/megatron/hybridep.py
+++ b/nemo_rl/models/megatron/hybridep.py
@@ -63,9 +63,7 @@ def configure_hybridep_packed_input_padding(
             )
         return
 
-    if not (
-        sequence_packing_enabled and uses_hybridep_flex_dispatcher(megatron_cfg)
-    ):
+    if not (sequence_packing_enabled and uses_hybridep_flex_dispatcher(megatron_cfg)):
         return
 
     padding_attr = "moe_hybridep_pad_uneven_dispatch_inputs"

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -308,6 +308,7 @@ from nemo_rl.models.megatron.draft.utils import (
 )
 from nemo_rl.models.megatron.hybridep import (
     configure_hybridep_packed_input_padding,
+    set_hybridep_dispatch_padding,
 )
 from nemo_rl.models.megatron.memory_saver import inference_model_alloc_region
 from nemo_rl.models.megatron.router_replay import (
@@ -878,10 +879,9 @@ def validate_megatron_config(megatron_cfg: Any, config: Mapping[str, Any]) -> No
     megatron_cfg.validate()
 
     if config["megatron_cfg"].get("moe_hybridep_prepad_packed_inputs"):
-        # Bridge 5ed9799 does not auto-enable per-layer padding because NeMo-RL
-        # supplies no Bridge dataset. Keep the opt-in authoritative if that gate
-        # changes or another config provider enables the field.
-        megatron_cfg.model.moe_hybridep_pad_uneven_dispatch_inputs = False
+        # Bridge cannot infer the packed layout because NeMo-RL supplies no
+        # Bridge dataset. Keep the explicit one-time prepadding authoritative.
+        set_hybridep_dispatch_padding(megatron_cfg.model, enabled=False)
 
 
 def setup_model_config(

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -889,17 +889,22 @@ class TestApplyMoeConfig:
         megatron_cfg.validate.assert_called_once_with()
         assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
 
+    @pytest.mark.parametrize(
+        "padding_attr",
+        [
+            "moe_hybridep_pad_uneven_dispatch_inputs",
+            "moe_hybridep_pad_variable_tokens",
+        ],
+    )
     @pytest.mark.parametrize("prepad_packed_inputs", [None, False])
     def test_hybridep_packed_inputs_fall_back_to_dispatch_padding(
-        self, prepad_packed_inputs
+        self, prepad_packed_inputs, padding_attr
     ):
         from nemo_rl.models.megatron.hybridep import (
             configure_hybridep_packed_input_padding,
         )
 
-        model_cfg = SimpleNamespace(
-            moe_hybridep_pad_uneven_dispatch_inputs=False,
-        )
+        model_cfg = SimpleNamespace(**{padding_attr: False})
         config = self._base_moe_cfg(
             expert_model_parallel_size=8,
             moe_flex_dispatcher_backend="hybridep",
@@ -912,7 +917,7 @@ class TestApplyMoeConfig:
 
         configure_hybridep_packed_input_padding(model_cfg, config)
 
-        assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+        assert getattr(model_cfg, padding_attr) is True
 
     def test_hybridep_packed_inputs_require_mcore_padding_support(self):
         from nemo_rl.models.megatron.hybridep import (
@@ -929,6 +934,19 @@ class TestApplyMoeConfig:
 
         with pytest.raises(RuntimeError, match="does not support uneven-input padding"):
             configure_hybridep_packed_input_padding(model_cfg, config)
+
+    def test_hybridep_padding_owner_updates_all_supported_fields(self):
+        from nemo_rl.models.megatron.hybridep import set_hybridep_dispatch_padding
+
+        model_cfg = SimpleNamespace(
+            moe_hybridep_pad_uneven_dispatch_inputs=True,
+            moe_hybridep_pad_variable_tokens=True,
+        )
+
+        set_hybridep_dispatch_padding(model_cfg, enabled=False)
+
+        assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is False
+        assert model_cfg.moe_hybridep_pad_variable_tokens is False
 
     def test_hybridep_input_prepadding_requires_flex_dispatcher(self, monkeypatch):
         from nemo_rl.models.megatron.setup import _apply_moe_config

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -927,7 +927,9 @@ class TestApplyMoeConfig:
         )
         config["sequence_packing"] = {"enabled": True}
 
-        with pytest.raises(RuntimeError, match="does not support uneven-input padding"):
+        with pytest.raises(
+            RuntimeError, match="does not support uneven-input padding"
+        ):
             configure_hybridep_packed_input_padding(model_cfg, config)
 
     def test_hybridep_input_prepadding_requires_flex_dispatcher(self, monkeypatch):

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -880,12 +880,38 @@ class TestApplyMoeConfig:
         config = self._base_moe_cfg(
             expert_model_parallel_size=8,
             moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_prepad_packed_inputs=False,
         )
+        config["sequence_packing"] = {"enabled": True}
 
         validate_megatron_config(megatron_cfg, config)
 
         megatron_cfg.validate.assert_called_once_with()
         assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+
+    @pytest.mark.parametrize("prepad_packed_inputs", [None, False])
+    def test_hybridep_packed_inputs_require_a_padding_owner(
+        self, prepad_packed_inputs
+    ):
+        from nemo_rl.models.megatron.setup import validate_megatron_config
+
+        model_cfg = SimpleNamespace(
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+        )
+        megatron_cfg = SimpleNamespace(model=model_cfg)
+        megatron_cfg.validate = MagicMock()
+        config = self._base_moe_cfg(
+            expert_model_parallel_size=8,
+            moe_flex_dispatcher_backend="hybridep",
+        )
+        if prepad_packed_inputs is not None:
+            config["megatron_cfg"]["moe_hybridep_prepad_packed_inputs"] = (
+                prepad_packed_inputs
+            )
+        config["sequence_packing"] = {"enabled": True}
+
+        with pytest.raises(ValueError, match="requires input-length alignment"):
+            validate_megatron_config(megatron_cfg, config)
 
     def test_hybridep_input_prepadding_requires_flex_dispatcher(self, monkeypatch):
         from nemo_rl.models.megatron.setup import _apply_moe_config

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -890,16 +890,16 @@ class TestApplyMoeConfig:
         assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
 
     @pytest.mark.parametrize("prepad_packed_inputs", [None, False])
-    def test_hybridep_packed_inputs_require_a_padding_owner(
+    def test_hybridep_packed_inputs_fall_back_to_dispatch_padding(
         self, prepad_packed_inputs
     ):
-        from nemo_rl.models.megatron.setup import validate_megatron_config
+        from nemo_rl.models.megatron.hybridep import (
+            configure_hybridep_packed_input_padding,
+        )
 
         model_cfg = SimpleNamespace(
             moe_hybridep_pad_uneven_dispatch_inputs=False,
         )
-        megatron_cfg = SimpleNamespace(model=model_cfg)
-        megatron_cfg.validate = MagicMock()
         config = self._base_moe_cfg(
             expert_model_parallel_size=8,
             moe_flex_dispatcher_backend="hybridep",
@@ -910,8 +910,25 @@ class TestApplyMoeConfig:
             )
         config["sequence_packing"] = {"enabled": True}
 
-        with pytest.raises(ValueError, match="requires input-length alignment"):
-            validate_megatron_config(megatron_cfg, config)
+        configure_hybridep_packed_input_padding(model_cfg, config)
+
+        assert model_cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+
+    def test_hybridep_packed_inputs_require_mcore_padding_support(self):
+        from nemo_rl.models.megatron.hybridep import (
+            configure_hybridep_packed_input_padding,
+        )
+
+        model_cfg = SimpleNamespace()
+        config = self._base_moe_cfg(
+            expert_model_parallel_size=8,
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_prepad_packed_inputs=False,
+        )
+        config["sequence_packing"] = {"enabled": True}
+
+        with pytest.raises(RuntimeError, match="does not support uneven-input padding"):
+            configure_hybridep_packed_input_padding(model_cfg, config)
 
     def test_hybridep_input_prepadding_requires_flex_dispatcher(self, monkeypatch):
         from nemo_rl.models.megatron.setup import _apply_moe_config

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -927,9 +927,7 @@ class TestApplyMoeConfig:
         )
         config["sequence_packing"] = {"enabled": True}
 
-        with pytest.raises(
-            RuntimeError, match="does not support uneven-input padding"
-        ):
+        with pytest.raises(RuntimeError, match="does not support uneven-input padding"):
             configure_hybridep_packed_input_padding(model_cfg, config)
 
     def test_hybridep_input_prepadding_requires_flex_dispatcher(self, monkeypatch):


### PR DESCRIPTION
## What

Guarantee aligned token counts for HybridEP when sequence packing is enabled.

## Why

Packed lengths can differ across expert-parallel ranks. Without one alignment owner, HybridEP collectives can consume different token counts and silently corrupt policy logprobs or hang.

## How

- Keep the existing one-time NeMo-RL pre-padding path when explicitly enabled.
- Otherwise enable Megatron-Core per-layer uneven-input padding automatically.
- Support both Megatron-Core padding field names and fail during setup if neither exists.

## Test

- Lyris GB200 targeted MCore tests: 5 passed.
- Qwen3.5-35B-A3B, 8 nodes x 4 GB200, Async/NCCL Reshard, BF16 training + MXFP8 FlashInfer TRTLLM rollout, HybridEP: 20/20 steps completed.
- Generation KL error: mean 0.00136, range 0.00095-0.00215.
- Steady state, steps 2-20: E2E 19.07 s, generation 1.98 s, policy training 6.74 s, policy/reference logprobs 5.82 s, refit 1.10 s.
- [W&B run](https://wandb.ai/nvidia/nemo-rl-mxfp8-training/runs/nm42a7w8)
