### PR TITLE
fix(grpo): mask excluded values before logprob exponentiation

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -474,6 +474,21 @@ class ClippedPGLossFn(LossFunction):
 
         mask = token_mask * sample_mask.unsqueeze(-1)
 
+        # Mask before exponentiation: multiplying an overflow by zero still yields NaN.
+        valid_tokens = mask.bool()
+        curr_logprobs = curr_logprobs.masked_fill(~valid_tokens, 0.0)
+        generation_logprobs = generation_logprobs.masked_fill(~valid_tokens, 0.0)
+        advantages = advantages.masked_fill(~valid_tokens, 0.0)
+        if prev_logprobs is not None:
+            prev_logprobs = prev_logprobs.masked_fill(~valid_tokens, 0.0)
+        if self.reference_policy_kl_penalty != 0:
+            reference_policy_logprobs = reference_policy_logprobs.masked_fill(
+                ~valid_tokens, 0.0
+            )
+            curr_logprobs_unfiltered = curr_logprobs_unfiltered.masked_fill(
+                ~valid_tokens, 0.0
+            )
+
         # For truly on-policy training, use curr_logprobs as prev_logprobs
         # This avoids computing prev_logprobs upstream
         if self.force_on_policy_ratio:

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -54,6 +54,68 @@ def test_clipped_pg_loss_config_rejects_invalid_reference_kl_penalty(
         ClippedPGLossConfig(reference_policy_kl_penalty=invalid_penalty)
 
 
+@pytest.mark.parametrize(
+    "token_level_loss,sequence_level_importance_ratios",
+    [(True, False), (False, False), (False, True)],
+)
+@pytest.mark.parametrize("force_on_policy_ratio", [True, False])
+@pytest.mark.parametrize("invalid_logprob", [-200.0, float("-inf"), float("nan")])
+def test_clipped_pg_loss_masks_extreme_values_before_exponentiation(
+    token_level_loss: bool,
+    force_on_policy_ratio: bool,
+    invalid_logprob: float,
+    sequence_level_importance_ratios: bool,
+) -> None:
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(
+            token_level_loss=token_level_loss,
+            force_on_policy_ratio=force_on_policy_ratio,
+            reference_policy_kl_penalty=0.01,
+            use_importance_sampling_correction=True,
+            sequence_level_importance_ratios=sequence_level_importance_ratios,
+        )
+    )
+    mask = torch.tensor([[0.0, 0.0, 1.0], [0.0, 1.0, 1.0]])
+    sample_mask = torch.tensor([1.0, 0.0])
+    results = []
+    for excluded_value in [0.0, invalid_logprob]:
+        current = torch.tensor(
+            [[excluded_value, -1.0], [excluded_value, excluded_value]],
+            requires_grad=True,
+        )
+        unfiltered = torch.tensor(
+            [[excluded_value, -1.0], [excluded_value, excluded_value]],
+            requires_grad=True,
+        )
+        old = torch.tensor(
+            [[0.0, excluded_value, -1.0], [0.0, excluded_value, excluded_value]]
+        )
+        data = BatchedDataDict(
+            {
+                "token_mask": mask,
+                "sample_mask": sample_mask,
+                "advantages": torch.tensor(
+                    [[0.0, excluded_value, 1.0], [0.0, excluded_value, excluded_value]]
+                ),
+                "prev_logprobs": old,
+                "generation_logprobs": torch.tensor(
+                    [[0.0, excluded_value, -1.0], [0.0, excluded_value, excluded_value]]
+                ),
+                "reference_policy_logprobs": old.clone(),
+                "curr_logprobs_unfiltered": unfiltered,
+            }
+        )
+        loss, metrics = loss_fn(current, data, torch.tensor(1.0), torch.tensor(1.0))
+        loss.backward()
+        assert torch.isfinite(loss)
+        assert torch.isfinite(current.grad).all()
+        assert torch.isfinite(unfiltered.grad).all()
+        assert all(torch.isfinite(torch.tensor(value)) for value in metrics.values())
+        results.append((loss.detach(), current.grad, unfiltered.grad))
+    for actual, expected in zip(results[1], results[0]):
+        torch.testing.assert_close(actual, expected)
+
+
 def setup_dpo_loss_test_data(vocab_size=16, batch_size=1):
     seq_len = 4
     data = {


### PR DESCRIPTION
# What does this PR do ?

Prevent masked tokens and excluded samples from producing NaN gradients in `ClippedPGLossFn`.

The loss currently computes probability ratios and KL terms before applying the loss mask. In float32, a log-probability difference of 200 overflows `exp`; multiplying the result by a zero mask still yields NaN. Masked `-inf` or NaN inputs can also contaminate reductions and diagnostics.

Zero the excluded log-probabilities and advantages before those operations, using the existing combined token/sample mask. Values at valid positions are unchanged. This covers the policy ratio, importance-sampling correction, reference KL penalty, and log-probability diagnostics without clamping valid-token ratios.

The regression test compares a clean batch against the same batch with extreme values in a masked prompt position and an excluded sample. It checks finite loss, gradients, and metrics, plus identical loss and input gradients. Its 18 cases cover token/sequence loss reduction, sequence importance ratios, on-policy/off-policy ratios, and finite overflow/`-inf`/NaN inputs.

# Issues

No linked issue.

# Usage

No configuration changes are needed.

```bash
python -m pytest tests/unit/algorithms/test_loss_functions.py -k clipped_pg_loss
```

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added regression tests.
- [ ] Ran the full unit and functional test suites locally; see the focused validation below.
- [x] No user-facing documentation changes are needed for this numerical bug fix.

# Additional Information

Validated against upstream main `d633032b2a8017c69ddfff9183deb42cab6b36f4`:

- Focused pytest run: **35 passed, 19 skipped, 49 deselected**, including all 18 new regression cases. The skipped tests require CUDA, which was unavailable in this environment.
  ```bash
  python -m pytest tests/unit/algorithms/test_loss_functions.py \
    -k clipped_pg_loss --confcutdir=tests/unit/algorithms --no-cov -q
  ```
  `--confcutdir` excludes the parent suite's automatic Ray-cluster fixtures for this local CPU run; the actual upstream loss implementation and test module are imported without stubs.
- An isolated reproduction using the upstream loss method and KL/reduction helpers failed all 18 cases before the fix and passed all 18 afterward.
- Ruff lint, Ruff format check, and `git diff --check` passed for the changed files.
- The full GPU unit and functional suites have not been run locally.
