### PR TITLE
fix(vlm): forward image payloads in async rollouts

### DIFF
--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -37,6 +37,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
 )
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
+from nemo_rl.data.multimodal_utils import NATIVE_MULTIMODAL_KEYS
 from nemo_rl.data_plane.schema import MASK_SAMPLE
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
@@ -570,6 +571,11 @@ class AsyncRolloutImpl:
     ) -> tuple[Completion, dict]:
         """Run one multi-turn rollout for a single generation index."""
         current_message_log = copy.deepcopy(input_sample["message_log"])
+        native_generation_data = {
+            key: input_sample[key]
+            for key in NATIVE_MULTIMODAL_KEYS
+            if key in input_sample
+        }
         current_extra_env_info = copy.deepcopy(input_sample["extra_env_info"])
         current_stop_strings = input_sample.get("stop_strings", None)
         task_name = input_sample["task_name"]
@@ -597,6 +603,11 @@ class AsyncRolloutImpl:
                 break
 
             turn_count += 1
+            turn_native_generation_data = dict(native_generation_data)
+            # Raw processor content describes only the original conversation.
+            # Later turns keep the media but use the updated pre-tokenized prefix.
+            if turn_count > 1 and "vllm_content" in turn_native_generation_data:
+                turn_native_generation_data["vllm_content"] = None
 
             # Generate response for this sample using async generation.
             # A failure here must not be absorbed: returning a partial completion
@@ -610,6 +621,7 @@ class AsyncRolloutImpl:
                 ) = await self._generate_response(
                     current_message_log,
                     current_stop_strings,
+                    native_generation_data=turn_native_generation_data,
                 )
             except Exception as e:
                 raise _classify_generation_failure(
@@ -736,6 +748,8 @@ class AsyncRolloutImpl:
         self,
         message_log: list[dict],
         stop_strings: list[str] | None,
+        *,
+        native_generation_data: dict[str, Any] | None = None,
     ) -> tuple[dict, torch.Tensor, dict[str, Any]]:
         """Generate a single-turn response for one sample.
 
@@ -760,6 +774,12 @@ class AsyncRolloutImpl:
         generation_input_data.update(
             flat_messages.get_multimodal_dict(as_tensors=False)
         )
+        if native_generation_data:
+            # This method handles one sample; vLLM's formatter expects batched
+            # native content/media side channels.
+            generation_input_data.update(
+                {key: [value] for key, value in native_generation_data.items()}
+            )
 
         # Generate response
         # TODO: update generate_async to return a single item directly

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -101,7 +101,7 @@ def _with_cut(buffer, callback):
     return _run(apply())
 
 
-def test_generate_response_forwards_message_log_media_to_generation() -> None:
+def test_generate_response_forwards_all_vllm_media_to_generation() -> None:
     captured: dict[str, BatchedDataDict] = {}
 
     class _Generation:
@@ -131,6 +131,7 @@ def test_generate_response_forwards_message_log_media_to_generation() -> None:
     manager._deadline_registry = None
     pixel_values = PackedTensor(torch.ones(2, 3, 4, 4), dim_to_pack=0)
     imgs_sizes = PackedTensor(torch.tensor([[4, 4], [4, 4]]), dim_to_pack=0)
+    native_image = object()
     message_log = [
         {
             "role": "user",
@@ -147,13 +148,22 @@ def test_generate_response_forwards_message_log_media_to_generation() -> None:
     ]
 
     assistant_message, input_lengths, _ = _run(
-        manager._generate_response(message_log, ["<stop>"])
+        manager._generate_response(
+            message_log,
+            ["<stop>"],
+            native_generation_data={
+                "vllm_content": "rendered prompt",
+                "vllm_images": [native_image],
+            },
+        )
     )
 
     generation_data = captured["data"]
     assert generation_data["input_ids"].tolist() == [[1, 2, 3, 4, 5]]
     assert generation_data["input_lengths"].tolist() == [5]
     assert generation_data["stop_strings"] == [["<stop>"]]
+    assert generation_data["vllm_content"] == ["rendered prompt"]
+    assert generation_data["vllm_images"] == [[native_image]]
     assert isinstance(generation_data["pixel_values"], PackedTensor)
     assert isinstance(generation_data["imgs_sizes"], PackedTensor)
     assert torch.equal(


### PR DESCRIPTION
# What does this PR do ?

Preserves native multimodal side-channel fields when SingleController dispatches async VLM rollouts, so vLLM and the training forward receive the same image input.

The async per-sample path previously rebuilt generation input from tokenized message data but dropped fields such as `vllm_content` and `vllm_images`. This made vLLM generation image-blind while Megatron recomputed log probabilities with the image, producing large `token_mult_prob_error` values.

For multi-turn rollouts, later turns retain native media while clearing stale `vllm_content`, allowing the updated tokenized prefix to be used.

This PR does not modify recipes or generation lengths. The existing defaults remain Qwen `max_new_tokens=1024` and Nemotron `max_new_tokens=4096`.

Validation results:
- Controlled unfixed Qwen reproduction: `train/token_mult_prob_error = 2.77639`
- Same controlled setup after the fix, vLLM TP1/TP2/TP4: approximately `1.02`
- Native Qwen configuration (`max_new_tokens=1024`, 8 prompts x 16 generations), 100/100 steps: all TMPE values below `1.05`; range `1.02006–1.02614`; truncation rate `0`
- Native Qwen W&B run: https://wandb.ai/nvidia/rohit-async_grpo_v2/runs/4t6osucc
- Native Nemotron configuration (`max_new_tokens=4096`, 8 prompts x 16 generations), 100/100 steps completed. Most aggregate TMPE values were approximately `1.03`; three outliers remain under investigation, including one immediately after checkpoint resume.
- Native Nemotron W&B runs: https://wandb.ai/nvidia/rohit-async_grpo_v2/runs/5g2qyqmb and https://wandb.ai/nvidia/rohit-async_grpo_v2/runs/y2govxqy

## Reproduction commands

Qwen native-length 100-step validation:

```bash
uv run --locked examples/run_grpo_single_controller.py \
  --config examples/configs/recipes/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n8g-megatron-single-controller-async.v1.yaml \
  grpo.max_num_steps=100 \
  logger.wandb_enabled=true \
  logger.tensorboard_enabled=true \
  logger.monitor_gpus=false \
  logger.wandb.project=rohit-async_grpo_v2 \
  logger.wandb.name=linglinj-qwen-image-fix-native1024
```

Nemotron native-length 100-step validation (3 nodes / 8 GPUs per node):

```bash
uv run --locked examples/run_grpo_single_controller.py \
  --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-3n8g-megatron-tp8ep8-single-controller-async.v1.yaml \
  grpo.max_num_steps=100 \
  policy.train_global_batch_size=128 \
  logger.wandb_enabled=true \
  logger.tensorboard_enabled=true \
  logger.monitor_gpus=false \
  logger.wandb.project=rohit-async_grpo_v2 \
  logger.wandb.name=linglinj-nemotron-native4096-gbs128
```
