### PR TITLE
feat(gym): add actor checkpoint participant

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -14,12 +14,14 @@
 import asyncio
 import math
 import os
+import secrets
 import subprocess
 import sys
+import time
 from collections import Counter
 from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, Optional, Protocol, TypedDict
+from typing import Any, Dict, List, NotRequired, Optional, Protocol, TypedDict, cast
 
 import ray
 import torch
@@ -39,6 +41,12 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_node_ip_local,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.environments.nemo_gym_checkpoint import (
+    CHECKPOINT_CONTROL_TOKEN_ENV,
+    CHECKPOINT_OPERATION_TIMEOUT_S,
+    ExecutionIdentity,
+    NemoGymCheckpointCoordinator,
+)
 from nemo_rl.environments.nemo_gym_multimodal import (
     _index_per_turn_images,
     _is_trainable_output_item,
@@ -334,6 +342,8 @@ class NemoGym(EnvironmentInterface):
 
     def __init__(self, cfg: NemoGymConfig):
         self.cfg = cfg
+        self._checkpoint_control_token = secrets.token_urlsafe(32)
+        self._checkpoint = NemoGymCheckpointCoordinator(self._checkpoint_control_token)
         # Populated by _spinup. Declared here so a restarted actor -- Ray recreates it
         # through __init__, which does not start the Gym servers -- reports what
         # actually happened instead of an AttributeError from deep inside a rollout.
@@ -349,6 +359,9 @@ class NemoGym(EnvironmentInterface):
         # _spinup replaces this from cfg. Keep restarted/unspun actors internally
         # complete so diagnostics and focused tests do not fail with AttributeError.
         self._token_capture_enabled = False
+        self._server_client: Any = None
+        self._control_headers: Dict[str, str] = {}
+        self._control_timeout_s = 60.0
         self._pad_dynamic_image_shapes = bool(cfg.get("pad_dynamic_image_shapes"))
         # Reconstruct the processor inside the actor (rather than serializing it
         # per rollout call) for full-trajectory multimodal postprocessing.
@@ -390,7 +403,7 @@ class NemoGym(EnvironmentInterface):
         self._require_spinup()
         self.rh.poll()
 
-    def _spinup(self) -> None:
+    async def _spinup(self) -> None:
         """Start the NeMo-Gym head server and rollout collection helper.
 
         Deferred from __init__ so the actor can be created cheaply (and
@@ -472,14 +485,17 @@ Depending on your data shape, you may want to change these values."""
         # Ledger-authoritative token capture: enable external staging in the
         # policy model server (via the policy_model global-config override
         # block the env yamls already use) and disable the legacy token echo.
-        token_capture = self.cfg.get("token_capture") or None
+        token_capture = cast(
+            Dict[str, Any] | None,
+            self.cfg.get("token_capture") or None,
+        )
         self._token_capture_enabled = bool(
             token_capture and token_capture.get("enabled")
         )
         self._server_client = None
-        self._control_headers: Dict[str, str] = {}
+        self._control_headers = {}
         self._control_timeout_s = 60.0
-        if self._token_capture_enabled:
+        if token_capture is not None and self._token_capture_enabled:
             policy_overrides = (
                 initial_global_config_dict.setdefault("policy_model", {})
                 .setdefault("responses_api_models", {})
@@ -512,6 +528,10 @@ Depending on your data shape, you may want to change these values."""
                 token_capture.get("control_timeout_s") or 60.0
             )
 
+        # Gym resolves this credential independently inside each serving
+        # process. Keep it out of serialized global config and install it
+        # before RunHelper copies the actor environment to subprocesses.
+        os.environ[CHECKPOINT_CONTROL_TOKEN_ENV] = self._checkpoint_control_token
         self.rh = RunHelper()
         self.rh.start(
             global_config_dict_parser_config=GlobalConfigDictParserConfig(
@@ -520,6 +540,10 @@ Depending on your data shape, you may want to change these values."""
                 initial_global_config_dict=DictConfig(initial_global_config_dict),
                 skip_load_from_cli=True,
             )
+        )
+        await self._checkpoint.discover(
+            self.rh._server_client.global_config_dict,
+            deadline_ts=time.time() + CHECKPOINT_OPERATION_TIMEOUT_S,
         )
 
         # Setup for rollout collection
@@ -552,6 +576,48 @@ Depending on your data shape, you may want to change these values."""
         value, so it still pays per task.
         """
         self._tokenizer = tokenizer
+
+    async def prepare_checkpoint(
+        self,
+        checkpoint_id: str,
+        deadline_ts: float,
+    ) -> dict[str, Any]:
+        """Prepare and leave the Gym rollout fleet paused."""
+        self._require_spinup()
+        return await self._checkpoint.prepare(checkpoint_id, deadline_ts)
+
+    async def commit_checkpoint(
+        self,
+        checkpoint_id: str,
+        checkpoint_dir: str,
+    ) -> dict[str, Any]:
+        """Commit Gym state and leave all participants paused."""
+        self._require_spinup()
+        return await self._checkpoint.commit(checkpoint_id, checkpoint_dir)
+
+    async def restore_checkpoint(
+        self,
+        checkpoint_id: str,
+        checkpoint_dir: str,
+    ) -> dict[str, Any]:
+        """Restore Gym state and leave all participants paused."""
+        self._require_spinup()
+        return await self._checkpoint.restore(checkpoint_id, checkpoint_dir)
+
+    async def resume(self, checkpoint_id: str) -> dict[str, Any]:
+        """Resume dependencies, agents, and actor dispatch in that order."""
+        self._require_spinup()
+        return await self._checkpoint.resume(checkpoint_id)
+
+    async def abort_checkpoint(self, checkpoint_id: str) -> dict[str, Any]:
+        """Abort the active transaction and reopen prepared participants."""
+        self._require_spinup()
+        return await self._checkpoint.abort(checkpoint_id)
+
+    def checkpoint_status(self, checkpoint_id: str) -> dict[str, Any]:
+        """Return bounded actor-local checkpoint status."""
+        self._require_spinup()
+        return self._checkpoint.status(checkpoint_id)
 
     # ── ledger control plane (token-capture mode) ───────────────────────────
 
@@ -605,22 +671,14 @@ Depending on your data shape, you may want to change these values."""
                 "NemoGym.set_tokenizer must be called before run_rollouts"
             )
         tokenizer = self._tokenizer
-
+        execution_identities = [
+            ExecutionIdentity.from_row(row) for row in nemo_gym_examples
+        ]
         for row in nemo_gym_examples:
             logical_rollout_id = row.get(NEMO_GYM_ROLLOUT_ID_KEY)
             attempt_index = row.get(NEMO_GYM_ATTEMPT_INDEX_KEY)
-            if not isinstance(logical_rollout_id, str) or not logical_rollout_id:
-                raise ValueError(
-                    f"{NEMO_GYM_ROLLOUT_ID_KEY} must be a non-empty string"
-                )
-            if (
-                isinstance(attempt_index, bool)
-                or not isinstance(attempt_index, int)
-                or attempt_index < 0
-            ):
-                raise ValueError(
-                    f"{NEMO_GYM_ATTEMPT_INDEX_KEY} must be a non-negative integer"
-                )
+            assert isinstance(logical_rollout_id, str)
+            assert isinstance(attempt_index, int)
             expected_capture_id = nemo_gym_capture_key(
                 logical_rollout_id, attempt_index
             )
@@ -628,6 +686,14 @@ Depending on your data shape, you may want to change these values."""
                 raise ValueError(
                     f"{NEMO_GYM_CAPTURE_ID_KEY} must equal {expected_capture_id!r}"
                 )
+        registered_identities: list[ExecutionIdentity] = []
+        try:
+            for row in nemo_gym_examples:
+                registered_identities.append(self._checkpoint.registry.register(row))
+        except (RuntimeError, ValueError):
+            for identity in registered_identities:
+                self._checkpoint.registry.release(identity)
+            raise
 
         from nemo_rl.utils.fastokens import maybe_patch_fastokens
 
@@ -653,6 +719,8 @@ Depending on your data shape, you may want to change these values."""
                 try:
                     nemo_gym_row, nemo_gym_result = await task
                 except Exception as error:
+                    for identity in execution_identities:
+                        self._checkpoint.registry.release(identity)
                     if hasattr(error, "response_content"):
                         print(
                             "EXCEPTION RESULT",
@@ -666,6 +734,8 @@ Depending on your data shape, you may want to change these values."""
                         # the whole point. The status and message are already in `detail`.
                         raise typed from None
                     raise
+            identity = ExecutionIdentity.from_row(nemo_gym_row)
+            self._checkpoint.registry.mark_terminal(identity)
 
             with timer.time(label=f"{timer_prefix}/postprocess_results"):
                 if self._token_capture_enabled:
@@ -690,11 +760,16 @@ Depending on your data shape, you may want to change these values."""
             if num_results == len(nemo_gym_examples):
                 timer.stop("_run_rollouts_total")
                 timing_metrics = timer.get_timing_metrics("sum")
-                total_time = timing_metrics.pop("_run_rollouts_total")
+                total_time = cast(
+                    float,
+                    timing_metrics.pop("_run_rollouts_total"),
+                )
+                postprocess_time = cast(
+                    float,
+                    timing_metrics[f"{timer_prefix}/postprocess_results"],
+                )
                 timing_metrics[f"{timer_prefix}/postprocess_results_pct"] = (
-                    100
-                    * timing_metrics[f"{timer_prefix}/postprocess_results"]
-                    / total_time
+                    100 * postprocess_time / total_time
                 )
 
             agent_name = nemo_gym_row["agent_ref"]["name"]
@@ -716,12 +791,18 @@ Depending on your data shape, you may want to change these values."""
             # task_source is resolved to agent_ref inside this Ray actor, after
             # the caller's row was serialized. Return the resolved ref explicitly
             # so the caller can hydrate its own row copy before postprocessing.
-            yield (
-                nemo_gym_row["_rowidx"],
-                nemo_gym_row["agent_ref"],
-                nemo_rl_result,
-                timing_metrics,
-            )
+            try:
+                yield (
+                    nemo_gym_row["_rowidx"],
+                    nemo_gym_row["agent_ref"],
+                    nemo_rl_result,
+                    timing_metrics,
+                )
+            finally:
+                await self._checkpoint.release(
+                    identity,
+                    agent_name=nemo_gym_row["agent_ref"]["name"],
+                )
 
     async def _postprocess_receipt_mode(
         self, nemo_gym_row: dict, nemo_gym_result: dict
@@ -1162,7 +1243,7 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
                         container[key], raw_initial_sources
                     )
 
