### PR TITLE
fix(data-plane): move mooncake's ports out of the ephemeral range

### DIFF
--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -35,6 +35,7 @@ import threading
 import time
 import warnings
 import weakref
+from collections.abc import Callable
 from importlib import resources
 from pathlib import Path
 from queue import Empty, SimpleQueue
@@ -55,6 +56,7 @@ from nemo_rl.data_plane.interfaces import (
     backend_config,
     data_plane_supports_checkpointing,
 )
+from nemo_rl.distributed.virtual_cluster import _reserve_data_plane_ports
 
 LOGGER = logging.getLogger(__name__)
 
@@ -597,6 +599,127 @@ def _patch_mooncake_staging_buffers(max_bytes: int) -> None:
     cls._nrl_staging_patched = True
 
 
+class _MooncakeMasterArgv:
+    """Stand-in for the mooncake bootstrap module's ``subprocess`` reference.
+
+    Overrides ``Popen``, and only for ``mooncake_master``'s argv; everything
+    else the bootstrap reaches for (``STDOUT``, the offload client's launch)
+    delegates to the real module untouched.
+    """
+
+    def __init__(self, wrapped: Any, metrics_port: int) -> None:
+        self._wrapped = wrapped
+        self.metrics_port = metrics_port
+        self.master_launched = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    def Popen(self, args: Any, *rest: Any, **kwargs: Any) -> Any:
+        """Append ``--metrics_port`` when this is the master being launched."""
+        if (
+            isinstance(args, (list, tuple))
+            and args
+            and os.path.basename(str(args[0])) == "mooncake_master"
+        ):
+            args = [*args, f"--metrics_port={self.metrics_port}"]
+            self.master_launched = True
+        return self._wrapped.Popen(args, *rest, **kwargs)
+
+
+_METRICS_PORT_DRIFT_CONSEQUENCE = (
+    "the --metrics_port TQ omits cannot be applied, leaving mooncake_master's "
+    "metrics server on its 9003 default inside this node's ephemeral range"
+)
+
+
+def _patch_mooncake_master_metrics_port(port: int) -> None:
+    """Move mooncake_master's metrics server onto a reserved *port*.
+
+    ``MasterAdminServer::Start`` binds the metrics socket before it consults
+    ``enable_metric_reporting``, and the master exits non-zero if that bind
+    fails, so the ``metrics_port`` gflag default (9003) is a port the job
+    depends on whether or not anything scrapes it — and it sits inside the
+    ephemeral range these nodes hand out as source ports. TQ forwards no
+    ``--metrics_port``, nor a ``--config_path`` file that could carry one, so
+    without this the metrics server is the one data-plane port that cannot
+    move into ray.sub's band and the master can still lose a startup race it
+    has no reason to be in.
+
+    TQ does build the master's argv in this process, though: ``tq.init`` ->
+    ``_maybe_create_tq_storage`` -> ``initialize_mooncake_storage`` all run on
+    the driver, so appending the flag to the ``subprocess.Popen`` the bootstrap
+    calls is enough. gflags takes the last occurrence of a repeated flag, so
+    this stays correct if a future TQ revision starts passing its own.
+
+    The provider registry holds a ``functools.wraps`` wrapper closed over the
+    original bootstrap function, so rebinding the module attribute alone would
+    never be called — the same trap ``extract_field_schema`` has. Re-registering
+    is also where the drift check lives: if the bootstrap ever launches the
+    master by some other route the flag stops landing silently, putting the
+    metrics server back on 9003, so the bootstrap is required to have gone
+    through the wrapped ``Popen``.
+    """
+    # Imported here, not at module top, so a TQ that has moved these
+    # submodules reports the drift below instead of failing this file's import.
+    try:
+        from transfer_queue.storage.bootstrap import mooncake_bootstrap as _bs
+        from transfer_queue.storage.bootstrap.provider import StorageBootstrapProvider
+    except ImportError as e:
+        raise _tq_shape_drift_error(
+            "storage.bootstrap is no longer importable",
+            _METRICS_PORT_DRIFT_CONSEQUENCE,
+            "import",
+        ) from e
+
+    installed = getattr(_bs, "subprocess", None)
+    if isinstance(installed, _MooncakeMasterArgv):
+        # The installed proxy is its own idempotence marker, rather than a
+        # separate _nrl_*_patched flag like the sibling patches use: it is the
+        # object that lets a re-init in the same process keep one wrapper and
+        # repoint it to the port this call reserved.
+        installed.metrics_port = port
+        return
+    if installed is None:
+        raise _tq_shape_drift_error(
+            "the mooncake bootstrap no longer launches the master via subprocess",
+            _METRICS_PORT_DRIFT_CONSEQUENCE,
+            "launch site",
+        )
+
+    bootstrap = StorageBootstrapProvider.get_provider("MooncakeStore")
+    if bootstrap is None:
+        raise _tq_shape_drift_error(
+            "MooncakeStore is no longer a registered bootstrap provider",
+            _METRICS_PORT_DRIFT_CONSEQUENCE,
+            "registry key",
+        )
+    # Rebound under a typed name because the None check above does not narrow
+    # ``get_provider``'s ``Callable | None`` inside the closure that calls it.
+    registered_bootstrap: Callable[..., Any] = bootstrap
+
+    argv = _MooncakeMasterArgv(installed, port)
+
+    def _bootstrap_with_metrics_port(conf: Any) -> Any:
+        argv.master_launched = False
+        result = registered_bootstrap(conf)
+        if not argv.master_launched:
+            raise _tq_shape_drift_error(
+                "the mooncake bootstrap ran without launching mooncake_master "
+                "through its subprocess.Popen",
+                _METRICS_PORT_DRIFT_CONSEQUENCE,
+                "launch site",
+            )
+        return result
+
+    # pyrefly: ignore[bad-assignment]  the proxy stands in for the module on purpose
+    _bs.subprocess = argv
+    # Upstream's own decorator, so the entry is stored exactly as TQ stores it.
+    StorageBootstrapProvider.register_provider("MooncakeStore")(
+        _bootstrap_with_metrics_port
+    )
+
+
 def _connect_existing() -> None:
     """Worker-process path: connect this process's client to the Ray cluster.
 
@@ -671,6 +794,12 @@ def _init_tq(cfg: DataPlaneConfig) -> None:
                 "Mooncake backend requires a local node IP; "
                 "_get_local_node_ip() returned empty."
             )
+        # All three of the master's listening ports come from one band below
+        # the ephemeral floor. The metrics port reaches the master through a
+        # patched argv rather than the config below, because TQ forwards no
+        # --metrics_port — see _patch_mooncake_master_metrics_port.
+        metadata_port, master_port, metrics_port = _reserve_data_plane_ports(3)
+        _patch_mooncake_master_metrics_port(metrics_port)
         # Sizes are per client process and RDMA-pinned — see MooncakeCpuConfig
         # in nemo_rl/data_plane/interfaces.py for the per-node arithmetic.
         mooncake_cfg = backend_config(cfg)
@@ -684,8 +813,8 @@ def _init_tq(cfg: DataPlaneConfig) -> None:
                     # _init_tq runs on the driver only — driver IS the
                     # head, so local_ip here is also the head's IP that
                     # mooncake_master + the metadata server bind to.
-                    "metadata_server": f"{local_ip}:50050",
-                    "master_server_address": f"{local_ip}:50051",
+                    "metadata_server": f"{local_ip}:{metadata_port}",
+                    "master_server_address": f"{local_ip}:{master_port}",
                     **_mooncake_transport_config(),
                     "use_gdr": bool(mooncake_cfg.use_gdr),
                     "gdr_staging_buffer_mb": int(mooncake_cfg.gdr_staging_buffer_mb),

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -139,6 +139,9 @@ def uv_py_executable(extras: Sequence[str]) -> str:
 #
 # Python port-range bounds below are half-open: [low, high).
 #
+#   1150-1199    Data plane (TQ/mooncake)        (DEFAULT_DATA_PLANE_PORT_RANGE_*, driver-local
+#                                                 allocation: metadata server, master RPC,
+#                                                 master metrics)
 #   [1202, 1300) SingleController gen. router    (driver-local allocation)
 #   1313-1399    Dynamo etcd/NATS control plane  (driver-local allocation)
 #   1400-1999    Master address / TCPStore       (cluster.master_port_range_low/high)
@@ -182,6 +185,16 @@ DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH = 8999
 # Master address / TCPStore range, tucked below the Ray worker-gRPC band (2000+).
 DEFAULT_MASTER_PORT_RANGE_LOW = 1400
 DEFAULT_MASTER_PORT_RANGE_HIGH = 1999
+# One band for every port the data plane binds on the driver: mooncake's
+# metadata server, the master's RPC endpoint, and the master's metrics server.
+# The defaults those three land on -- 50050 and 50051 from TransferQueue's
+# config.yaml, 9003 from mooncake_master's own gflag -- all sit inside the
+# 9000-65000 ephemeral range these nodes use, so the kernel can hand one out as
+# a source port for outgoing traffic before the master binds it. This band is
+# the gap left below the Ray GCS ports (1200+) — see ray.sub's port map. Fifty
+# ports is ample: one master serves the whole job.
+DEFAULT_DATA_PLANE_PORT_RANGE_LOW = 1150
+DEFAULT_DATA_PLANE_PORT_RANGE_HIGH = 1200
 
 # ---------------------------------------------------------------------------
 # Topology resource keys
@@ -355,6 +368,42 @@ def _get_free_consecutive_ports_local(
         f"Could not find {consecutive} consecutive free ports in "
         f"[{port_range_low}, {port_range_high})."
     )
+
+
+def _reserve_data_plane_ports(count: int) -> list[int]:
+    """Reserve *count* distinct ports for the data plane's driver-side servers.
+
+    The defaults those servers land on -- 50050 and 50051 from TransferQueue's
+    ``config.yaml``, 9003 from mooncake_master's ``metrics_port`` gflag -- sit
+    inside the 9000-65000 ephemeral range these nodes use. The kernel can
+    therefore hand any of them to an outgoing connection during the minutes
+    between job start and the master's bind, after which the master dies with
+    EADDRINUSE. That is why ray.sub's port map keeps every service below 9000,
+    and this allocates from the band that map leaves free.
+
+    Every one of these ports is passed to the servers explicitly and reaches
+    clients through the TQ controller actor rather than being assumed, so
+    relocating them costs nothing.
+
+    ``excluded_ports`` keeps the returned ports distinct, and
+    ``_get_free_port_local`` binds without ``SO_REUSEADDR``, matching
+    mooncake_master: a port obtainable only by reusing a lingering slot is not
+    one the master could bind either.
+
+    Returns:
+        *count* ports from the data-plane band, in allocation order.
+    """
+    reserved: list[int] = []
+    for _ in range(count):
+        reserved.append(
+            _get_free_port_local(
+                DEFAULT_DATA_PLANE_PORT_RANGE_LOW,
+                DEFAULT_DATA_PLANE_PORT_RANGE_HIGH,
+                max_retries=None,
+                excluded_ports=set(reserved),
+            )
+        )
+    return reserved
 
 
 def init_ray(log_dir: Optional[str] = None) -> None:

--- a/ray.sub
+++ b/ray.sub
@@ -162,6 +162,7 @@ fi
 #
 # Port layout (all below ephemeral floor at 9000). Python port-range bounds
 # are half-open: [low, high).
+#   1150-1199    Data plane: mooncake metadata server, master RPC, master metrics (driver-local allocation)
 #   1200-1201    Ray GCS + client server (head only)
 #   [1202, 1300) SingleController generation router (driver-local allocation)
 #   1301-1312    Ray management (node-mgr, obj-mgr, etc.; odd=worker, even=head)

--- a/tests/unit/data_plane/README.md
+++ b/tests/unit/data_plane/README.md
@@ -114,6 +114,18 @@ Generated audit of every test function under `tests/unit/data_plane/` with a one
 - `test_gdr_tensor_put_is_confirmed_once_and_never_falls_back` — A CUDA client's tensor PUT raises rather than downgrading to CPU RDMA, and logs the GDR confirmation exactly once.
 - `test_gdr_receiver_requires_cuda_initialized` — A policy receiver must initialize CUDA before attaching its GDR client.
 
+## `test_mooncake_metrics_port.py` (9 tests)
+
+- `test_master_argv_gains_the_reserved_metrics_port` — The proxy appends `--metrics_port=<reserved>` to `mooncake_master`'s argv.
+- `test_flag_is_appended_so_gflags_takes_it_last` — The flag lands last, which is the occurrence gflags keeps.
+- `test_binary_is_matched_by_basename` — An absolute path to the master still matches.
+- `test_other_launches_pass_through_untouched` — The offload client's launch is left alone and does not mark the master as launched.
+- `test_unknown_attributes_delegate_to_the_real_module` — Everything but `Popen` delegates to the real `subprocess`.
+- `test_patch_covers_the_registry_entry_that_is_actually_called` — Re-registration reaches the bootstrap TQ resolves, not just the module attribute.
+- `test_reinstalling_repoints_the_port_without_stacking` — A second install keeps one wrapper and repoints it.
+- `test_bootstrap_that_skips_the_wrapped_popen_is_a_drift_error` — A bootstrap that launches the master by another route fails loudly instead of silently keeping 9003.
+- `test_init_tq_reserves_every_master_port_from_the_band` — Metadata, master RPC and metrics ports all come from the data-plane band, and no `metrics_port` config key is sent.
+
 ## `test_message_log_decompose.py` (11 tests)
 
 - `test_decompose_message_log_basic_shapes` — Basic shapes of decompose output.

--- a/tests/unit/data_plane/test_mooncake_metrics_port.py
+++ b/tests/unit/data_plane/test_mooncake_metrics_port.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""mooncake_master's metrics server must land on a reserved port.
+
+The master binds its metrics socket before it consults
+``enable_metric_reporting`` and exits non-zero if that bind fails, so the
+``metrics_port`` gflag default (9003) is a port the job depends on whether or
+not anything scrapes it — and it is inside the ephemeral range these nodes hand
+out as source ports. TransferQueue passes neither ``--metrics_port`` nor a
+``--config_path`` file that could carry one, so the only way the port moves is
+the argv patch exercised here.
+
+Two things can quietly undo that: TQ launching the master by some other route
+(the flag stops landing), and the reservation being dropped so the port is no
+longer allocated from the band ray.sub documents. Both are asserted.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterator
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nemo_rl.data_plane.adapters import transfer_queue as tq_adapter
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_DATA_PLANE_PORT_RANGE_HIGH,
+    DEFAULT_DATA_PLANE_PORT_RANGE_LOW,
+)
+
+mooncake_bootstrap = pytest.importorskip(
+    "transfer_queue.storage.bootstrap.mooncake_bootstrap",
+    reason="transfer_queue not installed",
+)
+bootstrap_provider = pytest.importorskip(
+    "transfer_queue.storage.bootstrap.provider",
+    reason="transfer_queue not installed",
+)
+StorageBootstrapProvider = bootstrap_provider.StorageBootstrapProvider
+
+
+@pytest.fixture
+def unpatched_tq_bootstrap() -> Iterator[None]:
+    """Run the test against a pristine TQ bootstrap, then restore what was found.
+
+    "Not yet patched" cannot be assumed: the patch is process-wide, and
+    anything that reaches ``_init_tq`` first installs it -- the session-scoped
+    mooncake client in ``conftest.py``, or simply ``test_mooncake_gdr.py``,
+    which pytest collects before this file. An already-installed patch sends
+    ``_patch_mooncake_master_metrics_port`` down its idempotent early return,
+    which repoints the port without re-registering the provider, so the
+    installation assertions below would read the previous test's state.
+    """
+    original_subprocess = mooncake_bootstrap.subprocess
+    # The port a session-scoped client reserved has to survive these tests.
+    original_port = getattr(original_subprocess, "metrics_port", None)
+    original_provider = StorageBootstrapProvider.get_provider("MooncakeStore")
+    if isinstance(original_subprocess, tq_adapter._MooncakeMasterArgv):
+        # ``_wrapped`` is the real subprocess module, and the module-level
+        # ``initialize_mooncake_storage`` is the object register_provider put
+        # in the registry, so this pair is the state TQ boots with.
+        mooncake_bootstrap.subprocess = original_subprocess._wrapped
+        StorageBootstrapProvider._providers["mooncakestore"] = (
+            mooncake_bootstrap.initialize_mooncake_storage
+        )
+    yield
+    mooncake_bootstrap.subprocess = original_subprocess
+    if original_port is not None:
+        original_subprocess.metrics_port = original_port
+    # Assigned rather than re-registered: register_provider would wrap the
+    # entry a second time and leave the registry holding a different object
+    # than the one the next test starts from.
+    StorageBootstrapProvider._providers["mooncakestore"] = original_provider
+
+
+def _recording_subprocess() -> tuple[Any, list]:
+    launched: list = []
+    return SimpleNamespace(Popen=lambda args, **kwargs: launched.append(args)), launched
+
+
+def test_master_argv_gains_the_reserved_metrics_port() -> None:
+    """The flag TQ omits, appended to the argv TQ builds."""
+    stub, launched = _recording_subprocess()
+    argv = tq_adapter._MooncakeMasterArgv(stub, 1157)
+
+    argv.Popen(["mooncake_master", "--rpc_port=1151"], stdout=None)
+
+    assert launched == [["mooncake_master", "--rpc_port=1151", "--metrics_port=1157"]]
+    assert argv.master_launched
+
+
+def test_flag_is_appended_so_gflags_takes_it_last() -> None:
+    """gflags honours the last occurrence, so appending survives TQ starting
+    to pass a metrics port of its own."""
+    stub, launched = _recording_subprocess()
+    argv = tq_adapter._MooncakeMasterArgv(stub, 1157)
+
+    argv.Popen(["mooncake_master", "--metrics_port=9003"])
+
+    assert launched[0][-1] == "--metrics_port=1157"
+
+
+def test_binary_is_matched_by_basename() -> None:
+    """_init_tq puts the wheel's mooncake dir on PATH, but a future TQ could
+    resolve the binary to an absolute path instead."""
+    stub, launched = _recording_subprocess()
+    argv = tq_adapter._MooncakeMasterArgv(stub, 1157)
+
+    argv.Popen(["/opt/venv/lib/mooncake/mooncake_master", "--rpc_port=1151"])
+
+    assert launched[0][-1] == "--metrics_port=1157"
+
+
+def test_other_launches_pass_through_untouched() -> None:
+    """The offload client takes no metrics_port flag, and seeing it must not
+    count as the master having launched."""
+    stub, launched = _recording_subprocess()
+    argv = tq_adapter._MooncakeMasterArgv(stub, 1157)
+
+    argv.Popen(["mooncake_client", "-port=42052"])
+
+    assert launched == [["mooncake_client", "-port=42052"]]
+    assert not argv.master_launched
+
+
+def test_unknown_attributes_delegate_to_the_real_module() -> None:
+    """The bootstrap reaches for subprocess.STDOUT on the same reference."""
+    argv = tq_adapter._MooncakeMasterArgv(subprocess, 1157)
+
+    assert argv.STDOUT is subprocess.STDOUT
+    assert argv.Popen is not subprocess.Popen
+
+
+def test_patch_covers_the_registry_entry_that_is_actually_called(
+    unpatched_tq_bootstrap,
+) -> None:
+    """The registry holds a ``functools.wraps`` wrapper closed over the
+    original bootstrap, so rebinding the module attribute alone would leave the
+    called function unpatched — the same trap ``extract_field_schema`` has."""
+    before = StorageBootstrapProvider.get_provider("MooncakeStore")
+
+    tq_adapter._patch_mooncake_master_metrics_port(1157)
+
+    assert StorageBootstrapProvider.get_provider("MooncakeStore") is not before
+    assert isinstance(mooncake_bootstrap.subprocess, tq_adapter._MooncakeMasterArgv)
+
+
+def test_reinstalling_repoints_the_port_without_stacking(
+    unpatched_tq_bootstrap,
+) -> None:
+    """A second init in the same process must get the port it just reserved."""
+    tq_adapter._patch_mooncake_master_metrics_port(1157)
+    first = mooncake_bootstrap.subprocess
+
+    tq_adapter._patch_mooncake_master_metrics_port(1158)
+
+    assert mooncake_bootstrap.subprocess is first
+    assert first.metrics_port == 1158
+
+
+def test_bootstrap_that_skips_the_wrapped_popen_is_a_drift_error(
+    unpatched_tq_bootstrap,
+) -> None:
+    """If the flag stops landing, the metrics server is silently back on 9003
+    inside the ephemeral range — the failure this whole patch exists to avoid.
+    """
+    StorageBootstrapProvider.register_provider("MooncakeStore")(lambda conf: None)
+    tq_adapter._patch_mooncake_master_metrics_port(1157)
+    bootstrap = StorageBootstrapProvider.get_provider("MooncakeStore")
+
+    with pytest.raises(RuntimeError, match="without launching mooncake_master"):
+        bootstrap(None)
+
+
+def test_init_tq_reserves_every_master_port_from_the_band(
+    tmp_path, monkeypatch, unpatched_tq_bootstrap
+) -> None:
+    """End state: three distinct in-band ports, one of them carried by argv.
+
+    The metrics port is the one that does not travel in the config TQ reads, so
+    a test that only inspected the conf would pass with the flag never applied.
+    """
+    mooncake_dir = tmp_path / "mooncake"
+    mooncake_dir.mkdir()
+    mooncake_init = mooncake_dir / "__init__.py"
+    mooncake_init.touch()
+    (mooncake_dir / "mooncake_master").touch()
+
+    mooncake_module = ModuleType("mooncake")
+    mooncake_module.__file__ = str(mooncake_init)
+    mooncake_module.__path__ = [str(mooncake_dir)]  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mooncake", mooncake_module)
+    monkeypatch.setitem(sys.modules, "mooncake.store", ModuleType("mooncake.store"))
+
+    monkeypatch.setattr(tq_adapter.os, "environ", dict(tq_adapter.os.environ))
+    monkeypatch.setattr(tq_adapter, "_get_local_node_ip", lambda: "10.0.0.1")
+    monkeypatch.setattr(tq_adapter, "rdma_devices", lambda: "mlx5_0")
+    captured: dict = {}
+    monkeypatch.setattr(
+        tq_adapter.tq, "init", lambda *, conf: captured.update(conf=conf)
+    )
+
+    tq_adapter._init_tq(
+        {
+            "enabled": True,
+            "impl": "transfer_queue",
+            "backend": "mooncake_cpu",
+            "claim_meta_poll_interval_s": 0.5,
+            "mooncake_cpu": {},
+        }
+    )
+
+    store_cfg = captured["conf"]["backend"]["MooncakeStore"]
+    # An inert key: TQ's bootstrap never reads one, which is why the flag goes
+    # through the argv instead.
+    assert "metrics_port" not in store_cfg
+    ports = [
+        int(store_cfg["metadata_server"].rsplit(":", 1)[1]),
+        int(store_cfg["master_server_address"].rsplit(":", 1)[1]),
+        mooncake_bootstrap.subprocess.metrics_port,
+    ]
+    assert len(set(ports)) == 3, f"the master's servers must differ, got {ports}"
+    for port in ports:
+        assert (
+            DEFAULT_DATA_PLANE_PORT_RANGE_LOW
+            <= port
+            < DEFAULT_DATA_PLANE_PORT_RANGE_HIGH
+        ), f"port {port} escaped the band ray.sub's map documents"

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -25,7 +25,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 import ray
 
+from nemo_rl.distributed import virtual_cluster
 from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_DATA_PLANE_PORT_RANGE_HIGH,
+    DEFAULT_DATA_PLANE_PORT_RANGE_LOW,
     DEFAULT_DYNAMO_CONTROL_PORT_RANGE_LOW,
     DEFAULT_GENERATION_PORT_RANGE_HIGH,
     DEFAULT_GENERATION_PORT_RANGE_LOW,
@@ -48,6 +51,7 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_free_consecutive_ports_local,
     _get_free_port_local,
     _get_node_ip_and_free_port,
+    _reserve_data_plane_ports,
 )
 from nemo_rl.utils.venvs import create_local_venv
 from tests.unit.conftest import TEST_ASSETS_DIR
@@ -576,6 +580,81 @@ class TestGetFreeConsecutivePortsLocal:
             _get_free_consecutive_ports_local(14950, 15000, consecutive=0)
 
 
+class TestReserveDataPlanePorts:
+    """Tests for _reserve_data_plane_ports().
+
+    The defaults the data plane lands on -- 50050 for mooncake's metadata
+    server and 50051 for the master RPC, both from TransferQueue's config.yaml,
+    plus 9003 for the master's metrics server from its own gflag -- all sit
+    inside the 9000-65000 ephemeral range these nodes use. The kernel can hand
+    any of them to an outgoing connection in the minutes between job start and
+    the master's bind, and the master then exits with EADDRINUSE after every
+    node is already up.
+    """
+
+    def test_ports_are_distinct_bindable_and_in_band(self):
+        ports = _reserve_data_plane_ports(3)
+
+        # Distinctness is the regression worth guarding: without excluded_ports
+        # the allocator can hand back the same port twice, pointing two of the
+        # master's servers at one address.
+        assert len(set(ports)) == 3, f"all ports must differ, got {ports}"
+        for label, port in zip(("metadata", "master", "metrics"), ports):
+            assert (
+                DEFAULT_DATA_PLANE_PORT_RANGE_LOW
+                <= port
+                < DEFAULT_DATA_PLANE_PORT_RANGE_HIGH
+            ), f"{label} port {port} escaped the band ray.sub's map documents"
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                # No SO_REUSEADDR, matching mooncake_master: a port obtainable
+                # only by reusing a lingering slot is not one the master could
+                # bind either.
+                s.bind(("", port))
+
+    def test_ports_stay_below_the_ephemeral_floor(self):
+        ephemeral_range = Path("/proc/sys/net/ipv4/ip_local_port_range")
+        if not ephemeral_range.exists():
+            pytest.skip(f"{ephemeral_range} is unavailable on this platform")
+
+        ephemeral_low = int(ephemeral_range.read_text().split()[0])
+        assert max(_reserve_data_plane_ports(3)) < ephemeral_low
+
+    def test_occupied_port_is_routed_around(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as held:
+            try:
+                held.bind(("", DEFAULT_DATA_PLANE_PORT_RANGE_LOW))
+            except OSError:
+                pytest.skip(
+                    f"port {DEFAULT_DATA_PLANE_PORT_RANGE_LOW} is in use on this host"
+                )
+            held.listen(1)
+            ports = _reserve_data_plane_ports(3)
+
+        assert DEFAULT_DATA_PLANE_PORT_RANGE_LOW not in ports
+
+    def test_raises_when_the_band_cannot_satisfy_the_request(self, monkeypatch):
+        # A one-port band also proves each choice is excluded from the next:
+        # without that, the second call would reuse the first port instead of
+        # failing.
+        monkeypatch.setattr(
+            virtual_cluster,
+            "DEFAULT_DATA_PLANE_PORT_RANGE_HIGH",
+            DEFAULT_DATA_PLANE_PORT_RANGE_LOW + 1,
+        )
+        try:
+            # The one-port case has to succeed first, or a busy port would
+            # raise this same error before the exclusion is ever reached and
+            # the assertion below would pass for the wrong reason.
+            _reserve_data_plane_ports(1)
+        except RuntimeError:
+            pytest.skip(
+                f"port {DEFAULT_DATA_PLANE_PORT_RANGE_LOW} is in use on this host"
+            )
+
+        with pytest.raises(RuntimeError, match="Could not find a free port in range"):
+            _reserve_data_plane_ports(2)
+
+
 class TestRayVirtualClusterPortRange:
     """Tests for port range propagation in RayVirtualCluster."""
 
@@ -728,7 +807,8 @@ class TestVllmPortAssignment:
         assert "VLLM_PORT" not in env_vars
 
 
-def test_router_band_does_not_collide_with_ray_sub_ports():
+def _ray_sub_reserved_ports() -> set[int]:
+    """Every port ray.sub hands to Ray itself."""
     reserved = {
         _ray_sub_default("PORT"),
         _ray_sub_default("RAY_CLIENT_SERVER_PORT"),
@@ -750,6 +830,11 @@ def test_router_band_does_not_collide_with_ray_sub_ports():
             _ray_sub_default("MAX_WORKER_PORT") + 1,
         )
     )
+    return reserved
+
+
+def test_router_band_does_not_collide_with_ray_sub_ports():
+    reserved = _ray_sub_reserved_ports()
 
     router_band = set(
         range(
@@ -758,6 +843,15 @@ def test_router_band_does_not_collide_with_ray_sub_ports():
         )
     )
     assert not router_band & reserved, sorted(router_band & reserved)
+
+
+def test_data_plane_band_does_not_collide_with_ray_sub_ports():
+    reserved = _ray_sub_reserved_ports()
+
+    data_plane_band = set(
+        range(DEFAULT_DATA_PLANE_PORT_RANGE_LOW, DEFAULT_DATA_PLANE_PORT_RANGE_HIGH)
+    )
+    assert not data_plane_band & reserved, sorted(data_plane_band & reserved)
 
 
 def test_default_port_ranges_ordered_and_below_ephemeral_floor():
@@ -797,9 +891,18 @@ def test_default_port_ranges_ordered_and_below_ephemeral_floor():
         < DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH
     )
     assert DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH < EPHEMERAL_FLOOR
+    # The data-plane band sits below the Ray GCS ports, which is the only gap
+    # left under the router band, and has to hold every port mooncake's master
+    # listens on.
+    assert DEFAULT_DATA_PLANE_PORT_RANGE_LOW < DEFAULT_DATA_PLANE_PORT_RANGE_HIGH
+    assert DEFAULT_DATA_PLANE_PORT_RANGE_HIGH <= _ray_sub_default("PORT")
+    assert (
+        DEFAULT_DATA_PLANE_PORT_RANGE_HIGH - DEFAULT_DATA_PLANE_PORT_RANGE_LOW >= 3
+    ), "the band must fit the metadata, master RPC and metrics ports"
     # Avoid privileged ports (<1024).
     assert DEFAULT_GENERATION_ROUTER_PORT_RANGE_LOW > 1024
     assert DEFAULT_MASTER_PORT_RANGE_LOW > 1024
+    assert DEFAULT_DATA_PLANE_PORT_RANGE_LOW > 1024
 
 
 _REGISTRY_PROBE = """


