### PR TITLE
fix: fail fast when training dataloaders yield zero batches

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -31,7 +31,7 @@ from nemo_rl.algorithms.loss import (
     DistillationLossDataDict,
     DistillationLossFn,
 )
-from nemo_rl.algorithms.utils import set_seed
+from nemo_rl.algorithms.utils import check_train_dataloader_not_empty, set_seed
 from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -298,6 +298,12 @@ def setup(
         shuffle=data_config["shuffle"],
         collate_fn=rl_collate_fn,
         drop_last=True,
+    )
+    check_train_dataloader_not_empty(
+        dataloader,
+        dataset=train_dataset,
+        batch_size=distillation_config.num_prompts_per_step,
+        batch_size_source="distillation.num_prompts_per_step",
     )
 
     if last_checkpoint_path:

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -25,7 +25,11 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer
 
 from nemo_rl.algorithms.loss import DPOLossFn
-from nemo_rl.algorithms.utils import maybe_pad_last_batch, set_seed
+from nemo_rl.algorithms.utils import (
+    check_train_dataloader_not_empty,
+    maybe_pad_last_batch,
+    set_seed,
+)
 from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import preference_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -246,6 +250,12 @@ def setup(
         ),
         drop_last=True,
         num_workers=data_config["num_workers"],
+    )
+    check_train_dataloader_not_empty(
+        train_dataloader,
+        dataset=train_dataset,
+        batch_size=policy_config["train_global_batch_size"],
+        batch_size_source="policy.train_global_batch_size",
     )
 
     if last_checkpoint_path is not None:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -59,6 +59,7 @@ from nemo_rl.algorithms.reward_functions import (
 from nemo_rl.algorithms.utils import (
     WALL_CLOCK_EFFICIENCY_CATEGORIES,
     calculate_baseline_and_std_per_prompt,
+    check_train_dataloader_not_empty,
     get_gdpo_reward_component_keys,
     log_generation_metrics,
     print_efficiency_summary,
@@ -700,6 +701,17 @@ def setup(
             collate_fn=rl_collate_fn,
             drop_last=True,
             num_workers=data_config["num_workers"],
+        )
+        check_train_dataloader_not_empty(
+            dataloader,
+            dataset=dataset,
+            batch_size=dataloader_batch_size,
+            batch_size_source=(
+                "num_prompts_per_dataloader * batch_multiplier"
+                if data_config["use_multiple_dataloader"]
+                else "num_prompts_per_step * batch_multiplier"
+            ),
+            context=f" for task '{suffix.removeprefix('_')}'" if suffix else "",
         )
         if last_checkpoint_path is not None:
             load_dataloader_state(dataloader, last_checkpoint_path, data_config, suffix)

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -51,6 +51,7 @@ from nemo_rl.algorithms.reward_functions import (
     apply_reward_shaping,
 )
 from nemo_rl.algorithms.utils import (
+    check_train_dataloader_not_empty,
     print_efficiency_summary,
     print_performance_metrics,
     set_seed,
@@ -460,6 +461,12 @@ def setup(
         collate_fn=rl_collate_fn,
         drop_last=True,
         num_workers=data_config["num_workers"],
+    )
+    check_train_dataloader_not_empty(
+        dataloader,
+        dataset=dataset,
+        batch_size=dataloader_batch_size,
+        batch_size_source="num_prompts_per_step * batch_multiplier",
     )
     if last_checkpoint_path is not None:
         load_dataloader_state(dataloader, last_checkpoint_path, data_config)

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -25,7 +25,11 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer
 
 from nemo_rl.algorithms.loss import PreferenceLossFn
-from nemo_rl.algorithms.utils import maybe_pad_last_batch, set_seed
+from nemo_rl.algorithms.utils import (
+    check_train_dataloader_not_empty,
+    maybe_pad_last_batch,
+    set_seed,
+)
 from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import preference_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -196,6 +200,12 @@ def setup(
         ),
         drop_last=True,
         num_workers=data_config["num_workers"],
+    )
+    check_train_dataloader_not_empty(
+        train_dataloader,
+        dataset=train_dataset,
+        batch_size=policy_config["train_global_batch_size"],
+        batch_size_source="policy.train_global_batch_size",
     )
 
     if last_checkpoint_path is not None:

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -25,7 +25,11 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.loss.loss_functions import NLLLossFn
-from nemo_rl.algorithms.utils import maybe_pad_last_batch, set_seed
+from nemo_rl.algorithms.utils import (
+    check_train_dataloader_not_empty,
+    maybe_pad_last_batch,
+    set_seed,
+)
 from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -185,6 +189,12 @@ def setup(
             collate_fn=rl_collate_fn,
             drop_last=True,
             num_workers=data_config["num_workers"],
+        )
+        check_train_dataloader_not_empty(
+            train_dataloader,
+            dataset=train_dataset,
+            batch_size=policy_config["train_global_batch_size"],
+            batch_size_source="policy.train_global_batch_size",
         )
 
         if val_dataset is not None:

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -76,7 +76,7 @@ from nemo_rl.algorithms.single_controller_utils.rollout_checkpoint import (
     resolve_latest_snapshot,
     validate_bootstrap_anchor,
 )
-from nemo_rl.algorithms.utils import set_seed
+from nemo_rl.algorithms.utils import check_train_dataloader_not_empty, set_seed
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.multimodal_utils import WIRE_MULTIMODAL_FIELDS
 from nemo_rl.data.utils import load_dataloader_state, setup_response_data
@@ -1289,6 +1289,12 @@ def setup_single_controller(
         collate_fn=rl_collate_fn,
         drop_last=True,
         num_workers=data_config["num_workers"],
+    )
+    check_train_dataloader_not_empty(
+        dataloader,
+        dataset=dataset,
+        batch_size=algo_cfg.num_prompts_per_step,
+        batch_size_source="num_prompts_per_step",
     )
     if recovery_checkpoint_path is not None:
         print(

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -1091,23 +1091,17 @@ def check_train_dataloader_not_empty(
     batch_size_source: str,
     context: str = "",
 ) -> None:
-    """Fail fast when a ``drop_last`` train dataloader would yield zero batches.
+    """Fail fast when the training dataloader would yield zero batches.
 
-    Every training entry point builds its train dataloader with
-    ``drop_last=True``, so a batch size larger than the dataset produces a
-    dataloader of length zero: the training loop body never runs, yet epochs
-    advance and the run completes "successfully" without a single gradient
-    update. Raise up front and name the mismatch instead.
+    With ``drop_last=True``, an oversized batch can prevent all gradient
+    updates. Skip this check if the dataloader or dataset has no defined length.
 
     Args:
-        dataloader: The freshly constructed train dataloader.
-        dataset: The underlying train dataset (used for the message; a dataset
-            without ``__len__`` skips the check entirely).
-        batch_size: The batch size the dataloader was built with.
-        batch_size_source: Where that batch size comes from, as the user knows
-            it (e.g. ``policy.train_global_batch_size``); used in the message.
-        context: Optional suffix identifying the dataloader (e.g. a task name)
-            when a setup builds more than one.
+        dataloader: Training dataloader.
+        dataset: Underlying training dataset.
+        batch_size: Effective dataloader batch size.
+        batch_size_source: Configuration key or expression shown in the error.
+        context: Optional suffix identifying the dataloader in the error.
     """
     try:
         num_batches = len(dataloader)

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -1081,3 +1081,47 @@ def print_efficiency_summary(
     loggable["efficiency/efficiency_pct_is_per_step"] = float(pct_is_per_step)
 
     return loggable
+
+
+def check_train_dataloader_not_empty(
+    dataloader: Any,
+    *,
+    dataset: Any,
+    batch_size: int,
+    batch_size_source: str,
+    context: str = "",
+) -> None:
+    """Fail fast when a ``drop_last`` train dataloader would yield zero batches.
+
+    Every training entry point builds its train dataloader with
+    ``drop_last=True``, so a batch size larger than the dataset produces a
+    dataloader of length zero: the training loop body never runs, yet epochs
+    advance and the run completes "successfully" without a single gradient
+    update. Raise up front and name the mismatch instead.
+
+    Args:
+        dataloader: The freshly constructed train dataloader.
+        dataset: The underlying train dataset (used for the message; a dataset
+            without ``__len__`` skips the check entirely).
+        batch_size: The batch size the dataloader was built with.
+        batch_size_source: Where that batch size comes from, as the user knows
+            it (e.g. ``policy.train_global_batch_size``); used in the message.
+        context: Optional suffix identifying the dataloader (e.g. a task name)
+            when a setup builds more than one.
+    """
+    try:
+        num_batches = len(dataloader)
+        dataset_size = len(dataset)
+    except TypeError:
+        # Iterable-style dataset without a length; nothing to pre-check.
+        return
+    if num_batches > 0:
+        return
+    raise ValueError(
+        f"The train dataloader{context} would yield zero batches: "
+        f"{batch_size_source}={batch_size} exceeds the dataset size "
+        f"({dataset_size} samples), and with drop_last=True the only, partial "
+        f"batch is dropped. Training would silently complete without a single "
+        f"gradient update. Reduce {batch_size_source} to at most the dataset "
+        f"size, or provide more data."
+    )

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -48,7 +48,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     CrossTokenizerDistillationLossConfig,
     CrossTokenizerDistillationLossFn,
 )
-from nemo_rl.algorithms.utils import set_seed
+from nemo_rl.algorithms.utils import check_train_dataloader_not_empty, set_seed
 from nemo_rl.algorithms.x_token import TokenAligner
 from nemo_rl.algorithms.x_token.utils import (
     assert_teacher_student_batch_grid,
@@ -337,6 +337,12 @@ def setup(
         # via max_num_epochs respawn+re-init all workers at every epoch
         # boundary, which dominates step time when the epoch is short.
         persistent_workers=data_config["num_workers"] > 0,
+    )
+    check_train_dataloader_not_empty(
+        train_dataloader,
+        dataset=train_dataset,
+        batch_size=distillation_config["num_prompts_per_step"],
+        batch_size_source="distillation.num_prompts_per_step",
     )
     if last_checkpoint_path:
         load_dataloader_state(train_dataloader, last_checkpoint_path, data_config)

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -906,7 +906,11 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
     with (
         patch("nemo_rl.algorithms.distillation.Logger") as mock_logger,
         patch("nemo_rl.algorithms.distillation.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.distillation.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.distillation.StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
@@ -1035,7 +1039,12 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
         patch.object(distil_mod, "RayVirtualCluster", DummyCluster),
         patch.object(distil_mod, "Logger"),
         patch.object(distil_mod, "CheckpointManager") as mock_ckpt_mgr,
-        patch.object(distil_mod, "StatefulDataLoader"),
+        patch.object(
+            distil_mod,
+            "StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         patch.object(distil_mod, "Policy", DummyPolicy),
         patch.object(distil_mod, "VllmGeneration", DummyVllmGeneration),
         patch.object(
@@ -1181,7 +1190,12 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(monkeypatch):
         patch.object(distil_mod, "RayVirtualCluster", DummyCluster),
         patch.object(distil_mod, "Logger"),
         patch.object(distil_mod, "CheckpointManager") as mock_ckpt_mgr,
-        patch.object(distil_mod, "StatefulDataLoader"),
+        patch.object(
+            distil_mod,
+            "StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         patch.object(distil_mod, "Policy", DummyPolicy),
         patch.object(distil_mod, "VllmGeneration", DummyVllmGeneration),
         patch.object(
@@ -1364,7 +1378,11 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
     with (
         patch("nemo_rl.algorithms.distillation.Logger") as mock_logger,
         patch("nemo_rl.algorithms.distillation.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.distillation.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.distillation.StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",

--- a/tests/unit/algorithms/test_empty_train_dataloader_guard.py
+++ b/tests/unit/algorithms/test_empty_train_dataloader_guard.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock
+
+import pytest
+from torch.utils.data import IterableDataset
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from nemo_rl.algorithms.utils import check_train_dataloader_not_empty
+
+# Every algorithm setup builds its train dataloader with drop_last=True, so a
+# batch size larger than the dataset yields a zero-length dataloader and the
+# training loop silently never runs (#921). These tests cover the shared guard
+# the setups call right after constructing the dataloader, plus a regression
+# test through the real SFT setup path the issue reported.
+
+
+def _loader(dataset, batch_size: int, drop_last: bool = True):
+    return StatefulDataLoader(
+        dataset,
+        batch_size=batch_size,
+        drop_last=drop_last,
+    )
+
+
+def test_raises_when_batch_size_exceeds_dataset():
+    """bs=16 over 8 samples with drop_last=True is the reported silent no-op."""
+    dataset = list(range(8))
+    with pytest.raises(ValueError, match="zero batches") as excinfo:
+        check_train_dataloader_not_empty(
+            _loader(dataset, 16),
+            dataset=dataset,
+            batch_size=16,
+            batch_size_source="policy.train_global_batch_size",
+        )
+    message = str(excinfo.value)
+    assert "policy.train_global_batch_size=16" in message
+    assert "8 samples" in message
+    assert "gradient update" in message
+
+
+def test_passes_when_dataset_covers_at_least_one_batch():
+    dataset = list(range(16))
+    check_train_dataloader_not_empty(
+        _loader(dataset, 8),
+        dataset=dataset,
+        batch_size=8,
+        batch_size_source="policy.train_global_batch_size",
+    )
+
+
+def test_partial_epoch_is_not_flagged():
+    """dataset >= batch with a dropped remainder is normal, not an error."""
+    dataset = list(range(20))
+    check_train_dataloader_not_empty(
+        _loader(dataset, 8),
+        dataset=dataset,
+        batch_size=8,
+        batch_size_source="policy.train_global_batch_size",
+    )
+
+
+def test_without_drop_last_a_small_dataset_still_passes():
+    """A partial batch is kept when drop_last=False, so nothing to flag."""
+    dataset = list(range(8))
+    check_train_dataloader_not_empty(
+        _loader(dataset, 16, drop_last=False),
+        dataset=dataset,
+        batch_size=16,
+        batch_size_source="policy.train_global_batch_size",
+    )
+
+
+def test_iterable_dataset_without_len_is_skipped():
+    """Iterable-style datasets have no length, on the dataset or its
+    dataloader; the guard must skip them entirely rather than raise
+    ``TypeError`` probing either one."""
+
+    class _Stream(IterableDataset):
+        def __iter__(self):
+            yield from range(4)
+
+    stream = _Stream()
+    dataloader = StatefulDataLoader(stream, batch_size=16)
+    check_train_dataloader_not_empty(
+        dataloader,
+        dataset=stream,
+        batch_size=16,
+        batch_size_source="policy.train_global_batch_size",
+    )
+
+
+def test_context_names_the_dataloader():
+    """Multi-dataloader setups (GRPO tasks) must say which dataloader is empty."""
+    dataset = list(range(2))
+    with pytest.raises(ValueError, match="for task 'math'"):
+        check_train_dataloader_not_empty(
+            _loader(dataset, 4),
+            dataset=dataset,
+            batch_size=4,
+            batch_size_source="num_prompts_per_dataloader * batch_multiplier",
+            context=" for task 'math'",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage through the real SFT setup path reported in #921.
+# ---------------------------------------------------------------------------
+
+
+def _sft_master_config(train_global_batch_size: int):
+    """Minimal master config for driving sft.setup() up to the guard."""
+    master_config = MagicMock()
+    master_config.sft.seed = 42
+    master_config.policy = {"train_global_batch_size": train_global_batch_size}
+    master_config.data = {"shuffle": False, "num_workers": 0}
+    master_config.checkpointing = {}
+    # Use concrete cluster settings so the missing segment_size defaults to None,
+    # skipping Ray topology discovery before the mocked cluster sentinel.
+    master_config.cluster = {"num_nodes": 1, "gpus_per_node": 1}
+    return master_config
+
+
+class _ReachedClusterConstruction(Exception):
+    """Sentinel raised by the mocked cluster class: setup made it past the
+    guard and reached infrastructure construction."""
+
+
+def _patch_sft_infrastructure(monkeypatch):
+    """Mock everything before/after the data section so no Ray or model
+    infrastructure is touched; return the pieces whose usage we assert on."""
+    import nemo_rl.algorithms.sft as sft_module
+
+    monkeypatch.setattr(sft_module, "Logger", MagicMock())
+    monkeypatch.setattr(sft_module, "load_dataloader_state", MagicMock())
+    checkpoint_manager_cls = MagicMock()
+    checkpoint_manager_cls.return_value.get_latest_checkpoint_path.return_value = None
+    checkpoint_manager_cls.return_value.load_training_info.return_value = None
+    monkeypatch.setattr(sft_module, "CheckpointManager", checkpoint_manager_cls)
+    cluster_cls = MagicMock()
+    policy_cls = MagicMock()
+    monkeypatch.setattr(sft_module, "RayVirtualCluster", cluster_cls)
+    monkeypatch.setattr(sft_module, "Policy", policy_cls)
+    return sft_module, cluster_cls, policy_cls
+
+
+def test_sft_setup_fails_fast_on_oversized_batch(monkeypatch):
+    """The reported case (#921): 128 samples, batch size 1024. setup() must
+    raise before constructing the cluster or the policy."""
+    sft_module, cluster_cls, policy_cls = _patch_sft_infrastructure(monkeypatch)
+
+    with pytest.raises(ValueError, match="zero batches"):
+        sft_module.setup(
+            master_config=_sft_master_config(train_global_batch_size=1024),
+            tokenizer=MagicMock(),
+            train_dataset=list(range(128)),
+            val_dataset=None,
+        )
+
+    cluster_cls.assert_not_called()
+    policy_cls.assert_not_called()
+
+
+def test_sft_setup_accepts_dataset_equal_to_batch_size(monkeypatch):
+    """dataset size == batch size yields exactly one batch and must pass the
+    guard. The mocked cluster class raises a sentinel, so this test can only
+    pass if setup ran the real guard without raising and then reached cluster
+    construction; any earlier failure surfaces as its own exception."""
+    sft_module, cluster_cls, _ = _patch_sft_infrastructure(monkeypatch)
+    cluster_cls.side_effect = _ReachedClusterConstruction()
+
+    real_guard = sft_module.check_train_dataloader_not_empty
+    guard_spy = MagicMock(wraps=real_guard)
+    monkeypatch.setattr(sft_module, "check_train_dataloader_not_empty", guard_spy)
+
+    with pytest.raises(_ReachedClusterConstruction):
+        sft_module.setup(
+            master_config=_sft_master_config(train_global_batch_size=128),
+            tokenizer=MagicMock(),
+            train_dataset=list(range(128)),
+            val_dataset=None,
+        )
+
+    guard_spy.assert_called_once()

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2771,7 +2771,11 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
@@ -3049,7 +3053,11 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         pytest.raises(
             AssertionError,
             match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
@@ -3098,7 +3106,11 @@ def test_noncolocated_opd_teacher_must_fit_on_one_cluster_node(
     with (
         patch("nemo_rl.algorithms.grpo.Logger"),
         patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
-        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        patch(
+            "nemo_rl.algorithms.grpo.StatefulDataLoader",
+            # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+            **{"return_value.__len__.return_value": 10},
+        ),
         patch(
             "nemo_rl.algorithms.grpo.opd_module.reserve_teacher_clusters"
         ) as mock_reserve_teacher_clusters,

--- a/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
+++ b/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
@@ -275,7 +275,9 @@ def mock_xtoken_components():
 # ---------------------------------------------------------------------------
 
 
-def _patched_setup_call(master_config, *, student_vocab=32, teacher_vocab=24):
+def _patched_setup_call(
+    master_config, *, student_vocab=32, teacher_vocab=24, dataloader_len=10
+):
     """Drive setup() with every heavy collaborator patched out."""
     student_tok = _make_tokenizer(student_vocab)
     teacher_tok = _make_tokenizer(teacher_vocab)
@@ -299,7 +301,10 @@ def _patched_setup_call(master_config, *, student_vocab=32, teacher_vocab=24):
         mock_cp_cls.return_value.get_latest_checkpoint_path.return_value = None
         mock_cp_cls.return_value.load_training_info.return_value = None
         mock_cp_cls.return_value.get_resume_paths.return_value = (None, None)
-        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(spec=StatefulDataLoader)
+        # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(
+            spec=StatefulDataLoader, **{"__len__.return_value": dataloader_len}
+        )
         mock_policy_cls.side_effect = lambda *a, **kw: MagicMock(data_parallel_size=1)
 
         result = setup(
@@ -315,6 +320,20 @@ def _patched_setup_call(master_config, *, student_vocab=32, teacher_vocab=24):
             "loss": mock_loss_cls,
             "checkpointer": mock_cp_cls,
         }
+
+
+def test_setup_rejects_empty_train_dataloader():
+    """#921 guard: a train dataloader that would yield zero batches must fail
+    setup with an actionable error naming the configured batch size."""
+    with pytest.raises(ValueError, match="zero batches") as excinfo:
+        _patched_setup_call(_make_master_config(), dataloader_len=0)
+    assert "distillation.num_prompts_per_step" in str(excinfo.value)
+
+
+def test_setup_accepts_single_batch_train_dataloader():
+    """A dataset exactly one batch long (len(dataloader) == 1) passes the guard."""
+    _, mocks = _patched_setup_call(_make_master_config(), dataloader_len=1)
+    assert mocks["policy"].called
 
 
 def test_empty_teachers_list_rejected_at_config_load():
@@ -418,7 +437,10 @@ def test_setup_val_dataloader_gating(
         mock_cp_cls.return_value.get_latest_checkpoint_path.return_value = None
         mock_cp_cls.return_value.load_training_info.return_value = None
         mock_cp_cls.return_value.get_resume_paths.return_value = (None, None)
-        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(spec=StatefulDataLoader)
+        # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(
+            spec=StatefulDataLoader, **{"__len__.return_value": 10}
+        )
         mock_policy_cls.side_effect = lambda *a, **kw: MagicMock(data_parallel_size=1)
 
         (
@@ -770,7 +792,10 @@ def test_setup_builds_one_policy_per_teacher():
         mock_cp_cls.return_value.get_latest_checkpoint_path.return_value = None
         mock_cp_cls.return_value.load_training_info.return_value = None
         mock_cp_cls.return_value.get_resume_paths.return_value = (None, None)
-        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(spec=StatefulDataLoader)
+        # The zero-batch setup guard reads len(); a bare MagicMock is 0.
+        mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(
+            spec=StatefulDataLoader, **{"__len__.return_value": 10}
+        )
         mock_policy_cls.side_effect = lambda *a, **kw: MagicMock(data_parallel_size=1)
 
         (_student, teachers, *_rest) = setup(

--- a/tests/unit/single_controller/test_ppo_setup.py
+++ b/tests/unit/single_controller/test_ppo_setup.py
@@ -554,7 +554,7 @@ def patched_ppo_factories():
             sc_setup_mod,
             "setup_response_data",
             return_value=(list(range(8)), None, {"math": MagicMock()}, {}),
-        ),
+        ) as mock_response,
         patch.object(sc_setup_mod, "StatefulDataLoader", return_value=fake_dataloader),
         patch.object(
             sc_setup_mod,
@@ -590,6 +590,8 @@ def patched_ppo_factories():
             "_build_value": mock_value,
             "policy": fake_policy,
             "value": fake_value,
+            "dataloader": fake_dataloader,
+            "setup_response_data": mock_response,
         }
 
 
@@ -797,3 +799,31 @@ class TestTrainClusterSizesForTheCritic:
         else:
             # The critic never lands on the inference cluster.
             assert inference.kwargs["max_colocated_worker_groups"] == 1
+
+
+def test_ppo_setup_rejects_empty_train_dataloader(patched_ppo_factories):
+    """#921 guard: the PPO path fails setup before building any worker group."""
+    patched_ppo_factories["dataloader"].__len__ = MagicMock(return_value=0)
+
+    with pytest.raises(ValueError, match="zero batches") as excinfo:
+        setup_single_controller(
+            _ppo_master_config(), tokenizer=MagicMock(pad_token_id=0)
+        )
+
+    assert "num_prompts_per_step" in str(excinfo.value)
+    patched_ppo_factories["_build_trainer"].assert_not_called()
+
+
+def test_ppo_setup_accepts_dataset_equal_to_batch_size(patched_ppo_factories):
+    """A dataset exactly num_prompts_per_step long yields one batch and passes."""
+    patched_ppo_factories["setup_response_data"].return_value = (
+        list(range(4)),  # default num_prompts_per_step
+        None,
+        {"math": MagicMock()},
+        {},
+    )
+    patched_ppo_factories["dataloader"].__len__ = MagicMock(return_value=1)
+
+    setup_single_controller(_ppo_master_config(), tokenizer=MagicMock(pad_token_id=0))
+
+    patched_ppo_factories["_build_value"].assert_called_once()

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -2402,3 +2402,30 @@ def test_load_opd_full_teacher_lm_heads_rejects_two_teacher_checkpoints(monkeypa
             },
         )
     trainer.worker_group.run_all_workers_single_data.assert_not_called()
+
+
+def test_setup_rejects_empty_train_dataloader(patched_factories):
+    """#921 guard: a dataloader that would yield zero batches fails setup
+    before any cluster or trainer construction."""
+    patched_factories["dataloader"].__len__ = MagicMock(return_value=0)
+
+    with pytest.raises(ValueError, match="zero batches") as excinfo:
+        setup_single_controller(_make_master_config(), MagicMock(pad_token_id=0))
+
+    assert "num_prompts_per_step" in str(excinfo.value)
+    patched_factories["_build_clusters"].assert_not_called()
+
+
+def test_setup_accepts_dataset_equal_to_batch_size(patched_factories):
+    """A dataset exactly num_prompts_per_step long yields one batch and passes."""
+    patched_factories["setup_response_data"].return_value = (
+        list(range(4)),  # _make_master_config() default num_prompts_per_step
+        None,
+        patched_factories["env_handles"],
+        {},
+    )
+    patched_factories["dataloader"].__len__ = MagicMock(return_value=1)
+
+    setup_single_controller(_make_master_config(), MagicMock(pad_token_id=0))
+
+    patched_factories["_build_trainer"].assert_called_once()


### PR DESCRIPTION
# What does this PR do ?

Raises an actionable error during setup when a training dataloader would yield zero batches.

# Issues

Closes #921

# Usage

No configuration changes are required. For example, SFT with 128 samples and `policy.train_global_batch_size=1024` now raises an error directing the user to reduce the batch size or provide more data.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

With `drop_last=True`, an oversized batch can cause training to finish without any gradient updates. The shared guard covers SFT, DPO, RM, distillation, PPO, and GRPO, including GRPO’s per-task dataloaders. It reports the effective batch size, dataset size, and relevant configuration setting without automatically changing the batch size.

Repo pre-commit checks passed.