### PR TITLE
feat(data): add PackedTensor preprocessing modes

### DIFF
--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -69,6 +69,7 @@ _PLACEHOLDER_STYLE_PROCESSOR_NAMES = frozenset(
     {
         "NemotronNanoVLV2Processor",
         "NemotronH_Nano_Omni_Reasoning_V3Processor",
+        "NemotronH_Omni_Reasoning_V3Processor",
     }
 )
 
@@ -165,7 +166,8 @@ def row_shapes_key(field: str) -> str:
 # Keys inside the :func:`row_shapes_key` tag value. A plain dict rather than a
 # record because ``tags`` rides TQ's own serializer.
 ROW_GEOMETRY_SHAPES = "shapes"
-ROW_GEOMETRY_PAD = "pad"
+ROW_GEOMETRY_PREPROCESS_MODE = "preprocess_mode"
+ROW_GEOMETRY_PREPROCESS_KWARGS = "preprocess_kwargs"
 
 
 # Include-list of multimodal fields every forward-running dispatch (logprob
@@ -199,7 +201,7 @@ def multimodal_row_tags(
     contents.
 
     Carries ``shapes`` (per-row, and unrecoverable once ``to_wire`` flattens)
-    and ``pad`` (the field's policy flag). Deliberately *not* a pad target: the
+    and the field's preprocessing settings. Deliberately *not* a pad target: the
     width padding lands at is scratch that the model discards -- mcore crops it
     via ``imgs_sizes`` before patchification, and the AutoModel path rejects
     mixed-resolution batches outright -- so each consumer pads to its own view
@@ -223,11 +225,11 @@ def multimodal_row_tags(
                 "sample_ids, so a disagreement here would pair one sample's "
                 "pixels with another's shapes."
             )
-        pad = value.pad_to_max_shape
         for row, row_shapes in enumerate(shapes):
             tags[row][row_shapes_key(key)] = {
                 ROW_GEOMETRY_SHAPES: row_shapes,
-                ROW_GEOMETRY_PAD: pad,
+                ROW_GEOMETRY_PREPROCESS_MODE: value.preprocess_mode,
+                ROW_GEOMETRY_PREPROCESS_KWARGS: dict(value.preprocess_kwargs),
             }
     # ``None`` rather than ``B`` empty dicts: a text-only run has no packed
     # field, and an all-empty tags list would still be pickled on every
@@ -272,14 +274,78 @@ def reassemble_packed_multimodal(
                 + ". to_wire flattens each row, so without the companion the "
                 "true per-segment shapes are unrecoverable."
             )
-        # Indexed, not ``.get``-with-default: a producer-side rename of either
-        # key must fail here rather than silently restore ``pad=False``, which
-        # changes what ``as_tensor`` hands the vision encoder.
+        # Indexed, not ``.get``-with-default: a producer-side rename of any key
+        # must fail here rather than silently change what ``as_tensor`` hands
+        # the vision encoder.
         fields[key] = PackedTensor.from_wire(
             value,
             [[] if r is None else r[ROW_GEOMETRY_SHAPES] for r in rows],  # type: ignore[union-attr]
-            pad_to_max_shape=bool(present[0][ROW_GEOMETRY_PAD]),
+            preprocess_mode=present[0][ROW_GEOMETRY_PREPROCESS_MODE],
+            preprocess_kwargs=present[0][ROW_GEOMETRY_PREPROCESS_KWARGS],
         )
+
+
+def _patchify_segments(segments: list[torch.Tensor], *, patch_dim: int) -> torch.Tensor:
+    """Cut pixel segments into vision patches and pack them into one sequence.
+
+    Each ``[N, channels, H, W]`` segment is processed at its native resolution
+    into a ``[C_i, P²]`` block, where ``C_i`` is its spatial patch count and
+    ``P²`` is the flattened patch width (``channels * patch_dim**2``). Blocks
+    are packed along dimension zero, then a batch dimension is added to produce
+    ``[1, total_C, P²]``. Already-patchified segments in that final layout are
+    accepted so repeated materialization is safe.
+    """
+    if patch_dim <= 0:
+        raise ValueError(f"patch_dim must be positive, got {patch_dim}")
+
+    flattened: list[torch.Tensor] = []
+    for segment in segments:
+        if segment.ndim == 3:
+            if segment.shape[0] != 1:
+                raise ValueError(
+                    "Pre-patchified segments must be [1, total_C, P²], "
+                    f"got shape {tuple(segment.shape)}"
+                )
+            flattened.append(segment[0])
+            continue
+        if segment.ndim != 4:
+            raise ValueError(
+                "patchify expects [N, C, H, W] pixel segments or "
+                "[1, total_C, P²] pre-patchified segments, got shape "
+                f"{tuple(segment.shape)}"
+            )
+        count, channels, height, width = segment.shape
+        if height % patch_dim or width % patch_dim:
+            raise ValueError(
+                f"Image size {(height, width)} is not divisible by "
+                f"patch_dim={patch_dim}"
+            )
+        rows = height // patch_dim
+        columns = width // patch_dim
+        flattened.append(
+            segment.reshape(count, channels, rows, patch_dim, columns, patch_dim)
+            .permute(0, 2, 4, 1, 3, 5)
+            .reshape(count * rows * columns, channels * patch_dim * patch_dim)
+        )
+
+    widths = {tensor.shape[-1] for tensor in flattened}
+    if len(widths) != 1:
+        raise ValueError(
+            f"patchify produced mismatched P² widths {sorted(widths)}; "
+            "the segments do not share a channel count"
+        )
+    return torch.cat(flattened, dim=0).unsqueeze(0).contiguous()
+
+
+def _shared_preprocess_spec(
+    from_packed_tensors: list["PackedTensor"],
+) -> dict[str, Any]:
+    """Return the preprocessing setting shared by every input."""
+    first = from_packed_tensors[0]._preprocess_spec
+    assert all(
+        packed_tensor._preprocess_spec == first for packed_tensor in from_packed_tensors
+    ), "All packed tensors must have the same preprocess setting"
+    return first
 
 
 class PackedTensor:
@@ -325,7 +391,8 @@ class PackedTensor:
         tensors: Union[torch.Tensor, list[Optional[torch.Tensor]], list[None]],
         dim_to_pack: int,
         *,
-        pad_to_max_shape: bool = False,
+        preprocess_mode: Optional[str] = None,
+        preprocess_kwargs: Optional[dict[str, Any]] = None,
         _row_offsets: Optional[list[int]] = None,
         _segment_indices: Optional[list[int]] = None,
         _segment_provenance: Optional[list[bytes]] = None,
@@ -336,8 +403,10 @@ class PackedTensor:
             tensors: A tensor or list of per-item tensors. List entries may be
                 ``None`` for items without this modality.
             dim_to_pack: Dimension along which ``as_tensor`` concatenates.
-            pad_to_max_shape: Pad every non-packing dimension to its batch-wide
-                maximum before concatenating. All tensors must have the same rank.
+            preprocess_mode: Optional preprocessing applied by ``as_tensor``.
+                Supported values are ``pad_to_max_shape`` and ``patchify``.
+            preprocess_kwargs: Extra arguments for ``preprocess_mode``. Patchify
+                accepts ``patch_dim``.
         """
         assert tensors is not None, "Input tensors to PackedTensor cannot be None"
 
@@ -354,7 +423,13 @@ class PackedTensor:
                 f"Unsupported type for input tensors to PackedTensor: {type(tensors)}"
             )
         self.dim_to_pack = dim_to_pack
-        self.pad_to_max_shape = pad_to_max_shape
+        if preprocess_mode not in (None, "pad_to_max_shape", "patchify"):
+            raise ValueError(
+                f"Unknown preprocess_mode {preprocess_mode!r}; expected None, "
+                "'pad_to_max_shape', or 'patchify'"
+            )
+        self.preprocess_mode = preprocess_mode
+        self.preprocess_kwargs: dict[str, Any] = dict(preprocess_kwargs or {})
         if (_row_offsets is None) != (_segment_indices is None):
             raise ValueError(
                 "_row_offsets and _segment_indices must either both be set or both be None"
@@ -394,6 +469,14 @@ class PackedTensor:
         self.__dict__.setdefault("_row_offsets", None)
         self.__dict__.setdefault("_segment_indices", None)
         self.__dict__.setdefault("_segment_provenance", None)
+
+    @property
+    def _preprocess_spec(self) -> dict[str, Any]:
+        """Return keyword arguments that preserve preprocessing in a copy."""
+        return {
+            "preprocess_mode": self.preprocess_mode,
+            "preprocess_kwargs": self.preprocess_kwargs,
+        }
 
     @property
     def deduplication_enabled(self) -> bool:
@@ -445,7 +528,7 @@ class PackedTensor:
             copied = PackedTensor(
                 [deepcopy(item, memo) for item in self.tensors],
                 self.dim_to_pack,
-                pad_to_max_shape=self.pad_to_max_shape,
+                **self._preprocess_spec,
             )
         else:
             copied = PackedTensor(
@@ -455,7 +538,7 @@ class PackedTensor:
                     else [deepcopy(item, memo) for item in self.tensors]
                 ),
                 self.dim_to_pack,
-                pad_to_max_shape=self.pad_to_max_shape,
+                **self._preprocess_spec,
                 _row_offsets=(
                     list(self._row_offsets) if self._row_offsets is not None else None
                 ),
@@ -488,12 +571,21 @@ class PackedTensor:
         if len(non_none_tensors) == 0:
             return None
 
+        if self.preprocess_mode == "patchify":
+            if self.dim_to_pack != 0:
+                raise ValueError(
+                    f"patchify requires dim_to_pack=0, got {self.dim_to_pack}"
+                )
+            return _patchify_segments(non_none_tensors, **self.preprocess_kwargs).to(
+                device
+            )
+
         # Some multimodal processors produce a different shape per prompt,
         # such as dynamic-resolution images, variable-frame videos, or audio
         # feature sequences. Concatenation already permits the packing
         # dimension to vary; when explicitly requested, pad every other
         # dimension to the largest size in the batch.
-        if self.pad_to_max_shape:
+        if self.preprocess_mode == "pad_to_max_shape":
             ranks = {tensor.ndim for tensor in non_none_tensors}
             if len(ranks) != 1:
                 raise ValueError(
@@ -599,7 +691,7 @@ class PackedTensor:
                 else list(self.tensors)
             ),
             self.dim_to_pack,
-            pad_to_max_shape=self.pad_to_max_shape,
+            **self._preprocess_spec,
             _row_offsets=(
                 list(self._row_offsets) if self._row_offsets is not None else None
             ),
@@ -626,7 +718,7 @@ class PackedTensor:
             return PackedTensor(
                 tensors,
                 self.dim_to_pack,
-                pad_to_max_shape=self.pad_to_max_shape,
+                **self._preprocess_spec,
             )
 
         physical_remap: dict[int, int] = {}
@@ -650,7 +742,7 @@ class PackedTensor:
         return PackedTensor(
             tensors,
             self.dim_to_pack,
-            pad_to_max_shape=self.pad_to_max_shape,
+            **self._preprocess_spec,
             _row_offsets=row_offsets,
             _segment_indices=segment_indices,
             _segment_provenance=(
@@ -672,7 +764,7 @@ class PackedTensor:
             return cls(
                 [],
                 other.dim_to_pack,
-                pad_to_max_shape=other.pad_to_max_shape,
+                **other._preprocess_spec,
                 _row_offsets=[0] * (num_rows + 1),
                 _segment_indices=[],
                 _segment_provenance=[],
@@ -681,7 +773,7 @@ class PackedTensor:
             return cls(
                 [],
                 other.dim_to_pack,
-                pad_to_max_shape=other.pad_to_max_shape,
+                **other._preprocess_spec,
                 _row_offsets=[0],
                 _segment_indices=[],
                 _segment_provenance=None,
@@ -689,7 +781,7 @@ class PackedTensor:
         return cls(
             [None] * num_rows,
             other.dim_to_pack,
-            pad_to_max_shape=other.pad_to_max_shape,
+            **other._preprocess_spec,
         )
 
     @classmethod
@@ -718,10 +810,7 @@ class PackedTensor:
         assert len(set(dim_to_packs)) == 1, (
             "All packed tensors must have the same dim_to_pack"
         )
-        pad_to_max_shapes = [batch.pad_to_max_shape for batch in from_packed_tensors]
-        assert len(set(pad_to_max_shapes)) == 1, (
-            "All packed tensors must have the same pad_to_max_shape setting"
-        )
+        preprocess_spec = _shared_preprocess_spec(from_packed_tensors)
         if any(
             packed_tensor.deduplication_enabled
             or packed_tensor._row_offsets is not None
@@ -762,7 +851,7 @@ class PackedTensor:
             return cls(
                 tensors,
                 dim_to_packs[0],
-                pad_to_max_shape=pad_to_max_shapes[0],
+                **preprocess_spec,
                 _row_offsets=row_offsets,
                 _segment_indices=segment_indices,
                 _segment_provenance=provenances,
@@ -776,7 +865,7 @@ class PackedTensor:
         return cls(
             tensors,
             dim_to_pack,
-            pad_to_max_shape=pad_to_max_shapes[0],
+            **preprocess_spec,
         )
 
     @classmethod
@@ -800,7 +889,7 @@ class PackedTensor:
         return cls(
             concatenated.tensors,
             concatenated.dim_to_pack,
-            pad_to_max_shape=concatenated.pad_to_max_shape,
+            **concatenated._preprocess_spec,
             _row_offsets=[0, len(concatenated._segment_indices)],
             _segment_indices=concatenated._segment_indices,
             _segment_provenance=concatenated._segment_provenance,
@@ -836,10 +925,7 @@ class PackedTensor:
         assert len(set(dim_to_packs)) == 1, (
             "All packed tensors must have the same dim_to_pack"
         )
-        pad_to_max_shapes = [batch.pad_to_max_shape for batch in from_packed_tensors]
-        assert len(set(pad_to_max_shapes)) == 1, (
-            "All packed tensors must have the same pad_to_max_shape setting"
-        )
+        preprocess_spec = _shared_preprocess_spec(from_packed_tensors)
         if any(
             packed_tensor.deduplication_enabled
             or packed_tensor._row_offsets is not None
@@ -854,7 +940,7 @@ class PackedTensor:
         return cls(
             tensors,
             from_packed_tensors[0].dim_to_pack,
-            pad_to_max_shape=pad_to_max_shapes[0],
+            **preprocess_spec,
         )
 
     # ── Wire encoding (data-plane roundtrip) ─────────────────────────
@@ -948,12 +1034,12 @@ class PackedTensor:
         #     storage, and TQ never falls back to the deprecated strided layout.
         #   * The per-row concat is 1-D, so it cannot raise on segments whose
         #     trailing dims differ -- which is what previously forced
-        #     ``pad_to_max_shape`` to pad *before* the concat.
+        #     preprocessing to pad *before* the concat.
         #
         # The true shapes travel beside the payload (see the returned
         # ``shapes``) because TQ derives ``per_sample_shapes`` from what it is
         # handed: give it flat rows and it records flat lengths. Padding still
-        # happens for ``pad_to_max_shape`` values, but in worker memory at use
+        # happens for values that need it, but in worker memory at use
         # time via :meth:`as_tensor`, not on the wire.
         shapes = self._shapes_of(row_segments)
         # ``reshape(-1)`` on contiguous processor output is a view, so the
@@ -990,7 +1076,8 @@ class PackedTensor:
         nested: torch.Tensor,
         shapes: list[list[list[int]]],
         *,
-        pad_to_max_shape: bool = False,
+        preprocess_mode: Optional[str] = None,
+        preprocess_kwargs: Optional[dict[str, Any]] = None,
     ) -> Optional["PackedTensor"]:
         """Reconstruct from the value produced by :meth:`to_wire`.
 
@@ -1009,10 +1096,9 @@ class PackedTensor:
         reconstructs as legacy does: ``as_tensor`` returns ``None`` and
         ``logical_segment_counts_by_row`` reports 0 rather than 1.
 
-        ``pad_to_max_shape`` is restored onto the rebuilt value as a flag, not
+        The preprocessing settings are restored onto the rebuilt value, not
         materialized. Segments come back at their true shapes and stay separate
-        via the CSR row map, so nothing is padded or concatenated here;
-        :meth:`as_tensor` pads at use time.
+        via the CSR row map; :meth:`as_tensor` preprocesses at use time.
 
         Mirrors :meth:`to_wire`; both assume ``dim_to_pack=0``.
         """
@@ -1053,7 +1139,8 @@ class PackedTensor:
         return cls(
             segments_flat,  # type: ignore[arg-type]
             dim_to_pack=0,
-            pad_to_max_shape=pad_to_max_shape,
+            preprocess_mode=preprocess_mode,
+            preprocess_kwargs=preprocess_kwargs,
             _row_offsets=row_offsets,
             _segment_indices=list(range(len(segments_flat))),
         )
@@ -1071,7 +1158,7 @@ def encode_multimodal_for_wire(
     Payload only. Per-token fields ride rectangular; packed fields ride as one
     flattened ``torch.jagged`` value. The geometry :meth:`PackedTensor.from_wire`
     needs to undo that flattening -- per-row segment shapes plus the
-    ``pad_to_max_shape`` flag -- is minted separately by
+    preprocessing settings -- is minted separately by
     :func:`multimodal_row_tags` and shipped on ``KVBatchMeta.tags``. TQ cannot
     derive it, because it reads ``per_sample_shapes`` off the flattened rows it
     is handed.
@@ -1181,9 +1268,14 @@ def get_dim_to_pack_along(processor, key: str) -> int:
     return 0
 
 
-def get_pad_to_max_shape(processor: Any, key: str) -> bool:
-    """Return whether a processor input must pad non-packing dimensions."""
-    return uses_image_placeholder(processor) and key == "pixel_values"
+def get_preprocess(processor: Any, key: str) -> dict[str, Any]:
+    """Return materialization preprocessing for one processor input."""
+    if uses_image_placeholder(processor) and key == "pixel_values":
+        return {
+            "preprocess_mode": "patchify",
+            "preprocess_kwargs": {"patch_dim": 16},
+        }
+    return {"preprocess_mode": None, "preprocess_kwargs": {}}
 
 
 def extract_multimodal_model_inputs(
@@ -1245,7 +1337,7 @@ def extract_multimodal_model_inputs(
         extracted[key] = PackedTensor(
             value,
             dim_to_pack=get_dim_to_pack_along(processor, key),
-            pad_to_max_shape=get_pad_to_max_shape(processor, key),
+            **get_preprocess(processor, key),
         )
 
     for key in ("token_type_ids", "mm_token_type_ids"):
@@ -1385,13 +1477,13 @@ def media_sources_equal(
 def _materialize_ragged_pixel_values(
     processed: dict[str, Any], processor: Any
 ) -> dict[str, Any]:
-    """Fold a ragged per-image ``pixel_values`` list into one padded tensor.
+    """Fold a ragged per-image ``pixel_values`` list into one patch sequence.
 
     Processors with dynamic per-image resolution return a list of CHW tensors
     rather than a stacked batch. ``imgs_sizes`` is derived from the *unpadded*
     shapes first, since those exact sizes are what the projector slices with;
-    padding happens afterwards so downstream sees the single tensor its
-    torch.Tensor contract expects.
+    patchification happens afterwards so downstream sees the single tensor its
+    ``torch.Tensor`` contract expects.
     """
     processed = dict(processed)
     pixel_values = processed.get("pixel_values")
@@ -1417,7 +1509,7 @@ def _materialize_ragged_pixel_values(
 def _stack_ragged_pixel_values(
     processed: dict[str, Any], tiles: list[torch.Tensor], processor: Any
 ) -> None:
-    """Derive imgs_sizes from unpadded shapes, then pad into one tensor."""
+    """Derive image sizes, then patchify native-shape tiles into one tensor."""
     if uses_image_placeholder(processor) and "imgs_sizes" not in processed:
         processed["imgs_sizes"] = torch.tensor(
             [[int(item.shape[-2]), int(item.shape[-1])] for item in tiles],
@@ -1426,7 +1518,8 @@ def _stack_ragged_pixel_values(
     stacked = PackedTensor(
         [item.unsqueeze(0) for item in tiles],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
     ).as_tensor()
     assert stacked is not None
     processed["pixel_values"] = stacked

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -389,6 +389,7 @@ def vlm_preference_preprocessor(
     placeholder_style_processors = {
         "NemotronNanoVLV2Processor",
         "NemotronH_Nano_Omni_Reasoning_V3Processor",
+        "NemotronH_Omni_Reasoning_V3Processor",
     }
     message_processor = (
         _NemotronOmniPreferenceProcessorProxy(processor)
@@ -404,25 +405,33 @@ def vlm_preference_preprocessor(
             task_data_spec,
         )
 
-        # Mirror the canonical Nemotron Omni metadata contract. Dynamic-resolution
-        # image batches may differ spatially across rows, while imgs_sizes
-        # preserves the true crop consumed by model-owned patchification.
+        # Mirror the canonical Nemotron Omni metadata. Record native image sizes
+        # before patchification removes the spatial dimensions.
         for raw_message in message_log:
             message = cast(Any, raw_message)
             pixel_values = message.get("pixel_values")
             if not isinstance(pixel_values, PackedTensor):
                 continue
-            pixel_values.pad_to_max_shape = True
-            pixels = pixel_values.as_tensor()
-            if pixels is not None and pixels.ndim == 4 and "imgs_sizes" not in message:
-                num_images, _, height, width = pixels.shape
+            if "imgs_sizes" not in message:
+                image_sizes: list[list[int]] = []
+                for pixels in pixel_values.iter_logical_segments():
+                    if pixels is None:
+                        continue
+                    if pixels.ndim != 4:
+                        raise ValueError(
+                            "Nemotron Omni pixel values must be [N, C, H, W] "
+                            f"before patchification, got {tuple(pixels.shape)}"
+                        )
+                    image_sizes.extend(
+                        [[int(pixels.shape[-2]), int(pixels.shape[-1])]]
+                        * int(pixels.shape[0])
+                    )
                 message["imgs_sizes"] = PackedTensor(
-                    torch.tensor(
-                        [[height, width]] * num_images,
-                        dtype=torch.long,
-                    ),
+                    torch.tensor(image_sizes, dtype=torch.long),
                     dim_to_pack=0,
                 )
+            pixel_values.preprocess_mode = "patchify"
+            pixel_values.preprocess_kwargs = {"patch_dim": 16}
             imgs_sizes = message.get("imgs_sizes")
             if isinstance(imgs_sizes, PackedTensor) and "num_frames" not in message:
                 sizes = imgs_sizes.as_tensor()

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -116,7 +116,8 @@ def _broadcast_batched_data_dict(
                                 "empty_packed",
                                 len(v),
                                 v.dim_to_pack,
-                                v.pad_to_max_shape,
+                                v.preprocess_mode,
+                                v.preprocess_kwargs,
                             )
                         )
                         continue
@@ -130,7 +131,8 @@ def _broadcast_batched_data_dict(
                             str(values.device),
                             nested.offsets().tolist(),
                             shapes,
-                            v.pad_to_max_shape,
+                            v.preprocess_mode,
+                            v.preprocess_kwargs,
                         )
                     )
                 elif (
@@ -206,7 +208,14 @@ def _broadcast_batched_data_dict(
             ):
                 out[key] = tensor.to(src_device)
         elif kind == "packed_wire":
-            dtype_str, src_device, offsets, shapes, pad_to_max_shape = entry[2:]
+            (
+                dtype_str,
+                src_device,
+                offsets,
+                shapes,
+                preprocess_mode,
+                preprocess_kwargs,
+            ) = entry[2:]
             if is_leader:
                 flat = leader_flat[key].to(bcast_device)
             else:
@@ -224,17 +233,21 @@ def _broadcast_batched_data_dict(
                 if torch.device(src_device).type != torch.device(bcast_device).type:
                     nested = nested.to(src_device)
                 out[key] = PackedTensor.from_wire(
-                    nested, shapes, pad_to_max_shape=pad_to_max_shape
+                    nested,
+                    shapes,
+                    preprocess_mode=preprocess_mode,
+                    preprocess_kwargs=preprocess_kwargs,
                 )
         elif kind == "empty_packed":
             # Structural only: no payload, so followers rebuild from the
             # geometry and land on the leader's key set.
-            n_rows, dim_to_pack, pad_to_max_shape = entry[2:]
+            n_rows, dim_to_pack, preprocess_mode, preprocess_kwargs = entry[2:]
             if not is_leader:
                 out[key] = PackedTensor(
                     [None] * n_rows,
                     dim_to_pack,
-                    pad_to_max_shape=pad_to_max_shape,
+                    preprocess_mode=preprocess_mode,
+                    preprocess_kwargs=preprocess_kwargs,
                 )
         else:
             if not is_leader:

--- a/tests/unit/data/datasets/test_mmpr_tiny.py
+++ b/tests/unit/data/datasets/test_mmpr_tiny.py
@@ -241,7 +241,8 @@ class TestVLMProcessorMMPRTiny:
         assert result["task_name"] == "mmpr-tiny"
         user_message = result["message_log"][0]
         assert torch.equal(user_message["num_frames"].as_tensor(), torch.tensor([1]))
-        assert user_message["pixel_values"].pad_to_max_shape is True
+        assert user_message["pixel_values"].preprocess_mode == "patchify"
+        assert user_message["pixel_values"].preprocess_kwargs == {"patch_dim": 16}
         assert user_message["pixel_values"].as_tensor().dtype == torch.float32
 
     def test_text_only_row_preserves_formatted_vllm_content(self):

--- a/tests/unit/data/test_multimodal_dict.py
+++ b/tests/unit/data/test_multimodal_dict.py
@@ -23,8 +23,10 @@ from nemo_rl.data.multimodal_utils import (
     PER_TOKEN_MULTIMODAL_FIELDS,
     PackedTensor,
     encode_multimodal_for_wire,
+    get_preprocess,
     multimodal_row_tags,
     reassemble_packed_multimodal,
+    uses_image_placeholder,
 )
 from nemo_rl.distributed.batched_data_dict import (
     BatchedDataDict,
@@ -53,6 +55,28 @@ def test_packed_data_basic():
     # Test as_tensor
     expected_tensor = torch.cat([tensor1, tensor2], dim=0)
     assert torch.equal(batch.as_tensor(), expected_tensor)
+
+
+@pytest.mark.parametrize(
+    "processor_name",
+    [
+        "NemotronNanoVLV2Processor",
+        "NemotronH_Nano_Omni_Reasoning_V3Processor",
+        "NemotronH_Omni_Reasoning_V3Processor",
+    ],
+)
+def test_placeholder_processors_use_patchify(processor_name):
+    processor = type(processor_name, (), {})()
+
+    assert uses_image_placeholder(processor)
+    assert get_preprocess(processor, "pixel_values") == {
+        "preprocess_mode": "patchify",
+        "preprocess_kwargs": {"patch_dim": 16},
+    }
+    assert get_preprocess(processor, "imgs_sizes") == {
+        "preprocess_mode": None,
+        "preprocess_kwargs": {},
+    }
 
 
 def test_shard_by_batch_size_with_packed_data():
@@ -387,7 +411,7 @@ def test_packedtensor_pads_mixed_dynamic_resolution_images():
     second = 2 * torch.ones(1, 3, 4, 2)
 
     packed = PackedTensor(
-        [first, second], dim_to_pack=0, pad_to_max_shape=True
+        [first, second], dim_to_pack=0, preprocess_mode="pad_to_max_shape"
     ).as_tensor()
 
     assert packed.shape == (2, 3, 4, 4)
@@ -412,7 +436,7 @@ def test_dynamic_resolution_padding_is_cropped_before_radio_patchification():
     padded = PackedTensor(
         [small, large],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     ).as_tensor()
     # Use nonzero garbage so this test cannot pass merely because F.pad uses zero.
     padded[0, :, 32:, :] = 123
@@ -461,7 +485,7 @@ def test_packedtensor_pad_to_max_shape_supports_audio_and_video(
     second = 2 * torch.ones(second_shape)
 
     packed = PackedTensor(
-        [first, second], dim_to_pack=0, pad_to_max_shape=True
+        [first, second], dim_to_pack=0, preprocess_mode="pad_to_max_shape"
     ).as_tensor()
 
     assert packed.shape == expected_shape
@@ -476,7 +500,7 @@ def test_pad_to_max_shape_rejects_mismatched_ranks():
         PackedTensor(
             [torch.ones(1, 3, 4), torch.ones(1, 3)],
             dim_to_pack=0,
-            pad_to_max_shape=True,
+            preprocess_mode="pad_to_max_shape",
         ).as_tensor()
 
 
@@ -485,7 +509,7 @@ def test_pad_to_max_shape_rejects_out_of_range_dim():
         PackedTensor(
             [torch.ones(1, 3, 4), torch.ones(2, 3, 4)],
             dim_to_pack=3,
-            pad_to_max_shape=True,
+            preprocess_mode="pad_to_max_shape",
         ).as_tensor()
 
 
@@ -493,23 +517,126 @@ def test_pad_to_max_shape_supports_negative_pack_dim():
     packed = PackedTensor(
         [torch.ones(2, 3, 1), 2 * torch.ones(4, 3, 1)],
         dim_to_pack=-3,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     ).as_tensor()
 
     assert packed.shape == (6, 3, 1)
 
 
-def test_slice_preserves_pad_to_max_shape_flag():
+def test_slice_preserves_preprocess_spec():
     packed = PackedTensor(
         [torch.ones(1, 3, 2, 4), 2 * torch.ones(1, 3, 4, 2)],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
+        preprocess_kwargs={},
     )
 
     sliced = packed.slice([0, 1])
 
-    assert sliced.pad_to_max_shape is True
+    assert sliced.preprocess_mode == "pad_to_max_shape"
+    assert sliced.preprocess_kwargs == {}
     assert sliced.as_tensor().shape == (2, 3, 4, 4)
+
+
+def test_packedtensor_rejects_unknown_preprocess_mode():
+    with pytest.raises(ValueError, match="Unknown preprocess_mode"):
+        PackedTensor(
+            torch.ones(1, 3, 4, 4),
+            dim_to_pack=0,
+            preprocess_mode="jagged",
+        )
+
+
+def test_patchify_packs_mixed_resolutions_without_padding():
+    packed = PackedTensor(
+        [torch.ones(1, 3, 32, 32), 2 * torch.ones(1, 3, 64, 32)],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    ).as_tensor()
+
+    assert packed.shape == (1, 12, 768)
+    assert torch.all(packed[0, :4] == 1)
+    assert torch.all(packed[0, 4:] == 2)
+
+
+def test_patchify_preserves_pixel_order_within_a_patch():
+    image = torch.arange(3 * 2 * 2, dtype=torch.float32).reshape(1, 3, 2, 2)
+
+    packed = PackedTensor(
+        [image],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 2},
+    ).as_tensor()
+
+    assert packed.shape == (1, 1, 12)
+    torch.testing.assert_close(packed[0, 0], image.reshape(12))
+
+
+def test_patchify_accepts_already_patchified_segments():
+    raw = PackedTensor(
+        [torch.ones(1, 3, 32, 32)],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    )
+
+    once = raw.as_tensor()
+    assert once is not None
+    twice = PackedTensor(
+        [once],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    ).as_tensor()
+
+    torch.testing.assert_close(once, twice)
+
+
+def test_patchify_survives_flattened_concat():
+    first = PackedTensor(
+        [torch.ones(1, 3, 32, 32)],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    )
+    second = PackedTensor(
+        [2 * torch.ones(1, 3, 64, 32)],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    )
+
+    flattened = PackedTensor.flattened_concat([first, second])
+
+    assert len(flattened) == 2
+    assert flattened.as_tensor().shape == (1, 12, 768)
+    torch.testing.assert_close(
+        flattened.as_tensor(), PackedTensor.concat([first, second]).as_tensor()
+    )
+
+
+def test_patchify_rejects_indivisible_image_size():
+    with pytest.raises(ValueError, match="not divisible by patch_dim=16"):
+        PackedTensor(
+            [torch.ones(1, 3, 30, 32)],
+            dim_to_pack=0,
+            preprocess_mode="patchify",
+            preprocess_kwargs={"patch_dim": 16},
+        ).as_tensor()
+
+
+def test_concat_rejects_mixed_preprocess_settings():
+    padded = PackedTensor(
+        torch.ones(1, 3, 4, 4),
+        dim_to_pack=0,
+        preprocess_mode="pad_to_max_shape",
+    )
+    plain = PackedTensor(torch.ones(1, 3, 4, 4), dim_to_pack=0)
+
+    with pytest.raises(AssertionError, match="same preprocess setting"):
+        PackedTensor.concat([padded, plain])
 
 
 def test_packedtensor_dedup_uses_provenance_not_prompt_position():
@@ -559,12 +686,12 @@ def test_packedtensor_dedup_expands_before_dynamic_shape_padding():
     first = PackedTensor(
         torch.ones(1, 1, 2),
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     ).enable_deduplication()
     second = PackedTensor(
         2 * torch.ones(1, 2, 1),
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     ).enable_deduplication()
 
     packed = PackedTensor.concat([first, deepcopy(first), second])
@@ -632,25 +759,6 @@ def test_packedtensor_compact_dim_one_slice_empty_and_cloudpickle_roundtrip():
     assert empty.as_tensor() is None
 
 
-def test_packedtensor_unpickles_pre_deduplication_state():
-    tensor = torch.tensor([[1.0], [2.0]])
-    legacy = PackedTensor.__new__(PackedTensor)
-    legacy.__dict__ = {
-        "tensors": [tensor],
-        "dim_to_pack": 0,
-        "pad_to_max_shape": False,
-    }
-
-    restored = cloudpickle.loads(cloudpickle.dumps(legacy, protocol=5))
-
-    assert not restored.deduplication_enabled
-    assert len(restored) == 1
-    assert sum(restored.logical_segment_counts_by_row()) == 1
-    torch.testing.assert_close(restored.as_tensor(), tensor)
-    restored.enable_deduplication()
-    assert restored.deduplication_enabled
-
-
 def test_packedtensor_empty_legacy_rows_survive_copy_pickle_and_slice():
     legacy = PackedTensor(torch.tensor([[1.0]]), dim_to_pack=0)
     empty = PackedTensor.empty_rows_like(legacy, 0)
@@ -708,7 +816,7 @@ def test_to_wire_does_not_pad_segments_before_concat_under_dedup():
     packed = PackedTensor(
         [torch.ones(1, 3, 2, 4), 2 * torch.ones(1, 3, 4, 2)],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
         _row_offsets=[0, 2],
         _segment_indices=[0, 1],
     )
@@ -721,7 +829,9 @@ def test_to_wire_does_not_pad_segments_before_concat_under_dedup():
     assert [t.numel() for t in nested.unbind()] == [48]
     assert shapes == [[[1, 3, 2, 4], [1, 3, 4, 2]]]
 
-    restored = PackedTensor.from_wire(nested, shapes, pad_to_max_shape=True).as_tensor()
+    restored = PackedTensor.from_wire(
+        nested, shapes, preprocess_mode="pad_to_max_shape"
+    ).as_tensor()
     assert torch.equal(restored, expected)
 
 
@@ -758,7 +868,9 @@ def test_to_wire_does_not_materialize_pad_to_max_shape():
     # Same rank, different trailing dims — nemotron-omni style tiles.
     first = torch.ones(1, 3, 2, 4)
     second = 2 * torch.ones(2, 3, 4, 2)
-    packed = PackedTensor([first, second], dim_to_pack=0, pad_to_max_shape=True)
+    packed = PackedTensor(
+        [first, second], dim_to_pack=0, preprocess_mode="pad_to_max_shape"
+    )
 
     nested, shapes = packed.to_wire()
     rows = list(nested.unbind())
@@ -769,7 +881,9 @@ def test_to_wire_does_not_materialize_pad_to_max_shape():
 
     # Padding is reapplied on read, reproducing the pre-wire as_tensor().
     assert torch.equal(
-        PackedTensor.from_wire(nested, shapes, pad_to_max_shape=True).as_tensor(),
+        PackedTensor.from_wire(
+            nested, shapes, preprocess_mode="pad_to_max_shape"
+        ).as_tensor(),
         packed.as_tensor(),
     )
 
@@ -836,7 +950,8 @@ def test_encode_multimodal_for_wire_packed_emits_single_nested_entry():
         [[3, 4]],
         [[1, 4]],
     ]
-    assert tags[0]["pixel_values__row_shapes"]["pad"] is False
+    assert tags[0]["pixel_values__row_shapes"]["preprocess_mode"] is None
+    assert tags[0]["pixel_values__row_shapes"]["preprocess_kwargs"] == {}
 
 
 def test_multimodal_row_tags_does_not_encode_the_payload():
@@ -882,13 +997,20 @@ def test_reassemble_packed_multimodal_raises_without_companion():
 
 
 def test_reassemble_packed_multimodal_round_trips_with_companion():
-    packed = PackedTensor([torch.ones(3, 4), torch.ones(1, 4)], dim_to_pack=0)
+    packed = PackedTensor(
+        [torch.ones(1, 3, 32, 32), torch.ones(1, 3, 16, 32)],
+        dim_to_pack=0,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
+    )
     nested, _ = packed.to_wire()
     tags = multimodal_row_tags({"pixel_values": packed}, len(packed))
 
     fields = {"pixel_values": nested}
     reassemble_packed_multimodal(fields, tags)
 
+    assert fields["pixel_values"].preprocess_mode == "patchify"
+    assert fields["pixel_values"].preprocess_kwargs == {"patch_dim": 16}
     assert torch.equal(fields["pixel_values"].as_tensor(), packed.as_tensor())
 
 
@@ -1034,11 +1156,13 @@ def test_to_wire_carries_mixed_rank_rows():
     load-bearing. Reshaping on read restores the original ranks.
     """
     rows = [torch.ones(1, 3, 2), torch.ones(2, 3)]
-    packed = PackedTensor(list(rows), dim_to_pack=0, pad_to_max_shape=True)
+    packed = PackedTensor(list(rows), dim_to_pack=0, preprocess_mode="pad_to_max_shape")
 
     nested, shapes = packed.to_wire()
     assert [t.numel() for t in nested.unbind()] == [6, 6]
     assert shapes == [[[1, 3, 2]], [[2, 3]]]
 
-    restored = PackedTensor.from_wire(nested, shapes, pad_to_max_shape=True)
+    restored = PackedTensor.from_wire(
+        nested, shapes, preprocess_mode="pad_to_max_shape"
+    )
     assert [tuple(t.shape) for t in restored.tensors] == [(1, 3, 2), (2, 3)]

--- a/tests/unit/data/test_vlm_preference_processor.py
+++ b/tests/unit/data/test_vlm_preference_processor.py
@@ -101,6 +101,7 @@ def test_vlm_preference_processor_adds_nemotron_omni_media_metadata():
         result["message_log_rejected"],
     ):
         message = message_log[0]
-        assert message["pixel_values"].pad_to_max_shape
+        assert message["pixel_values"].preprocess_mode == "patchify"
+        assert message["pixel_values"].preprocess_kwargs == {"patch_dim": 16}
         assert message["imgs_sizes"].as_tensor().tolist() == [[15, 23]]
         assert message["num_frames"].as_tensor().tolist() == [1]

--- a/tests/unit/data_plane/test_leader_broadcast.py
+++ b/tests/unit/data_plane/test_leader_broadcast.py
@@ -91,7 +91,7 @@ def _packed(rows):
     return PackedTensor(
         [r.clone() if r is not None else None for r in rows],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     )
 
 
@@ -148,7 +148,9 @@ def _all_empty_body(rank: int):
             {
                 "input_ids": torch.arange(8, dtype=torch.long).reshape(2, 4),
                 "pixel_values": PackedTensor(
-                    [None, None], dim_to_pack=0, pad_to_max_shape=True
+                    [None, None],
+                    dim_to_pack=0,
+                    preprocess_mode="pad_to_max_shape",
                 ),
             }
         )
@@ -165,7 +167,8 @@ def _all_empty_body(rank: int):
     assert isinstance(packed, PackedTensor), type(packed).__name__
     assert packed.logical_segment_counts_by_row() == [0, 0]
     assert packed.as_tensor() is None
-    assert packed.pad_to_max_shape is True
+    assert packed.preprocess_mode == "pad_to_max_shape"
+    assert packed.preprocess_kwargs == {}
 
 
 def _unsupported_type_body(rank: int):

--- a/tests/unit/data_plane/test_local_sft.py
+++ b/tests/unit/data_plane/test_local_sft.py
@@ -47,7 +47,7 @@ def _put_multimodal_batch(
     pixels = PackedTensor(
         [torch.full((1, 2), 1.0), torch.full((2, 2), 2.0)],
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="pad_to_max_shape",
     ).enable_deduplication()
     fields = local_batch_to_tensordict(
         {
@@ -80,7 +80,7 @@ def test_local_round_trip_preserves_tensor_and_packed_tensor_fields() -> None:
     pixels = batch["pixel_values"]
     assert isinstance(pixels, PackedTensor)
     assert pixels.dim_to_pack == 0
-    assert pixels.pad_to_max_shape
+    assert pixels.preprocess_mode == "pad_to_max_shape"
     assert pixels.deduplication_enabled
     assert pixels.logical_segment_counts_by_row() == [1, 1]
     assert torch.equal(pixels.tensors[0], torch.full((1, 2), 1.0))

--- a/tests/unit/environments/test_nemo_gym_image_placeholders.py
+++ b/tests/unit/environments/test_nemo_gym_image_placeholders.py
@@ -60,7 +60,9 @@ class NemotronNanoVLV2Processor:
 def _ragged(*shapes: tuple[int, ...]) -> NemotronNanoVLV2Processor:
     return NemotronNanoVLV2Processor(
         [torch.ones(*shape) for shape in shapes],
-        imgs_sizes=torch.tensor([[4, 4]] * len(shapes), dtype=torch.long),
+        imgs_sizes=torch.tensor(
+            [[shape[-2], shape[-1]] for shape in shapes], dtype=torch.long
+        ),
     )
 
 
@@ -83,9 +85,9 @@ def test_ragged_output_requested_only_for_multi_image_turns():
         )
 
 
-def test_ragged_pixel_values_are_padded_to_one_tensor():
-    """Heterogeneous CHW tensors become a single padded tensor for the message."""
-    processor = _ragged((3, 2, 4), (3, 6, 4))
+def test_ragged_pixel_values_are_patchified_to_one_tensor():
+    """Heterogeneous CHW tensors become one packed patch sequence."""
+    processor = _ragged((3, 16, 32), (3, 32, 16))
     user_message: dict = {}
     attach_image_model_inputs_to_message(
         user_message,
@@ -94,10 +96,7 @@ def test_ragged_pixel_values_are_padded_to_one_tensor():
         pad_dynamic_image_shapes=True,
     )
     packed = user_message["pixel_values"].as_tensor()
-    # Two images, padded up to the tallest, channels preserved.
-    assert packed.shape[0] == 2
-    assert packed.shape[-3] == 3
-    assert packed.shape[-2] == 6
+    assert packed.shape == (1, 4, 768)
 
 
 def test_ragged_pixel_values_reject_non_chw_entries():

--- a/tests/unit/models/megatron/test_nemotron_omni_model.py
+++ b/tests/unit/models/megatron/test_nemotron_omni_model.py
@@ -241,7 +241,8 @@ def _deduplicated_expanded_fixture(device: torch.device):
             "pixel_values": PackedTensor(
                 [image.clone(), image.clone()],
                 dim_to_pack=0,
-                pad_to_max_shape=True,
+                preprocess_mode="patchify",
+                preprocess_kwargs={"patch_dim": 16},
             ),
             "imgs_sizes": PackedTensor(
                 [image_size.clone(), image_size.clone()],
@@ -252,7 +253,8 @@ def _deduplicated_expanded_fixture(device: torch.device):
     pixel_row = PackedTensor(
         image,
         dim_to_pack=0,
-        pad_to_max_shape=True,
+        preprocess_mode="patchify",
+        preprocess_kwargs={"patch_dim": 16},
     ).enable_deduplication()
     image_size_row = PackedTensor(
         image_size,


### PR DESCRIPTION
# What does this PR do ?

Adds configurable PackedTensor preprocessing and patchifies Nemotron Omni pixels before materialization.

- Replaces the top-level pad_to_max_shape boolean with preprocess_mode and preprocess_kwargs.
- Adds native-resolution patchification into per-image (C_i, P²) blocks, packs them on dimension 0, and returns (1, total_C, P²).
- Carries preprocessing settings through slicing, concatenation, wire transport, and materialization.
- Enables patchification with patch size 16 for supported Nemotron Omni processors.
- Adds NemotronH_Omni_Reasoning_V3Processor to the placeholder-style processor set.

# Issues

None.

# Usage

```python
PackedTensor(
    pixel_values,
    dim_to_pack=0,
    preprocess_mode="patchify",
    preprocess_kwargs={"patch_dim": 16},
)
```

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added or updated unit coverage for preprocessing and patchification.
- [x] Full pre-commit lint suite passed on Slurm job `18281365` (Ruff lint, import sorting, Ruff format, Pyrefly, and config checks).
- [x] Affected unit suite passed on Slurm job `18281365`: 90 passed, 1 skipped (`megatron.bridge` unavailable).
- [x] GRPO and SFT GPU recipe validation passed on Slurm job `18281365`.
- [x] Updated relevant inline documentation.

# Additional Information

- Stacked on #4070 via the `rohit/sft_v2_stage2` base branch. Retarget this PR to `main` after #4070 merges.

Scripts validated 

`uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-2n8g-megatron-tp8ep8.v1-tq_mooncake.yaml logger.wandb.name=grpo-nemotron-with-patches logger.wandb_enabled=true logger.wandb.project=sft-dev cluster.num_nodes=1`

<img width="651" height="290" alt="image" src="https://github.com/user-attachments/assets/a1d2d137-9d38-4ea6-bb09-b371988374ab" />

```
uv run examples/run_sft_v2.py --config examples/configs/recipes/vlm/vlm_sft-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8-energon.v1.packing.yaml logger.wandb.name=sft-nemotron-with-patches logger.wandb_enabled=true logger.wandb.project=sft-dev sft.max_steps=50
```
(brown: baseline, green: with patches)
<img width="1018" height="317" alt="image" src="https://github.com/user-attachments/assets/98088cdc-27c4-4d09-a241-fde190af6f2f" />

