### PR TITLE
fix: rank ray.sub topo_rank 1..N instead of stripping SLURM_TOPOLOGY_ADDR digits

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -207,10 +207,11 @@ Nodes sharing the same key belong to the same NVLink switch fabric (e.g. one GB2
 TOPO_RANK_KEY = "topo_rank"
 """Ray resource key for the SLURM topological rank.
 Dense ``1..N`` index of allocated nodes sorted by Slurm block name then hostname
-(see ``ray.sub`` / ``topo_rank_map.txt``). Falls back to ``SLURM_PROCID + 2`` on
-worker nodes (head node is pinned to ``1``), then to hostname digits when SLURM
-is unavailable. Values are always ``>= 1`` so that Ray does not drop the custom
-resource (Ray drops value-0 custom resources).
+(see ``ray.sub`` / ``topo_rank_map.txt``). ``N`` is fail-closed against Ray's
+``1e14`` custom-resource cap. Falls back to ``SLURM_PROCID + 2`` on worker nodes
+(head node is pinned to ``1``) if the map lookup misses. Values are always
+``>= 1`` so that Ray does not drop the custom resource (Ray drops value-0
+custom resources).
 Used to sort nodes within and across NVLink domains so rank assignment follows physical topology."""
 
 NVLINK_DOMAIN_UNKNOWN = "unknown"

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -190,7 +190,8 @@ DEFAULT_MASTER_PORT_RANGE_HIGH = 1999
 # into each worker node at cluster start-up. The probe pipeline is:
 #
 #   ray.sub  (topology_probe.sh)    -- parses nvidia-smi -q for ClusterUUID
-#                                   -- parses SLURM_TOPOLOGY_ADDR for topo_rank
+#                                   -- looks up a dense 1..N topo_rank from the
+#                                      allocation's sorted (block, hostname) map
 #                                   -- prefixes ClusterUUID with NVLINK_DOMAIN_PREFIX
 #                                   -- registers both as Ray custom resources
 #   virtual_cluster.py              -- reads these resources to sort ranks
@@ -205,10 +206,11 @@ Nodes sharing the same key belong to the same NVLink switch fabric (e.g. one GB2
 
 TOPO_RANK_KEY = "topo_rank"
 """Ray resource key for the SLURM topological rank.
-Derived from ``SLURM_TOPOLOGY_ADDR`` (when ``SLURM_TOPOLOGY_ADDR_PATTERN=block.node``),
-falling back to ``SLURM_PROCID + 2`` on worker nodes (head node is pinned to ``1``),
-then to hostname digits when SLURM is unavailable. Values are always ``>= 1`` so that
-Ray does not drop the custom resource (Ray drops value-0 custom resources).
+Dense ``1..N`` index of allocated nodes sorted by Slurm block name then hostname
+(see ``ray.sub`` / ``topo_rank_map.txt``). Falls back to ``SLURM_PROCID + 2`` on
+worker nodes (head node is pinned to ``1``), then to hostname digits when SLURM
+is unavailable. Values are always ``>= 1`` so that Ray does not drop the custom
+resource (Ray drops value-0 custom resources).
 Used to sort nodes within and across NVLink domains so rank assignment follows physical topology."""
 
 NVLINK_DOMAIN_UNKNOWN = "unknown"

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -190,7 +190,7 @@ DEFAULT_MASTER_PORT_RANGE_HIGH = 1999
 # into each worker node at cluster start-up. The probe pipeline is:
 #
 #   ray.sub  (topology_probe.sh)    -- parses nvidia-smi -q for ClusterUUID
-#                                   -- looks up a dense 1..N topo_rank from the
+#                                   -- looks up a 1..N topo_rank from the
 #                                      allocation's sorted (block, hostname) map
 #                                   -- prefixes ClusterUUID with NVLINK_DOMAIN_PREFIX
 #                                   -- registers both as Ray custom resources
@@ -206,7 +206,7 @@ Nodes sharing the same key belong to the same NVLink switch fabric (e.g. one GB2
 
 TOPO_RANK_KEY = "topo_rank"
 """Ray resource key for the SLURM topological rank.
-Dense ``1..N`` index of allocated nodes sorted by Slurm block name then hostname
+``1..N`` index of allocated nodes sorted by Slurm block name then hostname
 (see ``ray.sub`` / ``topo_rank_map.txt``). ``N`` is fail-closed against Ray's
 ``1e14`` custom-resource cap. Falls back to ``SLURM_PROCID + 2`` on worker nodes
 (head node is pinned to ``1``) if the map lookup misses. Values are always

--- a/ray.sub
+++ b/ray.sub
@@ -531,8 +531,15 @@ for _key in "${_topo_keys[@]}"; do
   printf '%s %s\n' "$_n" "$_rank" >> "$_topo_rank_map"
   _rank=$((_rank + 1))
 done
+# Ray rejects custom resource quantities above 1e14. Equality is allowed.
+# Do not wrap: a modulo would reintroduce collisions. Fail closed instead.
+_RAY_MAX_CUSTOM_RESOURCE=100000000000000
+if (( _rank - 1 > _RAY_MAX_CUSTOM_RESOURCE )); then
+  echo "[FATAL] topo_rank $((_rank - 1)) exceeds Ray's ${_RAY_MAX_CUSTOM_RESOURCE} custom-resource cap" >&2
+  exit 1
+fi
 echo "[INFO] Wrote dense topo_rank map (1..$((_rank - 1))) to $_topo_rank_map"
-unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _key _rank
+unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _key _rank _RAY_MAX_CUSTOM_RESOURCE
 
 # Write the topology probe script that runs inside each container.
 # Both head_cmd and worker_cmd source this to avoid duplication.
@@ -546,8 +553,9 @@ unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _k
 # TOPO_RANK: Topology-aware infrastructure rank.
 #   Fallback chain:
 #   1. Dense 1..N lookup from topo_rank_map.txt (sorted block name, then hostname)
-#   2. SLURM_PROCID + 2 on workers, head pinned to 1 (SLURM without the map)
-#   3. Hostname digits (non-SLURM fallback)
+#   2. SLURM_PROCID + 2 on workers, head pinned to 1 (map miss under SLURM)
+#   Hostname digit-stripping is intentionally omitted: it is unbounded and
+#   can exceed Ray's 1e14 cap. Missing topo_rank becomes TOPO_RANK_UNKNOWN.
 TOPO_PROBE_SCRIPT="$LOG_DIR/topology_probe.sh"
 cat > "$TOPO_PROBE_SCRIPT" <<TOPO_PROBE_EOF
 CLUSTER_UUID=\$(nvidia-smi -q 2>/dev/null | grep 'ClusterUUID' | head -1 | awk -F: '{print \$2}' | tr -d ' ')
@@ -567,11 +575,6 @@ if [[ -z "\$TOPO_RANK" && -n "\${SLURM_PROCID:-}" ]]; then
     TOPO_RANK=1
   else
     TOPO_RANK=\$(( 10#\$SLURM_PROCID + 2 ))
-  fi
-elif [[ -z "\$TOPO_RANK" ]]; then
-  _hostname_digits=\$(hostname | tr -dc '0-9')
-  if [[ -n "\$_hostname_digits" ]]; then
-    TOPO_RANK=\$(( 10#\$_hostname_digits ))
   fi
 fi
 

--- a/ray.sub
+++ b/ray.sub
@@ -496,7 +496,11 @@ ip_head=$head_node_ip:$PORT
 #
 # TOPO_RANK: Topology-aware infrastructure rank.
 #   Fallback chain:
-#   1. SLURM_TOPOLOGY_ADDR (block.node format) -> block_num * 10^10 + node_num
+#   1. SLURM_TOPOLOGY_ADDR (block.node format) ->
+#      (block_digits % 10^4) * 10^6 + (node_digits % 10^6)
+#      Bounded so the quantity stays under Ray's 1e14 custom-resource cap.
+#      The unbounded form block_digits * 10^10 + node_digits overflows when
+#      the block name strips to more than four digits (region/zone/site codes).
 #   2. SLURM_PROCID + 2 on workers, head pinned to 1 (SLURM without topology plugin)
 #   3. Hostname digits (non-SLURM fallback)
 #
@@ -521,7 +525,10 @@ if [[ -n "\${SLURM_TOPOLOGY_ADDR:-}" && "\${SLURM_TOPOLOGY_ADDR_PATTERN:-}" == "
   if [[ -n "\$_block_digits" && -n "\$_node_digits" ]]; then
     # Force base-10 interpretation; leading-zero digits like "08" would otherwise
     # be parsed as invalid octal by bash arithmetic, silently leaving TOPO_RANK empty.
-    TOPO_RANK=\$(( 10#\$_block_digits * 10000000000 + 10#\$_node_digits ))
+    # Bound both parts: Ray rejects custom resource quantities above 1e14, and
+    # provider naming can strip to far more digits than the original 10^10
+    # multiplier assumed. Worst case here is 9999*10^6 + 999999, about 1e10.
+    TOPO_RANK=\$(( (10#\$_block_digits % 10000) * 1000000 + (10#\$_node_digits % 1000000) ))
   fi
 elif [[ -n "\${SLURM_PROCID:-}" ]]; then
   # Head srun and worker srun each start their own SLURM_PROCID counter at 0.

--- a/ray.sub
+++ b/ray.sub
@@ -485,6 +485,55 @@ head_node_ip=${ip_addresses_array[0]}
 
 ip_head=$head_node_ip:$PORT
 
+# Dense topo_rank map for this allocation. Digit-stripping SLURM_TOPOLOGY_ADDR
+# into block_digits * 10^10 + node_digits overflows Ray's 1e14 custom-resource
+# cap as soon as a block name contributes more than four digits (region / zone
+# / site codes), and collides when distinct names share a numeric substring
+# ("rack-A1" vs "rack-B1"). Rank by sorted (block name, hostname) instead:
+# values are 1..N, unique, and independent of how many digits the names contain.
+#
+# Block names come from `scontrol show topology` BlockName= groups when present.
+# Nodes that are not in a reported block still get a unique hostname-order rank.
+# Head-node selection above stays on the hostname-sorted nodes_array; only the
+# rank map is reordered by topology.
+_topo_rank_map="$LOG_DIR/topo_rank_map.txt"
+declare -A _node_to_block=()
+_topo_txt=$(scontrol show topology 2>/dev/null || true)
+if [[ -n "$_topo_txt" ]]; then
+  while IFS= read -r _line; do
+    _block=""
+    _nodelist=""
+    if [[ "$_line" == *"BlockName="* ]]; then
+      _block="${_line#*BlockName=}"
+      _block="${_block%% *}"
+    fi
+    if [[ "$_line" == *"Nodes="* ]]; then
+      _nodelist="${_line#*Nodes=}"
+      _nodelist="${_nodelist%% *}"
+    fi
+    if [[ -n "$_block" && -n "$_nodelist" ]]; then
+      _expanded=$(scontrol show hostnames "$_nodelist" 2>/dev/null || true)
+      for _n in $_expanded; do
+        _node_to_block["$_n"]="$_block"
+      done
+    fi
+  done <<< "$_topo_txt"
+fi
+_topo_keys=()
+for _n in "${nodes_array[@]}"; do
+  _topo_keys+=("${_node_to_block[$_n]:-}|${_n}")
+done
+IFS=$'\n' _topo_keys=($(printf '%s\n' "${_topo_keys[@]}" | LC_ALL=C sort)); unset IFS
+: > "$_topo_rank_map"
+_rank=1
+for _key in "${_topo_keys[@]}"; do
+  _n="${_key#*|}"
+  printf '%s %s\n' "$_n" "$_rank" >> "$_topo_rank_map"
+  _rank=$((_rank + 1))
+done
+echo "[INFO] Wrote dense topo_rank map (1..$((_rank - 1))) to $_topo_rank_map"
+unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _key _rank
+
 # Write the topology probe script that runs inside each container.
 # Both head_cmd and worker_cmd source this to avoid duplication.
 # The script sets two variables: CLUSTER_UUID and TOPO_RANK.
@@ -496,19 +545,9 @@ ip_head=$head_node_ip:$PORT
 #
 # TOPO_RANK: Topology-aware infrastructure rank.
 #   Fallback chain:
-#   1. SLURM_TOPOLOGY_ADDR (block.node format) ->
-#      (block_digits % 10^4) * 10^6 + (node_digits % 10^6)
-#      Bounded so the quantity stays under Ray's 1e14 custom-resource cap.
-#      The unbounded form block_digits * 10^10 + node_digits overflows when
-#      the block name strips to more than four digits (region/zone/site codes).
-#   2. SLURM_PROCID + 2 on workers, head pinned to 1 (SLURM without topology plugin)
+#   1. Dense 1..N lookup from topo_rank_map.txt (sorted block name, then hostname)
+#   2. SLURM_PROCID + 2 on workers, head pinned to 1 (SLURM without the map)
 #   3. Hostname digits (non-SLURM fallback)
-#
-# TODO(ansubramania): Harden the SLURM_TOPOLOGY_ADDR digit-extraction logic for open source.
-#   The current approach (tr -dc '0-9') assumes block/node names contain
-#   unique numeric substrings, which holds on internal clusters but
-#   may produce collisions on other providers with different naming conventions
-#   (e.g., "rack-A1" vs "rack-B1" both yield "1").
 TOPO_PROBE_SCRIPT="$LOG_DIR/topology_probe.sh"
 cat > "$TOPO_PROBE_SCRIPT" <<TOPO_PROBE_EOF
 CLUSTER_UUID=\$(nvidia-smi -q 2>/dev/null | grep 'ClusterUUID' | head -1 | awk -F: '{print \$2}' | tr -d ' ')
@@ -517,20 +556,10 @@ if [[ -z "\$CLUSTER_UUID" ]]; then
 fi
 
 TOPO_RANK=""
-if [[ -n "\${SLURM_TOPOLOGY_ADDR:-}" && "\${SLURM_TOPOLOGY_ADDR_PATTERN:-}" == "block.node" ]]; then
-  _block_part="\${SLURM_TOPOLOGY_ADDR%%.*}"
-  _node_part="\${SLURM_TOPOLOGY_ADDR##*.}"
-  _block_digits=\$(echo "\$_block_part" | tr -dc '0-9')
-  _node_digits=\$(echo "\$_node_part" | tr -dc '0-9')
-  if [[ -n "\$_block_digits" && -n "\$_node_digits" ]]; then
-    # Force base-10 interpretation; leading-zero digits like "08" would otherwise
-    # be parsed as invalid octal by bash arithmetic, silently leaving TOPO_RANK empty.
-    # Bound both parts: Ray rejects custom resource quantities above 1e14, and
-    # provider naming can strip to far more digits than the original 10^10
-    # multiplier assumed. Worst case here is 9999*10^6 + 999999, about 1e10.
-    TOPO_RANK=\$(( (10#\$_block_digits % 10000) * 1000000 + (10#\$_node_digits % 1000000) ))
-  fi
-elif [[ -n "\${SLURM_PROCID:-}" ]]; then
+if [[ -f "$LOG_DIR/topo_rank_map.txt" && -n "\${SLURMD_NODENAME:-}" ]]; then
+  TOPO_RANK=\$(awk -v n="\$SLURMD_NODENAME" '\$1==n {print \$2; exit}' "$LOG_DIR/topo_rank_map.txt")
+fi
+if [[ -z "\$TOPO_RANK" && -n "\${SLURM_PROCID:-}" ]]; then
   # Head srun and worker srun each start their own SLURM_PROCID counter at 0.
   # Head hardcoded to 1; workers get +2 so worker[0]=2, worker[62]=64 -- keeps
   # all nodes at unique values >=1 (Ray drops value-0 custom resources).
@@ -539,7 +568,7 @@ elif [[ -n "\${SLURM_PROCID:-}" ]]; then
   else
     TOPO_RANK=\$(( 10#\$SLURM_PROCID + 2 ))
   fi
-else
+elif [[ -z "\$TOPO_RANK" ]]; then
   _hostname_digits=\$(hostname | tr -dc '0-9')
   if [[ -n "\$_hostname_digits" ]]; then
     TOPO_RANK=\$(( 10#\$_hostname_digits ))
@@ -725,7 +754,7 @@ fi
 
 # Clear MPI/PMIx/SLURM env vars inherited from the srun launcher so TRT-LLM's
 # MPI_Init (in the ray daemon child process below) starts clean.
-# NOTE: keep this after topology_probe.sh, which reads SLURM_TOPOLOGY_ADDR/SLURM_PROCID.
+# NOTE: keep this after topology_probe.sh, which reads SLURMD_NODENAME/SLURM_PROCID.
 for v in \$(env | awk -F= '/^(PMI|PMIX|MPI|OMPI|SLURM)_/{print \$1}'); do
     unset "\$v"
 done
@@ -927,7 +956,7 @@ source $LOG_DIR/topology_probe.sh
 
 # Clear MPI/PMIx/SLURM env vars inherited from the srun launcher so TRT-LLM's
 # MPI_Init (in the ray daemon child process below) starts clean.
-# NOTE: keep this after topology_probe.sh, which reads SLURM_TOPOLOGY_ADDR/SLURM_PROCID.
+# NOTE: keep this after topology_probe.sh, which reads SLURMD_NODENAME/SLURM_PROCID.
 for v in \$(env | awk -F= '/^(PMI|PMIX|MPI|OMPI|SLURM)_/{print \$1}'); do
     unset "\$v"
 done

--- a/ray.sub
+++ b/ray.sub
@@ -485,7 +485,7 @@ head_node_ip=${ip_addresses_array[0]}
 
 ip_head=$head_node_ip:$PORT
 
-# Dense topo_rank map for this allocation. Digit-stripping SLURM_TOPOLOGY_ADDR
+# 1..N topo_rank map for this allocation. Digit-stripping SLURM_TOPOLOGY_ADDR
 # into block_digits * 10^10 + node_digits overflows Ray's 1e14 custom-resource
 # cap as soon as a block name contributes more than four digits (region / zone
 # / site codes), and collides when distinct names share a numeric substring
@@ -538,7 +538,7 @@ if (( _rank - 1 > _RAY_MAX_CUSTOM_RESOURCE )); then
   echo "[FATAL] topo_rank $((_rank - 1)) exceeds Ray's ${_RAY_MAX_CUSTOM_RESOURCE} custom-resource cap" >&2
   exit 1
 fi
-echo "[INFO] Wrote dense topo_rank map (1..$((_rank - 1))) to $_topo_rank_map"
+echo "[INFO] Wrote topo_rank map (1..$((_rank - 1))) to $_topo_rank_map"
 unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _key _rank _RAY_MAX_CUSTOM_RESOURCE
 
 # Write the topology probe script that runs inside each container.
@@ -552,7 +552,7 @@ unset _node_to_block _topo_txt _line _block _nodelist _expanded _n _topo_keys _k
 #
 # TOPO_RANK: Topology-aware infrastructure rank.
 #   Fallback chain:
-#   1. Dense 1..N lookup from topo_rank_map.txt (sorted block name, then hostname)
+#   1. 1..N lookup from topo_rank_map.txt (sorted block name, then hostname)
 #   2. SLURM_PROCID + 2 on workers, head pinned to 1 (map miss under SLURM)
 #   Hostname digit-stripping is intentionally omitted: it is unbounded and
 #   can exceed Ray's 1e14 cap. Missing topo_rank becomes TOPO_RANK_UNKNOWN.

--- a/tests/unit/distributed/test_topology_placement.py
+++ b/tests/unit/distributed/test_topology_placement.py
@@ -129,9 +129,10 @@ class TestTopoRankValues:
         assert topo_rank == 7
 
     def test_block_node_combined_value(self):
-        # block.node format: $(( 10#2 * 10000000000 + 10#15 )) = 20000000015
-        topo_rank = int(20000000015.0)
-        assert topo_rank == 20000000015
+        # Dense allocation rank: sorted (block, hostname) -> 1..N.
+        # 1500-node job is still a small integer; must round-trip through Ray floats.
+        topo_rank = int(1500.0)
+        assert topo_rank == 1500
 
     def test_sorting_with_slurm_procid_ranks(self):
         # Nodes labelled by SLURM_PROCID (1..8) across two domains
@@ -160,10 +161,10 @@ class TestTopoRankValues:
         assert max(b_indices) < min(a_indices)
 
     def test_sorting_with_block_node_ranks(self):
-        # block.node: block 0 nodes 0..3, block 1 nodes 0..3
-        # block 0 has lower combined rank → should sort first
-        block0_ranks = [0 * 10000000000 + i for i in range(4)]
-        block1_ranks = [1 * 10000000000 + i for i in range(4)]
+        # Dense ranks: block 0 nodes 1..4, block 1 nodes 5..8
+        # block 0 has lower rank → should sort first
+        block0_ranks = list(range(1, 5))
+        block1_ranks = list(range(5, 9))
         bundle_data = _make_bundle_data(
             {
                 "nvlink_domain_A": block1_ranks,

--- a/tests/unit/distributed/test_topology_placement.py
+++ b/tests/unit/distributed/test_topology_placement.py
@@ -129,7 +129,7 @@ class TestTopoRankValues:
         assert topo_rank == 7
 
     def test_block_node_combined_value(self):
-        # Dense allocation rank: sorted (block, hostname) -> 1..N.
+        # Allocation index: sorted (block, hostname) -> 1..N.
         # 1500-node job is still a small integer; must round-trip through Ray floats.
         topo_rank = int(1500.0)
         assert topo_rank == 1500
@@ -161,7 +161,7 @@ class TestTopoRankValues:
         assert max(b_indices) < min(a_indices)
 
     def test_sorting_with_block_node_ranks(self):
-        # Dense ranks: block 0 nodes 1..4, block 1 nodes 5..8
+        # 1..N ranks: block 0 nodes 1..4, block 1 nodes 5..8
         # block 0 has lower rank → should sort first
         block0_ranks = list(range(1, 5))
         block1_ranks = list(range(5, 9))


### PR DESCRIPTION
ray.sub builds topo_rank as `block_digits * 1e10 + node_digits`. Ray rejects custom resources above 1e14, so any block name with more than four digits (region/zone/site codes) kills the head before any actor starts. The ValueError is only in ray-head.log; stdout looks like GCS never came up.

Don't strip digits. Sort the allocation by Slurm block name, then hostname, and assign 1..N. Fail if N > 1e14; wrapping would collide. Dropped the hostname-digit fallback for the same reason.
