### PR TITLE
fix: build refit metadata before communicator initialization

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -3723,10 +3723,11 @@ class MegatronPolicyWorkerImpl(
                 base=self._group_experts(proj, grouped_name, expert_groups)
             )
 
+        my_pp_stage = parallel_state.get_pipeline_model_parallel_rank()
         mapping = {}
         for layer_name in refit_info["layer_names"]:
             for p in refit_info["per_layer_params"][layer_name]:
-                if p.get("pp_stage", 0) != self.my_pp_stage:
+                if p.get("pp_stage", 0) != my_pp_stage:
                     continue
                 name = p["name"]
                 if p.get("grouped_expert_proj"):

--- a/tests/unit/models/megatron/test_group_experts.py
+++ b/tests/unit/models/megatron/test_group_experts.py
@@ -83,8 +83,11 @@ def test_group_experts_empty_group_raises():
 # shards (_iter_local_hf_param_shards) into LocalParamSpecs.  Fake the shard
 # iterator; _build_expert_groups / _group_experts run for real.
 # --------------------------------------------------------------------------
-def test_build_hf_to_local_param_map_train_side(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_hf_to_local_param_map_train_side(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from megatron.core import parallel_state
+
     from nemo_rl.weight_sync.nccl_reshard_utils import HFToLocalParamMap
 
     w = object.__new__(MegatronPolicyWorkerImpl)  # no __init__ / no megatron state

--- a/tests/unit/models/megatron/test_group_experts.py
+++ b/tests/unit/models/megatron/test_group_experts.py
@@ -83,11 +83,12 @@ def test_group_experts_empty_group_raises():
 # shards (_iter_local_hf_param_shards) into LocalParamSpecs.  Fake the shard
 # iterator; _build_expert_groups / _group_experts run for real.
 # --------------------------------------------------------------------------
-def test_build_hf_to_local_param_map_train_side():
+def test_build_hf_to_local_param_map_train_side(monkeypatch: pytest.MonkeyPatch) -> None:
+    from megatron.core import parallel_state
     from nemo_rl.weight_sync.nccl_reshard_utils import HFToLocalParamMap
 
     w = object.__new__(MegatronPolicyWorkerImpl)  # no __init__ / no megatron state
-    w.my_pp_stage = 0
+    monkeypatch.setattr(parallel_state, "get_pipeline_model_parallel_rank", lambda: 0)
     # opd_full off, mirroring __init__ when the config block is absent.
     w._opd_full_enabled = False
     w._opd_full_lm_head_lifecycle = None

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -27,9 +27,6 @@ import pytest
 import ray
 import torch
 
-
-
-
 from nemo_rl.algorithms.loss import (
     ClippedPGLossConfig,
     ClippedPGLossFn,
@@ -65,9 +62,13 @@ def test_refit_metadata_map_precedes_transport_init(
     worker = object.__new__(worker_module.MegatronPolicyWorkerImpl)
     local_name = f"model.layers.{pp_rank}.mlp.down_proj.weight"
     local_spec = LocalParamSpec(base=torch.ones(2, 2))
-    worker._iter_local_hf_param_shards = MagicMock(return_value=[(local_name, local_spec)])
+    worker._iter_local_hf_param_shards = MagicMock(
+        return_value=[(local_name, local_spec)]
+    )
     monkeypatch.setattr(
-        worker_module.parallel_state, "get_pipeline_model_parallel_rank", lambda: pp_rank
+        worker_module.parallel_state,
+        "get_pipeline_model_parallel_rank",
+        lambda: pp_rank,
     )
     info = {
         "layer_names": [f"model.layers.{rank}" for rank in range(4)],

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -27,6 +27,9 @@ import pytest
 import ray
 import torch
 
+
+
+
 from nemo_rl.algorithms.loss import (
     ClippedPGLossConfig,
     ClippedPGLossFn,
@@ -50,6 +53,38 @@ pytestmark = pytest.mark.mcore
 
 # Megatron Core/Bridge and worker-module imports stay test-local so pytest can
 # collect this module without the optional MCore/Transformer Engine stack.
+
+
+@pytest.mark.parametrize("pp_rank", [0, 1, 3])
+def test_refit_metadata_map_precedes_transport_init(
+    monkeypatch: pytest.MonkeyPatch, pp_rank: int
+) -> None:
+    import nemo_rl.models.policy.workers.megatron_policy_worker as worker_module
+    from nemo_rl.weight_sync.nccl_reshard_utils import LocalParamSpec
+
+    worker = object.__new__(worker_module.MegatronPolicyWorkerImpl)
+    local_name = f"model.layers.{pp_rank}.mlp.down_proj.weight"
+    local_spec = LocalParamSpec(base=torch.ones(2, 2))
+    worker._iter_local_hf_param_shards = MagicMock(return_value=[(local_name, local_spec)])
+    monkeypatch.setattr(
+        worker_module.parallel_state, "get_pipeline_model_parallel_rank", lambda: pp_rank
+    )
+    info = {
+        "layer_names": [f"model.layers.{rank}" for rank in range(4)],
+        "per_layer_params": {
+            f"model.layers.{rank}": [
+                {"name": f"model.layers.{rank}.mlp.down_proj.weight", "pp_stage": rank}
+            ]
+            for rank in range(4)
+        },
+    }
+
+    assert not hasattr(worker, "my_pp_stage")
+    mapping = worker._build_source_hf_to_local_param_map(info)
+    assert mapping.get(local_name) is local_spec
+    for rank in range(4):
+        if rank != pp_rank:
+            assert mapping.get(f"model.layers.{rank}.mlp.down_proj.weight") is None
 
 
 def _make_refit_task(


### PR DESCRIPTION
## Problem
Async NCCL reshard setup builds source metadata before initializing the refit communicator. The metadata builder reads `self.my_pp_stage`, which is assigned only during communicator initialization, and fails with `AttributeError`.

## Change
Read the pipeline rank from the already-initialized Megatron model parallel state. This preserves rank ownership without relying on transport initialization or assuming rank zero. No weight conversion or transfer logic changes.

## Validation
Added regression cases for pipeline ranks 0, 1, and 3 without a communicator-owned rank attribute. GPU regression execution is pending; this is a draft, not a validated 20-step result.

Observed in a GB200 Qwen3-30B-A3B Async run before the first refit. No documentation or configuration changes are required.