-        result = {
+        result: dict[str, Any] = {
             "message_log": nemo_rl_message_log,
             "input_message_log": nemo_rl_message_log[:1],
             "full_result": nemo_gym_result,
@@ -1321,7 +1402,7 @@ def build_nemo_gym_config(
         remaining ``env_configs["nemo_gym"]`` keys under
         ``initial_global_config_dict``. The caller's ``env_configs`` is not mutated.
     """
-    nemo_gym_dict = dict(env_configs["nemo_gym"])
+    nemo_gym_dict: dict[str, Any] = dict(env_configs["nemo_gym"])
 
     # NeMo-RL-side detection knobs are top-level NemoGymConfig fields
     # (where the detector reads them), not part of Gym's global config.

--- a/nemo_rl/environments/nemo_gym_checkpoint.py
+++ b/nemo_rl/environments/nemo_gym_checkpoint.py
@@ -1,0 +1,1698 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Actor-local coordination for NeMo Gym partial-rollout checkpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+CHECKPOINT_CONTROL_TOKEN_ENV = "NEMO_GYM_CHECKPOINT_CONTROL_TOKEN"
+GYM_CHECKPOINT_MANIFEST = "nemo_gym_checkpoint_manifest.json"
+GYM_CHECKPOINT_SCHEMA_VERSION = 1
+CHECKPOINT_OPERATION_TIMEOUT_S = 120.0
+MAX_CHECKPOINT_RESPONSE_BYTES = 1024 * 1024
+MAX_AGENT_COMPLETION_RECEIPTS = 4096
+_CHECKPOINT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ROLLOUT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_RESULT_DIGEST_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+_COMPONENT_KEYS = (
+    "responses_api_models",
+    "responses_api_agents",
+    "resources_servers",
+)
+
+
+class CheckpointParticipantKind(str, Enum):
+    """Checkpoint role of one Gym server instance."""
+
+    POLICY_MODEL = "policy_model"
+    AGENT = "agent"
+    RESOURCES = "resources"
+
+
+class ActorCheckpointPhase(str, Enum):
+    """Actor-local checkpoint transaction phase."""
+
+    IDLE = "idle"
+    PREPARING = "preparing"
+    PREPARED = "prepared"
+    COMMITTING = "committing"
+    COMMITTED_PAUSED = "committed_paused"
+    RESTORING = "restoring"
+    RESTORED_PAUSED = "restored_paused"
+    RESUMING = "resuming"
+    ABORTING = "aborting"
+
+
+class LiveExecutionState(str, Enum):
+    """Publication state of a rollout invocation owned by this actor."""
+
+    RUNNING = "running"
+    TERMINAL = "terminal"
+
+
+@dataclass(frozen=True, order=True)
+class ExecutionIdentity:
+    """Stable identity supplied by the rollout controller."""
+
+    rollout_id: str
+    attempt_index: int
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> ExecutionIdentity:
+        """Validate the identity already assigned to a Gym row."""
+        rollout_id = row.get("_ng_rollout_id")
+        attempt_index = row.get("_ng_attempt_index")
+        if (
+            not isinstance(rollout_id, str)
+            or _ROLLOUT_ID_PATTERN.fullmatch(rollout_id) is None
+        ):
+            raise ValueError(
+                "every NeMo Gym rollout row must carry a non-empty stable "
+                "_ng_rollout_id containing only letters, digits, dots, dashes, or underscores"
+            )
+        if (
+            not isinstance(attempt_index, int)
+            or isinstance(attempt_index, bool)
+            or attempt_index < 0
+        ):
+            raise ValueError(
+                "every NeMo Gym rollout row must carry a nonnegative integer _ng_attempt_index"
+            )
+        return cls(rollout_id=rollout_id, attempt_index=attempt_index)
+
+
+@dataclass(frozen=True)
+class AgentCompletionReceipt:
+    """Exact server-issued proof for one completed agent result."""
+
+    rollout_id: str
+    attempt_index: int
+    execution_generation: int
+    result_id: str
+    result_digest: str
+    _result_id_key: str = field(repr=False, compare=False)
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> AgentCompletionReceipt:
+        """Validate a completion receipt without deriving any of its fields."""
+        result_id_keys = [key for key in ("result_id", "result_identity") if key in raw]
+        if len(result_id_keys) != 1:
+            raise ValueError(
+                "Gym agent completion receipt must contain exactly one result ID field"
+            )
+        result_id_key = result_id_keys[0]
+        expected_keys = {
+            "rollout_id",
+            "attempt_index",
+            "execution_generation",
+            result_id_key,
+            "result_digest",
+        }
+        if set(raw) != expected_keys:
+            raise ValueError(
+                "Gym agent completion receipt contains missing or unexpected fields"
+            )
+        identity = ExecutionIdentity.from_row(
+            {
+                "_ng_rollout_id": raw.get("rollout_id"),
+                "_ng_attempt_index": raw.get("attempt_index"),
+            }
+        )
+        execution_generation = raw.get("execution_generation")
+        if (
+            not isinstance(execution_generation, int)
+            or isinstance(execution_generation, bool)
+            or execution_generation < 1
+        ):
+            raise ValueError(
+                "Gym agent completion receipt execution_generation must be a positive integer"
+            )
+        result_id = raw.get(result_id_key)
+        if (
+            not isinstance(result_id, str)
+            or not result_id
+            or len(result_id.encode("utf-8")) > 512
+        ):
+            raise ValueError(
+                "Gym agent completion receipt result ID must contain 1 to 512 UTF-8 bytes"
+            )
+        result_digest = raw.get("result_digest")
+        if (
+            not isinstance(result_digest, str)
+            or _RESULT_DIGEST_PATTERN.fullmatch(result_digest) is None
+        ):
+            raise ValueError(
+                "Gym agent completion receipt result_digest must be a lowercase SHA-256 digest"
+            )
+        return cls(
+            rollout_id=identity.rollout_id,
+            attempt_index=identity.attempt_index,
+            execution_generation=execution_generation,
+            result_id=result_id,
+            result_digest=result_digest,
+            _result_id_key=result_id_key,
+        )
+
+    @property
+    def identity(self) -> ExecutionIdentity:
+        """Return the logical rollout attempt named by this receipt."""
+        return ExecutionIdentity(self.rollout_id, self.attempt_index)
+
+    def to_request(self) -> dict[str, Any]:
+        """Return the exact wire schema issued by the Gym server."""
+        return {
+            "rollout_id": self.rollout_id,
+            "attempt_index": self.attempt_index,
+            "execution_generation": self.execution_generation,
+            self._result_id_key: self.result_id,
+            "result_digest": self.result_digest,
+        }
+
+
+@dataclass
+class LiveExecution:
+    """One actor-local rollout invocation."""
+
+    identity: ExecutionIdentity
+    state: LiveExecutionState = LiveExecutionState.RUNNING
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe execution record."""
+        return {
+            "rollout_id": self.identity.rollout_id,
+            "attempt_index": self.identity.attempt_index,
+            "state": self.state.value,
+        }
+
+
+class LiveExecutionRegistry:
+    """Track live actor membership and fence new dispatch during checkpoints."""
+
+    def __init__(self) -> None:
+        self._live: dict[ExecutionIdentity, LiveExecution] = {}
+        self._frozen_checkpoint_id: str | None = None
+        self._frozen_membership: tuple[LiveExecution, ...] = ()
+
+    def register(self, row: Mapping[str, Any]) -> ExecutionIdentity:
+        """Register one pre-assigned rollout attempt without changing its identity."""
+        if self._frozen_checkpoint_id is not None:
+            raise RuntimeError(
+                f"NeMo Gym dispatch is frozen for checkpoint {self._frozen_checkpoint_id!r}"
+            )
+        identity = ExecutionIdentity.from_row(row)
+        if identity in self._live:
+            raise ValueError(
+                f"rollout {identity.rollout_id!r} attempt {identity.attempt_index} is already live"
+            )
+        self._live[identity] = LiveExecution(identity)
+        return identity
+
+    def mark_terminal(self, identity: ExecutionIdentity) -> None:
+        """Mark a result terminal until the consumer acknowledges it."""
+        execution = self._require_live(identity)
+        execution.state = LiveExecutionState.TERMINAL
+
+    def release(self, identity: ExecutionIdentity) -> None:
+        """Release one result after it crosses the actor boundary."""
+        self._live.pop(identity, None)
+
+    def freeze(self, checkpoint_id: str) -> tuple[LiveExecution, ...]:
+        """Close dispatch and snapshot actor-local membership."""
+        _validate_checkpoint_id(checkpoint_id)
+        if self._frozen_checkpoint_id is not None:
+            if self._frozen_checkpoint_id != checkpoint_id:
+                raise RuntimeError(
+                    f"checkpoint {self._frozen_checkpoint_id!r} already owns the dispatch fence"
+                )
+            return self._frozen_membership
+        self._frozen_checkpoint_id = checkpoint_id
+        self._frozen_membership = tuple(
+            LiveExecution(execution.identity, execution.state)
+            for execution in sorted(self._live.values(), key=lambda item: item.identity)
+        )
+        return self._frozen_membership
+
+    def restore(
+        self,
+        checkpoint_id: str,
+        membership: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Restore a dispatch fence and its source-cut membership."""
+        _validate_checkpoint_id(checkpoint_id)
+        if self._live:
+            raise RuntimeError(
+                "cannot restore NeMo Gym dispatch while rollout calls are live"
+            )
+        if self._frozen_checkpoint_id not in (None, checkpoint_id):
+            raise RuntimeError(
+                f"checkpoint {self._frozen_checkpoint_id!r} already owns the dispatch fence"
+            )
+        restored: list[LiveExecution] = []
+        for raw in membership:
+            identity = ExecutionIdentity.from_row(
+                {
+                    "_ng_rollout_id": raw.get("rollout_id"),
+                    "_ng_attempt_index": raw.get("attempt_index"),
+                }
+            )
+            raw_state = raw.get("state")
+            if raw_state == LiveExecutionState.RUNNING.value:
+                state = LiveExecutionState.RUNNING
+            elif raw_state == LiveExecutionState.TERMINAL.value:
+                state = LiveExecutionState.TERMINAL
+            else:
+                raise ValueError(
+                    f"invalid live execution state for {identity}: {raw_state!r}"
+                )
+            restored.append(LiveExecution(identity, state))
+        self._frozen_checkpoint_id = checkpoint_id
+        self._frozen_membership = tuple(
+            sorted(restored, key=lambda item: item.identity)
+        )
+
+    def unfreeze(self, checkpoint_id: str) -> None:
+        """Reopen dispatch for the active transaction."""
+        if self._frozen_checkpoint_id != checkpoint_id:
+            raise RuntimeError(
+                f"checkpoint {checkpoint_id!r} does not own the dispatch fence "
+                f"(owner={self._frozen_checkpoint_id!r})"
+            )
+        self._frozen_checkpoint_id = None
+        self._frozen_membership = ()
+
+    def status(self) -> dict[str, Any]:
+        """Return bounded actor-local checkpoint diagnostics."""
+        running = sum(
+            execution.state == LiveExecutionState.RUNNING
+            for execution in self._live.values()
+        )
+        terminal = len(self._live) - running
+        return {
+            "frozen_checkpoint_id": self._frozen_checkpoint_id,
+            "live": len(self._live),
+            "running": running,
+            "terminal_unreleased": terminal,
+            "frozen_membership": len(self._frozen_membership),
+        }
+
+    def frozen_membership(self) -> list[dict[str, Any]]:
+        """Return the local source cut for the aggregate manifest."""
+        return [execution.to_dict() for execution in self._frozen_membership]
+
+    def _require_live(self, identity: ExecutionIdentity) -> LiveExecution:
+        execution = self._live.get(identity)
+        if execution is None:
+            raise KeyError(
+                f"rollout {identity.rollout_id!r} attempt {identity.attempt_index} is not live"
+            )
+        return execution
+
+
+@dataclass(frozen=True)
+class CheckpointCapabilities:
+    """Validated capability declaration from one Gym server."""
+
+    component: str
+    name: str
+    schema_version: int
+    admission_states: tuple[str, ...]
+    checkpoint_mode: str
+    concurrency_contract: str
+    multi_process_mode: str
+    num_workers: int
+    instance_role: str | None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> CheckpointCapabilities:
+        """Parse the fields required by actor-side orchestration."""
+        multi_process = raw.get("multi_process")
+        if not isinstance(multi_process, Mapping):
+            raise ValueError("Gym capabilities are missing multi_process")
+        admission_states = raw.get("admission_states")
+        if not isinstance(admission_states, list) or not all(
+            isinstance(state, str) for state in admission_states
+        ):
+            raise ValueError(
+                "Gym capabilities admission_states must be a list of strings"
+            )
+        component = _required_capability_string(raw, "component")
+        name = _required_capability_string(raw, "name")
+        checkpoint_mode = _required_capability_string(raw, "checkpoint_mode")
+        concurrency_contract = _required_capability_string(raw, "concurrency_contract")
+        multi_process_mode = _required_capability_string(multi_process, "mode")
+        schema_version = raw.get("schema_version")
+        num_workers = multi_process.get("num_workers")
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            raise ValueError("Gym capabilities schema_version must be an integer")
+        if (
+            not isinstance(num_workers, int)
+            or isinstance(num_workers, bool)
+            or num_workers < 1
+        ):
+            raise ValueError("Gym capabilities num_workers must be a positive integer")
+        instance_role = raw.get("instance_role")
+        if instance_role is not None and not isinstance(instance_role, str):
+            raise ValueError("Gym capabilities instance_role must be a string or null")
+        return cls(
+            component=component,
+            name=name,
+            schema_version=schema_version,
+            admission_states=tuple(admission_states),
+            checkpoint_mode=checkpoint_mode,
+            concurrency_contract=concurrency_contract,
+            multi_process_mode=multi_process_mode,
+            num_workers=num_workers,
+            instance_role=instance_role,
+        )
+
+
+@dataclass(frozen=True)
+class CheckpointParticipant:
+    """One checkpoint-capable Gym server and its direct control endpoint."""
+
+    participant_id: str
+    name: str
+    base_url: str
+    kind: CheckpointParticipantKind
+    capabilities: CheckpointCapabilities
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return stable participant metadata for the aggregate manifest."""
+        return {
+            "participant_id": self.participant_id,
+            "name": self.name,
+            "base_url": self.base_url,
+            "kind": self.kind.value,
+            "capabilities": asdict(self.capabilities),
+        }
+
+
+class CheckpointParticipantError(RuntimeError):
+    """A picklable participant failure retaining Gym's structured error fields."""
+
+    def __init__(
+        self,
+        participant: str,
+        endpoint: str,
+        detail: str,
+        *,
+        status: int | None = None,
+        gym_error_code: str | None = None,
+    ) -> None:
+        self.participant = participant
+        self.endpoint = endpoint
+        self.status = status
+        self.gym_error_code = gym_error_code
+        self.detail = detail
+        fields = [f"participant={participant}", f"endpoint={endpoint}"]
+        if status is not None:
+            fields.append(f"status={status}")
+        if gym_error_code is not None:
+            fields.append(f"gym_error_code={gym_error_code}")
+        super().__init__(f"Gym checkpoint call failed ({', '.join(fields)}): {detail}")
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        return (
+            _restore_participant_error,
+            (
+                self.participant,
+                self.endpoint,
+                self.detail,
+                self.status,
+                self.gym_error_code,
+            ),
+        )
+
+
+def _restore_participant_error(
+    participant: str,
+    endpoint: str,
+    detail: str,
+    status: int | None,
+    gym_error_code: str | None,
+) -> CheckpointParticipantError:
+    return CheckpointParticipantError(
+        participant,
+        endpoint,
+        detail,
+        status=status,
+        gym_error_code=gym_error_code,
+    )
+
+
+class ActorCheckpointError(RuntimeError):
+    """Actor transaction failure with phase and completed participants."""
+
+    def __init__(
+        self,
+        checkpoint_id: str,
+        phase: ActorCheckpointPhase,
+        completed_participants: Sequence[str],
+        cause: BaseException,
+    ) -> None:
+        self.checkpoint_id = checkpoint_id
+        self.phase = phase
+        self.completed_participants = tuple(completed_participants)
+        self.cause_detail = str(cause)
+        self.participant: str | None
+        self.endpoint: str | None
+        self.status: int | None
+        self.gym_error_code: str | None
+        if isinstance(cause, CheckpointParticipantError):
+            self.participant = cause.participant
+            self.endpoint = cause.endpoint
+            self.status = cause.status
+            self.gym_error_code = cause.gym_error_code
+        else:
+            self.participant = None
+            self.endpoint = None
+            self.status = None
+            self.gym_error_code = None
+        super().__init__(
+            f"NeMo Gym checkpoint {checkpoint_id!r} failed in phase {phase.value!r} "
+            f"after {list(completed_participants)!r}: {cause}"
+        )
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        return (
+            _restore_actor_error,
+            (
+                self.checkpoint_id,
+                self.phase,
+                self.completed_participants,
+                self.cause_detail,
+                self.participant,
+                self.endpoint,
+                self.status,
+                self.gym_error_code,
+            ),
+        )
+
+
+def _restore_actor_error(
+    checkpoint_id: str,
+    phase: ActorCheckpointPhase,
+    completed_participants: Sequence[str],
+    cause_detail: str,
+    participant: str | None,
+    endpoint: str | None,
+    status: int | None,
+    gym_error_code: str | None,
+) -> ActorCheckpointError:
+    cause: BaseException
+    if participant is not None and endpoint is not None:
+        cause = CheckpointParticipantError(
+            participant,
+            endpoint,
+            cause_detail,
+            status=status,
+            gym_error_code=gym_error_code,
+        )
+    else:
+        cause = RuntimeError(cause_detail)
+    return ActorCheckpointError(
+        checkpoint_id,
+        phase,
+        completed_participants,
+        cause,
+    )
+
+
+@dataclass(frozen=True)
+class ActorCheckpointResult:
+    """Opaque result returned through the Ray actor boundary."""
+
+    checkpoint_id: str
+    phase: ActorCheckpointPhase
+    participant_results: Mapping[str, Mapping[str, Any]]
+    manifest_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe and Ray-friendly result."""
+        return {
+            "checkpoint_id": self.checkpoint_id,
+            "phase": self.phase.value,
+            "participant_results": {
+                participant: dict(result)
+                for participant, result in self.participant_results.items()
+            },
+            "manifest_path": self.manifest_path,
+        }
+
+
+@dataclass
+class ActorCheckpointTransaction:
+    """Mutable actor-local state for one fenced checkpoint."""
+
+    checkpoint_id: str
+    phase: ActorCheckpointPhase
+    deadline_ts: float
+    participant_results: dict[str, dict[str, Any]] = field(default_factory=dict)
+    prepared_participants: set[str] = field(default_factory=set)
+    operation_results: dict[str, dict[str, Any]] = field(default_factory=dict)
+    manifest_path: str | None = None
+
+
+class CheckpointTransport:
+    """Deadline-bounded aiohttp transport for Gym checkpoint control calls."""
+
+    def __init__(self, bearer_token: str) -> None:
+        if not bearer_token:
+            raise ValueError("Gym checkpoint bearer token must not be empty")
+        self._headers = {"Authorization": f"Bearer {bearer_token}"}
+
+    async def request(
+        self,
+        participant: CheckpointParticipant,
+        method: str,
+        endpoint: str,
+        *,
+        deadline_ts: float,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue one direct control request inside the shared absolute deadline."""
+        remaining = _remaining(deadline_ts)
+        url = f"{participant.base_url.rstrip('/')}{endpoint}"
+        timeout = aiohttp.ClientTimeout(total=remaining)
+        try:
+            async with aiohttp.ClientSession(
+                timeout=timeout, headers=self._headers
+            ) as session:
+                async with session.request(
+                    method,
+                    url,
+                    json=dict(json_body) if json_body is not None else None,
+                    params=dict(params) if params is not None else None,
+                ) as response:
+                    body = await _read_bounded_response(
+                        participant,
+                        endpoint,
+                        response,
+                    )
+                    parsed = _decode_response(body)
+                    if response.status < 200 or response.status >= 300:
+                        error_code, detail = _gym_error(parsed, body)
+                        raise CheckpointParticipantError(
+                            participant.participant_id,
+                            endpoint,
+                            detail,
+                            status=response.status,
+                            gym_error_code=error_code,
+                        )
+        except CheckpointParticipantError:
+            raise
+        except (asyncio.TimeoutError, TimeoutError) as error:
+            raise CheckpointParticipantError(
+                participant.participant_id,
+                endpoint,
+                "absolute checkpoint deadline expired",
+                gym_error_code="deadline_exceeded",
+            ) from error
+        except aiohttp.ClientError as error:
+            raise CheckpointParticipantError(
+                participant.participant_id,
+                endpoint,
+                str(error),
+                gym_error_code="transport_error",
+            ) from error
+        if not isinstance(parsed, dict):
+            raise CheckpointParticipantError(
+                participant.participant_id,
+                endpoint,
+                "Gym checkpoint response must be a JSON object",
+                status=response.status,
+                gym_error_code="invalid_response",
+            )
+        return parsed
+
+
+class NemoGymCheckpointCoordinator:
+    """Coordinate one NemoGym actor's checkpoint transaction."""
+
+    def __init__(self, bearer_token: str) -> None:
+        self.registry = LiveExecutionRegistry()
+        self._transport = CheckpointTransport(bearer_token)
+        self._participants: list[CheckpointParticipant] = []
+        self._transaction: ActorCheckpointTransaction | None = None
+        self._retired_checkpoint_id: str | None = None
+        self._retired_results: dict[str, dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def discover(
+        self,
+        global_config: Mapping[str, Any],
+        *,
+        deadline_ts: float,
+    ) -> list[CheckpointParticipant]:
+        """Discover and validate the servers started by RunHelper."""
+        self._participants = await discover_checkpoint_participants(
+            global_config,
+            self._transport,
+            deadline_ts=deadline_ts,
+        )
+        return list(self._participants)
+
+    async def prepare(self, checkpoint_id: str, deadline_ts: float) -> dict[str, Any]:
+        """Freeze dispatch and prepare agents, policy admission, then resources."""
+        _validate_checkpoint_id(checkpoint_id)
+        _remaining(deadline_ts)
+        async with self._lock:
+            if self._retired_checkpoint_id == checkpoint_id:
+                raise RuntimeError(f"checkpoint {checkpoint_id!r} is stale")
+            transaction = self._transaction
+            if transaction is not None:
+                if transaction.checkpoint_id != checkpoint_id:
+                    raise RuntimeError(
+                        f"checkpoint {transaction.checkpoint_id!r} is already active "
+                        f"in phase {transaction.phase.value!r}"
+                    )
+                recorded = transaction.operation_results.get("prepare")
+                if recorded is not None:
+                    return recorded
+                if transaction.phase != ActorCheckpointPhase.PREPARING:
+                    raise RuntimeError(
+                        f"prepare is not valid in actor phase {transaction.phase.value!r}"
+                    )
+            else:
+                transaction = ActorCheckpointTransaction(
+                    checkpoint_id=checkpoint_id,
+                    phase=ActorCheckpointPhase.PREPARING,
+                    deadline_ts=deadline_ts,
+                )
+                self._transaction = transaction
+                self.registry.freeze(checkpoint_id)
+
+            try:
+                if self.registry.status()["terminal_unreleased"]:
+                    raise RuntimeError(
+                        "cannot prepare a NeMo Gym checkpoint while streamed agent "
+                        "results remain unacknowledged"
+                    )
+                agents = self._of_kind(CheckpointParticipantKind.AGENT)
+                policy_models = self._of_kind(CheckpointParticipantKind.POLICY_MODEL)
+                resources = self._of_kind(CheckpointParticipantKind.RESOURCES)
+                await self._run_participants(
+                    transaction,
+                    "prepare",
+                    agents,
+                    deadline_ts=deadline_ts,
+                )
+                await self._run_participants(
+                    transaction,
+                    "prepare",
+                    policy_models,
+                    deadline_ts=deadline_ts,
+                )
+                for participant in policy_models:
+                    await self._wait_for_policy_pause(
+                        transaction,
+                        participant,
+                        deadline_ts=deadline_ts,
+                    )
+                await self._run_participants(
+                    transaction,
+                    "prepare",
+                    resources,
+                    deadline_ts=deadline_ts,
+                )
+            except (CheckpointParticipantError, RuntimeError, ValueError) as error:
+                raise self._actor_error(transaction, error) from None
+
+            transaction.phase = ActorCheckpointPhase.PREPARED
+            result = self._result(transaction)
+            transaction.operation_results["prepare"] = result
+            return result
+
+    async def commit(
+        self, checkpoint_id: str, checkpoint_dir: str | Path
+    ) -> dict[str, Any]:
+        """Commit all participants and publish the aggregate manifest last."""
+        async with self._lock:
+            transaction = self._require_transaction(
+                checkpoint_id,
+                {
+                    ActorCheckpointPhase.PREPARED,
+                    ActorCheckpointPhase.COMMITTING,
+                    ActorCheckpointPhase.COMMITTED_PAUSED,
+                },
+            )
+            recorded = transaction.operation_results.get("commit")
+            if recorded is not None:
+                return recorded
+            transaction.phase = ActorCheckpointPhase.COMMITTING
+            deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+            transaction.deadline_ts = deadline_ts
+            try:
+                await self._run_participants(
+                    transaction,
+                    "commit",
+                    self._participants,
+                    deadline_ts=deadline_ts,
+                    checkpoint_dir=checkpoint_dir,
+                )
+                manifest_path = await asyncio.to_thread(
+                    write_checkpoint_manifest,
+                    Path(checkpoint_dir),
+                    checkpoint_id=checkpoint_id,
+                    participants=self._participants,
+                    participant_results=transaction.participant_results,
+                    live_membership=self.registry.frozen_membership(),
+                )
+            except (
+                CheckpointParticipantError,
+                OSError,
+                RuntimeError,
+                ValueError,
+            ) as error:
+                raise self._actor_error(transaction, error) from None
+            transaction.manifest_path = str(manifest_path)
+            transaction.phase = ActorCheckpointPhase.COMMITTED_PAUSED
+            result = self._result(transaction)
+            transaction.operation_results["commit"] = result
+            return result
+
+    async def restore(
+        self, checkpoint_id: str, checkpoint_dir: str | Path
+    ) -> dict[str, Any]:
+        """Verify the aggregate manifest and restore every participant paused."""
+        _validate_checkpoint_id(checkpoint_id)
+        async with self._lock:
+            if (
+                self._transaction is None
+                and self._retired_checkpoint_id == checkpoint_id
+            ):
+                raise RuntimeError(f"checkpoint {checkpoint_id!r} is stale")
+            if self._transaction is not None:
+                transaction = self._require_transaction(
+                    checkpoint_id,
+                    {
+                        ActorCheckpointPhase.RESTORING,
+                        ActorCheckpointPhase.RESTORED_PAUSED,
+                    },
+                )
+                recorded = transaction.operation_results.get("restore")
+                if recorded is not None:
+                    return recorded
+            else:
+                deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+                transaction = ActorCheckpointTransaction(
+                    checkpoint_id=checkpoint_id,
+                    phase=ActorCheckpointPhase.RESTORING,
+                    deadline_ts=deadline_ts,
+                )
+                self._transaction = transaction
+            transaction.phase = ActorCheckpointPhase.RESTORING
+            deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+            transaction.deadline_ts = deadline_ts
+            try:
+                manifest = await asyncio.to_thread(
+                    load_checkpoint_manifest,
+                    Path(checkpoint_dir),
+                )
+                self._validate_manifest_participants(manifest)
+                self.registry.restore(
+                    checkpoint_id, manifest.get("live_membership", [])
+                )
+                await self._run_participants(
+                    transaction,
+                    "restore",
+                    self._participants,
+                    deadline_ts=deadline_ts,
+                    checkpoint_dir=checkpoint_dir,
+                )
+            except (
+                CheckpointParticipantError,
+                OSError,
+                RuntimeError,
+                ValueError,
+            ) as error:
+                raise self._actor_error(transaction, error) from None
+            transaction.manifest_path = str(
+                Path(checkpoint_dir) / GYM_CHECKPOINT_MANIFEST
+            )
+            transaction.phase = ActorCheckpointPhase.RESTORED_PAUSED
+            result = self._result(transaction)
+            transaction.operation_results["restore"] = result
+            return result
+
+    async def resume(self, checkpoint_id: str) -> dict[str, Any]:
+        """Resume model/resources, then agents, then actor dispatch."""
+        async with self._lock:
+            retired = self._retired_result(checkpoint_id, "resume")
+            if retired is not None:
+                return retired
+            transaction = self._require_transaction(
+                checkpoint_id,
+                {
+                    ActorCheckpointPhase.COMMITTED_PAUSED,
+                    ActorCheckpointPhase.RESTORED_PAUSED,
+                    ActorCheckpointPhase.RESUMING,
+                },
+            )
+            transaction.phase = ActorCheckpointPhase.RESUMING
+            deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+            transaction.deadline_ts = deadline_ts
+            dependencies, agents = participant_groups(self._participants)
+            try:
+                await self._run_participants(
+                    transaction,
+                    "resume",
+                    dependencies,
+                    deadline_ts=deadline_ts,
+                )
+                await self._run_participants(
+                    transaction,
+                    "resume",
+                    agents,
+                    deadline_ts=deadline_ts,
+                )
+                self.registry.unfreeze(checkpoint_id)
+            except (CheckpointParticipantError, RuntimeError, ValueError) as error:
+                raise self._actor_error(transaction, error) from None
+            result = ActorCheckpointResult(
+                checkpoint_id=checkpoint_id,
+                phase=ActorCheckpointPhase.IDLE,
+                participant_results=transaction.participant_results,
+                manifest_path=transaction.manifest_path,
+            ).to_dict()
+            self._retire_transaction(checkpoint_id, "resume", result)
+            self._transaction = None
+            return result
+
+    async def abort(self, checkpoint_id: str) -> dict[str, Any]:
+        """Resume participants reached by a partial transaction and reopen dispatch."""
+        async with self._lock:
+            retired = self._retired_result(checkpoint_id, "abort")
+            if retired is not None:
+                return retired
+            transaction = self._require_transaction(
+                checkpoint_id,
+                {
+                    ActorCheckpointPhase.PREPARING,
+                    ActorCheckpointPhase.PREPARED,
+                    ActorCheckpointPhase.COMMITTING,
+                    ActorCheckpointPhase.COMMITTED_PAUSED,
+                    ActorCheckpointPhase.RESTORING,
+                    ActorCheckpointPhase.RESTORED_PAUSED,
+                    ActorCheckpointPhase.RESUMING,
+                    ActorCheckpointPhase.ABORTING,
+                },
+            )
+            transaction.phase = ActorCheckpointPhase.ABORTING
+            deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+            transaction.deadline_ts = deadline_ts
+            prepared = [
+                participant
+                for participant in self._participants
+                if participant.participant_id in transaction.prepared_participants
+            ]
+            dependencies, agents = participant_groups(prepared)
+            try:
+                await self._run_participants(
+                    transaction,
+                    "abort",
+                    dependencies,
+                    deadline_ts=deadline_ts,
+                    route_operation="resume",
+                )
+                await self._run_participants(
+                    transaction,
+                    "abort",
+                    agents,
+                    deadline_ts=deadline_ts,
+                    route_operation="resume",
+                )
+                self.registry.unfreeze(checkpoint_id)
+            except (CheckpointParticipantError, RuntimeError, ValueError) as error:
+                raise self._actor_error(transaction, error) from None
+            result = ActorCheckpointResult(
+                checkpoint_id=checkpoint_id,
+                phase=ActorCheckpointPhase.IDLE,
+                participant_results=transaction.participant_results,
+                manifest_path=transaction.manifest_path,
+            ).to_dict()
+            self._retire_transaction(checkpoint_id, "abort", result)
+            self._transaction = None
+            return result
+
+    async def release(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        agent_name: str,
+    ) -> None:
+        """Acknowledge an exact delivered-result receipt, then release membership."""
+        async with self._lock:
+            matching_agents = [
+                participant
+                for participant in self._of_kind(CheckpointParticipantKind.AGENT)
+                if agent_name in {participant.participant_id, participant.name}
+            ]
+            if len(matching_agents) > 1:
+                raise RuntimeError(
+                    f"multiple Gym checkpoint agents match resolved agent {agent_name!r}"
+                )
+            if matching_agents:
+                deadline_ts = time.time() + CHECKPOINT_OPERATION_TIMEOUT_S
+                checkpoint_id = (
+                    self._transaction.checkpoint_id
+                    if self._transaction is not None
+                    else "actor-delivery"
+                )
+                participant = matching_agents[0]
+                status = await self._transport.request(
+                    participant,
+                    "GET",
+                    "/ng-control/v1/agent-checkpoint/status",
+                    deadline_ts=deadline_ts,
+                    params={"checkpoint_id": checkpoint_id},
+                )
+                receipt = _completion_receipt_for(
+                    participant,
+                    status,
+                    identity,
+                )
+                acknowledgment = await self._transport.request(
+                    participant,
+                    "POST",
+                    "/ng-control/v1/agent-checkpoint/acknowledge",
+                    deadline_ts=deadline_ts,
+                    json_body=receipt.to_request(),
+                )
+                acknowledged = acknowledgment.get("acknowledged")
+                idempotent = acknowledgment.get("idempotent")
+                if (
+                    not isinstance(acknowledged, bool)
+                    or not isinstance(idempotent, bool)
+                    or not (acknowledged or idempotent)
+                ):
+                    raise CheckpointParticipantError(
+                        participant.participant_id,
+                        "/ng-control/v1/agent-checkpoint/acknowledge",
+                        f"invalid Gym completion acknowledgment: {acknowledgment!r}",
+                        gym_error_code="invalid_response",
+                    )
+            self.registry.release(identity)
+
+    def status(self, checkpoint_id: str) -> dict[str, Any]:
+        """Return actor-local transaction and bounded registry status."""
+        transaction = self._transaction
+        if transaction is None:
+            return {
+                "checkpoint_id": checkpoint_id,
+                "phase": ActorCheckpointPhase.IDLE.value,
+                "participants": [
+                    participant.to_dict() for participant in self._participants
+                ],
+                "registry": self.registry.status(),
+                "participant_results": {},
+                "manifest_path": None,
+            }
+        if transaction.checkpoint_id != checkpoint_id:
+            raise RuntimeError(
+                f"checkpoint {transaction.checkpoint_id!r} is active, not {checkpoint_id!r}"
+            )
+        return {
+            "checkpoint_id": checkpoint_id,
+            "phase": transaction.phase.value,
+            "participants": [
+                participant.to_dict() for participant in self._participants
+            ],
+            "registry": self.registry.status(),
+            "participant_results": dict(transaction.participant_results),
+            "manifest_path": transaction.manifest_path,
+        }
+
+    async def _run_participants(
+        self,
+        transaction: ActorCheckpointTransaction,
+        operation: str,
+        participants: Sequence[CheckpointParticipant],
+        *,
+        deadline_ts: float,
+        checkpoint_dir: str | Path | None = None,
+        route_operation: str | None = None,
+    ) -> None:
+        route_operation = route_operation or operation
+        for participant in participants:
+            result_key = f"{operation}:{participant.participant_id}"
+            if result_key in transaction.participant_results:
+                continue
+            if operation in {"prepare", "restore"}:
+                # Once a request is sent, a lost response cannot prove whether
+                # the server paused. Abort must conservatively try to resume it.
+                transaction.prepared_participants.add(participant.participant_id)
+            method, endpoint = participant_endpoint(participant, route_operation)
+            body: dict[str, Any] = {
+                "checkpoint_id": transaction.checkpoint_id,
+                "deadline_ts": deadline_ts,
+            }
+            if checkpoint_dir is not None:
+                body["checkpoint_dir"] = str(checkpoint_dir)
+            try:
+                result = await self._transport.request(
+                    participant,
+                    method,
+                    endpoint,
+                    deadline_ts=deadline_ts,
+                    json_body=body,
+                )
+            except CheckpointParticipantError as error:
+                if operation != "abort" or error.gym_error_code != "invalid_phase":
+                    raise
+                result = {
+                    "state": "already_accepting",
+                    "gym_error_code": error.gym_error_code,
+                }
+            transaction.participant_results[result_key] = result
+
+    async def _wait_for_policy_pause(
+        self,
+        transaction: ActorCheckpointTransaction,
+        participant: CheckpointParticipant,
+        *,
+        deadline_ts: float,
+    ) -> None:
+        result_key = f"prepare-status:{participant.participant_id}"
+        if result_key in transaction.participant_results:
+            return
+        method, endpoint = participant_endpoint(participant, "status")
+        remaining = _remaining(deadline_ts)
+        result = await self._transport.request(
+            participant,
+            method,
+            endpoint,
+            deadline_ts=deadline_ts,
+            params={
+                "checkpoint_id": transaction.checkpoint_id,
+                "deadline_ts": deadline_ts,
+                "wait_state": "paused",
+                "timeout_s": remaining,
+            },
+        )
+        if result.get("state") != "paused":
+            raise CheckpointParticipantError(
+                participant.participant_id,
+                endpoint,
+                f"policy model did not drain before the deadline: {result!r}",
+                gym_error_code="prepare_incomplete",
+            )
+        transaction.participant_results[result_key] = result
+        transaction.prepared_participants.add(participant.participant_id)
+
+    def _of_kind(self, kind: CheckpointParticipantKind) -> list[CheckpointParticipant]:
+        return [
+            participant
+            for participant in self._participants
+            if participant.kind == kind
+        ]
+
+    def _require_transaction(
+        self,
+        checkpoint_id: str,
+        allowed_phases: set[ActorCheckpointPhase],
+    ) -> ActorCheckpointTransaction:
+        _validate_checkpoint_id(checkpoint_id)
+        transaction = self._transaction
+        if transaction is None:
+            raise RuntimeError("no NeMo Gym checkpoint transaction is active")
+        if transaction.checkpoint_id != checkpoint_id:
+            raise RuntimeError(
+                f"checkpoint {transaction.checkpoint_id!r} is already active "
+                f"in phase {transaction.phase.value!r}"
+            )
+        if transaction.phase not in allowed_phases:
+            raise RuntimeError(
+                f"checkpoint operation is not valid in actor phase {transaction.phase.value!r}"
+            )
+        return transaction
+
+    def _validate_manifest_participants(self, manifest: Mapping[str, Any]) -> None:
+        raw_participants = manifest.get("participants")
+        if not isinstance(raw_participants, list):
+            raise ValueError("NeMo Gym checkpoint manifest participants must be a list")
+        source: set[tuple[str, str, str]] = set()
+        for entry in raw_participants:
+            if not isinstance(entry, Mapping):
+                raise ValueError("NeMo Gym checkpoint participant must be an object")
+            participant_id = entry.get("participant_id")
+            name = entry.get("name")
+            kind = entry.get("kind")
+            if not all(
+                isinstance(value, str) for value in (participant_id, name, kind)
+            ):
+                raise ValueError(
+                    "NeMo Gym checkpoint participant identity fields must be strings"
+                )
+            assert isinstance(participant_id, str)
+            assert isinstance(name, str)
+            assert isinstance(kind, str)
+            source.add((participant_id, name, kind))
+        current = {
+            (participant.participant_id, participant.name, participant.kind.value)
+            for participant in self._participants
+        }
+        if source != current:
+            raise ValueError(
+                f"NeMo Gym checkpoint participants do not match the running Gym fleet: "
+                f"checkpoint={sorted(source)!r}, current={sorted(current)!r}"
+            )
+
+    def _retired_result(
+        self,
+        checkpoint_id: str,
+        operation: str,
+    ) -> dict[str, Any] | None:
+        if self._retired_checkpoint_id != checkpoint_id:
+            return None
+        return self._retired_results.get(operation)
+
+    def _retire_transaction(
+        self,
+        checkpoint_id: str,
+        operation: str,
+        result: dict[str, Any],
+    ) -> None:
+        self._retired_checkpoint_id = checkpoint_id
+        self._retired_results = {operation: result}
+
+    @staticmethod
+    def _actor_error(
+        transaction: ActorCheckpointTransaction,
+        cause: BaseException,
+    ) -> ActorCheckpointError:
+        return ActorCheckpointError(
+            transaction.checkpoint_id,
+            transaction.phase,
+            sorted(transaction.prepared_participants),
+            cause,
+        )
+
+    @staticmethod
+    def _result(transaction: ActorCheckpointTransaction) -> dict[str, Any]:
+        return ActorCheckpointResult(
+            checkpoint_id=transaction.checkpoint_id,
+            phase=transaction.phase,
+            participant_results=transaction.participant_results,
+            manifest_path=transaction.manifest_path,
+        ).to_dict()
+
+
+async def discover_checkpoint_participants(
+    global_config: Mapping[str, Any],
+    transport: CheckpointTransport,
+    *,
+    deadline_ts: float,
+) -> list[CheckpointParticipant]:
+    """Discover checkpoint participants from RunHelper's resolved global config."""
+    candidates = _server_candidates(global_config)
+    declarations = await asyncio.gather(
+        *[
+            transport.request(
+                candidate,
+                "GET",
+                "/ng-control/v1/capabilities",
+                deadline_ts=deadline_ts,
+            )
+            for candidate in candidates
+        ]
+    )
+    participants: list[CheckpointParticipant] = []
+    for candidate, raw in zip(candidates, declarations):
+        capabilities = CheckpointCapabilities.from_mapping(raw)
+        if (
+            capabilities.component != candidate.capabilities.component
+            or capabilities.name != candidate.name
+        ):
+            raise ValueError(
+                f"Gym capabilities identity mismatch for {candidate.participant_id!r}: "
+                f"configured={candidate.capabilities.component}/{candidate.name}, "
+                f"served={capabilities.component}/{capabilities.name}"
+            )
+        if capabilities.multi_process_mode == "unmanaged":
+            raise ValueError(
+                f"Gym server {candidate.participant_id!r} uses unmanaged multi-process mode "
+                f"with {capabilities.num_workers} workers; checkpointing requires a single worker "
+                "or a service-level coordinator"
+            )
+        kind = _participant_kind(capabilities)
+        if kind is None:
+            continue
+        if capabilities.schema_version != GYM_CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Gym server {candidate.participant_id!r} declares unsupported checkpoint "
+                f"schema version {capabilities.schema_version}"
+            )
+        if capabilities.checkpoint_mode != "export_restore":
+            continue
+        if kind == CheckpointParticipantKind.POLICY_MODEL and not {
+            "accepting",
+            "draining",
+            "paused",
+        }.issubset(capabilities.admission_states):
+            raise ValueError(
+                f"policy model {candidate.participant_id!r} cannot enter all required admission states"
+            )
+        participants.append(
+            CheckpointParticipant(
+                participant_id=candidate.participant_id,
+                name=candidate.name,
+                base_url=candidate.base_url,
+                kind=kind,
+                capabilities=capabilities,
+            )
+        )
+    if not any(
+        participant.kind == CheckpointParticipantKind.POLICY_MODEL
+        for participant in participants
+    ):
+        raise ValueError(
+            "NeMo Gym checkpointing requires one checkpoint-capable policy model"
+        )
+    return sorted(participants, key=lambda participant: participant.participant_id)
+
+
+def write_checkpoint_manifest(
+    checkpoint_dir: Path,
+    *,
+    checkpoint_id: str,
+    participants: Sequence[CheckpointParticipant],
+    participant_results: Mapping[str, Mapping[str, Any]],
+    live_membership: Sequence[Mapping[str, Any]],
+) -> Path:
+    """Atomically publish the aggregate manifest after participant commits."""
+    checkpoint_dir = Path(checkpoint_dir)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = checkpoint_dir / GYM_CHECKPOINT_MANIFEST
+    files = _checkpoint_file_digests(checkpoint_dir)
+    integrity = _integrity_digest(files)
+    manifest = {
+        "schema_version": GYM_CHECKPOINT_SCHEMA_VERSION,
+        "checkpoint_id": checkpoint_id,
+        "participants": [participant.to_dict() for participant in participants],
+        "participant_results": {
+            participant: dict(result)
+            for participant, result in participant_results.items()
+        },
+        "live_membership": [dict(record) for record in live_membership],
+        "files": files,
+        "integrity_sha256": integrity,
+    }
+    temporary = manifest_path.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n")
+    _fsync_file(temporary)
+    os.replace(temporary, manifest_path)
+    _fsync_directory(checkpoint_dir)
+    return manifest_path
+
+
+def load_checkpoint_manifest(checkpoint_dir: Path) -> dict[str, Any]:
+    """Load and verify a previously published aggregate Gym manifest."""
+    checkpoint_dir = Path(checkpoint_dir)
+    manifest_path = checkpoint_dir / GYM_CHECKPOINT_MANIFEST
+    try:
+        raw = json.loads(manifest_path.read_text())
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"NeMo Gym checkpoint manifest is missing at {manifest_path}"
+        ) from None
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"NeMo Gym checkpoint manifest is invalid JSON: {error}"
+        ) from error
+    if not isinstance(raw, dict):
+        raise ValueError("NeMo Gym checkpoint manifest must be a JSON object")
+    if raw.get("schema_version") != GYM_CHECKPOINT_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported NeMo Gym checkpoint schema version: {raw.get('schema_version')!r}"
+        )
+    source_checkpoint_id = raw.get("checkpoint_id")
+    if not isinstance(source_checkpoint_id, str):
+        raise ValueError("NeMo Gym checkpoint manifest checkpoint_id must be a string")
+    _validate_checkpoint_id(source_checkpoint_id)
+    participants = raw.get("participants")
+    if not isinstance(participants, list) or not all(
+        isinstance(participant, Mapping) for participant in participants
+    ):
+        raise ValueError(
+            "NeMo Gym checkpoint manifest participants must be a list of objects"
+        )
+    live_membership = raw.get("live_membership")
+    if not isinstance(live_membership, list) or not all(
+        isinstance(execution, Mapping) for execution in live_membership
+    ):
+        raise ValueError(
+            "NeMo Gym checkpoint manifest live_membership must be a list of objects"
+        )
+    files = raw.get("files")
+    if not isinstance(files, dict) or not all(
+        isinstance(path, str) and isinstance(digest, str)
+        for path, digest in files.items()
+    ):
+        raise ValueError("NeMo Gym checkpoint manifest files must map paths to digests")
+    if raw.get("integrity_sha256") != _integrity_digest(files):
+        raise ValueError(
+            "NeMo Gym checkpoint manifest integrity digest does not match its file table"
+        )
+    for relative_path, expected_digest in files.items():
+        relative = Path(relative_path)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(
+                f"NeMo Gym checkpoint file path {relative_path!r} escapes the checkpoint directory"
+            )
+        path = checkpoint_dir / relative_path
+        if path.is_symlink() or not path.is_file() or _digest(path) != expected_digest:
+            raise ValueError(
+                f"NeMo Gym checkpoint file {relative_path!r} is missing or corrupted"
+            )
+    return raw
+
+
+def participant_endpoint(
+    participant: CheckpointParticipant, operation: str
+) -> tuple[str, str]:
+    """Map an actor operation to the current Gym route contract."""
+    if participant.kind == CheckpointParticipantKind.POLICY_MODEL:
+        endpoints = {
+            "prepare": ("POST", "/ng-control/v1/model-admission/pause"),
+            "status": ("GET", "/ng-control/v1/model-admission/status"),
+            "commit": ("POST", "/ng-control/v1/model-checkpoint/commit"),
+            "restore": ("POST", "/ng-control/v1/model-checkpoint/restore"),
+            "resume": ("POST", "/ng-control/v1/model-admission/resume"),
+        }
+    elif participant.kind == CheckpointParticipantKind.AGENT:
+        endpoints = {
+            operation_name: (
+                "GET" if operation_name == "status" else "POST",
+                f"/ng-control/v1/agent-checkpoint/{operation_name}",
+            )
+            for operation_name in ("prepare", "status", "commit", "restore", "resume")
+        }
+    else:
+        endpoints = {
+            operation_name: (
+                "GET" if operation_name == "status" else "POST",
+                f"/ng-control/v1/resources-checkpoint/{operation_name}",
+            )
+            for operation_name in ("prepare", "status", "commit", "restore", "resume")
+        }
+    try:
+        return endpoints[operation]
+    except KeyError as error:
+        raise ValueError(
+            f"unsupported Gym checkpoint operation {operation!r}"
+        ) from error
+
+
+def participant_groups(
+    participants: Sequence[CheckpointParticipant],
+) -> tuple[list[CheckpointParticipant], list[CheckpointParticipant]]:
+    """Split dependencies from agents for safe resume ordering."""
+    dependencies = [
+        participant
+        for participant in participants
+        if participant.kind
+        in (CheckpointParticipantKind.POLICY_MODEL, CheckpointParticipantKind.RESOURCES)
+    ]
+    agents = [
+        participant
+        for participant in participants
+        if participant.kind == CheckpointParticipantKind.AGENT
+    ]
+    return dependencies, agents
+
+
+def _completion_receipt_for(
+    participant: CheckpointParticipant,
+    status: Mapping[str, Any],
+    identity: ExecutionIdentity,
+) -> AgentCompletionReceipt:
+    raw_attempts = status.get("completed_unacknowledged_attempts")
+    endpoint = "/ng-control/v1/agent-checkpoint/status"
+    if not isinstance(raw_attempts, list):
+        raise CheckpointParticipantError(
+            participant.participant_id,
+            endpoint,
+            "Gym agent status is missing completed_unacknowledged_attempts",
+            gym_error_code="invalid_response",
+        )
+    if len(raw_attempts) > MAX_AGENT_COMPLETION_RECEIPTS:
+        raise CheckpointParticipantError(
+            participant.participant_id,
+            endpoint,
+            "Gym agent completion receipt inventory exceeds the actor safety bound",
+            gym_error_code="response_too_large",
+        )
+    matches: list[AgentCompletionReceipt] = []
+    try:
+        for attempt in raw_attempts:
+            if not isinstance(attempt, Mapping):
+                raise ValueError(
+                    "Gym completed-unacknowledged attempt must be an object"
+                )
+            raw_receipt = attempt.get("completion_receipt")
+            if not isinstance(raw_receipt, Mapping):
+                raise ValueError(
+                    "Gym completed-unacknowledged attempt is missing its completion receipt"
+                )
+            receipt = AgentCompletionReceipt.from_mapping(raw_receipt)
+            if receipt.identity == identity:
+                matches.append(receipt)
+    except ValueError as error:
+        raise CheckpointParticipantError(
+            participant.participant_id,
+            endpoint,
+            str(error),
+            gym_error_code="invalid_response",
+        ) from error
+    if len(matches) != 1:
+        raise CheckpointParticipantError(
+            participant.participant_id,
+            endpoint,
+            f"expected exactly one completion receipt for rollout "
+            f"{identity.rollout_id!r} attempt {identity.attempt_index}, "
+            f"found {len(matches)}",
+            gym_error_code="completion_receipt_mismatch",
+        )
+    return matches[0]
+
+
+def _server_candidates(global_config: Mapping[str, Any]) -> list[CheckpointParticipant]:
+    candidates: list[CheckpointParticipant] = []
+    for top_level_name, raw_entry in global_config.items():
+        if not isinstance(top_level_name, str) or not isinstance(raw_entry, Mapping):
+            continue
+        component_keys = [key for key in _COMPONENT_KEYS if key in raw_entry]
+        if len(component_keys) != 1:
+            continue
+        component = component_keys[0]
+        typed_entry = raw_entry[component]
+        if not isinstance(typed_entry, Mapping) or len(typed_entry) != 1:
+            continue
+        _, config = next(iter(typed_entry.items()))
+        if not isinstance(config, Mapping):
+            continue
+        host = config.get("host")
+        port = config.get("port")
+        if (
+            not isinstance(host, str)
+            or not isinstance(port, int)
+            or isinstance(port, bool)
+        ):
+            raise ValueError(
+                f"Gym server {top_level_name!r} is missing a concrete host and port"
+            )
+        placeholder = CheckpointCapabilities(
+            component=component,
+            name=top_level_name,
+            schema_version=0,
+            admission_states=(),
+            checkpoint_mode="unknown",
+            concurrency_contract="unknown",
+            multi_process_mode="unknown",
+            num_workers=1,
+            instance_role=None,
+        )
+        candidates.append(
+            CheckpointParticipant(
+                participant_id=top_level_name,
+                name=top_level_name,
+                base_url=f"http://{host}:{port}",
+                kind=CheckpointParticipantKind.RESOURCES,
+                capabilities=placeholder,
+            )
+        )
+    return sorted(candidates, key=lambda participant: participant.participant_id)
+
+
+def _participant_kind(
+    capabilities: CheckpointCapabilities,
+) -> CheckpointParticipantKind | None:
+    if capabilities.component == "responses_api_models":
+        if capabilities.instance_role != "policy":
+            return None
+        return CheckpointParticipantKind.POLICY_MODEL
+    if capabilities.component == "responses_api_agents":
+        return CheckpointParticipantKind.AGENT
+    if capabilities.component == "resources_servers":
+        return CheckpointParticipantKind.RESOURCES
+    raise ValueError(f"unknown Gym checkpoint component {capabilities.component!r}")
+
+
+def _required_capability_string(raw: Mapping[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Gym capabilities {key} must be a non-empty string")
+    return value
+
+
+def _validate_checkpoint_id(checkpoint_id: str) -> None:
+    if (
+        not isinstance(checkpoint_id, str)
+        or _CHECKPOINT_ID_PATTERN.fullmatch(checkpoint_id) is None
+    ):
+        raise ValueError(
+            "checkpoint_id must start with a letter or digit, contain only letters, "
+            "digits, dots, dashes, or underscores, and be at most 128 characters"
+        )
+
+
+def _remaining(deadline_ts: float) -> float:
+    if (
+        not isinstance(deadline_ts, (int, float))
+        or isinstance(deadline_ts, bool)
+        or not math.isfinite(deadline_ts)
+    ):
+        raise ValueError("checkpoint deadline_ts must be a finite Unix timestamp")
+    remaining = float(deadline_ts) - time.time()
+    if remaining <= 0:
+        raise CheckpointParticipantError(
+            "actor",
+            "deadline",
+            "absolute checkpoint deadline expired",
+            gym_error_code="deadline_exceeded",
+        )
+    return remaining
+
+
+async def _read_bounded_response(
+    participant: CheckpointParticipant,
+    endpoint: str,
+    response: aiohttp.ClientResponse,
+) -> bytes:
+    if (
+        response.content_length is not None
+        and response.content_length > MAX_CHECKPOINT_RESPONSE_BYTES
+    ):
+        raise CheckpointParticipantError(
+            participant.participant_id,
+            endpoint,
+            "Gym checkpoint response exceeds the actor safety bound",
+            status=response.status,
+            gym_error_code="response_too_large",
+        )
+    body = bytearray()
+    async for chunk in response.content.iter_chunked(64 * 1024):
+        body.extend(chunk)
+        if len(body) > MAX_CHECKPOINT_RESPONSE_BYTES:
+            raise CheckpointParticipantError(
+                participant.participant_id,
+                endpoint,
+                "Gym checkpoint response exceeds the actor safety bound",
+                status=response.status,
+                gym_error_code="response_too_large",
+            )
+    return bytes(body)
+
+
+def _decode_response(body: bytes) -> Any:
+    if not body:
+        return {}
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+
+def _gym_error(parsed: Any, body: bytes) -> tuple[str | None, str]:
+    if isinstance(parsed, Mapping):
+        error = parsed.get("error")
+        if isinstance(error, Mapping):
+            code = error.get("code")
+            detail = error.get("detail")
+            return (
+                code if isinstance(code, str) else None,
+                detail
+                if isinstance(detail, str)
+                else json.dumps(parsed, sort_keys=True),
+            )
+        detail = parsed.get("detail")
+        if isinstance(detail, str):
+            return None, detail
+    return None, body.decode(errors="replace")
+
+
+def _checkpoint_file_digests(checkpoint_dir: Path) -> dict[str, str]:
+    files: dict[str, str] = {}
+    for subdirectory in ("model-ledger", "agent", "resources"):
+        root = checkpoint_dir / subdirectory
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if path.is_file() and not path.is_symlink():
+                files[path.relative_to(checkpoint_dir).as_posix()] = _digest(path)
+    return files
+
+
+def _integrity_digest(files: Mapping[str, str]) -> str:
+    payload = json.dumps(dict(files), sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        for block in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as file_obj:
+        os.fsync(file_obj.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    directory_fd = os.open(path, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -169,6 +169,7 @@ project-includes = [
   "nemo_rl/environments/interfaces.py",
   "nemo_rl/environments/math_environment.py",
   "nemo_rl/environments/metrics.py",
+  "nemo_rl/environments/nemo_gym_checkpoint.py",
   "nemo_rl/environments/nemo_gym_multimodal.py",
   "nemo_rl/environments/nemo_gym_request.py",
   "nemo_rl/environments/nemotron_utils.py",

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -46,6 +46,7 @@ from nemo_rl.environments.nemo_gym import (
     setup_nemo_gym_config,
     validate_reward_components_match_scalar,
 )
+from nemo_rl.environments.nemo_gym_checkpoint import NemoGymCheckpointCoordinator
 from nemo_rl.environments.nemo_gym_multimodal import (
     _extract_static_video_messages,
     _inject_vllm_mm_processor_kwargs,
@@ -110,6 +111,7 @@ def test_rollout_progress_counter_is_built_after_gym_resolves_task_source(
             head_server_config = object()
             _token_capture_enabled = False
             _tokenizer = object()
+            _checkpoint = NemoGymCheckpointCoordinator("test")
 
             def _require_spinup(self):
                 pass
@@ -169,6 +171,7 @@ def test_token_capture_forwards_logical_id_and_attempt_unchanged() -> None:
         head_server_config = object()
         _token_capture_enabled = True
         _tokenizer = object()
+        _checkpoint = NemoGymCheckpointCoordinator("test")
 
         def _require_spinup(self):
             pass
@@ -1340,7 +1343,16 @@ def test_run_rollouts_requires_an_installed_tokenizer():
     assert gym._tokenizer is None
     gym.rh = object()  # satisfies _require_spinup
 
-    stream = gym.run_rollouts([{"_rowidx": 0}], "")
+    stream = gym.run_rollouts(
+        [
+            {
+                "_rowidx": 0,
+                "_ng_rollout_id": "rollout-0",
+                "_ng_attempt_index": 0,
+            }
+        ],
+        "",
+    )
     with pytest.raises(RuntimeError, match="set_tokenizer must be called"):
         asyncio.run(stream.__anext__())
 
@@ -1735,6 +1747,7 @@ def test_nemo_gym_run_rollouts_normalizes_mixed_media_before_dispatch(tmp_path):
             rch = _RolloutCollectionHelper()
             head_server_config = object()
             _token_capture_enabled = False
+            _checkpoint = NemoGymCheckpointCoordinator("test")
 
             def _require_spinup(self):
                 pass
@@ -1857,6 +1870,7 @@ def test_nemo_gym_megatron_multimodal_response_round_trip(tmp_path, modality):
             _tokenizer = _Tokenizer()
             _processor = None
             _token_capture_enabled = False
+            _checkpoint = NemoGymCheckpointCoordinator("test")
             # Bind the real postprocess: the assertions below are about its
             # message_log output, not about run_rollouts' dispatch alone.
             _postprocess_nemo_gym_to_nemo_rl_result = NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result

--- a/tests/unit/environments/test_nemo_gym_checkpoint.py
+++ b/tests/unit/environments/test_nemo_gym_checkpoint.py
@@ -1,0 +1,929 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import pickle
+import socket
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import pytest
+
+from nemo_rl.environments.nemo_gym_checkpoint import (
+    ActorCheckpointError,
+    ActorCheckpointPhase,
+    AgentCompletionReceipt,
+    CheckpointCapabilities,
+    CheckpointParticipant,
+    CheckpointParticipantError,
+    CheckpointParticipantKind,
+    CheckpointTransport,
+    ExecutionIdentity,
+    LiveExecutionRegistry,
+    NemoGymCheckpointCoordinator,
+    discover_checkpoint_participants,
+    load_checkpoint_manifest,
+)
+
+
+def _capabilities(
+    component: str,
+    name: str,
+    *,
+    checkpoint_mode: str = "export_restore",
+    instance_role: str | None = None,
+    multi_process_mode: str = "single_worker",
+) -> dict[str, Any]:
+    return {
+        "component": component,
+        "name": name,
+        "schema_version": 1,
+        "admission_states": (
+            ["accepting", "draining", "paused"]
+            if component == "responses_api_models"
+            else ["accepting"]
+        ),
+        "checkpoint_mode": checkpoint_mode,
+        "concurrency_contract": "stateless",
+        "multi_process": {
+            "mode": multi_process_mode,
+            "num_workers": 2 if multi_process_mode == "unmanaged" else 1,
+        },
+        "instance_role": instance_role,
+    }
+
+
+def _participant(
+    participant_id: str,
+    kind: CheckpointParticipantKind,
+) -> CheckpointParticipant:
+    component = {
+        CheckpointParticipantKind.POLICY_MODEL: "responses_api_models",
+        CheckpointParticipantKind.AGENT: "responses_api_agents",
+        CheckpointParticipantKind.RESOURCES: "resources_servers",
+    }[kind]
+    return CheckpointParticipant(
+        participant_id=participant_id,
+        name=participant_id,
+        base_url=f"http://{participant_id}.test",
+        kind=kind,
+        capabilities=CheckpointCapabilities.from_mapping(
+            _capabilities(
+                component,
+                participant_id,
+                instance_role=(
+                    "policy" if kind == CheckpointParticipantKind.POLICY_MODEL else None
+                ),
+            )
+        ),
+    )
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.json_bodies: list[dict[str, Any] | None] = []
+        self.capabilities: dict[str, dict[str, Any]] = {}
+        self.fail_once: dict[tuple[str, str], CheckpointParticipantError] = {}
+        self.responses: dict[tuple[str, str], dict[str, Any]] = {}
+
+    async def request(
+        self,
+        participant: CheckpointParticipant,
+        method: str,
+        endpoint: str,
+        *,
+        deadline_ts: float,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del method, deadline_ts, params
+        key = (participant.participant_id, endpoint)
+        self.calls.append(key)
+        self.json_bodies.append(json_body)
+        error = self.fail_once.pop(key, None)
+        if error is not None:
+            raise error
+        if key in self.responses:
+            return self.responses[key]
+        if endpoint.endswith("/capabilities"):
+            return self.capabilities[participant.participant_id]
+        if endpoint.endswith("/status"):
+            return {"state": "paused"}
+        if endpoint.endswith("/commit") and json_body is not None:
+            checkpoint_dir = Path(json_body["checkpoint_dir"])
+            subdirectory = {
+                CheckpointParticipantKind.POLICY_MODEL: "model-ledger",
+                CheckpointParticipantKind.AGENT: "agent",
+                CheckpointParticipantKind.RESOURCES: "resources",
+            }[participant.kind]
+            output = checkpoint_dir / subdirectory / participant.name / "manifest.json"
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({"participant": participant.participant_id}))
+        return {"state": "ok", "participant": participant.participant_id}
+
+
+def _global_config() -> dict[str, Any]:
+    return {
+        "policy": {
+            "responses_api_models": {
+                "implementation": {"host": "model.test", "port": 8001}
+            }
+        },
+        "judge": {
+            "responses_api_models": {
+                "implementation": {"host": "judge.test", "port": 8002}
+            }
+        },
+        "agent": {
+            "responses_api_agents": {
+                "implementation": {"host": "agent.test", "port": 8003}
+            }
+        },
+        "resources": {
+            "resources_servers": {
+                "implementation": {"host": "resources.test", "port": 8004}
+            }
+        },
+        "head_server": {"host": "head.test", "port": 8000},
+    }
+
+
+@pytest.mark.asyncio
+async def test_discovery_filters_auxiliary_and_stateless_servers() -> None:
+    fake = _FakeTransport()
+    fake.capabilities = {
+        "policy": _capabilities(
+            "responses_api_models", "policy", instance_role="policy"
+        ),
+        "judge": _capabilities(
+            "responses_api_models", "judge", instance_role="auxiliary"
+        ),
+        "agent": _capabilities("responses_api_agents", "agent"),
+        "resources": _capabilities(
+            "resources_servers", "resources", checkpoint_mode="stateless"
+        ),
+    }
+
+    participants = await discover_checkpoint_participants(
+        _global_config(),
+        fake,  # type: ignore[arg-type]
+        deadline_ts=time.time() + 10,
+    )
+
+    assert [
+        (participant.participant_id, participant.kind) for participant in participants
+    ] == [
+        ("agent", CheckpointParticipantKind.AGENT),
+        ("policy", CheckpointParticipantKind.POLICY_MODEL),
+    ]
+    assert len(fake.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_discovery_rejects_unmanaged_workers() -> None:
+    fake = _FakeTransport()
+    fake.capabilities = {
+        "policy": _capabilities(
+            "responses_api_models",
+            "policy",
+            instance_role="policy",
+            multi_process_mode="unmanaged",
+        ),
+        "judge": _capabilities(
+            "responses_api_models", "judge", instance_role="auxiliary"
+        ),
+        "agent": _capabilities(
+            "responses_api_agents", "agent", checkpoint_mode="stateless"
+        ),
+        "resources": _capabilities(
+            "resources_servers", "resources", checkpoint_mode="stateless"
+        ),
+    }
+
+    with pytest.raises(ValueError, match="unmanaged multi-process"):
+        await discover_checkpoint_participants(
+            _global_config(),
+            fake,  # type: ignore[arg-type]
+            deadline_ts=time.time() + 10,
+        )
+
+
+def test_live_registry_validates_identity_and_restores_frozen_membership() -> None:
+    registry = LiveExecutionRegistry()
+    row = {"_ng_rollout_id": "rollout-1", "_ng_attempt_index": 3}
+    identity = registry.register(row)
+    assert identity == ExecutionIdentity("rollout-1", 3)
+    registry.mark_terminal(identity)
+    frozen = registry.freeze("checkpoint-1")
+    assert frozen[0].to_dict()["state"] == "terminal"
+    with pytest.raises(RuntimeError, match="dispatch is frozen"):
+        registry.register({"_ng_rollout_id": "other", "_ng_attempt_index": 0})
+    registry.release(identity)
+    registry.unfreeze("checkpoint-1")
+
+    registry.restore("restore-1", [execution.to_dict() for execution in frozen])
+    assert registry.status()["frozen_membership"] == 1
+    registry.unfreeze("restore-1")
+    assert registry.status()["frozen_checkpoint_id"] is None
+
+
+@pytest.mark.parametrize(
+    "row,match",
+    [
+        ({"_ng_attempt_index": 0}, "_ng_rollout_id"),
+        (
+            {"_ng_rollout_id": "rollout", "_ng_attempt_index": -1},
+            "_ng_attempt_index",
+        ),
+        (
+            {"_ng_rollout_id": "rollout", "_ng_attempt_index": True},
+            "_ng_attempt_index",
+        ),
+    ],
+)
+def test_live_registry_rejects_missing_or_invalid_identity(
+    row: dict[str, Any],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        LiveExecutionRegistry().register(row)
+
+
+@pytest.mark.asyncio
+async def test_transport_preserves_bearer_status_and_gym_error_code() -> None:
+    from aiohttp import web
+
+    seen_authorization: list[str | None] = []
+
+    async def rejected(request: web.Request) -> web.Response:
+        seen_authorization.append(request.headers.get("Authorization"))
+        return web.json_response(
+            {"error": {"code": "checkpoint_conflict", "detail": "busy"}},
+            status=409,
+        )
+
+    app = web.Application()
+    app.router.add_post("/reject", rejected)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.SockSite(runner, _listening_socket())
+    await site.start()
+    participant = _participant("policy", CheckpointParticipantKind.POLICY_MODEL)
+    participant = CheckpointParticipant(
+        participant.participant_id,
+        participant.name,
+        _site_url(site),
+        participant.kind,
+        participant.capabilities,
+    )
+    try:
+        with pytest.raises(CheckpointParticipantError) as exc_info:
+            await CheckpointTransport("secret").request(
+                participant,
+                "POST",
+                "/reject",
+                deadline_ts=time.time() + 5,
+            )
+        assert exc_info.value.status == 409
+        assert exc_info.value.gym_error_code == "checkpoint_conflict"
+        assert exc_info.value.participant == "policy"
+        assert seen_authorization == ["Bearer secret"]
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_transport_refuses_an_expired_deadline_before_io() -> None:
+    participant = _participant("policy", CheckpointParticipantKind.POLICY_MODEL)
+    with pytest.raises(
+        CheckpointParticipantError,
+        match="absolute checkpoint deadline expired",
+    ) as exc_info:
+        await CheckpointTransport("secret").request(
+            participant,
+            "GET",
+            "/never",
+            deadline_ts=time.time() - 1,
+        )
+    assert exc_info.value.gym_error_code == "deadline_exceeded"
+
+
+def test_participant_error_pickling_preserves_structured_fields() -> None:
+    error = CheckpointParticipantError(
+        "policy",
+        "/prepare",
+        "busy",
+        status=409,
+        gym_error_code="checkpoint_conflict",
+    )
+    restored = pickle.loads(pickle.dumps(error))
+    assert restored.participant == "policy"
+    assert restored.endpoint == "/prepare"
+    assert restored.status == 409
+    assert restored.gym_error_code == "checkpoint_conflict"
+
+    actor_error = ActorCheckpointError(
+        "checkpoint-1",
+        ActorCheckpointPhase.PREPARING,
+        ["agent"],
+        error,
+    )
+    restored_actor_error = pickle.loads(pickle.dumps(actor_error))
+    assert restored_actor_error.phase == ActorCheckpointPhase.PREPARING
+    assert restored_actor_error.completed_participants == ("agent",)
+    assert "checkpoint_conflict" in restored_actor_error.cause_detail
+
+
+@pytest.mark.parametrize("attempt_index", [0, 1])
+@pytest.mark.asyncio
+async def test_delivery_acknowledges_exact_completion_receipt_before_release(
+    attempt_index: int,
+) -> None:
+    coordinator = NemoGymCheckpointCoordinator("secret")
+    fake = _FakeTransport()
+    coordinator._transport = fake  # type: ignore[assignment]
+    coordinator._participants = [_participant("agent", CheckpointParticipantKind.AGENT)]
+    identity = coordinator.registry.register(
+        {
+            "_ng_rollout_id": "rollout-1",
+            "_ng_attempt_index": attempt_index,
+        }
+    )
+    coordinator.registry.mark_terminal(identity)
+    receipt = {
+        "rollout_id": "rollout-1",
+        "attempt_index": attempt_index,
+        "execution_generation": attempt_index + 1,
+        "result_identity": f"result-{attempt_index}",
+        "result_digest": f"{attempt_index + 1:064x}",
+    }
+    fake.responses[("agent", "/ng-control/v1/agent-checkpoint/status")] = {
+        "completed_unacknowledged_attempts": [{"completion_receipt": receipt}]
+    }
+    fake.responses[("agent", "/ng-control/v1/agent-checkpoint/acknowledge")] = {
+        "acknowledged": True,
+        "idempotent": False,
+    }
+
+    await coordinator.release(identity, agent_name="agent")
+
+    assert coordinator.registry.status()["live"] == 0
+    assert fake.calls[-2:] == [
+        ("agent", "/ng-control/v1/agent-checkpoint/status"),
+        ("agent", "/ng-control/v1/agent-checkpoint/acknowledge"),
+    ]
+    assert fake.json_bodies[-1] == receipt
+
+
+@pytest.mark.asyncio
+async def test_delivery_receipt_mismatch_retains_terminal_membership() -> None:
+    coordinator = NemoGymCheckpointCoordinator("secret")
+    fake = _FakeTransport()
+    coordinator._transport = fake  # type: ignore[assignment]
+    coordinator._participants = [_participant("agent", CheckpointParticipantKind.AGENT)]
+    identity = coordinator.registry.register(
+        {"_ng_rollout_id": "rollout-1", "_ng_attempt_index": 0}
+    )
+    coordinator.registry.mark_terminal(identity)
+    fake.responses[("agent", "/ng-control/v1/agent-checkpoint/status")] = {
+        "completed_unacknowledged_attempts": []
+    }
+
+    with pytest.raises(
+        CheckpointParticipantError,
+        match="expected exactly one completion receipt",
+    ):
+        await coordinator.release(identity, agent_name="agent")
+
+    assert coordinator.registry.status()["terminal_unreleased"] == 1
+    assert not any(endpoint.endswith("/acknowledge") for _, endpoint in fake.calls)
+
+
+@pytest.mark.asyncio
+async def test_prepare_fails_closed_for_yielded_unacknowledged_result() -> None:
+    coordinator, fake = _coordinator_with_all_participants()
+    identity = coordinator.registry.register(
+        {"_ng_rollout_id": "rollout-1", "_ng_attempt_index": 0}
+    )
+    coordinator.registry.mark_terminal(identity)
+
+    with pytest.raises(ActorCheckpointError, match="remain unacknowledged"):
+        await coordinator.prepare("checkpoint-1", time.time() + 10)
+
+    assert coordinator.status("checkpoint-1")["phase"] == "preparing"
+    assert coordinator.status("checkpoint-1")["registry"]["frozen_checkpoint_id"] == (
+        "checkpoint-1"
+    )
+    assert fake.calls == []
+
+
+def test_completion_receipt_accepts_current_and_final_result_id_names() -> None:
+    common = {
+        "rollout_id": "rollout-1",
+        "attempt_index": 1,
+        "execution_generation": 2,
+        "result_digest": "a" * 64,
+    }
+    current = AgentCompletionReceipt.from_mapping(
+        {**common, "result_identity": "result-current"}
+    )
+    final = AgentCompletionReceipt.from_mapping({**common, "result_id": "result-final"})
+
+    assert current.to_request()["result_identity"] == "result-current"
+    assert final.to_request()["result_id"] == "result-final"
+
+
+@pytest.mark.asyncio
+async def test_prepare_commit_and_resume_are_idempotent_and_ordered(
+    tmp_path: Path,
+) -> None:
+    coordinator, fake = _coordinator_with_all_participants()
+    identity = coordinator.registry.register(
+        {"_ng_rollout_id": "rollout-1", "_ng_attempt_index": 0}
+    )
+
+    first_prepare = await coordinator.prepare("checkpoint-1", time.time() + 10)
+    second_prepare = await coordinator.prepare("checkpoint-1", time.time() + 10)
+    assert first_prepare == second_prepare
+    assert first_prepare["phase"] == "prepared"
+    assert coordinator.status("checkpoint-1")["registry"]["frozen_membership"] == 1
+
+    first_commit = await coordinator.commit("checkpoint-1", tmp_path)
+    second_commit = await coordinator.commit("checkpoint-1", tmp_path)
+    assert first_commit == second_commit
+    manifest = load_checkpoint_manifest(tmp_path)
+    assert manifest["checkpoint_id"] == "checkpoint-1"
+    assert len(manifest["files"]) == 3
+
+    first_resume = await coordinator.resume("checkpoint-1")
+    calls_after_resume = len(fake.calls)
+    second_resume = await coordinator.resume("checkpoint-1")
+    assert second_resume == first_resume
+    assert len(fake.calls) == calls_after_resume
+    resume_calls = [
+        participant
+        for participant, endpoint in fake.calls
+        if endpoint.endswith("/resume")
+    ]
+    assert resume_calls[-3:] == ["policy", "resources", "agent"]
+    assert coordinator.status("checkpoint-1")["phase"] == "idle"
+
+    coordinator.registry.release(identity)
+    restored = await coordinator.restore("restore-1", tmp_path)
+    assert restored["phase"] == "restored_paused"
+    assert coordinator.status("restore-1")["registry"]["frozen_membership"] == 1
+    await coordinator.resume("restore-1")
+    assert coordinator.status("restore-1")["phase"] == "idle"
+
+    first_file = tmp_path / next(iter(manifest["files"]))
+    first_file.write_text("corrupted")
+    with pytest.raises(ValueError, match="missing or corrupted"):
+        load_checkpoint_manifest(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_partial_prepare_can_abort_only_touched_participants_in_order() -> None:
+    coordinator, fake = _coordinator_with_all_participants()
+    fake.fail_once[("policy", "/ng-control/v1/model-admission/pause")] = (
+        CheckpointParticipantError(
+            "policy",
+            "/ng-control/v1/model-admission/pause",
+            "unavailable",
+            status=503,
+            gym_error_code="unavailable",
+        )
+    )
+
+    with pytest.raises(ActorCheckpointError) as exc_info:
+        await coordinator.prepare("checkpoint-1", time.time() + 10)
+    assert exc_info.value.completed_participants == ("agent", "policy")
+
+    await coordinator.abort("checkpoint-1")
+    resume_calls = [
+        participant
+        for participant, endpoint in fake.calls
+        if endpoint.endswith("/resume")
+    ]
+    assert resume_calls == ["policy", "agent"]
+    assert coordinator.status("checkpoint-1")["phase"] == "idle"
+
+
+def _coordinator_with_all_participants() -> tuple[
+    NemoGymCheckpointCoordinator,
+    _FakeTransport,
+]:
+    coordinator = NemoGymCheckpointCoordinator("secret")
+    fake = _FakeTransport()
+    coordinator._transport = fake  # type: ignore[assignment]
+    coordinator._participants = [
+        _participant("policy", CheckpointParticipantKind.POLICY_MODEL),
+        _participant("agent", CheckpointParticipantKind.AGENT),
+        _participant("resources", CheckpointParticipantKind.RESOURCES),
+    ]
+    return coordinator, fake
+
+
+def _listening_socket() -> socket.socket:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(128)
+    sock.setblocking(False)
+    return sock
+
+
+def _site_url(site: Any) -> str:
+    server = site._server
+    assert server is not None
+    host, port = server.sockets[0].getsockname()[:2]
+    return f"http://{host}:{port}"
+
+
+@pytest.mark.asyncio
+async def test_embedded_gym_model_participant_prepare_and_abort() -> None:
+    import uvicorn
+    from fastapi import FastAPI
+    from nemo_gym._checkpoint import (
+        AdmissionLimiter,
+        ControlCapabilities,
+        ControlFence,
+        MultiProcessCapability,
+        install_control_plane,
+        install_model_admission,
+    )
+
+    token = "embedded-secret"
+    app = FastAPI()
+    fence = ControlFence()
+    limiter = AdmissionLimiter()
+    capabilities = ControlCapabilities(
+        component="responses_api_models",
+        name="policy",
+        admission_states=["accepting", "draining", "paused"],
+        checkpoint_mode="export_restore",
+        multi_process=MultiProcessCapability(mode="single_worker"),
+        instance_role="policy",
+    )
+    install_control_plane(app, capabilities=capabilities, fence=fence)
+    install_model_admission(
+        app,
+        limiter=limiter,
+        fence=fence,
+        instance_role="policy",
+        auth_token=token,
+    )
+    sock = _listening_socket()
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off"))
+    server_task = asyncio.create_task(server.serve(sockets=[sock]))
+    while not server.started:
+        await asyncio.sleep(0.01)
+    host, port = sock.getsockname()[:2]
+    config = {
+        "policy": {
+            "responses_api_models": {"implementation": {"host": host, "port": port}}
+        }
+    }
+    coordinator = NemoGymCheckpointCoordinator(token)
+    try:
+        await coordinator.discover(config, deadline_ts=time.time() + 5)
+        prepared = await coordinator.prepare("checkpoint-1", time.time() + 5)
+        assert prepared["phase"] == "prepared"
+        assert limiter.counts()["state"] == "paused"
+        await coordinator.abort("checkpoint-1")
+        assert limiter.counts()["state"] == "accepting"
+    finally:
+        server.should_exit = True
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_integrated_gym_delivery_checkpoint_and_receipt_replay(
+    tmp_path: Path,
+) -> None:
+    import uvicorn
+    from fastapi import FastAPI
+    from nemo_gym import _checkpoint as gym_checkpoint
+
+    if not hasattr(gym_checkpoint, "AgentAcknowledgeRequest"):
+        pytest.skip("requires the integrated Gym completion-acknowledgment contract")
+
+    from nemo_gym._checkpoint import (
+        RESOURCE_REQUEST_ID_HEADER,
+        AdmissionLimiter,
+        AgentCheckpointParticipant,
+        ControlCapabilities,
+        ControlFence,
+        MultiProcessCapability,
+        ResourcesCheckpointParticipant,
+        ResourceSnapshot,
+        install_agent_checkpoint,
+        install_control_plane,
+        install_model_admission,
+        install_model_checkpoint,
+        install_resources_checkpoint,
+    )
+    from nemo_gym.rollout_correlation import (
+        ATTEMPT_INDEX_HEADER,
+        ROLLOUT_ID_HEADER,
+    )
+    from nemo_gym.token_id_capture.lineage import FileLineageStore
+
+    token = "integrated-secret"
+
+    def capabilities(
+        component: str,
+        name: str,
+        *,
+        instance_role: str | None = None,
+    ) -> ControlCapabilities:
+        return ControlCapabilities(
+            component=component,
+            name=name,
+            admission_states=(
+                ["accepting", "draining", "paused"]
+                if component == "responses_api_models"
+                else ["accepting"]
+            ),
+            checkpoint_mode="export_restore",
+            concurrency_contract=(
+                "serialized_per_session"
+                if component != "responses_api_models"
+                else "stateless"
+            ),
+            multi_process=MultiProcessCapability(
+                mode="single_worker",
+                num_workers=1,
+            ),
+            instance_role=instance_role,
+        )
+
+    model_app = FastAPI()
+    model_fence = ControlFence()
+    limiter = AdmissionLimiter()
+    ledger = FileLineageStore(tmp_path / "ledger")
+    install_control_plane(
+        model_app,
+        capabilities=capabilities(
+            "responses_api_models",
+            "policy",
+            instance_role="policy",
+        ),
+        fence=model_fence,
+    )
+    install_model_admission(
+        model_app,
+        limiter=limiter,
+        fence=model_fence,
+        instance_role="policy",
+        auth_token=token,
+    )
+    install_model_checkpoint(
+        model_app,
+        fence=model_fence,
+        limiter=limiter,
+        ledger_provider=lambda: ledger,
+        file_ledger_root_provider=lambda: ledger.checkpoint_root,
+        instance_role="policy",
+        server_name="policy",
+        auth_token=token,
+    )
+
+    agent_app = FastAPI()
+    agent_fence = ControlFence()
+    agent_participant = AgentCheckpointParticipant("agent")
+    install_control_plane(
+        agent_app,
+        capabilities=capabilities("responses_api_agents", "agent"),
+        fence=agent_fence,
+    )
+    install_agent_checkpoint(
+        agent_app,
+        participant=agent_participant,
+        fence=agent_fence,
+        auth_token=token,
+    )
+
+    resource_state: dict[tuple[str, int], dict[str, int]] = {}
+    resource_calls = 0
+
+    async def export_resource_state(
+        rollout_id: str,
+        attempt_index: int,
+    ) -> dict[str, Any]:
+        return dict(resource_state[(rollout_id, attempt_index)])
+
+    async def restore_resource_states(snapshots: list[ResourceSnapshot]) -> None:
+        resource_state.clear()
+        resource_state.update(
+            {
+                (snapshot.rollout_id, snapshot.attempt_index): dict(snapshot.state)
+                for snapshot in snapshots
+            }
+        )
+
+    resources_participant = ResourcesCheckpointParticipant(
+        export_state=export_resource_state,
+        restore_states=restore_resource_states,
+    )
+    resources_app = FastAPI()
+    resources_fence = ControlFence()
+    install_control_plane(
+        resources_app,
+        capabilities=capabilities("resources_servers", "resources"),
+        fence=resources_fence,
+    )
+
+    @resources_app.post("/seed")
+    async def seed_resource() -> dict[str, int]:
+        nonlocal resource_calls
+        resource_calls += 1
+        resource_state[("resource-rollout", 0)] = {"value": resource_calls}
+        return {"value": resource_calls}
+
+    install_resources_checkpoint(
+        resources_app,
+        participant=resources_participant,
+        fence=resources_fence,
+        auth_token=token,
+        server_name="resources",
+        route_kind=lambda path, method: (
+            "start" if path == "/seed" and method == "POST" else None
+        ),
+    )
+
+    apps = [model_app, agent_app, resources_app]
+    sockets = [_listening_socket() for _ in apps]
+    servers = [
+        uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off"))
+        for app in apps
+    ]
+    server_tasks = [
+        asyncio.create_task(server.serve(sockets=[sock]))
+        for server, sock in zip(servers, sockets)
+    ]
+    while not all(server.started for server in servers):
+        await asyncio.sleep(0.01)
+    urls = [
+        f"http://{sock.getsockname()[0]}:{sock.getsockname()[1]}" for sock in sockets
+    ]
+    config = {
+        "policy": {
+            "responses_api_models": {
+                "implementation": {
+                    "host": sockets[0].getsockname()[0],
+                    "port": sockets[0].getsockname()[1],
+                }
+            }
+        },
+        "agent": {
+            "responses_api_agents": {
+                "implementation": {
+                    "host": sockets[1].getsockname()[0],
+                    "port": sockets[1].getsockname()[1],
+                }
+            }
+        },
+        "resources": {
+            "resources_servers": {
+                "implementation": {
+                    "host": sockets[2].getsockname()[0],
+                    "port": sockets[2].getsockname()[1],
+                }
+            }
+        },
+    }
+    coordinator = NemoGymCheckpointCoordinator(token)
+    try:
+        await coordinator.discover(config, deadline_ts=time.time() + 10)
+
+        for attempt_index in (0, 1):
+            execution = await agent_participant.begin(
+                "delivery-rollout",
+                attempt_index,
+                task=asyncio.current_task(),
+            )
+            await agent_participant.finish(
+                execution,
+                outcome="completed",
+                result={"id": f"result-{attempt_index}", "reward": 1.0},
+            )
+            identity = coordinator.registry.register(
+                {
+                    "_ng_rollout_id": "delivery-rollout",
+                    "_ng_attempt_index": attempt_index,
+                }
+            )
+            coordinator.registry.mark_terminal(identity)
+            await coordinator.release(identity, agent_name="agent")
+        assert agent_participant.status()["acknowledged_completed"] == 2
+        assert coordinator.registry.status()["live"] == 0
+
+        resource_headers = {
+            ROLLOUT_ID_HEADER: "resource-rollout",
+            ATTEMPT_INDEX_HEADER: "0",
+            RESOURCE_REQUEST_ID_HEADER: "seed-1",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{urls[2]}/seed",
+                json={"value": 1},
+                headers=resource_headers,
+            ) as response:
+                first_resource_result = await response.json()
+            async with session.post(
+                f"{urls[2]}/seed",
+                json={"value": 1},
+                headers=resource_headers,
+            ) as response:
+                replayed_resource_result = await response.json()
+        assert replayed_resource_result == first_resource_result
+        assert resource_calls == 1
+        resources_participant.retire("resource-rollout", 0)
+        resource_state.clear()
+
+        live_identity = coordinator.registry.register(
+            {
+                "_ng_rollout_id": "checkpoint-rollout",
+                "_ng_attempt_index": 0,
+            }
+        )
+        checkpoint_dir = tmp_path / "checkpoint"
+        prepared = await coordinator.prepare(
+            "checkpoint-1",
+            time.time() + 10,
+        )
+        assert prepared["phase"] == "prepared"
+        committed = await coordinator.commit("checkpoint-1", checkpoint_dir)
+        assert committed["phase"] == "committed_paused"
+        manifest = load_checkpoint_manifest(checkpoint_dir)
+        assert manifest["checkpoint_id"] == "checkpoint-1"
+        await coordinator.resume("checkpoint-1")
+        coordinator.registry.release(live_identity)
+
+        servers[2].should_exit = True
+        await server_tasks[2]
+        resources_participant = ResourcesCheckpointParticipant(
+            export_state=export_resource_state,
+            restore_states=restore_resource_states,
+            restore_expected=True,
+        )
+        resources_app = FastAPI()
+        resources_fence = ControlFence()
+        install_control_plane(
+            resources_app,
+            capabilities=capabilities("resources_servers", "resources"),
+            fence=resources_fence,
+        )
+        install_resources_checkpoint(
+            resources_app,
+            participant=resources_participant,
+            fence=resources_fence,
+            auth_token=token,
+            server_name="resources",
+            route_kind=lambda path, method: (
+                "start" if path == "/seed" and method == "POST" else None
+            ),
+        )
+        sockets[2] = _listening_socket()
+        servers[2] = uvicorn.Server(
+            uvicorn.Config(
+                resources_app,
+                log_level="error",
+                lifespan="off",
+            )
+        )
+        server_tasks[2] = asyncio.create_task(servers[2].serve(sockets=[sockets[2]]))
+        while not servers[2].started:
+            await asyncio.sleep(0.01)
+        config["resources"]["resources_servers"]["implementation"] = {
+            "host": sockets[2].getsockname()[0],
+            "port": sockets[2].getsockname()[1],
+        }
+        await coordinator.discover(config, deadline_ts=time.time() + 10)
+
+        restored = await coordinator.restore("restore-1", checkpoint_dir)
+        assert restored["phase"] == "restored_paused"
+        await coordinator.resume("restore-1")
+
+        checkpoint_file = checkpoint_dir / next(iter(manifest["files"]))
+        checkpoint_file.write_bytes(b"corrupt")
+        with pytest.raises(ValueError, match="missing or corrupted"):
+            load_checkpoint_manifest(checkpoint_dir)
+    finally:
+        for server in servers:
+            server.should_exit = True
+        await asyncio.gather(*server_tasks)

--- a/tests/unit/environments/test_nemo_gym_health.py
+++ b/tests/unit/environments/test_nemo_gym_health.py
@@ -116,7 +116,17 @@ class TestUnspunActor:
         env = _unspun()
         with pytest.raises(RuntimeError, match="_spinup\\(\\) was never called"):
             # run_rollouts is an async generator, so the guard fires on first advance.
-            gen = env.run_rollouts([{"agent_ref": {"name": "a"}}], None, "timing/x")
+            gen = env.run_rollouts(
+                [
+                    {
+                        "agent_ref": {"name": "a"},
+                        "_ng_rollout_id": "rollout-0",
+                        "_ng_attempt_index": 0,
+                    }
+                ],
+                None,
+                "timing/x",
+            )
             import asyncio
 
             asyncio.run(anext(gen))
@@ -143,7 +153,14 @@ def test_run_rollouts_resolves_task_source_before_reading_agent_ref():
     env.head_server_config = "head-server"
     env.rch = _TaskSourceResolvingRolloutHelper()
 
-    rows = [{"task_source": "workplace_assistant"}]
+    rows = [
+        {
+            "task_source": "workplace_assistant",
+            "_ng_rollout_id": "rollout-0",
+            "_ng_attempt_index": 0,
+            "_ng_capture_id": "rollout-0",
+        }
+    ]
     asyncio.run(_drain(env.run_rollouts(rows, "timing/test")))
 
     assert rows[0]["agent_ref"]["name"] == "workplace_assistant_simple_agent"
@@ -164,7 +181,15 @@ def test_run_rollouts_echoes_resolved_agent_ref_with_streamed_result():
         return [
             item
             async for item in env.run_rollouts(
-                [{"task_source": "workplace_assistant", "_rowidx": 0}],
+                [
+                    {
+                        "task_source": "workplace_assistant",
+                        "_rowidx": 0,
+                        "_ng_rollout_id": "rollout-0",
+                        "_ng_attempt_index": 0,
+                        "_ng_capture_id": "rollout-0",
+                    }
+                ],
                 "timing/test",
             )
         ]


### PR DESCRIPTION
## Summary

- discover checkpoint-capable Gym model, agent, and resources participants from live capabilities
- coordinate deadline-bounded prepare, commit, restore, resume, abort, and status operations inside the `NemoGym` Ray actor
- freeze actor-local rollout membership and acknowledge exact server-issued completion receipts before releasing delivered results
- validate aggregate manifest identity and integrity while keeping checkpoint payloads opaque to NeMo RL
- pin NeMo Gym to generation-safe stack head [`91ea76cec`](https://github.com/NVIDIA-NeMo/Gym/commit/91ea76cec2eb150d56548d46ffbdfbd707805972) from [Gym#2946](https://github.com/NVIDIA-NeMo/Gym/pull/2946)

This is the second PR in the stack and depends on [RL#4085](https://github.com/NVIDIA-NeMo/RL/pull/4085). It intentionally excludes `SingleController` orchestration.

## Validation

- focused actor and existing `NemoGym` tests against the final Gym pin: 65 passed
- actor-focused suite before the final pin: 73 passed
- integrated Gym contract tests: 3 passed
- Gym generation-safe stack: 624 passed
- Ruff and formatting: passed
- focused Pyrefly: 0 errors
