### PR TITLE
fix: capture inner vLLM TP-worker nsys traces for ALL ranks

### DIFF
--- a/nemo_rl/distributed/worker_group_utils.py
+++ b/nemo_rl/distributed/worker_group_utils.py
@@ -63,7 +63,6 @@ def get_nsight_config_if_pattern_matches(worker_name: str) -> dict[str, Any]:
                 # Profile will only start/stop when torch.cuda.profiler.start()/stop() is called
                 "capture-range": "cudaProfilerApi",
                 "capture-range-end": "stop",
-                "cuda-graph-trace": "node",
             }
             # User-supplied flags from NRL_NSYS_EXTRA_OPTIONS override the defaults
             # above. Use this to add flags like gpu-metrics-device, cuda-memory-usage,

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -1669,6 +1669,39 @@ class VllmInternalWorkerExtension:
     def stop_gpu_profiling(self) -> None:
         """Stop GPU profiling."""
         torch.cuda.profiler.stop()
+        # Finalize THIS inner worker's nsys trace NON-DESTRUCTIVELY. `nsys stop --session`
+        # writes a complete .nsys-rep for the running capture WITHOUT killing the process, so
+        # there is no worker death and therefore no engine fault-tolerance cascade (which would
+        # SIGKILL the sibling workers before nsys could finalize -- leaving unconvertible .qdstrm
+        # and losing all-but-one rank). Runs on EVERY inner worker via
+        # collective_rpc("stop_gpu_profiling"); each stops all locally-visible sessions
+        # (idempotent). Only when nsys profiling is active.
+        import os
+
+        if os.environ.get("NRL_NSYS_WORKER_PATTERNS"):
+            import subprocess
+
+            try:
+                out = subprocess.run(
+                    ["nsys", "sessions", "list"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                ).stdout
+                for line in out.splitlines():
+                    parts = line.split()
+                    if parts and parts[0].isdigit():
+                        try:
+                            subprocess.run(
+                                ["nsys", "stop", "--session=" + parts[0]],
+                                capture_output=True,
+                                text=True,
+                                timeout=180,
+                            )
+                        except Exception:
+                            pass
+            except Exception:
+                pass
 
 
 class VllmInternalWorkerExtensionWithCheckpointEngine(

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -832,7 +832,10 @@ class BaseVllmGenerationWorker:
         tracing until start_gpu_profiling() triggers cudaProfilerStart() on each
         internal worker via collective_rpc.
         """
-        from nemo_rl.utils.nsys import NRL_NSYS_PROFILE_STEP_RANGE
+        from nemo_rl.utils.nsys import (
+            NRL_NSYS_EXTRA_OPTIONS,
+            NRL_NSYS_PROFILE_STEP_RANGE,
+        )
 
         nsight_config = {
             "t": "cuda,cudnn,cublas,nvtx",
@@ -841,9 +844,13 @@ class BaseVllmGenerationWorker:
             "s": "none",
             "capture-range": "cudaProfilerApi",
             "capture-range-end": "repeat",
-            "cuda-graph-trace": "node",
         }
+        # User-supplied flags from NRL_NSYS_EXTRA_OPTIONS override the defaults (e.g.
+        # t=cuda-sw,nvtx on platforms where the HW cuda target crashes at cudaProfilerStart).
+        if NRL_NSYS_EXTRA_OPTIONS:
+            nsight_config.update(NRL_NSYS_EXTRA_OPTIONS)
 
+        # vLLM v1 Ray executor (VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0).
         try:
             from vllm.v1.executor.ray_executor import RayDistributedExecutor
         except ImportError:
@@ -857,6 +864,24 @@ class BaseVllmGenerationWorker:
             return ray_remote_kwargs
 
         RayDistributedExecutor._configure_ray_workers_use_nsight = _patched_configure
+
+        # vLLM v2 Ray executor (default for vLLM >= 0.25). It has no
+        # _configure_ray_workers_use_nsight; the nsight config is built in
+        # _build_runtime_env. Wrap it so the same deferred-capture config applies.
+        try:
+            from vllm.v1.executor.ray_executor_v2 import RayExecutorV2
+
+            _orig_build_runtime_env = RayExecutorV2._build_runtime_env
+
+            def _patched_build_runtime_env(self):
+                runtime_env = _orig_build_runtime_env(self)
+                if self.parallel_config.ray_workers_use_nsight:
+                    runtime_env["nsight"] = nsight_config
+                return runtime_env
+
+            RayExecutorV2._build_runtime_env = _patched_build_runtime_env
+        except ImportError:
+            pass
 
     def _get_raw_spec_counters(self) -> dict[str, float | list[float]]:
         """Get speculative decoding metrics from the vLLM engine.

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -865,23 +865,11 @@ class BaseVllmGenerationWorker:
 
         RayDistributedExecutor._configure_ray_workers_use_nsight = _patched_configure
 
-        # vLLM v2 Ray executor (default for vLLM >= 0.25). It has no
-        # _configure_ray_workers_use_nsight; the nsight config is built in
-        # _build_runtime_env. Wrap it so the same deferred-capture config applies.
-        try:
-            from vllm.v1.executor.ray_executor_v2 import RayExecutorV2
-
-            _orig_build_runtime_env = RayExecutorV2._build_runtime_env
-
-            def _patched_build_runtime_env(self):
-                runtime_env = _orig_build_runtime_env(self)
-                if self.parallel_config.ray_workers_use_nsight:
-                    runtime_env["nsight"] = nsight_config
-                return runtime_env
-
-            RayExecutorV2._build_runtime_env = _patched_build_runtime_env
-        except ImportError:
-            pass
+        # vLLM v2 Ray executor (default for vLLM >= 0.25) is built inside the vLLM
+        # EngineCore subprocess (spawn -> pristine vLLM import), so an in-process
+        # monkey-patch here cannot reach it. Its inner-worker nsight config is instead
+        # installed by the `vllm.general_plugins` entry point in
+        # nemo_rl.utils.vllm_nsight_plugin, which vLLM loads inside that subprocess.
 
     def _get_raw_spec_counters(self) -> dict[str, float | list[float]]:
         """Get speculative decoding metrics from the vLLM engine.

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import os
 import copy
 import gc
 import logging
@@ -224,6 +225,32 @@ class VllmAsyncGenerationWorkerImpl(
 
         self.llm = None
         self.vllm_device_ids = None
+
+    async def start_gpu_profiling(self) -> None:
+        """Start GPU profiling.
+
+        The async engine's collective_rpc is a coroutine; the inherited sync
+        start_gpu_profiling would drop it un-awaited, so the inner TP workers
+        never receive cudaProfilerStart. Await it here so every inner worker starts.
+        """
+        torch.cuda.profiler.start()
+        if self.llm is not None:
+            await self.llm.collective_rpc("start_gpu_profiling", args=tuple())
+
+    async def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling.
+
+        Awaits collective_rpc("stop_gpu_profiling") so cudaProfilerStop reaches every
+        inner worker; the patched VllmInternalWorkerExtension.stop_gpu_profiling then
+        finalizes each inner worker's nsys trace in place via `nsys stop --session`
+        (non-destructive, all ranks). Grace-sleep lets all inner workers finish writing
+        their .nsys-rep before the run tears down.
+        """
+        torch.cuda.profiler.stop()
+        if self.llm is not None:
+            await self.llm.collective_rpc("stop_gpu_profiling", args=tuple())
+            if os.environ.get("NRL_NSYS_WORKER_PATTERNS"):
+                await asyncio.sleep(30)
 
     def _return_routed_experts_enabled(self) -> bool:
         engine_args = getattr(self, "llm_async_engine_args", None)

--- a/nemo_rl/utils/vllm_nsight_plugin.py
+++ b/nemo_rl/utils/vllm_nsight_plugin.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM general plugin: deferred-capture nsight config for the v2 inner TP workers.
+
+vLLM loads plugins registered in the ``vllm.general_plugins`` entry-point group
+*early in every process it starts* -- including the spawned EngineCore subprocess
+where the v2 ``RayExecutorV2`` builds the runtime_env for the inner ``RayWorkerProc``
+workers. NeMo-RL cannot reach that subprocess with an in-process monkey-patch
+(``spawn`` = fresh interpreter, pristine vLLM import), so without this the inner
+workers launch with vLLM's stock always-on nsight config (``worker_process_%p``,
+no capture-range) that never finalizes under the teardown SIGKILL.
+
+This plugin runs inside that subprocess and installs the same deferred-capture
+nsight config NeMo-RL uses for the outer/policy workers, so tracing is gated by the
+``cudaProfilerStart/Stop`` NeMo-RL fires over ``NRL_NSYS_PROFILE_STEP_RANGE`` and each
+inner worker's trace is finalized non-destructively (see
+``VllmInternalWorkerExtension.stop_gpu_profiling``). It is a no-op unless
+``NRL_NSYS_WORKER_PATTERNS`` is set, and no-ops on vLLM builds without the v2 executor
+(the v1 executor is patched in-process in ``vllm_worker.py``).
+"""
+
+import os
+
+
+def register_nsight_inner_worker_profiling() -> None:
+    """vLLM general-plugin entry point; called by ``load_general_plugins()``."""
+    # Only act when NeMo-RL nsys profiling is requested (same gate as the workers).
+    if not os.environ.get("NRL_NSYS_WORKER_PATTERNS"):
+        return
+
+    try:
+        from vllm.v1.executor.ray_executor_v2 import RayExecutorV2
+    except ImportError:
+        # Older vLLM without the v2 executor -- nothing to patch here; the v1 path
+        # is handled in-process by NeMo-RL's own monkey-patch.
+        return
+
+    if getattr(RayExecutorV2, "_nrl_nsight_patched", False):
+        return
+
+    _orig_build_runtime_env = RayExecutorV2._build_runtime_env
+
+    def _patched_build_runtime_env(self):
+        runtime_env = _orig_build_runtime_env(self)
+        if self.parallel_config.ray_workers_use_nsight:
+            import json
+
+            rng = os.environ.get("NRL_NSYS_PROFILE_STEP_RANGE", "all")
+            nsight_config = {
+                "t": "cuda,cudnn,cublas,nvtx",
+                "o": f"'vllm_tp_worker_{rng}_%p'",
+                "stop-on-exit": "true",
+                "s": "none",
+                "capture-range": "cudaProfilerApi",
+                "wait": "primary",
+                "capture-range-end": "stop",
+            }
+            # NRL_NSYS_EXTRA_OPTIONS lets the user override the trace target, e.g.
+            # t=cuda-sw,nvtx on platforms where the HW cuda target crashes at
+            # cudaProfilerStart.
+            extra = os.environ.get("NRL_NSYS_EXTRA_OPTIONS")
+            if extra:
+                nsight_config.update(json.loads(extra))
+            runtime_env["nsight"] = nsight_config
+        return runtime_env
+
+    RayExecutorV2._build_runtime_env = _patched_build_runtime_env
+    RayExecutorV2._nrl_nsight_patched = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ dependencies = [
   "mooncake-transfer-engine-cuda13==0.3.11.post1 ; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
 ]
 
+# vLLM loads plugins in this group via load_general_plugins() in EVERY process it
+# starts, including the spawned EngineCore subprocess where RayExecutorV2 builds the
+# inner-worker runtime_env -- which an in-process monkey-patch cannot reach. This
+# installs the deferred-capture nsight config for the inner vLLM TP workers so nsys
+# profiling produces per-rank traces on the v2 executor.
+[project.entry-points."vllm.general_plugins"]
+nemo_rl_nsight_inner = "nemo_rl.utils.vllm_nsight_plugin:register_nsight_inner_worker_profiling"
+
 
 [project.optional-dependencies]
 fsdp = [


### PR DESCRIPTION
# What does this PR do ?
Fixes multi-rank generation-profiling so that every inner vLLM tensor-parallel worker writes a complete nsys trace (previously TP>1 generation profiling produced zero usable inner traces, and crashed at init).

# Issues

No tracked issue; standalone fix
Multi-rank generation (inner vLLM tensor-parallel worker) nsys profiling previously produced NO usable traces: at teardown the inner workers are SIGKILLed, so nsys never writes the stream footer and the .qdstrm is an incomplete, unconvertible capture. On the async engine the inner workers never even received cudaProfilerStart. On aarch64 GB200 the default cuda-graph-trace=node HW-CUPTI path also SIGSEGVs at cudaProfilerStart. 

# Usage

Enable generation + policy nsys profiling as usual — inner TP-worker traces now finalize for all ranks:
```
# Profile policy (training) + vLLM (generation) workers, steps 2..4 (left-incl/right-excl).
# cuda-sw is the aarch64 GB200-safe trace target (HW `cuda` SIGSEGVs at cudaProfilerStart).
export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"
export NRL_NSYS_PROFILE_STEP_RANGE="2:5"
export NRL_NSYS_EXTRA_OPTIONS='{"t":"cuda-sw,nvtx"}'

uv run examples/run_grpo.py --config examples/configs/grpo_math_1B_megatron.yaml \
    policy.generation.vllm_cfg.tensor_parallel_size=2 \
    grpo.max_num_steps=5
```
Result: one *_2:5_<pid>.nsys-rep per rank — megatron_policy_worker_*, vllm_generation_worker_* (outer), and one vllm_tp_worker_* per inner TP rank (the traces that were missing before).

# Repro of the issue and validation of the fix

qwen3-32b, async engine, vLLM tensor_parallel_size=2 (so real inner Ray TP workers exist), single NVLink-local node, profile window 1:3. The two runs differ only by this patch:

```
┌──────────────────────────────┬────────────────────────────────────────────┬───────────────────────────────┐
│                              │             BEFORE (unpatched)             │        AFTER (this PR)        │
├──────────────────────────────┼────────────────────────────────────────────┼───────────────────────────────┤
│ inner vllm_tp_worker traces  │ 0                                          │ 32                            │
├──────────────────────────────┼────────────────────────────────────────────┼───────────────────────────────┤
│ outer vllm_generation_worker │ —                                          │ 32                            │
├──────────────────────────────┼────────────────────────────────────────────┼───────────────────────────────┤
│ megatron_policy_worker       │ —                                          │ 32                            │
├──────────────────────────────┼────────────────────────────────────────────┼───────────────────────────────┤
│ segfaults at EngineCore init │ 5 (CUPTI × cuda-graph-trace=node, aarch64) │ 0                             │
├──────────────────────────────┼────────────────────────────────────────────┼───────────────────────────────┤
│ profile-window entry         │ never fired                                │ fired, trained through window │
└──────────────────────────────┴────────────────────────────────────────────┴───────────────────────────────┘
```
Why it failed before:
1. On aarch64 GB200 the default cuda-graph-trace=node HW-CUPTI path SIGSEGVs at cudaProfilerStart → inner EngineCore workers die at init.
2. On the async engine the inherited sync start/stop_gpu_profiling dropped the collective_rpc(...) coroutine un-awaited → inner workers never received cudaProfilerStart/Stop.
3. At teardown the inner TP workers are SIGKILLed → nsys never writes the stream footer → the .qdstrm is an incomplete, unconvertible capture (at most one rank survived).

Backward-compat (non-regression) — all PASS, 0 crashes:
```
┌────────────────────────────────────┬───────────────┬─────────────────────────────┬──────────────┐
│              Use case              │ inner workers │           traces            │   outcome    │
├────────────────────────────────────┼───────────────┼─────────────────────────────┼──────────────┤
│ sync + TP=1 (VllmGenerationWorker) │ none (TP=1)   │ 8 gen + 8 policy            │ ✅ unchanged │
├────────────────────────────────────┼───────────────┼─────────────────────────────┼──────────────┤
│ async + TP=1                       │ none (TP=1)   │ gen + policy                │ ✅ unchanged │
├────────────────────────────────────┼───────────────┼─────────────────────────────┼──────────────┤
│ async + TP>1                       │ present       │ full inner + outer + policy │ ✅ fixed     │
└────────────────────────────────────┴───────────────┴─────────────────────────────┴──────────────┘
```
Container Image: nvcr.io#nvidian/nemo-rl:nightly 

All three use cases run the same GRPO entrypoint on a Ray-on-Slurm cluster; only the vLLM parallelism/engine and profile knobs differ. Common profiling env (set on the launch shell so it propagates to every node/worker):
```
export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"   # profile policy (train) + vLLM (gen) workers
export NRL_NSYS_PROFILE_STEP_RANGE="1:3"            # left-incl / right-excl; fires cudaProfilerStart@1, stop@3
export NRL_NSYS_EXTRA_OPTIONS='{"t":"cuda-sw,nvtx"}' # trace-target override (use on platforms where the HW `cuda` target crashes at cudaProfilerStart)
```
Traces land per worker under each Ray session dir:
.../<jobid>-logs/ray/<node>/session_*/logs/nsight/<class>_<range>_<pid>.nsys-rep

Use case 1 — async + TP>1 (the fix: inner-worker traces)
```
uv run examples/run_grpo.py \
  --config examples/configs/recipes/llm/performance/grpo-qwen3-32b.yaml \
  policy.generation.vllm_cfg.async_engine=true \
  policy.generation.vllm_cfg.tensor_parallel_size=2 \
  grpo.max_num_steps=5
```
Expected: three trace classes — megatron_policy_worker_*, vllm_async_generation_worker_* (outer), and vllm_tp_worker_1:3_%p (one per inner TP rank = #engines × TP). The vllm_tp_worker_ prefix (vs stock vLLM's worker_process_%p) is the proof the deferred-capture config reached the inner EngineCore subprocess. Before the fix: the inner workers segfault at init / produce zero finalized inner traces.

Use case 2 — sync + TP=1 (non-regression)
```
uv run examples/run_grpo.py \
  --config examples/configs/recipes/llm/performance/grpo-qwen3-32b.yaml \
  policy.generation.vllm_cfg.async_engine=false \
  policy.generation.vllm_cfg.tensor_parallel_size=1 \
  grpo.max_num_steps=5
```
Expected: megatron_policy_worker_* + vllm_generation_worker_* only. At TP=1 each GPU is its own engine (no inner Ray workers), so there is no vllm_tp_worker; the plugin is a no-op. Run completes, 0 crashes.

Use case 3 — async + TP=1 (non-regression)
```
uv run examples/run_grpo.py \
  --config examples/configs/recipes/llm/performance/grpo-qwen3-32b.yaml \
  policy.generation.vllm_cfg.async_engine=true \
  policy.generation.vllm_cfg.tensor_parallel_size=1 \
  grpo.max_num_steps=5
```
Expected: same as case 2 — vllm_generation_worker_* + megatron_policy_worker_*, no inner workers, 0 crashes.

## Four minimal changes:

- distributed/worker_group_utils.py: drop cuda-graph-trace=node from the policy/outer nsight config (fragile CUPTI on aarch64; user can re-add via NRL_NSYS_EXTRA_OPTIONS).

- models/generation/vllm/vllm_worker.py (_patch_vllm_nsight_config): honor NRL_NSYS_EXTRA_OPTIONS so the trace target is overridable (e.g. cuda-sw on aarch64), drop cuda-graph-trace.

- models/generation/vllm/vllm_worker_async.py: override start/stop_gpu_profiling as async and AWAIT collective_rpc, so cudaProfilerStart/Stop actually reach every inner worker on the async engine (the inherited sync methods dropped the coroutine un-awaited); plus a short grace after stop so nsys can finalize.

- models/generation/vllm/vllm_backend.py (VllmInternalWorkerExtension.stop_gpu_profiling): after cudaProfilerStop, finalize each inner worker's live nsys capture NON-DESTRUCTIVELY via `nsys stop --session`. This writes a complete .nsys-rep without killing the process, so no worker death and no engine fault-tolerance cascade -- every rank finalizes (vs at most one before). Runs on all inner workers via the existing collective_rpc("stop_gpu_profiling") broadcast.



# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

