### PR TITLE
fix(vllm): allow BF16 rollout with inherited quantization exclusions

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -205,10 +205,17 @@ def _log_effective_quantization_ignore_patterns(
         return
 
     hf_overrides = vllm_kwargs.get("hf_overrides")
-    if not isinstance(hf_overrides, dict):
-        return
-    quantization_config = hf_overrides.get("quantization_config")
+    quantization_config = (
+        hf_overrides.get("quantization_config")
+        if isinstance(hf_overrides, dict)
+        else None
+    )
     if not isinstance(quantization_config, dict):
+        if vllm_cfg.get("precision") in ("bf16", "bfloat16"):
+            logger.warning(
+                "Ignoring quantization_ignore_patterns because rollout precision is BF16 "
+                "and no quantization configuration is active. Continuing without quantization exclusions."
+            )
         return
     effective_ignore = quantization_config.get("ignore", [])
     print(f"NRL_MXFP8_EFFECTIVE_IGNORE={effective_ignore}")

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -204,9 +204,13 @@ def _log_effective_quantization_ignore_patterns(
     if not vllm_cfg.get("quantization_ignore_patterns"):
         return
 
-    effective_ignore = vllm_kwargs["hf_overrides"]["quantization_config"].get(
-        "ignore", []
-    )
+    hf_overrides = vllm_kwargs.get("hf_overrides")
+    if not isinstance(hf_overrides, dict):
+        return
+    quantization_config = hf_overrides.get("quantization_config")
+    if not isinstance(quantization_config, dict):
+        return
+    effective_ignore = quantization_config.get("ignore", [])
     print(f"NRL_MXFP8_EFFECTIVE_IGNORE={effective_ignore}")
 
 

--- a/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
+++ b/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
@@ -65,14 +65,30 @@ def test_does_not_log_ignore_patterns_when_unconfigured(capsys) -> None:
         {"hf_overrides": {"quantization_config": None}},
     ],
 )
+@pytest.mark.parametrize("precision", ["bf16", "bfloat16"])
 def test_bf16_rollout_can_inherit_ignore_patterns(
-    vllm_kwargs: dict[str, Any], capsys: pytest.CaptureFixture[str]
+    vllm_kwargs: dict[str, Any], precision: str,
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture,
 ) -> None:
     _log_effective_quantization_ignore_patterns(
-        {"precision": "bfloat16", "quantization_ignore_patterns": ["*self_attn.*"]},
+        {"precision": precision, "quantization_ignore_patterns": ["*self_attn.*"]},
         vllm_kwargs,
     )
     assert capsys.readouterr().out == ""
+    assert "Ignoring quantization_ignore_patterns because rollout precision is BF16" in caplog.text
+
+
+def test_mixed_mxfp8_rollout_keeps_exclusions_without_bf16_warning(
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture,
+) -> None:
+    _log_effective_quantization_ignore_patterns(
+        {"precision": "fp8", "is_mx": True,
+         "num_first_layers_in_bf16": 2, "num_last_layers_in_bf16": 6,
+         "quantization_ignore_patterns": ["*self_attn.*"]},
+        {"hf_overrides": {"quantization_config": {"ignore": ["model.layers.0.*"]}}},
+    )
+    assert "model.layers.0.*" in capsys.readouterr().out
+    assert not caplog.records
 
 
 def test_fp8_and_user_hf_overrides_coexist():

--- a/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
+++ b/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
@@ -67,24 +67,34 @@ def test_does_not_log_ignore_patterns_when_unconfigured(capsys) -> None:
 )
 @pytest.mark.parametrize("precision", ["bf16", "bfloat16"])
 def test_bf16_rollout_can_inherit_ignore_patterns(
-    vllm_kwargs: dict[str, Any], precision: str,
-    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture,
+    vllm_kwargs: dict[str, Any],
+    precision: str,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     _log_effective_quantization_ignore_patterns(
         {"precision": precision, "quantization_ignore_patterns": ["*self_attn.*"]},
         vllm_kwargs,
     )
     assert capsys.readouterr().out == ""
-    assert "Ignoring quantization_ignore_patterns because rollout precision is BF16" in caplog.text
+    assert (
+        "Ignoring quantization_ignore_patterns because rollout precision is BF16"
+        in caplog.text
+    )
 
 
 def test_mixed_mxfp8_rollout_keeps_exclusions_without_bf16_warning(
-    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     _log_effective_quantization_ignore_patterns(
-        {"precision": "fp8", "is_mx": True,
-         "num_first_layers_in_bf16": 2, "num_last_layers_in_bf16": 6,
-         "quantization_ignore_patterns": ["*self_attn.*"]},
+        {
+            "precision": "fp8",
+            "is_mx": True,
+            "num_first_layers_in_bf16": 2,
+            "num_last_layers_in_bf16": 6,
+            "quantization_ignore_patterns": ["*self_attn.*"],
+        },
         {"hf_overrides": {"quantization_config": {"ignore": ["model.layers.0.*"]}}},
     )
     assert "model.layers.0.*" in capsys.readouterr().out

--- a/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
+++ b/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
@@ -58,8 +58,12 @@ def test_does_not_log_ignore_patterns_when_unconfigured(capsys) -> None:
 
 @pytest.mark.parametrize(
     "vllm_kwargs",
-    [{}, {"hf_overrides": {}}, {"hf_overrides": None},
-     {"hf_overrides": {"quantization_config": None}}],
+    [
+        {},
+        {"hf_overrides": {}},
+        {"hf_overrides": None},
+        {"hf_overrides": {"quantization_config": None}},
+    ],
 )
 def test_bf16_rollout_can_inherit_ignore_patterns(
     vllm_kwargs: dict[str, Any], capsys: pytest.CaptureFixture[str]

--- a/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
+++ b/tests/unit/models/generation/test_vllm_fp8_hf_overrides.py
@@ -21,6 +21,8 @@ silently reverted (#2188), and re-fixed (#2904). These tests pin the merge
 behavior so it cannot regress a third time.
 """
 
+from typing import Any
+
 import pytest
 
 from nemo_rl.models.generation.vllm.vllm_worker import (
@@ -51,6 +53,21 @@ def test_logs_effective_quantization_ignore_patterns(capsys) -> None:
 def test_does_not_log_ignore_patterns_when_unconfigured(capsys) -> None:
     _log_effective_quantization_ignore_patterns({}, {})
 
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    "vllm_kwargs",
+    [{}, {"hf_overrides": {}}, {"hf_overrides": None},
+     {"hf_overrides": {"quantization_config": None}}],
+)
+def test_bf16_rollout_can_inherit_ignore_patterns(
+    vllm_kwargs: dict[str, Any], capsys: pytest.CaptureFixture[str]
+) -> None:
+    _log_effective_quantization_ignore_patterns(
+        {"precision": "bfloat16", "quantization_ignore_patterns": ["*self_attn.*"]},
+        vllm_kwargs,
+    )
     assert capsys.readouterr().out == ""
 
 


### PR DESCRIPTION
## Summary
BF16 rollout can inherit `quantization_ignore_patterns` from an MXFP8 recipe. The scope logger currently raises `KeyError: 'quantization_config'` before model initialization because BF16 has no generated quantization config.

Skip this diagnostic when its configuration is absent. Existing MXFP8 output and quantization-config validation are unchanged. No changes to weight loading, refit, or kernels.

## Tests
- Four missing/null-config regression cases fail before the fix.
- GB200, vLLM 0.25.1: 256 generation/refit tests pass with this fix on the integration branch, including all 14 HF-override tests.
- Fresh 20-step BF16 rollout reruns are submitted; E2E results are pending.
