### PR TITLE
perf(data-plane): avoid local batch copies

### DIFF
--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -19,10 +19,10 @@ import re
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
-from copy import deepcopy
+from copy import copy, deepcopy
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import requests
 import torch
@@ -348,18 +348,6 @@ def _shared_preprocess_spec(
     return first
 
 
-class PackedTensorBroadcastMetadata(TypedDict):
-    dtype: str
-    source_device: str
-    shapes: list[Optional[tuple[int, ...]]]
-    dim_to_pack: int
-    preprocess_mode: Optional[str]
-    preprocess_kwargs: dict[str, Any]
-    row_offsets: Optional[list[int]]
-    segment_indices: Optional[list[int]]
-    segment_provenance: Optional[list[bytes]]
-
-
 class PackedTensor:
     """A logical batch of rows backed by packable tensor segments.
 
@@ -484,8 +472,18 @@ class PackedTensor:
 
     def broadcast_parts(
         self, device: Any
-    ) -> tuple[PackedTensorBroadcastMetadata, torch.Tensor]:
-        """Coalesce physical segments for a tensor-native replica broadcast."""
+    ) -> tuple[
+        "PackedTensor",
+        list[Optional[tuple[int, ...]]],
+        str,
+        str,
+        torch.Tensor,
+    ]:
+        """Split semantic state from physical data for replica broadcast.
+
+        The tensor-free header retains every other instance attribute, so new
+        semantic state does not require a parallel broadcast schema update.
+        """
         tensors = [tensor for tensor in self.tensors if tensor is not None]
         dtype = tensors[0].dtype if tensors else torch.uint8
         source_device = tensors[0].device if tensors else torch.device(device)
@@ -500,38 +498,22 @@ class PackedTensor:
             if tensors
             else torch.empty(0, dtype=dtype, device=device)
         )
-        metadata: PackedTensorBroadcastMetadata = {
-            "dtype": str(dtype),
-            "source_device": str(source_device),
-            "shapes": [
-                None if tensor is None else tuple(tensor.shape)
-                for tensor in self.tensors
-            ],
-            "dim_to_pack": self.dim_to_pack,
-            "preprocess_mode": self.preprocess_mode,
-            "preprocess_kwargs": dict(self.preprocess_kwargs),
-            "row_offsets": (
-                None if self._row_offsets is None else list(self._row_offsets)
-            ),
-            "segment_indices": (
-                None if self._segment_indices is None else list(self._segment_indices)
-            ),
-            "segment_provenance": (
-                None
-                if self._segment_provenance is None
-                else list(self._segment_provenance)
-            ),
-        }
-        return metadata, payload
+        header = copy(self)
+        header.tensors = []
+        shapes = [
+            None if tensor is None else tuple(tensor.shape) for tensor in self.tensors
+        ]
+        return header, shapes, str(dtype), str(source_device), payload
 
-    @classmethod
-    def from_broadcast_parts(
-        cls, metadata: PackedTensorBroadcastMetadata, payload: torch.Tensor
+    def rebuild_from_broadcast_parts(
+        self,
+        shapes: list[Optional[tuple[int, ...]]],
+        payload: torch.Tensor,
     ) -> "PackedTensor":
-        """Rebuild a PackedTensor from :meth:`broadcast_parts` output."""
+        """Attach received physical data to a header from ``broadcast_parts``."""
         tensors: list[Optional[torch.Tensor]] = []
         offset: int = 0
-        for shape in metadata["shapes"]:
+        for shape in shapes:
             if shape is None:
                 tensors.append(None)
                 continue
@@ -542,18 +524,11 @@ class PackedTensor:
             offset += numel
         if offset != payload.numel():
             raise ValueError(
-                f"PackedTensor broadcast metadata describes {offset} elements, "
+                f"PackedTensor broadcast shapes describe {offset} elements, "
                 f"but the payload has {payload.numel()}."
             )
-        return cls(
-            tensors,
-            metadata["dim_to_pack"],
-            preprocess_mode=metadata["preprocess_mode"],
-            preprocess_kwargs=metadata["preprocess_kwargs"],
-            _row_offsets=metadata["row_offsets"],
-            _segment_indices=metadata["segment_indices"],
-            _segment_provenance=metadata["segment_provenance"],
-        )
+        self.tensors = tensors
+        return self
 
     @property
     def _preprocess_spec(self) -> dict[str, Any]:

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union
 
 import requests
 import torch
@@ -348,6 +348,18 @@ def _shared_preprocess_spec(
     return first
 
 
+class PackedTensorBroadcastMetadata(TypedDict):
+    dtype: str
+    source_device: str
+    shapes: list[Optional[tuple[int, ...]]]
+    dim_to_pack: int
+    preprocess_mode: Optional[str]
+    preprocess_kwargs: dict[str, Any]
+    row_offsets: Optional[list[int]]
+    segment_indices: Optional[list[int]]
+    segment_provenance: Optional[list[bytes]]
+
+
 class PackedTensor:
     """A logical batch of rows backed by packable tensor segments.
 
@@ -469,6 +481,79 @@ class PackedTensor:
         self.__dict__.setdefault("_row_offsets", None)
         self.__dict__.setdefault("_segment_indices", None)
         self.__dict__.setdefault("_segment_provenance", None)
+
+    def broadcast_parts(
+        self, device: Any
+    ) -> tuple[PackedTensorBroadcastMetadata, torch.Tensor]:
+        """Coalesce physical segments for a tensor-native replica broadcast."""
+        tensors = [tensor for tensor in self.tensors if tensor is not None]
+        dtype = tensors[0].dtype if tensors else torch.uint8
+        source_device = tensors[0].device if tensors else torch.device(device)
+        if any(tensor.dtype != dtype for tensor in tensors):
+            raise TypeError("PackedTensor segments must have one dtype for broadcast.")
+        if any(tensor.device != source_device for tensor in tensors):
+            raise TypeError(
+                "PackedTensor segments must be on one device for broadcast."
+            )
+        payload = (
+            torch.cat([tensor.to(device).contiguous().view(-1) for tensor in tensors])
+            if tensors
+            else torch.empty(0, dtype=dtype, device=device)
+        )
+        metadata: PackedTensorBroadcastMetadata = {
+            "dtype": str(dtype),
+            "source_device": str(source_device),
+            "shapes": [
+                None if tensor is None else tuple(tensor.shape)
+                for tensor in self.tensors
+            ],
+            "dim_to_pack": self.dim_to_pack,
+            "preprocess_mode": self.preprocess_mode,
+            "preprocess_kwargs": dict(self.preprocess_kwargs),
+            "row_offsets": (
+                None if self._row_offsets is None else list(self._row_offsets)
+            ),
+            "segment_indices": (
+                None if self._segment_indices is None else list(self._segment_indices)
+            ),
+            "segment_provenance": (
+                None
+                if self._segment_provenance is None
+                else list(self._segment_provenance)
+            ),
+        }
+        return metadata, payload
+
+    @classmethod
+    def from_broadcast_parts(
+        cls, metadata: PackedTensorBroadcastMetadata, payload: torch.Tensor
+    ) -> "PackedTensor":
+        """Rebuild a PackedTensor from :meth:`broadcast_parts` output."""
+        tensors: list[Optional[torch.Tensor]] = []
+        offset: int = 0
+        for shape in metadata["shapes"]:
+            if shape is None:
+                tensors.append(None)
+                continue
+            numel: int = 1
+            for dimension in shape:
+                numel *= dimension
+            tensors.append(payload.narrow(0, offset, numel).view(shape))
+            offset += numel
+        if offset != payload.numel():
+            raise ValueError(
+                f"PackedTensor broadcast metadata describes {offset} elements, "
+                f"but the payload has {payload.numel()}."
+            )
+        return cls(
+            tensors,
+            metadata["dim_to_pack"],
+            preprocess_mode=metadata["preprocess_mode"],
+            preprocess_kwargs=metadata["preprocess_kwargs"],
+            _row_offsets=metadata["row_offsets"],
+            _segment_indices=metadata["segment_indices"],
+            _segment_provenance=metadata["segment_provenance"],
+        )
 
     @property
     def _preprocess_spec(self) -> dict[str, Any]:

--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -471,13 +471,13 @@ class PackedTensor:
         self.__dict__.setdefault("_segment_provenance", None)
 
     def broadcast_parts(
-        self, device: Any
+        self,
     ) -> tuple[
         "PackedTensor",
         list[Optional[tuple[int, ...]]],
         str,
         str,
-        torch.Tensor,
+        list[torch.Tensor],
     ]:
         """Split semantic state from physical data for replica broadcast.
 
@@ -486,24 +486,39 @@ class PackedTensor:
         """
         tensors = [tensor for tensor in self.tensors if tensor is not None]
         dtype = tensors[0].dtype if tensors else torch.uint8
-        source_device = tensors[0].device if tensors else torch.device(device)
+        source_device = tensors[0].device if tensors else torch.device("cpu")
         if any(tensor.dtype != dtype for tensor in tensors):
             raise TypeError("PackedTensor segments must have one dtype for broadcast.")
         if any(tensor.device != source_device for tensor in tensors):
             raise TypeError(
                 "PackedTensor segments must be on one device for broadcast."
             )
-        payload = (
-            torch.cat([tensor.to(device).contiguous().view(-1) for tensor in tensors])
-            if tensors
-            else torch.empty(0, dtype=dtype, device=device)
-        )
         header = copy(self)
         header.tensors = []
+        header.preprocess_kwargs = dict(self.preprocess_kwargs)
+        header._row_offsets = (
+            None if self._row_offsets is None else list(self._row_offsets)
+        )
+        header._segment_indices = (
+            None if self._segment_indices is None else list(self._segment_indices)
+        )
+        header._segment_provenance = (
+            None if self._segment_provenance is None else list(self._segment_provenance)
+        )
+        tensor_attributes = [
+            name
+            for name, value in header.__dict__.items()
+            if isinstance(value, torch.Tensor)
+        ]
+        if tensor_attributes:
+            raise TypeError(
+                "PackedTensor broadcast header must be tensor-free; give attributes "
+                f"{tensor_attributes} their own payload."
+            )
         shapes = [
             None if tensor is None else tuple(tensor.shape) for tensor in self.tensors
         ]
-        return header, shapes, str(dtype), str(source_device), payload
+        return header, shapes, str(dtype), str(source_device), tensors
 
     def rebuild_from_broadcast_parts(
         self,

--- a/nemo_rl/data_plane/adapters/local.py
+++ b/nemo_rl/data_plane/adapters/local.py
@@ -94,26 +94,28 @@ def _value_batch_size(value: Any) -> int:
         ) from error
 
 
-def _copy_batch_value(value: Any) -> Any:
-    if isinstance(value, torch.Tensor):
-        return value.detach().clone()
-    return deepcopy(value)
+def _is_identity_indices(indices: list[int], batch_size: int) -> bool:
+    return len(indices) == batch_size and all(
+        index == position for position, index in enumerate(indices)
+    )
 
 
 def _select_batch_value(value: Any, indices: list[int]) -> Any:
+    if _is_identity_indices(indices, _value_batch_size(value)):
+        return value
     if isinstance(value, torch.Tensor):
         index = torch.tensor(indices, dtype=torch.long, device=value.device)
-        return value.index_select(0, index).detach().clone()
+        return value.index_select(0, index)
     if isinstance(value, PackedTensor):
         if not indices:
             return PackedTensor.empty_rows_like(value, 0)
-        return deepcopy(value.slice(indices))
+        return value.slice(indices)
     if isinstance(value, tuple):
-        return tuple(deepcopy(value[index]) for index in indices)
+        return tuple(value[index] for index in indices)
     if isinstance(value, list):
-        return [deepcopy(value[index]) for index in indices]
+        return [value[index] for index in indices]
     try:
-        return deepcopy(value[indices])
+        return value[indices]
     except (IndexError, KeyError, TypeError) as error:
         raise TypeError(
             f"Cannot select rows from local field type {type(value).__name__}."
@@ -385,7 +387,7 @@ class LocalDataPlaneClient(DataPlaneClient):
                         f"Local field {name!r} has batch size {actual_size}, "
                         f"expected {len(sample_ids)}."
                     )
-                batch[name] = _copy_batch_value(value)
+                batch[name] = value
 
         partition.sample_ids = list(sample_ids)
         partition.batch = batch

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -184,17 +184,20 @@ def _broadcast_batched_data_dict(
             header, shapes, dtype_str, source_device = entry[2:]
             if is_leader:
                 segments = packed_segments.pop(key)
-                flat_payload = (
-                    torch.cat([segment.contiguous().view(-1) for segment in segments])
+                tensor = (
+                    torch.cat(
+                        [
+                            segment.to(bcast_device).contiguous().view(-1)
+                            for segment in segments
+                        ]
+                    )
                     if segments
                     else torch.empty(
                         0,
                         dtype=getattr(torch, dtype_str.split(".")[-1]),
-                        device=source_device,
+                        device=bcast_device,
                     )
                 )
-                tensor = flat_payload.to(bcast_device)
-                del flat_payload
             else:
                 dtype = getattr(torch, dtype_str.split(".")[-1])
                 numel = sum(

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -103,8 +103,12 @@ def _broadcast_batched_data_dict(
                         (k, "tensor", str(v.dtype), tuple(v.shape), str(v.device))
                     )
                 elif isinstance(v, PackedTensor):
-                    metadata, packed_payloads[k] = v.broadcast_parts(bcast_device)
-                    descriptor.append((k, "packed_tensor", metadata))
+                    header, shapes, dtype, source_device, packed_payloads[k] = (
+                        v.broadcast_parts(bcast_device)
+                    )
+                    descriptor.append(
+                        (k, "packed_tensor", header, shapes, dtype, source_device)
+                    )
                 elif (
                     v is None
                     or isinstance(v, (str, int, float, bool))
@@ -178,15 +182,13 @@ def _broadcast_batched_data_dict(
             ):
                 out[key] = tensor.to(src_device)
         elif kind == "packed_tensor":
-            metadata = entry[2]
+            header, shapes, dtype_str, source_device = entry[2:]
             if is_leader:
                 tensor = packed_payloads[key]
             else:
-                dtype = getattr(torch, metadata["dtype"].split(".")[-1])
+                dtype = getattr(torch, dtype_str.split(".")[-1])
                 numel = sum(
-                    torch.Size(shape).numel()
-                    for shape in metadata["shapes"]
-                    if shape is not None
+                    torch.Size(shape).numel() for shape in shapes if shape is not None
                 )
                 tensor = torch.empty(numel, dtype=dtype, device=bcast_device)
             if tensor.numel():
@@ -198,12 +200,9 @@ def _broadcast_batched_data_dict(
                     torch.distributed.broadcast(tensor, src=src, group=group)
             packed_payloads.pop(key, None)
             if not is_leader:
-                if (
-                    torch.device(metadata["source_device"]).type
-                    != torch.device(bcast_device).type
-                ):
-                    tensor = tensor.to(metadata["source_device"])
-                out[key] = PackedTensor.from_broadcast_parts(metadata, tensor)
+                if torch.device(source_device).type != torch.device(bcast_device).type:
+                    tensor = tensor.to(source_device)
+                out[key] = header.rebuild_from_broadcast_parts(shapes, tensor)
         else:
             if not is_leader:
                 out[key] = entry[2]

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -87,10 +87,9 @@ def _broadcast_batched_data_dict(
     backend = torch.distributed.get_backend(group)
     bcast_device: Any = torch.cuda.current_device() if backend == "nccl" else "cpu"
 
-    # Leader-only: the flat physical payload of each packed field, kept from
-    # the descriptor pass so coalescing runs once and deduplicated segments
-    # cross the collective only once.
-    packed_payloads: dict[str, torch.Tensor] = {}
+    # Leader-only: keep physical segments uncoalesced until their broadcast
+    # turn so only one packed payload is staged on the GPU at a time.
+    packed_segments: dict[str, list[torch.Tensor]] = {}
     leader_error: Exception | None = None
 
     if is_leader:
@@ -103,8 +102,8 @@ def _broadcast_batched_data_dict(
                         (k, "tensor", str(v.dtype), tuple(v.shape), str(v.device))
                     )
                 elif isinstance(v, PackedTensor):
-                    header, shapes, dtype, source_device, packed_payloads[k] = (
-                        v.broadcast_parts(bcast_device)
+                    header, shapes, dtype, source_device, packed_segments[k] = (
+                        v.broadcast_parts()
                     )
                     descriptor.append(
                         (k, "packed_tensor", header, shapes, dtype, source_device)
@@ -184,7 +183,18 @@ def _broadcast_batched_data_dict(
         elif kind == "packed_tensor":
             header, shapes, dtype_str, source_device = entry[2:]
             if is_leader:
-                tensor = packed_payloads[key]
+                segments = packed_segments.pop(key)
+                flat_payload = (
+                    torch.cat([segment.contiguous().view(-1) for segment in segments])
+                    if segments
+                    else torch.empty(
+                        0,
+                        dtype=getattr(torch, dtype_str.split(".")[-1]),
+                        device=source_device,
+                    )
+                )
+                tensor = flat_payload.to(bcast_device)
+                del flat_payload
             else:
                 dtype = getattr(torch, dtype_str.split(".")[-1])
                 numel = sum(
@@ -196,13 +206,14 @@ def _broadcast_batched_data_dict(
                     wire = tensor.to(torch.int32)
                     torch.distributed.broadcast(wire, src=src, group=group)
                     tensor = wire.to(torch.int16)
+                    del wire
                 else:
                     torch.distributed.broadcast(tensor, src=src, group=group)
-            packed_payloads.pop(key, None)
             if not is_leader:
                 if torch.device(source_device).type != torch.device(bcast_device).type:
                     tensor = tensor.to(source_device)
                 out[key] = header.rebuild_from_broadcast_parts(shapes, tensor)
+            del tensor
         else:
             if not is_leader:
                 out[key] = entry[2]

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -87,10 +87,10 @@ def _broadcast_batched_data_dict(
     backend = torch.distributed.get_backend(group)
     bcast_device: Any = torch.cuda.current_device() if backend == "nccl" else "cpu"
 
-    # Leader-only: the flat payload of each packed field, kept from the
-    # descriptor pass so ``to_wire``'s ``torch.cat`` of the whole column runs
-    # once, not once per pass (multimodal_utils.py:203 warns about exactly this).
-    leader_flat: dict[str, torch.Tensor] = {}
+    # Leader-only: the flat physical payload of each packed field, kept from
+    # the descriptor pass so coalescing runs once and deduplicated segments
+    # cross the collective only once.
+    packed_payloads: dict[str, torch.Tensor] = {}
     leader_error: Exception | None = None
 
     if is_leader:
@@ -103,38 +103,8 @@ def _broadcast_batched_data_dict(
                         (k, "tensor", str(v.dtype), tuple(v.shape), str(v.device))
                     )
                 elif isinstance(v, PackedTensor):
-                    nested, shapes = v.to_wire()
-                    if nested is None:
-                        # Every row empty -- a shard holding only media-free
-                        # samples. The key still has to cross: consumers branch on
-                        # the key set (``len(get_multimodal_dict(...)) > 0`` decides
-                        # whether the caller's position_ids are used), and the
-                        # independent-fetch path keeps it. Ship geometry alone.
-                        descriptor.append(
-                            (
-                                k,
-                                "empty_packed",
-                                len(v),
-                                v.dim_to_pack,
-                                v.preprocess_mode,
-                                v.preprocess_kwargs,
-                            )
-                        )
-                        continue
-                    values = nested.values()
-                    leader_flat[k] = values
-                    descriptor.append(
-                        (
-                            k,
-                            "packed_wire",
-                            str(values.dtype),
-                            str(values.device),
-                            nested.offsets().tolist(),
-                            shapes,
-                            v.preprocess_mode,
-                            v.preprocess_kwargs,
-                        )
-                    )
+                    metadata, packed_payloads[k] = v.broadcast_parts(bcast_device)
+                    descriptor.append((k, "packed_tensor", metadata))
                 elif (
                     v is None
                     or isinstance(v, (str, int, float, bool))
@@ -207,48 +177,33 @@ def _broadcast_batched_data_dict(
                 and torch.device(src_device).type != torch.device(bcast_device).type
             ):
                 out[key] = tensor.to(src_device)
-        elif kind == "packed_wire":
-            (
-                dtype_str,
-                src_device,
-                offsets,
-                shapes,
-                preprocess_mode,
-                preprocess_kwargs,
-            ) = entry[2:]
+        elif kind == "packed_tensor":
+            metadata = entry[2]
             if is_leader:
-                flat = leader_flat[key].to(bcast_device)
+                tensor = packed_payloads[key]
             else:
-                dtype = getattr(torch, dtype_str.split(".")[-1])
-                flat = torch.empty(offsets[-1], dtype=dtype, device=bcast_device)
-            torch.distributed.broadcast(flat, src=src, group=group)
-            # Drop the cached CPU concat now it has shipped: holding it to
-            # the end of the loop keeps three copies of the largest column
-            # live at once (segments, concat, device copy).
-            leader_flat.pop(key, None)
+                dtype = getattr(torch, metadata["dtype"].split(".")[-1])
+                numel = sum(
+                    torch.Size(shape).numel()
+                    for shape in metadata["shapes"]
+                    if shape is not None
+                )
+                tensor = torch.empty(numel, dtype=dtype, device=bcast_device)
+            if tensor.numel():
+                if tensor.dtype == torch.int16:
+                    wire = tensor.to(torch.int32)
+                    torch.distributed.broadcast(wire, src=src, group=group)
+                    tensor = wire.to(torch.int16)
+                else:
+                    torch.distributed.broadcast(tensor, src=src, group=group)
+            packed_payloads.pop(key, None)
             if not is_leader:
-                nested = torch.nested.nested_tensor_from_jagged(
-                    flat, torch.tensor(offsets, dtype=torch.int64, device=flat.device)
-                )
-                if torch.device(src_device).type != torch.device(bcast_device).type:
-                    nested = nested.to(src_device)
-                out[key] = PackedTensor.from_wire(
-                    nested,
-                    shapes,
-                    preprocess_mode=preprocess_mode,
-                    preprocess_kwargs=preprocess_kwargs,
-                )
-        elif kind == "empty_packed":
-            # Structural only: no payload, so followers rebuild from the
-            # geometry and land on the leader's key set.
-            n_rows, dim_to_pack, preprocess_mode, preprocess_kwargs = entry[2:]
-            if not is_leader:
-                out[key] = PackedTensor(
-                    [None] * n_rows,
-                    dim_to_pack,
-                    preprocess_mode=preprocess_mode,
-                    preprocess_kwargs=preprocess_kwargs,
-                )
+                if (
+                    torch.device(metadata["source_device"]).type
+                    != torch.device(bcast_device).type
+                ):
+                    tensor = tensor.to(metadata["source_device"])
+                out[key] = PackedTensor.from_broadcast_parts(metadata, tensor)
         else:
             if not is_leader:
                 out[key] = entry[2]

--- a/tests/unit/data_plane/test_leader_broadcast.py
+++ b/tests/unit/data_plane/test_leader_broadcast.py
@@ -138,6 +138,50 @@ def _round_trip_body(rank: int):
     assert torch.equal(packed.as_tensor(), expected.as_tensor())
 
 
+def _deduplicated_round_trip_body(rank: int):
+    first_physical_row = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    third_physical_row = torch.arange(3, dtype=torch.float32).reshape(1, 3)
+    physical_rows = [
+        first_physical_row,
+        None,
+        third_physical_row,
+    ]
+    data = (
+        BatchedDataDict(
+            {
+                "pixel_values": PackedTensor(
+                    physical_rows,
+                    dim_to_pack=0,
+                    preprocess_mode="patchify",
+                    preprocess_kwargs={"patch_dim": 2},
+                    _row_offsets=[0, 1, 2, 4],
+                    _segment_indices=[0, 1, 2, 0],
+                    _segment_provenance=[b"a", b"b", b"c"],
+                )
+            }
+        )
+        if rank == 0
+        else None
+    )
+
+    out = _broadcast_batched_data_dict(
+        data, is_leader=(rank == 0), src=0, group=dist.group.WORLD
+    )
+
+    packed = out["pixel_values"]
+    assert isinstance(packed, PackedTensor), type(packed).__name__
+    assert packed.preprocess_mode == "patchify"
+    assert packed.preprocess_kwargs == {"patch_dim": 2}
+    assert packed._row_offsets == [0, 1, 2, 4]
+    assert packed._segment_indices == [0, 1, 2, 0]
+    assert packed._segment_provenance == [b"a", b"b", b"c"]
+    assert packed.tensors[1] is None
+    assert packed.tensors[0] is not None
+    assert packed.tensors[2] is not None
+    assert torch.equal(packed.tensors[0], first_physical_row)
+    assert torch.equal(packed.tensors[2], third_physical_row)
+
+
 def _all_empty_body(rank: int):
     # One DP shard of a mixed image/text batch can hold only media-free
     # samples. ``pixel_values`` is still in ``meta.fields``, so the shard
@@ -180,6 +224,10 @@ def _unsupported_type_body(rank: int):
 
 def test_leader_broadcast_round_trip(tmp_path):
     _run_two_ranks(_round_trip_body, str(tmp_path / "init"))
+
+
+def test_leader_broadcast_preserves_packed_tensor_deduplication(tmp_path):
+    _run_two_ranks(_deduplicated_round_trip_body, str(tmp_path / "init_dedup"))
 
 
 def test_leader_broadcast_keeps_media_free_packed_key(tmp_path):

--- a/tests/unit/data_plane/test_leader_broadcast.py
+++ b/tests/unit/data_plane/test_leader_broadcast.py
@@ -11,16 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit test for ``_broadcast_batched_data_dict`` on a 2-rank gloo group.
+"""Tests for ``_broadcast_batched_data_dict`` on two-rank process groups.
 
 Exercises the helper that backs ``_fetch(fetch_policy="leader_broadcast")``.
-Runs on CPU (gloo) so it stays in the no-GPU Tier 1 lane.
+Most cases run on CPU with Gloo; one optional NCCL case covers device staging.
 """
 
 from __future__ import annotations
 
 import os
 
+import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -30,13 +31,15 @@ from nemo_rl.data_plane.worker_mixin import _broadcast_batched_data_dict
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 
-def _in_gloo_group(body, rank: int, world_size: int, tmp_init_file: str, q):
-    """Run ``body(rank)`` in a gloo group, reporting the outcome via ``q``."""
+def _in_group(body, rank: int, world_size: int, tmp_init_file: str, q, backend):
+    """Run ``body(rank)`` in a process group, reporting the outcome via ``q``."""
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
+    if backend == "nccl":
+        torch.cuda.set_device(rank)
     dist.init_process_group(
-        backend="gloo",
+        backend=backend,
         init_method=f"file://{tmp_init_file}",
         rank=rank,
         world_size=world_size,
@@ -50,12 +53,12 @@ def _in_gloo_group(body, rank: int, world_size: int, tmp_init_file: str, q):
         dist.destroy_process_group()
 
 
-def _collect_two_rank_results(body, tmp_init_file: str):
+def _collect_two_rank_results(body, tmp_init_file: str, backend: str = "gloo"):
     """Spawn two ranks over ``body`` and collect both outcomes."""
     ctx = mp.get_context("spawn")
     q = ctx.Queue()
     procs = [
-        ctx.Process(target=_in_gloo_group, args=(body, rank, 2, tmp_init_file, q))
+        ctx.Process(target=_in_group, args=(body, rank, 2, tmp_init_file, q, backend))
         for rank in range(2)
     ]
     for p in procs:
@@ -73,9 +76,9 @@ def _collect_two_rank_results(body, tmp_init_file: str):
             p.join(timeout=5)
 
 
-def _run_two_ranks(body, tmp_init_file: str):
+def _run_two_ranks(body, tmp_init_file: str, backend: str = "gloo"):
     """Spawn two ranks over ``body`` and require both to report ok."""
-    results = _collect_two_rank_results(body, tmp_init_file)
+    results = _collect_two_rank_results(body, tmp_init_file, backend)
     assert results == [(0, "ok"), (1, "ok")], results
 
 
@@ -215,6 +218,44 @@ def _all_empty_body(rank: int):
     assert packed.preprocess_kwargs == {}
 
 
+def _nccl_cpu_packed_round_trip_body(rank: int):
+    first = torch.arange(6, dtype=torch.int16).reshape(2, 3)
+    second = torch.arange(3, dtype=torch.int16).reshape(1, 3) + 10
+    data = (
+        BatchedDataDict(
+            {
+                "pixel_values": PackedTensor(
+                    [first, None, second],
+                    dim_to_pack=0,
+                    _row_offsets=[0, 1, 2, 4],
+                    _segment_indices=[0, 1, 2, 0],
+                    _segment_provenance=[b"a", b"b", b"c"],
+                )
+            }
+        )
+        if rank == 0
+        else None
+    )
+
+    out = _broadcast_batched_data_dict(
+        data, is_leader=(rank == 0), src=0, group=dist.group.WORLD
+    )
+
+    packed = out["pixel_values"]
+    assert packed._row_offsets == [0, 1, 2, 4]
+    assert packed._segment_indices == [0, 1, 2, 0]
+    assert packed._segment_provenance == [b"a", b"b", b"c"]
+    assert packed.tensors[1] is None
+    assert packed.tensors[0] is not None
+    assert packed.tensors[2] is not None
+    assert packed.tensors[0].device.type == "cpu"
+    assert packed.tensors[2].device.type == "cpu"
+    assert packed.tensors[0].dtype == torch.int16
+    assert packed.tensors[2].dtype == torch.int16
+    assert torch.equal(packed.tensors[0], first)
+    assert torch.equal(packed.tensors[2], second)
+
+
 def _unsupported_type_body(rank: int):
     data = BatchedDataDict({"source_ids": ["a", "b"]}) if rank == 0 else None
     _broadcast_batched_data_dict(
@@ -238,6 +279,34 @@ def test_leader_broadcast_keeps_media_free_packed_key(tmp_path):
     set than the same shard on the independent-fetch path.
     """
     _run_two_ranks(_all_empty_body, str(tmp_path / "init_empty"))
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="two CUDA devices are required for NCCL broadcast",
+)
+def test_leader_broadcast_restores_cpu_packed_tensor_after_nccl(tmp_path):
+    _run_two_ranks(
+        _nccl_cpu_packed_round_trip_body,
+        str(tmp_path / "init_nccl"),
+        backend="nccl",
+    )
+
+
+def test_packed_tensor_broadcast_rejects_tensor_header_state():
+    packed = _packed(_pixel_rows())
+    packed.__dict__["cached_tensor"] = torch.ones(1)
+
+    with pytest.raises(TypeError, match="header must be tensor-free"):
+        packed.broadcast_parts()
+
+
+def test_packed_tensor_broadcast_rejects_oversized_payload():
+    packed = PackedTensor([torch.ones(2)], dim_to_pack=0)
+    header, shapes, _, _, _ = packed.broadcast_parts()
+
+    with pytest.raises(ValueError, match="shapes describe 2 elements"):
+        header.rebuild_from_broadcast_parts(shapes, torch.ones(3))
 
 
 def test_leader_broadcast_reports_descriptor_error_to_all_ranks(tmp_path):

--- a/tests/unit/data_plane/test_local_sft.py
+++ b/tests/unit/data_plane/test_local_sft.py
@@ -87,6 +87,39 @@ def test_local_round_trip_preserves_tensor_and_packed_tensor_fields() -> None:
     assert torch.equal(pixels.tensors[1], torch.full((2, 2), 2.0))
 
 
+def test_local_full_fetch_shares_tensor_storage() -> None:
+    client = _client()
+    _register(client)
+    input_ids = torch.tensor([[1, 2, 0], [3, 4, 5]])
+    pixel_rows = [torch.full((1, 2), 1.0), torch.full((2, 2), 2.0)]
+    pixels = PackedTensor(
+        pixel_rows,
+        dim_to_pack=0,
+        preprocess_mode="pad_to_max_shape",
+    ).enable_deduplication()
+    fields = local_batch_to_tensordict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": torch.tensor([2, 3]),
+            "pixel_values": pixels,
+            "source_ids": ["source-a", "source-b"],
+        },
+        batch_size=2,
+    )
+    meta = client.put_samples(
+        sample_ids=["a", "b"],
+        partition_id="step-0",
+        fields=fields,
+        tags=[{"source": "source-a"}, {"source": "source-b"}],
+    )
+    batch = materialize_local(client.get_data(meta))
+
+    assert batch["input_ids"].data_ptr() == input_ids.data_ptr()
+    fetched_pixels = batch["pixel_values"]
+    assert fetched_pixels.tensors[0] is pixel_rows[0]
+    assert fetched_pixels.tensors[1] is pixel_rows[1]
+
+
 def test_local_subset_preserves_requested_order_and_packed_rows() -> None:
     client = _client()
     _register(client)


### PR DESCRIPTION
# What does this PR do ?

Avoids unnecessary copies when fetching full or subset batches from the local data plane. It also preserves PackedTensor physical-segment sharing across replica broadcasts when that sharing reaches the worker intact, including the local data-plane path. The TQ storage codec remains unchanged.

Packed payloads are coalesced and moved to the collective device one field at a time, which bounds GPU staging memory for large multimodal batches.

Adds coverage that verifies full local fetches share tensor storage and replica broadcasts preserve PackedTensor row mappings, sharing metadata, preprocessing configuration, and physical tensors. A two-rank NCCL test covers CPU-to-GPU staging, CPU restoration, and int16 transport.

This PR is stacked on https://github.com/NVIDIA-NeMo/RL/pull/4082 via `rohit/packedtensor_padding`.

# Issues

None.

# Usage

No user-facing API changes.

# Before your PR is "Ready for review"

**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? The replica-broadcast scope is documented above.

# Additional Information

Validated on Slurm job `18295320` (`pool0-01445`, 8xH100):

```text
uv run --frozen --group test pytest --confcutdir=tests/unit/data_plane -q tests/unit/data_plane/test_leader_broadcast.py tests/unit/data_plane/test_local_sft.py
uv run --frozen --group test pytest --confcutdir=tests/unit/data -m "not mcore" -q tests/unit/data/test_multimodal_dict.py
```

Results: 17 data-plane tests passed, including the two-rank NCCL test; 59 PackedTensor tests passed. Ruff and Pyrefly passed for the changed implementation files.