### PR DESCRIPTION
## Overview

The ports this stack lands on for the mooncake data plane -- 50050 for the metadata server and 50051 for the master RPC, both from [TransferQueue's `config.yaml`](https://github.com/Ascend/TransferQueue/blob/c51614308b68c8d7a87c9b3ef62d59e14c69bde2/transfer_queue/config.yaml#L43-L45) rather than from mooncake, which defaults its HTTP metadata server to 8080 and off, plus 9003 for the master's metrics server from [`mooncake_master`'s own gflag](https://github.com/kvcache-ai/Mooncake/blob/v0.3.11/mooncake-store/src/master.cpp#L69) -- all sit inside the 9000-65000 ephemeral range these nodes use. The kernel can hand any of them to an outgoing connection during the minutes between job start and the master's bind, after which the master exits with `EADDRINUSE` and takes the run down with every node already up. Job 3678431 lost 10 nodes for 22 minutes this way: the master bound 50051 and 50050, then died on 9003 a second later.

`ray.sub`'s port map already documents this hazard and pins every other service below 9000. This allocates all three ports from one data-plane band in the gap that map leaves free (1150-1199) and records the band in both copies of the map, instead of hardcoding ports inside the range the kernel draws from. Every one of them reaches clients through the TQ controller actor rather than being assumed, so relocating them costs nothing.

The reservation (`_reserve_data_plane_ports`) lives next to the other port helpers in `virtual_cluster.py` and allocates through `_get_free_port_local` with `excluded_ports`, the way `ManagedDynamoRuntime` already allocates its etcd/NATS/frontend ports: distinct by construction, and bound without `SO_REUSEADDR`, matching `mooncake_master` -- a port obtainable only by reusing a lingering slot is not one the master could bind either.

### The metrics port needs a different route to the master

TransferQueue passes `mooncake_master` neither `--metrics_port` nor a `--config_path` file that could carry one ([`mooncake_bootstrap.py#L110-L128`](https://github.com/Ascend/TransferQueue/blob/c51614308b68c8d7a87c9b3ef62d59e14c69bde2/transfer_queue/storage/bootstrap/mooncake_bootstrap.py#L110-L128)), and `mooncake_master` reads a config file only when `--config_path` is given, so a config key for it is inert. Its bind is not optional either: [`MasterAdminServer::Start`](https://github.com/kvcache-ai/Mooncake/blob/v0.3.11/mooncake-store/src/rpc_service.cpp#L228-L237) binds the socket before it consults `enable_metric_reporting`, and the master returns 1 when that bind fails. 9003 is the port that actually killed job 3678431.

TQ does build the master's argv **in this process**, though -- `tq.init` -> [`_maybe_create_tq_storage`](https://github.com/Ascend/TransferQueue/blob/c51614308b68c8d7a87c9b3ef62d59e14c69bde2/transfer_queue/interface.py#L71-L88) -> `initialize_mooncake_storage` all run on the driver -- so `_patch_mooncake_master_metrics_port` wraps the `subprocess.Popen` that bootstrap calls and appends `--metrics_port=<reserved>`, alongside the three TQ patches this adapter already installs. gflags takes the last occurrence of a repeated flag, so this stays correct if upstream starts passing its own.

The [provider registry](https://github.com/Ascend/TransferQueue/blob/c51614308b68c8d7a87c9b3ef62d59e14c69bde2/transfer_queue/storage/bootstrap/provider.py#L26-L36) holds a `functools.wraps` wrapper closed over the original bootstrap function, so the registry entry is re-registered too -- the same trap `extract_field_schema` has, where rebinding only the defining module leaves the called function unpatched. That wrapper is also where the drift check lives: if a future TQ revision launches the master by some other route, the flag would stop landing silently and the metrics server would be back on 9003, so the bootstrap is required to have gone through the wrapped `Popen`. The patch can be deleted outright once TQ forwards a `metrics_port` from `conf.backend.MooncakeStore`.

# What does this PR do ?

Moves every port mooncake's master listens on -- metadata server, master RPC and master metrics -- into the 1150-1199 band that `ray.sub`'s port map leaves free, so none of them is drawn from the kernel's ephemeral range any more.

# Issues

Job 3678431 (10 nodes lost for 22 minutes to `mooncake_master` exiting with `EADDRINUSE`).

# Usage

No user-facing configuration change: the ports are allocated on the driver and reach clients through the TQ controller actor.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Band and allocator tests sit with the other port helpers in `tests/unit/distributed/test_virtual_cluster.py` and import no TransferQueue, so they run in the base unit-test environment: `TestReserveDataPlanePorts` (distinctness, band, ephemeral floor, occupied-port avoidance, exhaustion), `test_data_plane_band_does_not_collide_with_ray_sub_ports`, and data-plane assertions in `test_default_port_ranges_ordered_and_below_ephemeral_floor` (including that the band is wide enough for all three ports).

The argv patch is covered in `tests/unit/data_plane/test_mooncake_metrics_port.py`: the flag is appended for `mooncake_master` (bare or absolute path) and never for the offload client, unknown attributes delegate to the real `subprocess`, the registry entry that is actually called gets patched, re-init repoints the port instead of stacking wrappers, a bootstrap that skips the wrapped `Popen` raises, and `_init_tq` end-to-end hands out three distinct in-band ports with no `metrics_port` key in the config TQ reads.
